### PR TITLE
Refs #136: Add a stabilisation period for the launched Virtuoso container

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.rnorth.duct-tape</groupId>
             <artifactId>duct-tape</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/modules/virtuoso/src/main/java/org/testcontainers/containers/VirtuosoContainer.java
+++ b/modules/virtuoso/src/main/java/org/testcontainers/containers/VirtuosoContainer.java
@@ -1,64 +1,106 @@
 package org.testcontainers.containers;
 
-import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.rnorth.ducttape.inconsistents.Inconsistents;
+import org.rnorth.ducttape.ratelimits.RateLimiter;
+import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
 
 public class VirtuosoContainer<SELF extends VirtuosoContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
-	public static final String NAME = "virtuoso";
-	public static final String IMAGE = "tenforce/virtuoso";
-	public static final Integer JDBC_PORT = 1111;
-	public static final Integer SPARQL_SERVICE_PORT = 8890;    
+    public static final String NAME = "virtuoso";
+    public static final String IMAGE = "tenforce/virtuoso";
+    public static final Integer JDBC_PORT = 1111;
+    public static final Integer SPARQL_SERVICE_PORT = 8890;
+    private static final RateLimiter LIVENESS_RATE_LIMITER = RateLimiterBuilder.newBuilder()
+            .withConstantThroughput()
+            .withRate(1, TimeUnit.SECONDS)
+            .build();
 
-	public VirtuosoContainer() {
-		super(IMAGE + ":latest");
-	}
-    
-	public VirtuosoContainer(String dockerImageName) {
-		super(dockerImageName);
-	}
-	
-	@Override
-	protected void configure() {
-		addExposedPort(JDBC_PORT);
-		addExposedPort(SPARQL_SERVICE_PORT);
-		addEnv("DBA_PASSWORD", getPassword());
-		addEnv("SPARQL_UPDATE", "true");
-		addEnv("DEFAULT_GRAPH", "http://localhost:8890/DAV");
-		addExposedPorts(JDBC_PORT, SPARQL_SERVICE_PORT);
-	}
+    public VirtuosoContainer() {
+        super(IMAGE + ":1.0.0-virtuoso7.2.2");
+    }
 
-	@Override
-	protected String getDriverClassName() {
-		return "virtuoso.jdbc4.Driver";
-	}
+    public VirtuosoContainer(String dockerImageName) {
+        super(dockerImageName);
+    }
 
-	@Override
-	public String getJdbcUrl() {
-		return "jdbc:virtuoso://" + getContainerIpAddress() + ":" + getMappedPort(JDBC_PORT);
-	}
-	
-	public String getSparqlUrl() {
-		return "http://" + getContainerIpAddress() + ":" + getMappedPort(SPARQL_SERVICE_PORT) + "/sparql";
-	}
+    @Override
+    protected void configure() {
+        addExposedPort(JDBC_PORT);
+        addExposedPort(SPARQL_SERVICE_PORT);
+        addEnv("DBA_PASSWORD", getPassword());
+        addEnv("SPARQL_UPDATE", "true");
+        addEnv("DEFAULT_GRAPH", "http://localhost:8890/DAV");
+        addExposedPorts(JDBC_PORT, SPARQL_SERVICE_PORT);
+    }
 
-	@Override
-	public String getUsername() {
-		return "dba";
-	}
+    @Override
+    protected String getDriverClassName() {
+        return "virtuoso.jdbc4.Driver";
+    }
 
-	@Override
-	public String getPassword() {
-		return "myDbaPassword";
-	}
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:virtuoso://" + getContainerIpAddress() + ":" + getMappedPort(JDBC_PORT);
+    }
 
-	@Override
-	protected String getTestQueryString() {
-		return "SELECT 1";
-	}
+    public String getSparqlUrl() {
+        return "http://" + getContainerIpAddress() + ":" + getMappedPort(SPARQL_SERVICE_PORT) + "/sparql";
+    }
 
-	@Override
-	protected Integer getLivenessCheckPort() {
-		return getMappedPort(JDBC_PORT);
-	}
+    @Override
+    public String getUsername() {
+        return "dba";
+    }
 
+    @Override
+    public String getPassword() {
+        return "myDbaPassword";
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1";
+    }
+
+    @Override
+    protected Integer getLivenessCheckPort() {
+        return getMappedPort(JDBC_PORT);
+    }
+
+    @Override
+    protected void waitUntilContainerStarted() {
+        // Repeatedly try and open a connection to the DB and execute a test query
+
+        logger().info("Waiting for database connection to become available at {} using query '{}'", getJdbcUrl(), getTestQueryString());
+
+        // Wait for consecutive JDBC connection successes over a period of time. The Virtuoso container seems
+        //  to initially return a connection that fails on subsequent attempts, so wait for a consistently stable connection
+        Inconsistents.retryUntilConsistent(5, 120, TimeUnit.SECONDS, () -> {
+            //noinspection CodeBlock2Expr
+            return LIVENESS_RATE_LIMITER.getWhenReady(() -> {
+                if (!isRunning()) {
+                    throw new ContainerLaunchException("Container failed to start");
+                }
+
+                try {
+                    Connection connection = createConnection("");
+
+                    boolean success = connection.createStatement().execute(this.getTestQueryString());
+
+                    if (success) {
+                        logger().info("Obtained a connection to container ({})", this.getJdbcUrl());
+                        return true;
+                    } else {
+                        throw new SQLException("Failed to execute test query");
+                    }
+                } catch (SQLException e) {
+                    throw new ContainerLaunchException(e.getMessage());
+                }
+            });
+        });
+    }
 }

--- a/modules/virtuoso/src/test/java/org/testcontainers/containers/VirtuosoJDBCDriverTest.java
+++ b/modules/virtuoso/src/test/java/org/testcontainers/containers/VirtuosoJDBCDriverTest.java
@@ -14,8 +14,8 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 public class VirtuosoJDBCDriverTest {
 
     @Test
-    public void testVirtuosoWithNoSpecifiedVersion() throws SQLException {
-        performSimpleTest("jdbc:tc:virtuoso://hostname/databasename");
+    public void testVirtuosoWithSpecifiedVersion() throws SQLException {
+        performSimpleTest("jdbc:tc:virtuoso:1.0.0-virtuoso7.2.2://hostname/databasename");
     }
 
 

--- a/modules/virtuoso/src/test/resources/logback-test.xml
+++ b/modules/virtuoso/src/test/resources/logback-test.xml
@@ -16,5 +16,6 @@
     <logger name="org.testcontainers.shaded.org.apache.http" level="WARN"/>
     <logger name="org.testcontainers.shaded.com.github.dockerjava" level="WARN"/>
     <logger name="org.zeroturnaround.exec" level="WARN"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
     <logger name="com.zaxxer.hikari" level="INFO"/>
 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,6 @@
         <module>modules/postgresql</module>
         <module>modules/selenium</module>
         <module>modules/nginx</module>
-        <module>modules/virtuoso</module>
     </modules>
 
     <profiles>
@@ -161,6 +160,7 @@
             <id>proprietary-deps</id>
             <modules>
                 <module>modules/oracle-xe</module>
+                <module>modules/virtuoso</module>
             </modules>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
         <module>modules/postgresql</module>
         <module>modules/selenium</module>
         <module>modules/nginx</module>
+        <module>modules/virtuoso</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
… as it seems newer versions of the base container are responding OK to the first 'SELECT 1' but then rejecting the subsequent query.

Lock down Virtuoso containers to a fixed tag rather than latest, unless specified.
Reduce verbosity of logs for Virtuoso tests.