### PR TITLE
feature/extended-selenium-grid-containers

### DIFF
--- a/docs/usage/webdriver_containers.md
+++ b/docs/usage/webdriver_containers.md
@@ -75,3 +75,23 @@ Note that the seconds parameter to `withRecordingMode` should be a directory whe
 ## More examples
 
 A few different examples are shown in [ChromeWebDriverContainerTest.java](https://github.com/testcontainers/testcontainers-java/blob/master/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java).
+
+# Extended Selenium Grid containers
+
+To be able to run tests within dedicated hub / nodes containers (for further scaling), you can use the following items:
+
+ * `GenericGridContainer` - base class for all Selenium Grid containers. Provides common API for starting child containers with video recording feature support. Only for internal usage.
+ * `SeleniumHubContainer` - dedicated Selenium Grid Hub container without VNC and video recording support. Could be used with dedicated nodes.
+ * `SeleniumNodeContainer` - dedicated Selenium Grid Node container with VNC and video recording support. Could be linked with dedicated hub by provided address. Supports ports exposing and volumes mounting. Could be safely used with object pool for further scaling.
+ * `SeleniumStandaloneContainer` - `WebDriver` independent `BrowseWebDroverContainer`'s alternative.
+
+Note that `WebDriver` dependency was completely removed to let end-user fully control testing flow by his own.
+
+All listed containers use the following enums to provide better flexibility while configuration phase:
+ 
+ * `Browser` - contains a list of supported browsers. Note that standalone chrome / firefox items are splitted due to the differences in containers' creation logic.
+ * `SeleniumImage` - contains a list of official [SeleniumHQ](https://github.com/SeleniumHQ/docker-selenium) images, mapped with corresponding browsers. Note that versions are set to `latest` by default.
+ 
+Containers' connection obtaining was revised due to the fact the containers themselves were splitted, and `WebDriver` dependency was removed. There was added a special utility class `SeleniumHttpUtils` for detecting if hub / node is ready for interaction before actual test execution is started.
+
+As soon as the following PR is merged, there will be added extensive `TestNG` usage examples with scaling feature.

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -33,5 +33,26 @@
             <artifactId>jetty</artifactId>
             <version>6.1.25</version>
         </dependency>
+
+        <!-- Concise and flexible API for polling hub container, until it's up and running -->
+        <dependency>
+            <groupId>com.jayway.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>1.7.0</version>
+        </dependency>
+
+        <!-- Java 8 functional-style extension -->
+        <dependency>
+            <groupId>com.javaslang</groupId>
+            <artifactId>javaslang</artifactId>
+            <version>2.0.0-RC4</version>
+        </dependency>
+
+        <!-- Required for checking if hub / node is ready for further interaction -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -12,6 +13,26 @@
     <artifactId>selenium</artifactId>
     <name>TestContainers :: Selenium</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <browser>chrome</browser>
+                        <scaleFirefox>1</scaleFirefox>
+                        <scaleChrome>1</scaleChrome>
+                    </systemPropertyVariables>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng-suites/parent-suite.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -19,12 +40,29 @@
             <version>${project.version}</version>
         </dependency>
 
-        <!-- WebDriver dependency as 'provided' scope -->
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+
+        <!-- WebDriver factory and Selenium dependencies -->
+        <dependency>
+            <groupId>ru.stqa.selenium</groupId>
+            <artifactId>webdriver-factory</artifactId>
+            <version>2.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-remote-driver</artifactId>
-            <version>2.45.0</version>
-            <scope>provided</scope>
+            <artifactId>selenium-java</artifactId>
+            <version>2.52.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-server</artifactId>
+            <version>2.52.0</version>
         </dependency>
 
         <!-- Use Jetty for testing -->
@@ -48,11 +86,11 @@
             <version>2.0.0-RC4</version>
         </dependency>
 
-        <!-- Required for checking if hub / node is ready for further interaction -->
+        <!-- Object pool implemented via ConcurrentLinkedQueue / Semaphore for nodes allocation -->
         <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <groupId>org.vibur</groupId>
+            <artifactId>vibur-object-pool</artifactId>
+            <version>7.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -34,7 +34,7 @@
             <version>6.1.25</version>
         </dependency>
 
-        <!-- Concise and flexible API for polling hub container, until it's up and running -->
+        <!-- Concise and flexible API for polling hub / node containers, until they're up and running -->
         <dependency>
             <groupId>com.jayway.awaitility</groupId>
             <artifactId>awaitility</artifactId>

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -28,8 +28,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class BrowserWebDriverContainer extends GenericContainer implements VncService, LinkableContainer {
 
-    private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:latest";
-    private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:latest";
+    private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:2.52.0";
+    private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:2.52.0";
     private static final String DEFAULT_PASSWORD = "secret";
     private static final int SELENIUM_PORT = 4444;
     private static final int VNC_PORT = 5900;

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -28,8 +28,8 @@ import java.util.concurrent.TimeUnit;
  */
 public class BrowserWebDriverContainer extends GenericContainer implements VncService, LinkableContainer {
 
-    private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:2.45.0";
-    private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:2.45.0";
+    private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:latest";
+    private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:latest";
     private static final String DEFAULT_PASSWORD = "secret";
     private static final int SELENIUM_PORT = 4444;
     private static final int VNC_PORT = 5900;

--- a/modules/selenium/src/main/java/org/testcontainers/grid/containers/GenericGridContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/containers/GenericGridContainer.java
@@ -1,0 +1,187 @@
+package org.testcontainers.grid.containers;
+
+import javaslang.control.Try;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.VncRecordingSidekickContainer;
+import org.testcontainers.containers.traits.LinkableContainer;
+import org.testcontainers.containers.traits.VncService;
+import org.testcontainers.grid.enums.Browser;
+import org.testcontainers.grid.enums.SeleniumImage;
+
+import java.io.File;
+import java.net.URL;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public abstract class GenericGridContainer extends GenericContainer implements VncService, LinkableContainer {
+
+	// Constants required for child containers
+	public static final int DEFAULT_VNC_PORT = 5900;
+	public static final int DEFAULT_HUB_PORT = 4444;
+	public static final int DEFAULT_NODE_PORT = 5555;
+
+	public static final String DEFAULT_HUB_URL = "http://localhost:4444/wd/hub";
+	public static final String DEFAULT_HUB_API_URL = "http://localhost:4444/grid/api/hub";
+	public static final String DEFAULT_PROXY_URL = "http://localhost:4444/grid/api/proxy?id=http://localhost:4444";
+	public static final String DEFAULT_VNC_PASSWORD = "secret";
+
+	public static final long POLLING_TIMEOUT = 20;
+	public static final long POLLING_INTERVAL = 1;
+
+	private VncRecordingMode recordingMode;
+	private File vncRecordingDirectory;
+	private VncRecordingSidekickContainer<GenericGridContainer> recordingContainer;
+	private static final SimpleDateFormat FILENAME_DATE_FORMAT = new SimpleDateFormat("YYYYMMdd-HHmmss");
+	private static final AtomicInteger RECORDINGS_COUNTER = new AtomicInteger();
+
+	private Browser browser;
+	private SeleniumImage image;
+
+	public GenericGridContainer(final SeleniumImage image) {
+		validateImage(image);
+		super.setDockerImageName(image.toString());
+
+		this.image = image;
+		this.browser = image.getBrowser();
+		this.recordingMode = VncRecordingMode.SKIP;
+		this.vncRecordingDirectory = new File("/tmp");
+	}
+
+	public abstract void validateImage(SeleniumImage image);
+
+	public abstract String getHubAddress();
+
+	public abstract int getHubPort();
+
+	@Override
+	protected void configure() {
+		final String timeZone = Optional.ofNullable(System.getProperty("user.timezone"))
+				.filter(tZone -> tZone.length() > 0)
+				.orElse("Etc/UTC");
+
+		addEnv("TZ", timeZone);
+		setCommand("/opt/bin/entry_point.sh");
+	}
+
+	@Override
+	public String getVncAddress() {
+		return "vnc://vnc:secret@" + getContainerIpAddress() + ":" + getMappedPort(DEFAULT_VNC_PORT);
+	}
+
+	@Override
+	public String getPassword() {
+		return DEFAULT_VNC_PASSWORD;
+	}
+
+	@Override
+	public int getPort() {
+		return DEFAULT_VNC_PORT;
+	}
+
+	public URL getSeleniumAddress() {
+		return Try.of(() -> new URL("http", getHubAddress(), getHubPort(), "/wd/hub"))
+				.getOrElseTry(() -> new URL(DEFAULT_HUB_URL));
+	}
+
+	public String getInternalIpAddress() {
+		return Optional.ofNullable(getContainerInfo())
+				.map(info -> info.getNetworkSettings().getIpAddress())
+				.orElse("localhost");
+	}
+
+	public Browser getBrowser() {
+		return browser;
+	}
+
+	public SeleniumImage getImage() {
+		return image;
+	}
+
+	public void cleanUpRecordingsCounter() {
+		RECORDINGS_COUNTER.set(0);
+	}
+
+	public VncRecordingMode getRecordingMode() {
+		return recordingMode;
+	}
+
+	public void startRecording() {
+		if (recordingMode != VncRecordingMode.SKIP) {
+			logger().info("Starting VNC recording");
+
+			if (recordingContainer != null && recordingContainer.isRunning()) {
+				recordingContainer.stop();
+			}
+
+			recordingContainer = new VncRecordingSidekickContainer<>(this);
+			recordingContainer.start();
+		}
+	}
+
+	public void stopAndRetainRecording(final String testName, final boolean isPassed) {
+		boolean finalizeRecords;
+
+		switch (getRecordingMode()) {
+			case RECORD_ALL:
+				finalizeRecords = true;
+				break;
+			case RECORD_FAILING:
+				finalizeRecords = isPassed;
+				break;
+			default:
+			case SKIP:
+				finalizeRecords = false;
+				break;
+		}
+
+		if (finalizeRecords)
+			stopAndRetainRecording(testName);
+	}
+
+	public void stopAndRetainRecording(final String testName) {
+		final File recordingFile = new File(vncRecordingDirectory, "recording-" + testName + "-" +
+				browser.toString() + "-" + FILENAME_DATE_FORMAT.format(new Date()) + "-" +
+				RECORDINGS_COUNTER.incrementAndGet() + ".flv");
+
+		Optional.ofNullable(recordingContainer)
+				.ifPresent(recording -> {
+					logger().info("Screen recordings for test {} will be stored at: {}", testName, recordingFile);
+					recording.stopAndRetainRecording(recordingFile);
+				});
+
+		recordingContainer = null;
+	}
+
+	public void setRecordingMode(final VncRecordingMode recordingMode) {
+		this.recordingMode = recordingMode;
+	}
+
+	public void setVncRecordingDirectory(final File vncRecordingDirectory) {
+		if (!vncRecordingDirectory.isDirectory())
+			throw new IllegalArgumentException(vncRecordingDirectory + " is not a directory");
+
+		this.vncRecordingDirectory = vncRecordingDirectory;
+	}
+
+	public GenericGridContainer withLinkToContainer(final LinkableContainer otherContainer, final String alias) {
+		addLink(otherContainer, alias);
+		return this;
+	}
+
+	public GenericGridContainer withFileSystemBind(final String hostFolder, final String containerFolder, final BindMode permissions) {
+		addFileSystemBind(hostFolder, containerFolder, permissions);
+		return this;
+	}
+
+	public GenericGridContainer withRecordingMode(final VncRecordingMode recordingMode, final File vncRecordingDirectory) {
+		setRecordingMode(recordingMode);
+		setVncRecordingDirectory(vncRecordingDirectory);
+		return this;
+	}
+
+	public enum VncRecordingMode {
+		SKIP, RECORD_ALL, RECORD_FAILING
+	}
+}

--- a/modules/selenium/src/main/java/org/testcontainers/grid/containers/GenericGridContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/containers/GenericGridContainer.java
@@ -27,7 +27,7 @@ public abstract class GenericGridContainer extends GenericContainer implements V
 	public static final String DEFAULT_PROXY_URL = "http://localhost:4444/grid/api/proxy?id=http://localhost:4444";
 	public static final String DEFAULT_VNC_PASSWORD = "secret";
 
-	public static final long POLLING_TIMEOUT = 20;
+	public static final long POLLING_TIMEOUT = 60;
 	public static final long POLLING_INTERVAL = 1;
 
 	private VncRecordingMode recordingMode;

--- a/modules/selenium/src/main/java/org/testcontainers/grid/containers/SeleniumHubContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/containers/SeleniumHubContainer.java
@@ -1,0 +1,95 @@
+package org.testcontainers.grid.containers;
+
+import javaslang.control.Try;
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHttpRequest;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.traits.LinkableContainer;
+import org.testcontainers.grid.enums.SeleniumImage;
+
+import java.io.File;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.given;
+import static org.testcontainers.grid.utils.SeleniumHttpUtils.checkHostState;
+
+public class SeleniumHubContainer extends GenericGridContainer {
+
+	public SeleniumHubContainer() {
+		this(SeleniumImage.HUB);
+		setRecordingMode(VncRecordingMode.SKIP);
+	}
+
+	public SeleniumHubContainer(final SeleniumImage image) {
+		super(image);
+	}
+
+	@Override
+	public void validateImage(final SeleniumImage image) {
+		if (image != SeleniumImage.HUB)
+			throw new IllegalArgumentException("Invalid image specified for hub container");
+	}
+
+	@Override
+	protected void configure() {
+		super.configure();
+		addExposedPorts(DEFAULT_HUB_PORT);
+	}
+
+	@Override
+	public SeleniumHubContainer withLinkToContainer(final LinkableContainer linkToContainer, final String alias) {
+		super.withLinkToContainer(linkToContainer, alias);
+		return this;
+	}
+
+	@Override
+	public SeleniumHubContainer withFileSystemBind(final String hostFolder, final String containerFolder, final BindMode permissions) {
+		super.withFileSystemBind(hostFolder, containerFolder, permissions);
+		return this;
+	}
+
+	@Override
+	public SeleniumHubContainer withRecordingMode(final VncRecordingMode recordingMode, final File vncRecordingDirectory) {
+		super.withRecordingMode(recordingMode, vncRecordingDirectory);
+		return this;
+	}
+
+	@Override
+	protected void waitUntilContainerStarted() {
+		given().ignoreExceptions()
+				.atMost(POLLING_TIMEOUT, TimeUnit.SECONDS)
+				.pollInterval(POLLING_INTERVAL, TimeUnit.SECONDS)
+				.until(() -> {
+					final boolean isConnected = checkHostState(new HttpHost(getHubAddress(), getHubPort()),
+							new BasicHttpRequest("GET", getHubUrl().toExternalForm()));
+					logger().info("Obtained a connection to ({}) = {}", getHubUrl(), isConnected);
+					return isConnected;
+				});
+	}
+
+	@Override
+	protected Integer getLivenessCheckPort() {
+		return getHubPort();
+	}
+
+	@Override
+	public String getHubAddress() {
+		return getContainerIpAddress();
+	}
+
+	@Override
+	public int getHubPort() {
+		return getMappedPort(DEFAULT_HUB_PORT);
+	}
+
+	public SeleniumHubContainer startHub() {
+		super.start();
+		return this;
+	}
+
+	private URL getHubUrl() {
+		return Try.of(() -> new URL("http", getHubAddress(), getHubPort(), "/grid/api/hub"))
+				.getOrElseTry(() -> new URL(DEFAULT_HUB_API_URL));
+	}
+}

--- a/modules/selenium/src/main/java/org/testcontainers/grid/containers/SeleniumNodeContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/containers/SeleniumNodeContainer.java
@@ -1,0 +1,114 @@
+package org.testcontainers.grid.containers;
+
+import javaslang.control.Try;
+import org.apache.http.HttpHost;
+import org.apache.http.message.BasicHttpRequest;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.traits.LinkableContainer;
+import org.testcontainers.grid.enums.SeleniumImage;
+
+import java.io.File;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static com.jayway.awaitility.Awaitility.given;
+import static org.testcontainers.grid.utils.SeleniumHttpUtils.checkHostState;
+
+public class SeleniumNodeContainer extends GenericGridContainer {
+
+	private String hubAddress;
+	private int hubPort;
+
+	public SeleniumNodeContainer() {
+		this(SeleniumImage.CHROME_NODE_DEBUG);
+		setRecordingMode(VncRecordingMode.RECORD_FAILING);
+	}
+
+	public SeleniumNodeContainer(final SeleniumImage image) {
+		super(image);
+	}
+
+	@Override
+	public void validateImage(final SeleniumImage image) {
+		if (image != SeleniumImage.CHROME_NODE_DEBUG && image != SeleniumImage.FIREFOX_NODE_DEBUG)
+			throw new IllegalArgumentException("Invalid image specified for node container");
+	}
+
+	public SeleniumNodeContainer withHubAddress(final String hubAddress) {
+		this.hubAddress = hubAddress;
+		return this;
+	}
+
+	public SeleniumNodeContainer withHubPort(final int hubPort) {
+		this.hubPort = hubPort;
+		return this;
+	}
+
+	@Override
+	protected void waitUntilContainerStarted() {
+		given().ignoreExceptions()
+				.atMost(POLLING_TIMEOUT, TimeUnit.SECONDS)
+				.pollInterval(POLLING_INTERVAL, TimeUnit.SECONDS)
+				.until(() -> {
+					final boolean isConnected = checkHostState(new HttpHost(getHubAddress(), getHubPort()),
+							new BasicHttpRequest("GET", getProxyUrl().toExternalForm()));
+					logger().info("Obtained a connection to ({}) = {}", getProxyUrl(), isConnected);
+					return isConnected;
+				});
+	}
+
+	@Override
+	public SeleniumNodeContainer withRecordingMode(final VncRecordingMode recordingMode, final File vncRecordingDirectory) {
+		super.withRecordingMode(recordingMode, vncRecordingDirectory);
+		return this;
+	}
+
+	@Override
+	public SeleniumNodeContainer withLinkToContainer(final LinkableContainer linkToContainer, final String alias) {
+		super.withLinkToContainer(linkToContainer, alias);
+		return this;
+	}
+
+	@Override
+	public SeleniumNodeContainer withFileSystemBind(final String hostFolder, final String containerFolder, final BindMode permissions) {
+		super.withFileSystemBind(hostFolder, containerFolder, permissions);
+		return this;
+	}
+
+	@Override
+	public String getHubAddress() {
+		return hubAddress;
+	}
+
+	@Override
+	public int getHubPort() {
+		return hubPort;
+	}
+
+	@Override
+	protected Integer getLivenessCheckPort() {
+		return getMappedPort(DEFAULT_VNC_PORT);
+	}
+
+	@Override
+	protected void configure() {
+		super.configure();
+		addExposedPorts(DEFAULT_VNC_PORT);
+	}
+
+	public SeleniumNodeContainer startNode() {
+		super.start();
+		cleanUpRecordingsCounter();
+		return this;
+	}
+
+	public SeleniumNodeContainer startVideoRecording() {
+		super.startRecording();
+		return this;
+	}
+
+	private URL getProxyUrl() {
+		return Try.of(() -> new URL("http", getHubAddress(), getHubPort(), "/grid/api/proxy?id=http://" +
+				getInternalIpAddress() + ":" + DEFAULT_NODE_PORT)).getOrElseTry(() -> new URL(DEFAULT_PROXY_URL));
+	}
+}

--- a/modules/selenium/src/main/java/org/testcontainers/grid/containers/SeleniumStandaloneContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/containers/SeleniumStandaloneContainer.java
@@ -1,0 +1,69 @@
+package org.testcontainers.grid.containers;
+
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.traits.LinkableContainer;
+import org.testcontainers.grid.enums.SeleniumImage;
+
+import java.io.File;
+
+public class SeleniumStandaloneContainer extends GenericGridContainer {
+
+	public SeleniumStandaloneContainer() {
+		this(SeleniumImage.CHROME_STANDALONE_DEBUG);
+		setRecordingMode(VncRecordingMode.RECORD_FAILING);
+	}
+
+	public SeleniumStandaloneContainer(final SeleniumImage image) {
+		super(image);
+	}
+
+	@Override
+	public void validateImage(final SeleniumImage image) {
+		if (image != SeleniumImage.CHROME_STANDALONE_DEBUG && image != SeleniumImage.FIREFOX_STANDALONE_DEBUG)
+			throw new IllegalArgumentException("Invalid image specified for standalone container");
+	}
+
+	@Override
+	public SeleniumStandaloneContainer withRecordingMode(final VncRecordingMode recordingMode, final File vncRecordingDirectory) {
+		super.withRecordingMode(recordingMode, vncRecordingDirectory);
+		return this;
+	}
+
+	@Override
+	public SeleniumStandaloneContainer withLinkToContainer(final LinkableContainer linkToContainer, final String alias) {
+		super.withLinkToContainer(linkToContainer, alias);
+		return this;
+	}
+
+	@Override
+	public SeleniumStandaloneContainer withFileSystemBind(final String hostFolder, final String containerFolder, final BindMode permissions) {
+		super.withFileSystemBind(hostFolder, containerFolder, permissions);
+		return this;
+	}
+
+	@Override
+	public String getHubAddress() {
+		return getContainerIpAddress();
+	}
+
+	@Override
+	public int getHubPort() {
+		return getMappedPort(DEFAULT_HUB_PORT);
+	}
+
+	@Override
+	protected Integer getLivenessCheckPort() {
+		return getMappedPort(DEFAULT_HUB_PORT);
+	}
+
+	@Override
+	protected void configure() {
+		super.configure();
+		addExposedPorts(DEFAULT_HUB_PORT, DEFAULT_VNC_PORT);
+	}
+
+	public SeleniumStandaloneContainer startGrid() {
+		super.start();
+		return this;
+	}
+}

--- a/modules/selenium/src/main/java/org/testcontainers/grid/enums/Browser.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/enums/Browser.java
@@ -1,0 +1,29 @@
+package org.testcontainers.grid.enums;
+
+import java.util.stream.Stream;
+
+public enum Browser {
+
+	CHROME("chrome"),
+	FIREFOX("firefox"),
+	CHROME_STANDALONE("standalone-chrome"),
+	FIREFOX_STANDALONE("standalone-firefox"),
+	NONE("");
+
+	private String name;
+
+	Browser(final String name) {
+		this.name = name;
+	}
+
+	public static Browser getName(final String browserName, final boolean isStandalone) {
+		return Stream.of(values())
+				.filter(browser -> browser.name.equals(isStandalone ? "standalone-" + browserName : browserName))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("Unable to get browser with name " + browserName));
+	}
+
+	public String toString() {
+		return name;
+	}
+}

--- a/modules/selenium/src/main/java/org/testcontainers/grid/enums/SeleniumImage.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/enums/SeleniumImage.java
@@ -8,10 +8,10 @@ import java.util.stream.Stream;
 public enum SeleniumImage {
 
 	HUB("selenium/hub:latest", Browser.NONE),
-	FIREFOX_NODE_DEBUG("selenium/node-firefox-debug:latest", Browser.FIREFOX),
-	CHROME_NODE_DEBUG("selenium/node-chrome-debug:latest", Browser.CHROME),
-	CHROME_STANDALONE_DEBUG("selenium/standalone-chrome-debug:latest", Browser.CHROME_STANDALONE),
-	FIREFOX_STANDALONE_DEBUG("selenium/standalone-firefox-debug:latest", Browser.FIREFOX_STANDALONE);
+	FIREFOX_NODE_DEBUG("selenium/node-firefox-debug:2.52.0", Browser.FIREFOX),
+	CHROME_NODE_DEBUG("selenium/node-chrome-debug:2.52.0", Browser.CHROME),
+	CHROME_STANDALONE_DEBUG("selenium/standalone-chrome-debug:2.52.0", Browser.CHROME_STANDALONE),
+	FIREFOX_STANDALONE_DEBUG("selenium/standalone-firefox-debug:2.52.0", Browser.FIREFOX_STANDALONE);
 
 	private String name;
 	private Browser browser;

--- a/modules/selenium/src/main/java/org/testcontainers/grid/enums/SeleniumImage.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/enums/SeleniumImage.java
@@ -1,0 +1,39 @@
+package org.testcontainers.grid.enums;
+
+import java.util.stream.Stream;
+
+/**
+ * A list of available SeleniumHQ images to give users more freedom in creating containers
+ */
+public enum SeleniumImage {
+
+	HUB("selenium/hub:latest", Browser.NONE),
+	FIREFOX_NODE_DEBUG("selenium/node-firefox-debug:latest", Browser.FIREFOX),
+	CHROME_NODE_DEBUG("selenium/node-chrome-debug:latest", Browser.CHROME),
+	CHROME_STANDALONE_DEBUG("selenium/standalone-chrome-debug:latest", Browser.CHROME_STANDALONE),
+	FIREFOX_STANDALONE_DEBUG("selenium/standalone-firefox-debug:latest", Browser.FIREFOX_STANDALONE);
+
+	private String name;
+	private Browser browser;
+
+	SeleniumImage(final String name, final Browser browser) {
+		this.name = name;
+		this.browser = browser;
+	}
+
+	public static SeleniumImage extractImage(final Browser browser) {
+		return Stream.of(SeleniumImage.values())
+				.filter(image -> browser.equals(image.browser))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("Unable to find image for " + browser.toString()));
+	}
+
+	public Browser getBrowser() {
+		return browser;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+}

--- a/modules/selenium/src/main/java/org/testcontainers/grid/utils/SeleniumHttpUtils.java
+++ b/modules/selenium/src/main/java/org/testcontainers/grid/utils/SeleniumHttpUtils.java
@@ -1,0 +1,67 @@
+package org.testcontainers.grid.utils;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.message.BasicHttpRequest;
+import org.openqa.selenium.remote.internal.HttpClientFactory;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static java.util.Objects.nonNull;
+
+public final class SeleniumHttpUtils {
+
+	private static final Logger LOGGER = Logger.getLogger(SeleniumHttpUtils.class.getName());
+
+	public static boolean checkHostState(final HttpHost host, final BasicHttpRequest basicHttpRequest) {
+		return Optional.ofNullable(basicHttpRequest)
+				.map(request -> execute(host, request))
+				.filter(response -> nonNull(response) && response.getStatusLine().getStatusCode() == 200)
+				.map(SeleniumHttpUtils::extractObject)
+				.filter(json -> nonNull(json) && json.get("success").getAsBoolean())
+				.isPresent();
+	}
+
+	public static HttpResponse execute(final HttpHost host, final BasicHttpRequest request) {
+		HttpResponse response;
+
+		try {
+			response = new HttpClientFactory().getHttpClient().execute(host, request);
+		} catch (Exception ex) {
+			LOGGER.severe("Unable to execute http request: " + ex.getMessage());
+			response = null;
+		}
+
+		return response;
+	}
+
+	public static JsonObject extractObject(final HttpResponse response) {
+		JsonObject jsonObject;
+
+		try (final BufferedReader bufferedReader = new BufferedReader(
+				new InputStreamReader(response.getEntity().getContent()))) {
+			final StringBuilder buffer = new StringBuilder();
+			String line;
+
+			while ((line = bufferedReader.readLine()) != null) {
+				buffer.append(line);
+			}
+
+			jsonObject = new JsonParser().parse(buffer.toString()).getAsJsonObject();
+		} catch (Exception ex) {
+			LOGGER.severe("Unable to extract json object: " + ex.getMessage());
+			jsonObject = null;
+		}
+
+		return jsonObject;
+	}
+
+	private SeleniumHttpUtils() {
+		throw new UnsupportedOperationException("Illegal access to private constructor");
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/config/XMLConfig.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/config/XMLConfig.java
@@ -1,0 +1,29 @@
+package org.testcontainers.testng.config;
+
+import org.testcontainers.grid.enums.Browser;
+
+import java.util.Map;
+
+/**
+ * Special container for storing TestNG xml parameters.
+ */
+public class XMLConfig {
+
+	private Map<String, String> parameters;
+
+	public XMLConfig(final Map<String, String> parameters) {
+		this.parameters = parameters;
+	}
+
+	public String getParameter(final String key) {
+		return parameters.getOrDefault(key, "");
+	}
+
+	public Browser getBrowser() {
+		return getBrowser(false);
+	}
+
+	public Browser getBrowser(final boolean isStandalone) {
+		return Browser.getName(getParameter("browser"), isStandalone);
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/pool/NodeFactory.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/pool/NodeFactory.java
@@ -1,0 +1,45 @@
+package org.testcontainers.testng.pool;
+
+import org.testcontainers.grid.containers.SeleniumNodeContainer;
+import org.vibur.objectpool.PoolObjectFactory;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Factory required by vibur-object-pool for creating / destroying selenium grid nodes.
+ */
+public class NodeFactory implements PoolObjectFactory<SeleniumNodeContainer> {
+
+	private final List<SeleniumNodeContainer> nodes;
+	private final AtomicInteger counter;
+
+	public NodeFactory(final List<SeleniumNodeContainer> nodes) {
+		if (nodes == null || nodes.size() < 1)
+			throw new IllegalArgumentException("Collection can't be missing or empty");
+
+		this.nodes = nodes;
+		this.counter = new AtomicInteger(this.nodes.size() - 1);
+	}
+
+	@Override
+	public SeleniumNodeContainer create() {
+		return nodes.get(counter.getAndDecrement());
+	}
+
+	@Override
+	public boolean readyToTake(final SeleniumNodeContainer obj) {
+		return true;
+	}
+
+	@Override
+	public boolean readyToRestore(final SeleniumNodeContainer obj) {
+		return true;
+	}
+
+	@Override
+	public void destroy(final SeleniumNodeContainer obj) {
+		obj.stop();
+		nodes.remove(obj);
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/pool/NodeListener.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/pool/NodeListener.java
@@ -1,0 +1,24 @@
+package org.testcontainers.testng.pool;
+
+import org.testcontainers.grid.containers.SeleniumNodeContainer;
+import org.vibur.objectpool.listener.Listener;
+
+import java.util.logging.Logger;
+
+/**
+ * Author: Serhii Korol.
+ */
+public class NodeListener implements Listener<SeleniumNodeContainer> {
+
+	private final Logger logger = Logger.getLogger(getClass().getName());
+
+	@Override
+	public void onTake(SeleniumNodeContainer object) {
+		logger.info("Took " + object.getBrowser());
+	}
+
+	@Override
+	public void onRestore(SeleniumNodeContainer object) {
+		logger.info("Restored " + object.getBrowser());
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/pool/PoolFactory.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/pool/PoolFactory.java
@@ -1,0 +1,39 @@
+package org.testcontainers.testng.pool;
+
+import org.testcontainers.grid.enums.Browser;
+import org.testcontainers.grid.containers.GenericGridContainer;
+import org.testcontainers.grid.containers.SeleniumHubContainer;
+import org.testcontainers.grid.containers.SeleniumNodeContainer;
+import org.vibur.objectpool.ConcurrentLinkedPool;
+import org.vibur.objectpool.PoolService;
+
+import java.io.File;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+import static org.testcontainers.grid.enums.SeleniumImage.extractImage;
+
+/**
+ * Wrapped vibur-object-pool initializer; requires hub instance, browser type and pool size specification.
+ */
+public final class PoolFactory {
+
+	public static PoolService<SeleniumNodeContainer> getNodePool(final SeleniumHubContainer hub, final Browser browser, final int poolSize) {
+		return new ConcurrentLinkedPool<>(getNodesFactory(hub, browser, poolSize), 1, poolSize, true, new NodeListener());
+	}
+
+	private static NodeFactory getNodesFactory(final SeleniumHubContainer hub, final Browser browser, final int poolSize) {
+		return new NodeFactory(IntStream.range(0, poolSize)
+				.parallel()
+				.mapToObj(i -> new SeleniumNodeContainer(extractImage(browser))
+						.withHubAddress(hub.getHubAddress())
+						.withHubPort(hub.getHubPort())
+						.withRecordingMode(GenericGridContainer.VncRecordingMode.RECORD_ALL, new File("target"))
+						.withLinkToContainer(hub, "hub"))
+				.collect(toList()));
+	}
+
+	private PoolFactory() {
+		throw new UnsupportedOperationException("Illegal access to private constructor");
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/runner/BaseStandaloneTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/runner/BaseStandaloneTest.java
@@ -1,0 +1,55 @@
+package org.testcontainers.testng.runner;
+
+import javaslang.control.Try;
+import org.openqa.selenium.WebDriver;
+import org.testcontainers.grid.enums.Browser;
+import org.testcontainers.testng.selenium.SeleniumStandalone;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * Test runner for standalone container. Extend it by test classes to automatically create standalone instance
+ * with corresponding driver. Note that it uses -Dbrowser property for setting up required browser type.
+ */
+public class BaseStandaloneTest {
+
+	private static SeleniumStandalone seleniumStandalone;
+	private final Logger logger = Logger.getLogger(getClass().getName());
+
+	@BeforeSuite
+	public void prepareContainers() {
+		Try.run(() -> seleniumStandalone = new SeleniumStandalone(Browser.getName(System.getProperty("browser", "firefox"), true)))
+				.onFailure(ex -> logger.severe(ex.getMessage()));
+	}
+
+	@BeforeMethod
+	public void setUp() {
+		Try.run(() -> getGrid().ifPresent(SeleniumStandalone::createDriverAndStartRecording))
+				.onFailure(ex -> logger.severe(ex.getMessage()));
+	}
+
+	@AfterMethod
+	public void tearDown(final ITestResult result) {
+		getGrid().ifPresent(grid -> grid.closeDriverAndStopRecording(result.getMethod().getMethodName(), result.isSuccess()));
+	}
+
+	@AfterSuite
+	public void stopGrid() {
+		getGrid().ifPresent(SeleniumStandalone::stopGrid);
+	}
+
+	public Optional<SeleniumStandalone> getGrid() {
+		return Optional.ofNullable(seleniumStandalone);
+	}
+
+	public WebDriver getDriver() {
+		return getGrid().map(SeleniumStandalone::getDriver)
+				.orElseThrow(() -> new AssertionError("Can't find web driver"));
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/runner/BaseTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/runner/BaseTest.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 import java.util.function.Function;
 
 /**
- * Test runner for separate HUB_CONTAINER / nodes containers with pooling feature. Extend it by test classes to automatically
+ * Test runner for separate hubContainer / nodes containers with pooling feature. Extend it by test classes to automatically
  * create standalone instance with corresponding driver. Note that it uses 'browser' parameter, picked from testng xml,
  * for setting up required browser types. Use -DscaleChrome / -DscaleFirefox properties to allocate required amount
  * of node containers.
@@ -32,7 +32,7 @@ public class BaseTest {
 	private static final int FIREFOX_POOL_SIZE = Integer.valueOf(System.getProperty("scaleFirefox", "1"));
 	private static final int CHROME_POOL_SIZE = Integer.valueOf(System.getProperty("scaleChrome", "1"));
 
-	private static final SeleniumHubContainer HUB_CONTAINER = new SeleniumHubContainer().startHub();
+	private static SeleniumHubContainer hubContainer;
 	private static PoolService<SeleniumNodeContainer> firefoxPool;
 	private static PoolService<SeleniumNodeContainer> chromePool;
 
@@ -41,8 +41,9 @@ public class BaseTest {
 	@BeforeSuite
 	public void startGrid() {
 		Try.run(() -> {
-			firefoxPool = PoolFactory.getNodePool(HUB_CONTAINER, Browser.FIREFOX, FIREFOX_POOL_SIZE);
-			chromePool = PoolFactory.getNodePool(HUB_CONTAINER, Browser.CHROME, CHROME_POOL_SIZE);
+			hubContainer = new SeleniumHubContainer().startHub();
+			firefoxPool = PoolFactory.getNodePool(hubContainer, Browser.FIREFOX, FIREFOX_POOL_SIZE);
+			chromePool = PoolFactory.getNodePool(hubContainer, Browser.CHROME, CHROME_POOL_SIZE);
 		}).getOrElseThrow((Function<Throwable, AssertionError>) AssertionError::new);
 	}
 
@@ -83,7 +84,7 @@ public class BaseTest {
 	}
 
 	private void terminateHub() {
-		HUB_CONTAINER.stop();
+		hubContainer.stop();
 	}
 
 	private Map.Entry<Browser, SeleniumNodeContainer> takeNode(final Browser browser) {
@@ -120,7 +121,6 @@ public class BaseTest {
 			}
 			gridContainer.stopNode();
 		});
-		seleniumNode = null;
 	}
 
 	private Optional<PoolService<SeleniumNodeContainer>> getFirefoxPool() {

--- a/modules/selenium/src/test/java/org/testcontainers/testng/runner/BaseTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/runner/BaseTest.java
@@ -1,0 +1,133 @@
+package org.testcontainers.testng.runner;
+
+import javaslang.control.Try;
+import org.openqa.selenium.WebDriver;
+import org.testcontainers.grid.enums.Browser;
+import org.testcontainers.grid.containers.SeleniumHubContainer;
+import org.testcontainers.grid.containers.SeleniumNodeContainer;
+import org.testcontainers.testng.config.XMLConfig;
+import org.testcontainers.testng.pool.PoolFactory;
+import org.testcontainers.testng.selenium.SeleniumNode;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeSuite;
+import org.vibur.objectpool.PoolService;
+
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Test runner for separate HUB_CONTAINER / nodes containers with pooling feature. Extend it by test classes to automatically
+ * create standalone instance with corresponding driver. Note that it uses 'browser' parameter, picked from testng xml,
+ * for setting up required browser types. Use -DscaleChrome / -DscaleFirefox properties to allocate required amount
+ * of node containers.
+ */
+public class BaseTest {
+
+	private static final int FIREFOX_POOL_SIZE = Integer.valueOf(System.getProperty("scaleFirefox", "1"));
+	private static final int CHROME_POOL_SIZE = Integer.valueOf(System.getProperty("scaleChrome", "1"));
+
+	private static final SeleniumHubContainer HUB_CONTAINER = new SeleniumHubContainer().startHub();
+	private static PoolService<SeleniumNodeContainer> firefoxPool;
+	private static PoolService<SeleniumNodeContainer> chromePool;
+
+	private SeleniumNode seleniumNode;
+
+	@BeforeSuite
+	public void startGrid() {
+		Try.run(() -> {
+			firefoxPool = PoolFactory.getNodePool(HUB_CONTAINER, Browser.FIREFOX, FIREFOX_POOL_SIZE);
+			chromePool = PoolFactory.getNodePool(HUB_CONTAINER, Browser.CHROME, CHROME_POOL_SIZE);
+		}).getOrElseThrow((Function<Throwable, AssertionError>) AssertionError::new);
+	}
+
+	@BeforeMethod
+	public void setUp(final ITestContext context) {
+		Try.run(() -> {
+			final XMLConfig config = new XMLConfig(context.getCurrentXmlTest().getAllParameters());
+			seleniumNode = new SeleniumNode(takeNode(config.getBrowser()))
+					.createDriverAndStartRecording();
+		}).getOrElseThrow((Function<Throwable, AssertionError>) AssertionError::new);
+	}
+
+	@AfterMethod
+	public void tearDown(final ITestResult result) {
+		getNode().ifPresent(node ->
+				node.closeWebDriverAndStopRecording(result.getMethod().getMethodName(), result.isSuccess()));
+		restoreNode();
+	}
+
+	@AfterSuite
+	public void stopGrid() {
+		terminatePools();
+		terminateHub();
+	}
+
+	public WebDriver getDriver() {
+		return getNode().map(SeleniumNode::getDriver)
+				.orElseThrow(() -> new AssertionError("Can't find web driver"));
+	}
+
+	private Optional<SeleniumNode> getNode() {
+		return Optional.ofNullable(seleniumNode);
+	}
+
+	private void terminatePools() {
+		getFirefoxPool().ifPresent(PoolService::terminate);
+		getChromePool().ifPresent(PoolService::terminate);
+	}
+
+	private void terminateHub() {
+		HUB_CONTAINER.stop();
+	}
+
+	private Map.Entry<Browser, SeleniumNodeContainer> takeNode(final Browser browser) {
+		SeleniumNodeContainer currentNode;
+		switch (browser) {
+			case CHROME:
+				currentNode = getChromePool().map(PoolService::take)
+						.map(SeleniumNodeContainer::startNode)
+						.map(SeleniumNodeContainer::startVideoRecording)
+						.orElseThrow(() -> new IllegalArgumentException("Unable to take chrome node"));
+				break;
+			default:
+			case FIREFOX:
+				currentNode = getFirefoxPool().map(PoolService::take)
+						.map(SeleniumNodeContainer::startNode)
+						.map(SeleniumNodeContainer::startVideoRecording)
+						.orElseThrow(() -> new IllegalArgumentException("Unable to take firefox node"));
+				break;
+		}
+
+		return new AbstractMap.SimpleImmutableEntry<>(browser, currentNode);
+	}
+
+	private void restoreNode() {
+		getNode().ifPresent(gridContainer -> {
+			switch (gridContainer.getBrowser()) {
+				case CHROME:
+					getChromePool().ifPresent(pool -> pool.restore(gridContainer.getNode()));
+					break;
+				default:
+				case FIREFOX:
+					getFirefoxPool().ifPresent(pool -> pool.restore(gridContainer.getNode()));
+					break;
+			}
+			gridContainer.stopNode();
+		});
+		seleniumNode = null;
+	}
+
+	private Optional<PoolService<SeleniumNodeContainer>> getFirefoxPool() {
+		return Optional.ofNullable(firefoxPool);
+	}
+
+	private Optional<PoolService<SeleniumNodeContainer>> getChromePool() {
+		return Optional.ofNullable(chromePool);
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/selenium/SeleniumNode.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/selenium/SeleniumNode.java
@@ -1,0 +1,76 @@
+package org.testcontainers.testng.selenium;
+
+import javaslang.control.Try;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.testcontainers.grid.enums.Browser;
+import org.testcontainers.grid.containers.SeleniumNodeContainer;
+import ru.stqa.selenium.factory.WebDriverFactory;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+/**
+ * Simple wrapper for handling node container / webdriver instances.
+ */
+public class SeleniumNode {
+
+	private Map.Entry<Browser, SeleniumNodeContainer> node;
+	private WebDriver driver;
+
+	private final Logger logger = Logger.getLogger(getClass().getName());
+
+	public SeleniumNode(final Map.Entry<Browser, SeleniumNodeContainer> node) {
+		this.node = node;
+	}
+
+	public SeleniumNodeContainer getNode() {
+		return node.getValue();
+	}
+
+	public Browser getBrowser() {
+		return node.getKey();
+	}
+
+	public WebDriver getDriver() {
+		return driver;
+	}
+
+	public void stopNode() {
+		node.getValue().stop();
+	}
+
+	public SeleniumNode createDriverAndStartRecording() {
+		this.driver = WebDriverFactory.getDriver(getNode().getSeleniumAddress().toExternalForm(),
+				getCapabilities(getBrowser()));
+		getNode().startVideoRecording();
+		return this;
+	}
+
+	public void closeWebDriverAndStopRecording(final String testName, final boolean isPassed) {
+		Optional.ofNullable(getDriver())
+				.ifPresent(driver -> Try.run(driver::quit)
+						.onFailure(ex -> logger.info("Cannot close WebDriver: " + ex.getMessage())));
+		getNode().stopAndRetainRecording(testName, isPassed);
+	}
+
+	private Capabilities getCapabilities(final Browser browser) {
+		Capabilities capabilities;
+
+		switch (browser) {
+			case CHROME:
+			case CHROME_STANDALONE:
+				capabilities = DesiredCapabilities.chrome();
+				break;
+			case FIREFOX:
+			case FIREFOX_STANDALONE:
+			default:
+				capabilities = DesiredCapabilities.firefox();
+				break;
+		}
+
+		return capabilities;
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/selenium/SeleniumStandalone.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/selenium/SeleniumStandalone.java
@@ -1,0 +1,76 @@
+package org.testcontainers.testng.selenium;
+
+import javaslang.control.Try;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.testcontainers.grid.enums.Browser;
+import org.testcontainers.grid.containers.GenericGridContainer;
+import org.testcontainers.grid.containers.SeleniumStandaloneContainer;
+import ru.stqa.selenium.factory.WebDriverFactory;
+
+import java.io.File;
+import java.util.Optional;
+import java.util.logging.Logger;
+
+import static org.testcontainers.grid.enums.SeleniumImage.extractImage;
+
+/**
+ * Simple wrapper for handling standalone container / webdriver instances.
+ */
+public class SeleniumStandalone {
+
+	private SeleniumStandaloneContainer standaloneContainer;
+	private WebDriver driver;
+
+	private final Logger logger = Logger.getLogger(getClass().getName());
+
+	public SeleniumStandalone(final Browser browser) {
+		this.standaloneContainer = new SeleniumStandaloneContainer(extractImage(browser))
+				.withRecordingMode(GenericGridContainer.VncRecordingMode.RECORD_ALL, new File("target"))
+				.startGrid();
+	}
+
+	public SeleniumStandaloneContainer getStandalone() {
+		return standaloneContainer;
+	}
+
+	public void stopGrid() {
+		standaloneContainer.stop();
+	}
+
+	public void closeDriverAndStopRecording(final String testName, final boolean isPassed) {
+		Optional.ofNullable(getDriver())
+				.ifPresent(driver -> Try.run(driver::quit)
+						.onFailure(ex -> logger.info("Can't close WebDriver: " + ex.getMessage())));
+		getStandalone().stopAndRetainRecording(testName, isPassed);
+	}
+
+	public void createDriverAndStartRecording() {
+		this.driver = WebDriverFactory.getDriver(getStandalone().getSeleniumAddress().toExternalForm(),
+				getCapabilities(getStandalone().getBrowser()));
+		getStandalone().startRecording();
+	}
+
+	public WebDriver getDriver() {
+		return driver;
+	}
+
+	private Capabilities getCapabilities(final Browser browser) {
+		Capabilities capabilities;
+
+		switch (browser) {
+			case CHROME:
+			case CHROME_STANDALONE:
+				capabilities = DesiredCapabilities.chrome();
+				break;
+			case FIREFOX:
+			case FIREFOX_STANDALONE:
+			default:
+				capabilities = DesiredCapabilities.firefox();
+				break;
+		}
+
+		return capabilities;
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/tests/SeleniumGridParallelTests.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/tests/SeleniumGridParallelTests.java
@@ -1,0 +1,49 @@
+package org.testcontainers.testng.tests;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testcontainers.testng.runner.BaseTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class SeleniumGridParallelTests extends BaseTest {
+
+	@Test
+	public void simplePlainSeleniumTest() {
+		WebDriver driver = getDriver();
+		assertNotNull(driver);
+
+		driver.get("https://wikipedia.org");
+		WebElement searchInput = driver.findElement(By.name("search"));
+
+		searchInput.sendKeys("Rick Astley");
+		searchInput.submit();
+
+		WebElement otherPage = driver.findElement(By.linkText("Rickrolling"));
+		otherPage.click();
+
+		boolean expectedTextFound = driver.findElements(By.cssSelector("p"))
+				.stream()
+				.anyMatch(element -> element.getText().contains("meme"));
+
+		assertTrue(expectedTextFound, "The word 'meme' is found on a page about rickrolling");
+	}
+
+	@Test
+	public void googleSearchTest() {
+		WebDriver driver = getDriver();
+		assertNotNull(driver);
+
+		driver.get("https://google.com.ua");
+		driver.findElement(By.id("lst-ib")).sendKeys("automation" + Keys.ENTER);
+
+		new WebDriverWait(driver, 10)
+				.until((WebDriver d) -> d.findElements(By.cssSelector(".r>a")).size() > 0);
+
+		assertEquals("automation", driver.findElement(By.id("lst-ib")).getAttribute("value"));
+	}
+}

--- a/modules/selenium/src/test/java/org/testcontainers/testng/tests/SeleniumGridStandAloneTests.java
+++ b/modules/selenium/src/test/java/org/testcontainers/testng/tests/SeleniumGridStandAloneTests.java
@@ -1,0 +1,51 @@
+package org.testcontainers.testng.tests;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.testcontainers.testng.runner.BaseStandaloneTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class SeleniumGridStandAloneTests extends BaseStandaloneTest {
+
+	@Test
+	public void simplePlainSeleniumTest() {
+		WebDriver driver = getDriver();
+		assertNotNull(driver);
+
+		driver.get("https://wikipedia.org");
+		WebElement searchInput = driver.findElement(By.name("search"));
+
+		searchInput.sendKeys("Rick Astley");
+		searchInput.submit();
+
+		WebElement otherPage = driver.findElement(By.linkText("Rickrolling"));
+		otherPage.click();
+
+		boolean expectedTextFound = driver.findElements(By.cssSelector("p"))
+				.stream()
+				.anyMatch(element -> element.getText().contains("meme"));
+
+		assertTrue(expectedTextFound, "The word 'meme' is found on a page about rickrolling");
+	}
+
+	@Test
+	public void googleSearchTest() {
+		WebDriver driver = getDriver();
+		assertNotNull(driver);
+
+		driver.get("https://google.com.ua");
+		driver.findElement(By.id("lst-ib")).sendKeys("automation" + Keys.ENTER);
+
+		new WebDriverWait(driver, 10)
+				.until((WebDriver d) -> d.findElements(By.cssSelector(".r>a")).size() > 0);
+
+		assertEquals("automation", driver.findElement(By.id("lst-ib")).getAttribute("value"));
+	}
+}

--- a/modules/selenium/src/test/resources/testng-suites/common-suite.xml
+++ b/modules/selenium/src/test/resources/testng-suites/common-suite.xml
@@ -1,0 +1,27 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Selenium Grid sample parallel suite" parallel="tests" thread-count="2">
+    <test name="First Chrome test">
+        <parameter name="browser" value="chrome"/>
+        <classes>
+            <class name="org.testcontainers.testng.tests.SeleniumGridParallelTests">
+                <methods>
+                    <include name="simplePlainSeleniumTest"/>
+                    <include name="googleSearchTest"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+    <test name="First Firefox test">
+        <parameter name="browser" value="firefox"/>
+        <classes>
+            <class name="org.testcontainers.testng.tests.SeleniumGridParallelTests">
+                <methods>
+                    <include name="googleSearchTest"/>
+                    <include name="simplePlainSeleniumTest"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+</suite>

--- a/modules/selenium/src/test/resources/testng-suites/parent-suite.xml
+++ b/modules/selenium/src/test/resources/testng-suites/parent-suite.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suite name="Parent suite">
+    <suite-files>
+        <suite-file path="standalone-suite.xml" />
+        <suite-file path="common-suite.xml" />
+    </suite-files>
+</suite>

--- a/modules/selenium/src/test/resources/testng-suites/parent-suite.xml
+++ b/modules/selenium/src/test/resources/testng-suites/parent-suite.xml
@@ -1,7 +1,8 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
 <suite name="Parent suite">
     <suite-files>
         <suite-file path="standalone-suite.xml" />
-        <!--<suite-file path="common-suite.xml" />-->
+        <suite-file path="common-suite.xml" />
     </suite-files>
 </suite>

--- a/modules/selenium/src/test/resources/testng-suites/parent-suite.xml
+++ b/modules/selenium/src/test/resources/testng-suites/parent-suite.xml
@@ -2,6 +2,6 @@
 <suite name="Parent suite">
     <suite-files>
         <suite-file path="standalone-suite.xml" />
-        <suite-file path="common-suite.xml" />
+        <!--<suite-file path="common-suite.xml" />-->
     </suite-files>
 </suite>

--- a/modules/selenium/src/test/resources/testng-suites/standalone-suite.xml
+++ b/modules/selenium/src/test/resources/testng-suites/standalone-suite.xml
@@ -1,0 +1,14 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="Selenium Grid sample standalone suite">
+    <test name="Common junit tests" junit="true">
+        <packages>
+            <package name="org.testcontainers.junit.*"/>
+        </packages>
+    </test>
+    <test name="Standalone chrome tests">
+        <classes>
+            <class name="org.testcontainers.testng.tests.SeleniumGridStandAloneTests"/>
+        </classes>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
             <version>4.12</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.10</version>
+        </dependency>
+
         <!-- Project lombok for additional safety/convenience support -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <name>Viktor Schulz</name>
             <email>vschulz@mail.uni-mannheim.de</email>
         </developer>
+        <developer>
+            <id>sskorol</id>
+            <name>Sergey Korol</name>
+            <email>serhii.s.korol@gmail.com</email>
+        </developer>
     </developers>
 
     <dependencies>


### PR DESCRIPTION
Revised Selenium containers for better scaling and avoiding JUnit / WebDriver dependencies:
- created GenericGridContainer to allow better flexibility in creating dedicated SeleniumHQ containers;
- created SeleniumHubContainer for standalone usage with dedicated nodes; note that it doesn't support VNC / video recording;
- created SeleniumNodeContainer with VNC / video recording support for standalone usage with SeleniumHubContainer;
- created SeleniumStandaloneContainer as an alternative to BrowserWebDriverContainer, but without WebDriver dependency;
- created 2 enums: Browser / SeleniumImage for better containers management;
- created SeleniumHttpUtils for checking if container is ready to be used by tests;
- added brief overview into webdriver_containers.md.
- added required dependencies and developer's info
