### PR TITLE
Added module for OpenLink Virtuoso test container

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Alex Boldt <boldtalex@gmail.com>
 Robert Požarickij <robert.pozarickij@gmail.com>
 Matthieu Baechler <matthieu.baechler@gmail.com>
 Krystian Nowak <krystian.nowak@gmail.com>
+Viktor Schulz <vschulz@mail.uni-mannheim.de>

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Testcontainers will try to connect to a Docker daemon using the following strate
 
 ### Usage modes
 
-* [Temporary database containers](usage/database_containers.md) - specialized MySQL, PostgreSQL and Oracle XE container support
+* [Temporary database containers](usage/database_containers.md) - specialized MySQL, PostgreSQL, Oracle XE and Virtuoso container support
 * [Webdriver containers](usage/webdriver_containers.md) - run a Dockerized Chrome or Firefox browser ready for Selenium/Webdriver operations - complete with automatic video recording
 * [Generic containers](usage/generic_containers.md) - run any Docker container as a test dependency
 * [Docker compose](usage/docker_compose.md) - reuse services defined in a Docker Compose YAML file

--- a/docs/usage/database_containers.md
+++ b/docs/usage/database_containers.md
@@ -14,7 +14,7 @@ You can obtain a temporary database in one of two ways:
  * **JUnit @Rule/@ClassRule**: this mode starts a database inside a container before your tests and tears it down afterwards.
  * **Using a specially modified JDBC URL**: after making a very simple modification to your system's JDBC URL string, TestContainers will provide a disposable stand-in database that can be used without requiring modification to your application code.
 
-TestContainers currently supports MySQL, PostgreSQL and Oracle XE.
+TestContainers currently supports MySQL, PostgreSQL, Oracle XE and Virtuoso.
 
 > Note: Oracle XE support does not bundle the proprietary Oracle JDBC drivers - you must provide these yourself.
 
