### PR TITLE
Use environment variable for the IP of the docker host.

### DIFF
--- a/core/src/main/java/org/testcontainers/SingletonDockerClient.java
+++ b/core/src/main/java/org/testcontainers/SingletonDockerClient.java
@@ -58,7 +58,10 @@ public class SingletonDockerClient {
 
             return builder;
         } else {
-            dockerHostIpAddress = "127.0.0.1";
+            dockerHostIpAddress = System.getenv("DOCKER_HOST");
+            if (dockerHostIpAddress == null) {
+            	dockerHostIpAddress = "127.0.0.1";
+            }
             return DefaultDockerClient.fromEnv();
         }
     }


### PR DESCRIPTION
To use docker in a VM (on a windows host for example) it is necessary to
use a different IP than "127.0.0.1". If the variable is not set
"127.0.0.1" is used just like before.