### PR TITLE
Set Java memory limits suitable for running tests on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
     DOCKER_HOST: tcp://127.0.0.1:2376
     DOCKER_TLS_VERIFY: 0
     MAVEN_OPTS: -Xmx512m
+    _JAVA_OPTIONS: "-Xms512m -Xmx1024m"
 dependencies:
   override:
     - "sudo docker -d -e lxc -s btrfs -H 0.0.0.0:2376 -H unix:///var/run/docker.sock --log-level=debug --debug=true":


### PR DESCRIPTION
To resolve #46 