### PR TITLE
upgrade docker-java to 2.2.0 to fix unix socket support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,3 +2,4 @@ Richard North <rich.north@gmail.com>
 Gurpreet Sohal <gurpreet@gurpreetsohal.com>
 Alex Boldt <boldtalex@gmail.com>
 Robert Požarickij <robert.pozarickij@gmail.com>
+Matthieu Baechler <matthieu.baechler@gmail.com>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>2.1.1</version>
+            <version>2.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.zeroturnaround</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
             <name>Robert Požarickij</name>
             <email>robert.pozarickij@gmail.com&gt;</email>
         </developer>
+        <developer>
+            <id>mbaechler</id>
+            <name>Matthieu Baechler</name>
+            <email>matthieu.baechler@gmail.com</email>
+        </developer>
     </developers>
 
     <dependencies>


### PR DESCRIPTION
Following https://github.com/testcontainers/testcontainers-java/issues/61 issue, I fixed an issue into docker-java https://github.com/docker-java/docker-java/pull/457 and docker-java 2.2.0 contains it.

We just need testcontainers-java to depend on docker-java 2.2.0 to have this issue fixed.