### PR TITLE
Fix for #89 - add finite limit for retrying docker pull

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerFetchException.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerFetchException.java
@@ -7,4 +7,8 @@ public class ContainerFetchException extends RuntimeException {
     public ContainerFetchException(String s, Exception e) {
         super(s, e);
     }
+
+    public ContainerFetchException(String s) {
+        super(s);
+    }
 }

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -241,8 +241,14 @@ public class GenericContainer extends FailureDetectingExternalResource implement
 
         logger().info("Pulling docker image: {}. Please be patient; this may take some time but only needs to be done once.", imageName);
         profiler.start("Pull image");
+        int attempts = 0;
         while (!AVAILABLE_IMAGE_NAME_CACHE.contains(imageName)) {
             // The image is not available locally - pull it
+
+            if (attempts++ >= 3) {
+                logger().error("Retry limit reached while trying to pull image: " + imageName + ". Please check output of `docker pull " + imageName + "`");
+                throw new ContainerFetchException("Retry limit reached while trying to pull image: " + imageName);
+            }
 
             PullImageResultCallback resultCallback = dockerClient.pullImageCmd(imageName).exec(new PullImageResultCallback());
 

--- a/core/src/test/java/org/testcontainers/junit/NonExistentImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/junit/NonExistentImagePullTest.java
@@ -1,0 +1,22 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.testcontainers.containers.ContainerFetchException;
+import org.testcontainers.containers.GenericContainer;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertThrows;
+
+/**
+ * Created by rnorth on 20/03/2016.
+ */
+public class NonExistentImagePullTest {
+
+    @Test(timeout = 60_000L)
+    public void pullingNonExistentImageFailsGracefully() {
+
+        assertThrows("Pulling a nonexistent container will cause an exception to be thrown",
+                ContainerFetchException.class, () -> {
+                    return new GenericContainer("richnorth/nonexistent:latest");
+                });
+    }
+}


### PR DESCRIPTION
To avoid infinite loop if the specified image is not available.