### PR TITLE
Adds pluggable wait strategy, and HTTP(S) implementation.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ Krystian Nowak <krystian.nowak@gmail.com>
 Viktor Schulz <vschulz@mail.uni-mannheim.de>
 Asaf Mesika <asaf.mesika@gmail.com>
 Sergei Egorov <bsideup@gmail.com>
+Pete Cornish <outofcoffee@gmail.com>

--- a/core/src/main/java/org/testcontainers/containers/ContainerLaunchException.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerLaunchException.java
@@ -3,7 +3,7 @@ package org.testcontainers.containers;
 /**
  * AN exception that may be raised during launch of a container.
  */
-class ContainerLaunchException extends RuntimeException {
+public class ContainerLaunchException extends RuntimeException {
 
     public ContainerLaunchException(String message) {
         super(message);

--- a/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
@@ -1,0 +1,44 @@
+package org.testcontainers.containers.wait;
+
+import org.rnorth.ducttape.TimeoutException;
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Waits until a socket connection can be established on a port exposed or mapped by the container.
+ *
+ * @author richardnorth
+ */
+public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy {
+    @Override
+    protected void waitUntilReady() {
+        final Integer port = getLivenessCheckPort();
+        if (null == port) {
+            return;
+        }
+
+        final String ipAddress = DockerClientFactory.instance().dockerHostIpAddress();
+        try {
+            Unreliables.retryUntilSuccess((int) startupTimeout.getSeconds(), TimeUnit.SECONDS, () -> {
+                getRateLimiter().doWhenReady(() -> {
+                    try {
+                        new Socket(ipAddress, port).close();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                return true;
+            });
+
+        } catch (TimeoutException e) {
+            throw new ContainerLaunchException("Timed out waiting for container port to open (" +
+                    ipAddress + ":" + port + " should be listening)");
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/wait/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HttpWaitStrategy.java
@@ -1,0 +1,158 @@
+package org.testcontainers.containers.wait;
+
+import com.google.common.base.Strings;
+import com.google.common.io.BaseEncoding;
+import org.rnorth.ducttape.TimeoutException;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
+
+/**
+ * Waits until an HTTP(S) endpoint returns a given status code.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class HttpWaitStrategy extends GenericContainer.AbstractWaitStrategy {
+    /**
+     * Authorization HTTP header.
+     */
+    private static final String HEADER_AUTHORIZATION = "Authorization";
+
+    /**
+     * Basic Authorization scheme prefix.
+     */
+    private static final String AUTH_BASIC = "Basic ";
+
+    private String path = "/";
+    private int statusCode = HttpURLConnection.HTTP_OK;
+    private boolean tlsEnabled;
+    private String username;
+    private String password;
+
+    /**
+     * Waits for the given status code.
+     *
+     * @param statusCode the expected status code
+     * @return this
+     */
+    public HttpWaitStrategy forStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
+    /**
+     * Waits for the given path.
+     *
+     * @param path the path to check
+     * @return this
+     */
+    public HttpWaitStrategy forPath(String path) {
+        this.path = path;
+        return this;
+    }
+
+    /**
+     * Indicates that the status check should use HTTPS.
+     *
+     * @return this
+     */
+    public HttpWaitStrategy usingTls() {
+        this.tlsEnabled = true;
+        return this;
+    }
+
+    /**
+     * Authenticate with HTTP Basic Authorization credentials.
+     *
+     * @param username the username
+     * @param password the password
+     * @return this
+     */
+    public HttpWaitStrategy withBasicCredentials(String username, String password) {
+        this.username = username;
+        this.password = password;
+        return this;
+    }
+
+    @Override
+    protected void waitUntilReady() {
+        final Integer livenessCheckPort = getLivenessCheckPort();
+        if (null == livenessCheckPort) {
+            logger().warn("No exposed ports or mapped ports - cannot wait for status");
+            return;
+        }
+
+        final String uri = buildLivenessUri(livenessCheckPort).toString();
+        logger().info("Waiting for {} seconds for URL: {}", startupTimeout.getSeconds(), uri);
+
+        // try to connect to the URL
+        try {
+            retryUntilSuccess((int) startupTimeout.getSeconds(), TimeUnit.SECONDS, () -> {
+                getRateLimiter().doWhenReady(() -> {
+                    try {
+                        final HttpURLConnection connection = (HttpURLConnection) new URL(uri).openConnection();
+
+                        // authenticate
+                        if (!Strings.isNullOrEmpty(username)) {
+                            connection.setRequestProperty(HEADER_AUTHORIZATION, buildAuthString(username, password));
+                            connection.setUseCaches(false);
+                        }
+
+                        connection.setRequestMethod("GET");
+                        connection.connect();
+
+                        if (statusCode != connection.getResponseCode()) {
+                            throw new RuntimeException(String.format("HTTP response code was: %s",
+                                    connection.getResponseCode()));
+                        }
+
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+                return true;
+            });
+
+        } catch (TimeoutException e) {
+            throw new ContainerLaunchException(String.format(
+                    "Timed out waiting for URL to be accessible (%s should return HTTP %s)", uri, statusCode));
+        }
+    }
+
+    /**
+     * Build the URI on which to check if the container is ready.
+     *
+     * @param livenessCheckPort the liveness port
+     * @return the liveness URI
+     */
+    private URI buildLivenessUri(int livenessCheckPort) {
+        final String scheme = (tlsEnabled ? "https" : "http") + "://";
+        final String host = DockerClientFactory.instance().dockerHostIpAddress();
+
+        final String portSuffix;
+        if ((tlsEnabled && 443 == livenessCheckPort) || (!tlsEnabled && 80 == livenessCheckPort)) {
+            portSuffix = "";
+        } else {
+            portSuffix = ":" + String.valueOf(livenessCheckPort);
+        }
+
+        return URI.create(scheme + host + portSuffix + path);
+    }
+
+    /**
+     * @param username the username
+     * @param password the password
+     * @return a basic authentication string for the given credentials
+     */
+    private String buildAuthString(String username, String password) {
+        return AUTH_BASIC + BaseEncoding.base64().encode((username + ":" + password).getBytes());
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/wait/Wait.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/Wait.java
@@ -1,0 +1,54 @@
+package org.testcontainers.containers.wait;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Convenience class with logic for building common {@link WaitStrategy} instances.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class Wait {
+    /**
+     * Convenience method to return the default WaitStrategy.
+     *
+     * @return a WaitStrategy
+     */
+    public static WaitStrategy defaultWaitStrategy() {
+        return forListeningPort();
+    }
+
+    /**
+     * Convenience method to return a WaitStrategy for an exposed or mapped port.
+     *
+     * @return the WaitStrategy
+     * @see HostPortWaitStrategy
+     */
+    public static HostPortWaitStrategy forListeningPort() {
+        return new HostPortWaitStrategy();
+    }
+
+    /**
+     * Convenience method to return a WaitStrategy for an HTTP endpoint.
+     *
+     * @param path the path to check
+     * @return the WaitStrategy
+     * @see HttpWaitStrategy
+     */
+    public static HttpWaitStrategy forHttp(String path) {
+        return new HttpWaitStrategy()
+                .forPath(path)
+                .forStatusCode(HttpURLConnection.HTTP_OK);
+    }
+
+    /**
+     * Convenience method to return a WaitStrategy for an HTTPS endpoint.
+     *
+     * @param path the path to check
+     * @return the WaitStrategy
+     * @see HttpWaitStrategy
+     */
+    public static HttpWaitStrategy forHttps(String path) {
+        return forHttp(path)
+                .usingTls();
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/wait/WaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/WaitStrategy.java
@@ -1,0 +1,25 @@
+package org.testcontainers.containers.wait;
+
+import org.testcontainers.containers.GenericContainer;
+
+import java.time.Duration;
+
+/**
+ * Approach to determine whether a container is ready.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public interface WaitStrategy {
+    /**
+     * Wait until the container has started.
+     *
+     * @param container the container for which to wait
+     */
+    void waitUntilReady(GenericContainer container);
+
+    /**
+     * @param startupTimeout the duration for which to wait
+     * @return this
+     */
+    WaitStrategy withStartupTimeout(Duration startupTimeout);
+}

--- a/core/src/test/java/org/testcontainers/junit/wait/AbstractWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/AbstractWaitStrategyTest.java
@@ -1,0 +1,96 @@
+package org.testcontainers.junit.wait;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.rnorth.ducttape.RetryCountExceededException;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.WaitStrategy;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.*;
+
+/**
+ * Common test methods for {@link WaitStrategy} implementations.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public abstract class AbstractWaitStrategyTest<W extends WaitStrategy> {
+    private static final long WAIT_TIMEOUT_MILLIS = 3000;
+    private static final String IMAGE_NAME = "alpine:latest";
+
+    /**
+     * Indicates that the WaitStrategy has completed waiting successfully.
+     */
+    private AtomicBoolean ready;
+
+    /**
+     * Subclasses should return an instance of {@link W} that sets {@code ready} to {@code true},
+     * if the wait was successful.
+     *
+     * @param ready the AtomicBoolean on which to indicate success
+     * @return WaitStrategy implementation
+     */
+    @NotNull
+    protected abstract W buildWaitStrategy(final AtomicBoolean ready);
+
+    @Before
+    public void setUp() throws Exception {
+        ready = new AtomicBoolean(false);
+    }
+
+    /**
+     * Starts a GenericContainer with the {@link #IMAGE_NAME} image, passing the given {@code shellCommand} as
+     * a parameter to {@literal sh -c} (the container CMD).
+     *
+     * @param shellCommand the shell command to execute
+     * @return the (unstarted) container
+     */
+    private GenericContainer startContainerWithCommand(String shellCommand) {
+        final WaitStrategy waitStrategy = buildWaitStrategy(ready)
+                .withStartupTimeout(Duration.ofMillis(WAIT_TIMEOUT_MILLIS));
+
+        // apply WaitStrategy to container
+        return new GenericContainer(IMAGE_NAME)
+                .withExposedPorts(8080)
+                .withCommand("sh", "-c", shellCommand)
+                .waitingFor(waitStrategy);
+    }
+
+    /**
+     * Expects that the WaitStrategy returns successfully after connection to a container with a listening port.
+     *
+     * @param shellCommand the shell command to execute
+     * @throws Exception
+     */
+    protected void waitUntilReadyAndSucceed(String shellCommand) throws Exception {
+        final GenericContainer container = startContainerWithCommand(shellCommand);
+
+        // start() blocks until successful or timeout
+        container.start();
+
+        assertTrue(String.format("Expected container to be ready after timeout of %sms",
+                WAIT_TIMEOUT_MILLIS), ready.get());
+    }
+
+    /**
+     * Expects that the WaitStrategy throws a {@link RetryCountExceededException} after unsuccessful connection
+     * to a container with a listening port.
+     *
+     * @param shellCommand the shell command to execute
+     * @throws Exception
+     */
+    protected void waitUntilReadyAndTimeout(String shellCommand) throws Exception {
+        final GenericContainer container = startContainerWithCommand(shellCommand);
+        try {
+            // start() blocks until successful or timeout
+            container.start();
+            fail(RetryCountExceededException.class + " expected");
+
+        } catch (RetryCountExceededException e) {
+            assertFalse(String.format("Wait should have timed-out after %sms",
+                    WAIT_TIMEOUT_MILLIS), ready.get());
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/wait/HostPortWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/HostPortWaitStrategyTest.java
@@ -1,0 +1,52 @@
+package org.testcontainers.junit.wait;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.rnorth.ducttape.RetryCountExceededException;
+import org.testcontainers.containers.wait.HostPortWaitStrategy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tests for {@link HostPortWaitStrategy}.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class HostPortWaitStrategyTest extends AbstractWaitStrategyTest<HostPortWaitStrategy> {
+    /**
+     * Expects that the WaitStrategy returns successfully after connection to a container with a listening port.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWaitUntilReady_Success() throws Exception {
+        waitUntilReadyAndSucceed("nc -lp 8080");
+    }
+
+    /**
+     * Expects that the WaitStrategy throws a {@link RetryCountExceededException} after unsuccessful connection
+     * to a container with a listening port within the timeout period.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWaitUntilReady_Timeout() throws Exception {
+        waitUntilReadyAndTimeout("");
+    }
+
+    /**
+     * @param ready the AtomicBoolean on which to indicate success
+     * @return the WaitStrategy under test
+     */
+    @NotNull
+    protected HostPortWaitStrategy buildWaitStrategy(final AtomicBoolean ready) {
+        return new HostPortWaitStrategy() {
+            @Override
+            protected void waitUntilReady() {
+                // blocks until ready or timeout occurs
+                super.waitUntilReady();
+                ready.set(true);
+            }
+        };
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/wait/HttpWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/HttpWaitStrategyTest.java
@@ -1,0 +1,57 @@
+package org.testcontainers.junit.wait;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.rnorth.ducttape.RetryCountExceededException;
+import org.testcontainers.containers.wait.HttpWaitStrategy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tests for {@link HttpWaitStrategy}.
+ *
+ * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
+ */
+public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrategy> {
+    /**
+     * Doubly-escaped newline sequence indicating end of the HTTP header.
+     */
+    private static final String DOUBLE_NEWLINE = "\\\r\\\n\\\r\\\n";
+
+    /**
+     * Expects that the WaitStrategy returns successfully after receiving an HTTP 200 response from the container.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWaitUntilReady_Success() throws Exception {
+        waitUntilReadyAndSucceed("echo -e \"HTTP/1.1 200 OK" + DOUBLE_NEWLINE + "\" | nc -lp 8080");
+    }
+
+    /**
+     * Expects that the WaitStrategy throws a {@link RetryCountExceededException} after not receiving an HTTP 200
+     * response from the container within the timeout period.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWaitUntilReady_Timeout() throws Exception {
+        waitUntilReadyAndTimeout("echo -e \"HTTP/1.1 400 Bad Request" + DOUBLE_NEWLINE + "\" | nc -lp 8080");
+    }
+
+    /**
+     * @param ready the AtomicBoolean on which to indicate success
+     * @return the WaitStrategy under test
+     */
+    @NotNull
+    protected HttpWaitStrategy buildWaitStrategy(final AtomicBoolean ready) {
+        return new HttpWaitStrategy() {
+            @Override
+            protected void waitUntilReady() {
+                // blocks until ready or timeout occurs
+                super.waitUntilReady();
+                ready.set(true);
+            }
+        };
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <name>Viktor Schulz</name>
             <email>vschulz@mail.uni-mannheim.de</email>
         </developer>
+        <developer>
+            <id>pcornish</id>
+            <name>Pete Cornish</name>
+            <email>outofcoffee@gmail.com</email>
+        </developer>
     </developers>
 
     <repositories>


### PR DESCRIPTION
# Purpose

This PR adds a pluggable wait strategy, to enable containers to be checked for readiness using arbitrary logic.

It also adds an HTTP(S) wait strategy to wait for a particular endpoint to be available.

# Implementation

* Refactored existing `waitForListeningPort(...)` logic into its own class.
* Adds new HTTP(S) wait implementation

# Examples

Wait for 200 OK:
```
@ClassRule
public static GenericContainer elasticsearch =
    new GenericContainer("elasticsearch:2.3")
               .withExposedPorts(9200)
               .waitingFor(Wait.forHttp("/all"));
```

Wait for arbitrary status code on an HTTPS endpoint:
```
@ClassRule
public static GenericContainer elasticsearch =
    new GenericContainer("elasticsearch:2.3")
               .withExposedPorts(9200)
               .waitingFor(Wait.forHttp("/all")
               .forStatusCode("301)
               .usingTls());
```