### PR TITLE
Added prefix to Slf4jLogConsumer to be able to distinguish outputs

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
@@ -9,13 +9,19 @@ import java.util.function.Consumer;
  */
 public class Slf4jLogConsumer implements Consumer<OutputFrame> {
     private final Logger logger;
+    private String prefix = "";
 
     public Slf4jLogConsumer(Logger logger) {
         this.logger = logger;
     }
 
+    public Slf4jLogConsumer setPrefix(String prefix) {
+        this.prefix = "["+prefix+"]";
+        return this;
+    }
+
     @Override
     public void accept(OutputFrame outputFrame) {
-        logger.info("{}: {}", outputFrame.getType(), outputFrame.getUtf8String());
+        logger.info("{} {}: {}", prefix, outputFrame.getType(), outputFrame.getUtf8String());
     }
 }

--- a/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
@@ -15,13 +15,13 @@ public class Slf4jLogConsumer implements Consumer<OutputFrame> {
         this.logger = logger;
     }
 
-    public Slf4jLogConsumer setPrefix(String prefix) {
-        this.prefix = "["+prefix+"]";
+    public Slf4jLogConsumer withPrefix(String prefix) {
+        this.prefix = "["+prefix+"] ";
         return this;
     }
 
     @Override
     public void accept(OutputFrame outputFrame) {
-        logger.info("{} {}: {}", prefix, outputFrame.getType(), outputFrame.getUtf8String());
+        logger.info("{}{}: {}", prefix, outputFrame.getType(), outputFrame.getUtf8String());
     }
 }


### PR DESCRIPTION
Added prefix to Slf4jLogConsumer to be able to distinguish outputs from multiple dockers using the same JUnit logger