### PR TITLE
Avoid container leaks by setting hook before container creation

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -132,6 +132,15 @@ public class GenericContainer extends FailureDetectingExternalResource implement
             profiler.start("Prepare container configuration and host configuration");
             configure();
 
+            profiler.start("Set up shutdown hooks");
+            // If the JVM stops without the container being stopped, try and stop the container.
+            // We have to add it here, even before we create a container, to make sure that it
+            // will be destroyed even if there was an issue during container creation.
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                logger().trace("Hit shutdown hook for container {}", GenericContainer.this.containerId);
+                GenericContainer.this.stop();
+            }));
+
             logger().info("Creating container for image: {}", dockerImageName);
             profiler.start("Create container");
             CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName);
@@ -172,14 +181,6 @@ public class GenericContainer extends FailureDetectingExternalResource implement
 
             throw new ContainerLaunchException("Could not create/start container", e);
         } finally {
-
-            profiler.start("Set up shutdown hooks");
-            // If the JVM stops without the container being stopped, try and stop the container
-            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-                logger().trace("Hit shutdown hook for container {}", GenericContainer.this.containerId);
-                GenericContainer.this.stop();
-            }));
-
             profiler.stop().log();
         }
     }


### PR DESCRIPTION
Hi!

If somebody will stop execution during the container creation, especially during the "waitUntilContainerStarted" phase, hook **will not** be executed, seems like finally doesn't work in case of the SIGTERM. 

Symptoms: I see a lot of non-destroyed containers after test execution when we stop our Jenkins job.

This fix will add a hook just before container is being created to make sure that it will be executed afterwards.


Thanks!