### PR TITLE
add support for extra hosts to GenericContainer

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -74,7 +74,7 @@ public class GenericContainer extends FailureDetectingExternalResource implement
     private List<String> portBindings = new ArrayList<>();
 
     @NonNull
-	private List<String> extraHosts = new ArrayList<>();
+    private List<String> extraHosts = new ArrayList<>();
 
     @NonNull
     private Future<String> image;
@@ -506,13 +506,13 @@ public class GenericContainer extends FailureDetectingExternalResource implement
 
     /**
      * Add an extra host entry to be passed to the container
-     *
-     * @param hostEntry for e.g. "somehost:192.168.47.11"
+     * @param hostname
+     * @param ipAddress
      * @return this
      */
-    public GenericContainer withExtraHost(String hostEntry) {
-    	this.extraHosts.add(hostEntry);
-    	return this;
+    public GenericContainer withExtraHost(String hostname, String ipAddress) {
+        this.extraHosts.add(String.format("%s:%s", hostname, ipAddress));
+        return this;
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -9,9 +9,11 @@ import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.model.*;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
+
 import org.jetbrains.annotations.Nullable;
 import org.junit.runner.Description;
 import org.rnorth.ducttape.TimeoutException;
@@ -72,6 +74,9 @@ public class GenericContainer extends FailureDetectingExternalResource implement
     private List<String> portBindings = new ArrayList<>();
 
     @NonNull
+	private List<String> extraHosts = new ArrayList<>();
+
+    @NonNull
     private Future<String> image;
 
     @NonNull
@@ -110,6 +115,7 @@ public class GenericContainer extends FailureDetectingExternalResource implement
 
     @Nullable
     private InspectContainerResponse containerInfo;
+
 
     private static final Set<String> AVAILABLE_IMAGE_NAME_CACHE = new HashSet<>();
     private static final RateLimiter DOCKER_CLIENT_RATE_LIMITER = RateLimiterBuilder
@@ -336,6 +342,10 @@ public class GenericContainer extends FailureDetectingExternalResource implement
         createCommand.withLinks(linksArray);
 
         createCommand.withPublishAllPorts(true);
+
+        String[] extraHostsArray = extraHosts.stream()
+        		 .toArray(String[]::new);
+        createCommand.withExtraHosts(extraHostsArray);
     }
 
     /**
@@ -494,6 +504,16 @@ public class GenericContainer extends FailureDetectingExternalResource implement
         return this;
     }
 
+    /**
+     * Add an extra host entry to be passed to the container
+     *
+     * @param hostEntry for e.g. "somehost:192.168.47.11"
+     * @return this
+     */
+    public GenericContainer withExtraHost(String hostEntry) {
+    	this.extraHosts.add(hostEntry);
+    	return this;
+    }
 
     /**
      * Map a resource (file or directory) on the classpath to a path inside the container.

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -99,7 +99,7 @@ public class GenericContainerRuleTest {
     @ClassRule
     public static GenericContainer alpineExtrahost = new GenericContainer("alpine:3.2")
             .withExposedPorts(80)
-            .withExtraHost("somehost:192.168.1.10")
+            .withExtraHost("somehost", "192.168.1.10")
             .withCommand("/bin/sh", "-c", "while true; do cat /etc/hosts | nc -l -p 80; done");
 
     @Test
@@ -280,9 +280,9 @@ public class GenericContainerRuleTest {
         StringBuffer hosts = new StringBuffer();
         String line = br.readLine();
         while (line != null) {
-        	hosts.append(line);
-        	hosts.append("\n");
-        	line = br.readLine();
+            hosts.append(line);
+            hosts.append("\n");
+            line = br.readLine();
         }
 
         Matcher matcher = Pattern.compile("^192.168.1.10\\s.*somehost", Pattern.MULTILINE).matcher(hosts.toString());


### PR DESCRIPTION
Hi, we are using testcontainers in our project to run end2end tests with selenium. Our web application runs on a vagrant box and rely on host names for rendering different states.

I have added support for the extra hosts property of the docker API for a GenericContainer.

It would be nice if this change will find it's way into your project.