@@ -41,6 +41,7 @@ Examples/Tests:
  * [MySQL](https://github.com/testcontainers/testcontainers-java/blob/master/modules/mysql/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java)
  * [PostgreSQL](https://github.com/testcontainers/testcontainers-java/blob/master/modules/postgresql/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java)
  * [Oracle-XE](https://github.com/testcontainers/testcontainers-java/blob/master/modules/oracle-xe/src/test/java/org/testcontainers/junit/SimpleOracleTest.java)
+ * [Virtuoso](https://github.com/testcontainers/testcontainers-java/blob/master/modules/virtuoso/src/test/java/org/testcontainers/junit/SimpleVirtuosoTest.java)
 
 ### JDBC URL
 
@@ -67,6 +68,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 #### Using PostgreSQL
 
 `jdbc:tc:postgresql://hostname/databasename`
+
 
 ## Using an init script
 
@@ -99,3 +101,11 @@ is a directory on the classpath containing .cnf files, the following URL can be 
 
 Any .cnf files in this classpath directory will be mapped into the database container's /etc/mysql/conf.d directory,
 and will be able to override server settings when the container starts.
+
+### Additional Non-standard Methods
+
+#### Virtuoso SPARQL Service URL
+
+VirtuosoContainer provides access to the SPARQL service URL
+
+    String sparqlServiceUrl = ((VirtuosoContainer)container).getSparqlUrl();

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  */
 public class ContainerDatabaseDriver implements Driver {
 
-    private static final Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:(mysql|postgresql|oracle)(:([^:]+))?://[^\\?]+(\\?.*)?");
+    private static final Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^:]+))?://[^\\?]+(\\?.*)?");
     private static final Pattern INITSCRIPT_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITSCRIPT=([^\\?&]+).*");
     private static final Pattern INITFUNCTION_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITFUNCTION=" +
             "((\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)*\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +

--- a/modules/virtuoso/pom.xml
+++ b/modules/virtuoso/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.testcontainers</groupId>
+		<artifactId>testcontainers-parent</artifactId>
+		<version>1.0.2-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	
+	<artifactId>virtuoso</artifactId>
+	<name>TestContainers :: JDBC :: Virtuoso</name>
+	
+	<repositories>
+		<repository>
+			<id>ldstack</id>
+			<url>http://mvn.linkeddata.org/content/groups/linkeddata.org/</url>
+		</repository>
+	</repositories>
+  
+	<dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jdbc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- Database driver for testing -->
+        <dependency>
+            <groupId>virtuoso</groupId>
+            <artifactId>jdbc-driver</artifactId>
+            <version>4.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Database connection pool for testing -->
+        <dependency>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP-java6</artifactId>
+            <version>2.3.8</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-dbutils</groupId>
+            <artifactId>commons-dbutils</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+	
+</project>

--- a/modules/virtuoso/src/main/java/org/testcontainers/containers/VirtuosoContainer.java
+++ b/modules/virtuoso/src/main/java/org/testcontainers/containers/VirtuosoContainer.java
@@ -1,0 +1,64 @@
+package org.testcontainers.containers;
+
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+public class VirtuosoContainer  extends JdbcDatabaseContainer {
+
+	public static final String NAME = "virtuoso";
+	public static final String IMAGE = "tenforce/virtuoso";
+	public static final Integer JDBC_PORT = 1111;
+	public static final Integer SPARQL_SERVICE_PORT = 8890;    
+
+	public VirtuosoContainer() {
+		super(IMAGE + ":latest");
+	}
+    
+	public VirtuosoContainer(String dockerImageName) {
+		super(dockerImageName);
+	}
+	
+	@Override
+	protected void configure() {
+		addExposedPort(JDBC_PORT);
+		addExposedPort(SPARQL_SERVICE_PORT);
+		addEnv("DBA_PASSWORD", getPassword());
+		addEnv("SPARQL_UPDATE", "true");
+		addEnv("DEFAULT_GRAPH", "http://localhost:8890/DAV");
+		addExposedPorts(JDBC_PORT, SPARQL_SERVICE_PORT);
+	}
+
+	@Override
+	protected String getDriverClassName() {
+		return "virtuoso.jdbc4.Driver";
+	}
+
+	@Override
+	public String getJdbcUrl() {
+		return "jdbc:virtuoso://" + getContainerIpAddress() + ":" + getMappedPort(JDBC_PORT);
+	}
+	
+	public String getSparqlUrl() {
+		return "http://" + getContainerIpAddress() + ":" + getMappedPort(SPARQL_SERVICE_PORT) + "/sparql";
+	}
+
+	@Override
+	public String getUsername() {
+		return "dba";
+	}
+
+	@Override
+	public String getPassword() {
+		return "myDbaPassword";
+	}
+
+	@Override
+	protected String getTestQueryString() {
+		return "SELECT 1";
+	}
+
+	@Override
+	protected Integer getLivenessCheckPort() {
+		return getMappedPort(JDBC_PORT);
+	}
+
+}

--- a/modules/virtuoso/src/main/java/org/testcontainers/containers/VirtuosoContainerProvider.java
+++ b/modules/virtuoso/src/main/java/org/testcontainers/containers/VirtuosoContainerProvider.java
@@ -1,0 +1,17 @@
+package org.testcontainers.containers;
+
+import org.testcontainers.containers.JdbcDatabaseContainerProvider;
+
+public class VirtuosoContainerProvider extends JdbcDatabaseContainerProvider {
+	
+	@Override
+	public boolean supports(String databaseType) {
+		return databaseType.equals(VirtuosoContainer.NAME);
+	}
+
+	@Override
+	public VirtuosoContainer newInstance(String tag) {
+		return new VirtuosoContainer(VirtuosoContainer.IMAGE + ":" + tag);
+	}
+	
+}

--- a/modules/virtuoso/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
+++ b/modules/virtuoso/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.testcontainers.containers.VirtuosoContainerProvider

--- a/modules/virtuoso/src/test/java/org/testcontainers/containers/VirtuosoJDBCDriverTest.java
+++ b/modules/virtuoso/src/test/java/org/testcontainers/containers/VirtuosoJDBCDriverTest.java
@@ -1,0 +1,45 @@
+package org.testcontainers.containers;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.apache.commons.dbutils.QueryRunner;
+import org.apache.commons.dbutils.ResultSetHandler;
+import org.junit.Test;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+
+public class VirtuosoJDBCDriverTest {
+
+    @Test
+    public void testVirtuosoWithNoSpecifiedVersion() throws SQLException {
+        performSimpleTest("jdbc:tc:virtuoso://hostname/databasename");
+    }
+
+
+    private void performSimpleTest(String jdbcUrl) throws SQLException {
+        HikariDataSource dataSource = getDataSource(jdbcUrl, 1);
+        new QueryRunner(dataSource).query("SELECT 1", new ResultSetHandler<Object>() {
+            @Override
+            public Object handle(ResultSet rs) throws SQLException {
+                rs.next();
+                int resultSetInt = rs.getInt(1);
+                assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                return true;
+            }
+        });
+        dataSource.close();
+    }
+
+    private HikariDataSource getDataSource(String jdbcUrl, int poolSize) {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(jdbcUrl);
+        hikariConfig.setConnectionTestQuery("SELECT 1");
+        hikariConfig.setMinimumIdle(1);
+        hikariConfig.setMaximumPoolSize(poolSize);
+
+        return new HikariDataSource(hikariConfig);
+    }
+}

--- a/modules/virtuoso/src/test/java/org/testcontainers/junit/SimpleVirtuosoTest.java
+++ b/modules/virtuoso/src/test/java/org/testcontainers/junit/SimpleVirtuosoTest.java
@@ -1,0 +1,37 @@
+package org.testcontainers.junit;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.VirtuosoContainer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+
+public class SimpleVirtuosoTest {
+
+    @Rule
+    public VirtuosoContainer virtuoso = new VirtuosoContainer();
+
+    @Test
+    public void testSimple() throws SQLException {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(virtuoso.getJdbcUrl());
+        hikariConfig.setUsername(virtuoso.getUsername());
+        hikariConfig.setPassword(virtuoso.getPassword());
+        hikariConfig.setConnectionTestQuery("SELECT 1");
+
+        HikariDataSource ds = new HikariDataSource(hikariConfig);
+        Statement statement = ds.getConnection().createStatement();
+        statement.execute("SELECT 1");
+        ResultSet resultSet = statement.getResultSet();
+
+        resultSet.next();
+        int resultSetInt = resultSet.getInt(1);
+        assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+    }
+}

--- a/modules/virtuoso/src/test/resources/logback-test.xml
+++ b/modules/virtuoso/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.apache.http" level="WARN"/>
+    <logger name="org.testcontainers.shaded.org.apache.http" level="WARN"/>
+    <logger name="org.testcontainers.shaded.com.github.dockerjava" level="WARN"/>
+    <logger name="org.zeroturnaround.exec" level="WARN"/>
+    <logger name="com.zaxxer.hikari" level="INFO"/>
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,11 @@
             <name>Matthieu Baechler</name>
             <email>matthieu.baechler@gmail.com</email>
         </developer>
+        <developer>
+            <id>v-schulz</id>
+            <name>Viktor Schulz</name>
+            <email>vschulz@mail.uni-mannheim.de</email>
+        </developer>
     </developers>
 
     <dependencies>
@@ -143,6 +148,7 @@
         <module>modules/postgresql</module>
         <module>modules/selenium</module>
         <module>modules/nginx</module>
+		<module>modules/virtuoso</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
The test container runs the tenforce/virtuoso image (OpenLink Virtuoso). 
The extended database container class provides both JDBC and SPARQL service urls.

In addition the container database driver now uses a more generic
pattern that is not just limited to the provided modules. Thus it is
easier to add own modules without modifying the regex pattern 
(only smaller case letters allowed at the moment).