### PR TITLE
Automatic selenium version matching

### DIFF
--- a/docs/usage/webdriver_containers.md
+++ b/docs/usage/webdriver_containers.md
@@ -10,6 +10,8 @@ from SeleniumHQ's [docker-selenium](https://github.com/SeleniumHQ/docker-seleniu
   is a working Docker installation and your Java JUnit test suite.
 * Browsers are always launched from a fixed, clean image. This means no configuration drift from user changes or
   automatic browser upgrades.
+* Compatibility between browser version and the Selenium API is assured: a compatible version of the browser docker
+  images will be automatically selected to match the version of `selenium-api-*.jar` on the classpath
 * Additionally the use of a clean browser prevents leakage of cookies, cached data or other state between tests.
 * **VNC screen recording**: Test Containers can automatically record video of test runs (optionally capturing just
   failing tests)

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
-            <version>2.45.0</version>
+            <version>2.52.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/modules/selenium/src/main/java/org/testcontainers/containers/SeleniumUtils.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/SeleniumUtils.java
@@ -1,0 +1,70 @@
+package org.testcontainers.containers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+/**
+ * Utility methods for Selenium.
+ */
+public class SeleniumUtils {
+
+    public static final String DEFAULT_SELENIUM_VERSION = "2.45.0";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SeleniumUtils.class);
+
+    private SeleniumUtils() {}
+
+    /**
+     * Based on the JARs detected on the classpath, determine which version of selenium-api is available.
+     * @return the detected version of Selenium API, or DEFAULT_SELENIUM_VERSION if it could not be determined
+     */
+    public static String determineClasspathSeleniumVersion() {
+        Set<String> seleniumVersions = new HashSet<>();
+        try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            Enumeration<URL> manifests = classLoader.getResources("META-INF/MANIFEST.MF");
+
+            while (manifests.hasMoreElements()) {
+                URL manifestURL = manifests.nextElement();
+                try (InputStream is = manifestURL.openStream()) {
+                    Manifest manifest = new Manifest();
+                    manifest.read(is);
+
+                    Attributes buildInfo = manifest.getAttributes("Build-Info");
+                    if (buildInfo != null) {
+                        String seleniumVersion = buildInfo.getValue("Selenium-Version");
+
+                        if (seleniumVersion != null) {
+                            seleniumVersions.add(seleniumVersion);
+                            LOGGER.info("Selenium API version {} detected on classpath", seleniumVersion);
+                        }
+                    }
+                }
+
+            }
+
+        } catch (Exception e) {
+            LOGGER.debug("Failed to determine Selenium-Version from selenium-api JAR Manifest", e);
+        }
+
+        if (seleniumVersions.size() == 0) {
+            LOGGER.warn("Failed to determine Selenium version from classpath - will use default version of {}", DEFAULT_SELENIUM_VERSION);
+            return DEFAULT_SELENIUM_VERSION;
+        }
+
+        String foundVersion = seleniumVersions.iterator().next();
+        if (seleniumVersions.size() > 1) {
+            LOGGER.warn("Multiple versions of Selenium API found on classpath - will select {}, but this may not be reliable", foundVersion);
+        }
+
+        return foundVersion;
+    }
+}

--- a/modules/selenium/src/main/java/org/testcontainers/containers/SeleniumUtils.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/SeleniumUtils.java
@@ -14,7 +14,7 @@ import java.util.jar.Manifest;
 /**
  * Utility methods for Selenium.
  */
-public class SeleniumUtils {
+public final class SeleniumUtils {
 
     public static final String DEFAULT_SELENIUM_VERSION = "2.45.0";
 


### PR DESCRIPTION
Prior to this the version of docker-selenium drivers used was fixed at 2.45.0. This could be somewhat risky if users had a different, newer, version of selenium-api in their projects.

This change makes the library detect the classpath version of selenium-api, and use that to select an appropriate docker-selenium container version.