### PR TITLE
ContainerDatabaseDriver.connect misbehaviour fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
-Richard North <rich.north@gmail.com>
+﻿Richard North <rich.north@gmail.com>
 Gurpreet Sohal <gurpreet@gurpreetsohal.com>
 Alex Boldt <boldtalex@gmail.com>
 Robert Požarickij <robert.pozarickij@gmail.com>
+Krystian Nowak <krystian.nowak@gmail.com>

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -72,6 +72,13 @@ public class ContainerDatabaseDriver implements Driver {
     @Override
     public synchronized Connection connect(String url, final Properties info) throws SQLException {
 
+    	/**
+    	 * The driver should return "null" if it realizes it is the wrong kind of driver to connect to the given URL.
+    	 */
+    	if(!acceptsURL(url)) {
+    		return null;
+    	}
+    	
         String queryString = "";
         /**
          * If we already have a running container for this exact connection string, we want to connect

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ContainerDatabaseDriverTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ContainerDatabaseDriverTest.java
@@ -1,0 +1,35 @@
+package org.testcontainers.jdbc;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ContainerDatabaseDriverTest {
+
+	private static final String PLAIN_POSTGRESQL_JDBC_URL = "jdbc:postgresql://localhost:5432/test";
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void shouldNotTryToConnectToNonMatchingJdbcUrlDirectly() throws SQLException {
+		ContainerDatabaseDriver driver = new ContainerDatabaseDriver();
+		Connection connection = driver.connect(PLAIN_POSTGRESQL_JDBC_URL, new Properties());
+		Assert.assertNull(connection);
+	}
+
+	@Test
+	public void shouldNotTryToConnectToNonMatchingJdbcUrlViaDriverManager() throws SQLException {
+		thrown.expect(SQLException.class);
+		thrown.expectMessage(CoreMatchers.startsWith("No suitable driver found for "));
+		DriverManager.getConnection(PLAIN_POSTGRESQL_JDBC_URL);
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -38,7 +38,12 @@
         <developer>
             <id>rpozarickij</id>
             <name>Robert Požarickij</name>
-            <email>robert.pozarickij@gmail.com&gt;</email>
+            <email>robert.pozarickij@gmail.com</email>
+        </developer>
+        <developer>
+            <id>krystiannowak</id>
+            <name>Krystian Nowak</name>
+            <email>krystian.nowak@gmail.com</email>
         </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
### Wrong behaviour of `ContainerDatabaseDriver.connect` causing `DriverManager.getConnection` misbehaviour

> The driver should return "null" if it realizes it is the wrong kind of driver to connect to the given URL.
> his will be common, as when the JDBC driver manager is asked to connect to a given URL it passes the URL to each loaded driver in turn.

(from `java.sql.Driver` connect method's JavaDocs)

Currently the driver throws an `IllegalArgumentException`:
`JDBC URL matches jdbc:tc: prefix but the database or tag name could not be identified`

> The only exception expected is SQLException: if a database access error occurs or the url is "null"
> The driver should throw an SQLException if it is the right driver to connect to the given URL but has trouble connecting to the database.

Potentially the current `acceptsURL` method's behaviour might be reused for that - and this is used in the PR.

