### PR TITLE
Amend liveness check port lookup to also check port bindings

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -286,6 +286,8 @@ public class GenericContainer extends FailureDetectingExternalResource implement
     protected Integer getLivenessCheckPort() {
         if (exposedPorts.size() > 0) {
             return getMappedPort(exposedPorts.get(0));
+        } else if (portBindings.size() > 0) {
+            return PortBinding.parse(portBindings.get(0)).getBinding().getHostPort();
         } else {
             return null;
         }


### PR DESCRIPTION
Refs #128: Amend liveness check port lookup to also check port bindings (used for fixed port mapping) if no ports are exposed via the usual mechanism