### PR TITLE
relocate all container kill/remove code to a utility class

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ContainerReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ContainerReaper.java
@@ -1,0 +1,80 @@
+package org.testcontainers.utility;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.DockerException;
+import com.github.dockerjava.api.InternalServerErrorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.DockerClientFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * Component that responsible for container removal and automatic cleanup of dead containers at JVM shutdown.
+ */
+public final class ContainerReaper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerReaper.class);
+    private static ContainerReaper instance;
+    private final DockerClient dockerClient;
+    private Map<String, String> registeredContainers = new HashMap<>();
+
+    private ContainerReaper() {
+        dockerClient = DockerClientFactory.instance().client();
+
+        // If the JVM stops without containers being stopped, try and stop the container.
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            for (Map.Entry<String, String> entry : new HashSet<>(registeredContainers.entrySet())) {
+                stopAndRemoveContainer(entry.getKey(), entry.getValue());
+            }
+        }));
+    }
+
+    public synchronized static ContainerReaper instance() {
+        if (instance == null) {
+            instance = new ContainerReaper();
+        }
+
+        return instance;
+    }
+
+    /**
+     * Register a container to be cleaned up, either on explicit call to stopAndRemoveContainer, or at JVM shutdown.
+     * @param containerId the ID of the container
+     * @param imageName the image name of the container (used for logging)
+     */
+    public void registerContainerForCleanup(String containerId, String imageName) {
+        registeredContainers.put(containerId, imageName);
+    }
+
+    /**
+     * Stop a potentially running container and remove it, including associated volumes.
+     * @param containerId the ID of the container
+     * @param imageName the image name of the container (used for logging)
+     */
+    public void stopAndRemoveContainer(String containerId, String imageName) {
+        try {
+            LOGGER.trace("Stopping container: {}", containerId);
+            dockerClient.killContainerCmd(containerId).exec();
+            LOGGER.trace("Stopped container: {}", imageName);
+        } catch (DockerException e) {
+            LOGGER.trace("Error encountered shutting down container (ID: {}) - it may not have been stopped, or may already be stopped: {}", containerId, e.getMessage());
+        }
+
+        try {
+            LOGGER.trace("Stopping container: {}", containerId);
+            try {
+                dockerClient.removeContainerCmd(containerId).withRemoveVolumes(true).withForce(true).exec();
+                LOGGER.info("Removed container and associated volume(s): {}", imageName);
+            } catch (InternalServerErrorException e) {
+                LOGGER.trace("Exception when removing container with associated volume(s): {} (due to {})", imageName, e.getMessage());
+            }
+        } catch (DockerException e) {
+            LOGGER.trace("Error encountered shutting down container (ID: {}) - it may not have been stopped, or may already be stopped: {}", containerId, e.getMessage());
+        }
+
+        registeredContainers.remove(containerId);
+    }
+}

--- a/core/src/main/java/org/testcontainers/utility/ContainerReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ContainerReaper.java
@@ -7,9 +7,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Component that responsible for container removal and automatic cleanup of dead containers at JVM shutdown.
@@ -19,7 +19,7 @@ public final class ContainerReaper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ContainerReaper.class);
     private static ContainerReaper instance;
     private final DockerClient dockerClient;
-    private Map<String, String> registeredContainers = new HashMap<>();
+    private Map<String, String> registeredContainers = new ConcurrentHashMap<>();
 
     private ContainerReaper() {
         dockerClient = DockerClientFactory.instance().client();

--- a/core/src/test/java/org/testcontainers/junit/TestBadCleanup.java
+++ b/core/src/test/java/org/testcontainers/junit/TestBadCleanup.java
@@ -1,0 +1,23 @@
+package org.testcontainers.junit;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+
+/**
+ * Failing test for manual testing of container cleanup.
+ */
+public class TestBadCleanup {
+   @Rule
+   public GenericContainer failingContainer =
+         new GenericContainer("alpine:3.2")
+               .withCommand("/bin/sh","-c","false")
+               .withExposedPorts(8080);   
+
+   @Test @Ignore
+   public void testBadCleanup() throws Exception {
+      // no op
+      // this test will pass, but a "docker ps -a" afterward will see two leftover containers.
+   }
+}


### PR DESCRIPTION
This is able to cleanup all container IDs that are created, as opposed to containers that are started. Refs #102, #110 