### PR TITLE
Improve stream cleanup for followed container output

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -681,6 +681,7 @@ public class GenericContainer extends FailureDetectingExternalResource implement
             @Override
             public void close() throws IOException {
                 consumer.accept(OutputFrame.END);
+                super.close();
             }
         });
     }


### PR DESCRIPTION
Ensure that ResultCallbackTemplate close() method is fired so that streams are closed along with containers. Refs #94,#96