### PR TITLE
Work-around for visible-assertions dependency issue.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,13 @@
         </developer>
     </developers>
 
+    <repositories>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -85,9 +92,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.rnorth.visible-assertions</groupId>
+            <groupId>com.github.rnorth</groupId>
             <artifactId>visible-assertions</artifactId>
-            <version>1.0.2</version>
+            <version>040134e667</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/shade-test/pom.xml
+++ b/shade-test/pom.xml
@@ -26,9 +26,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.rnorth.visible-assertions</groupId>
+            <groupId>com.github.rnorth</groupId>
             <artifactId>visible-assertions</artifactId>
-            <version>1.0.4</version>
+            <version>040134e667</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Using https://jitpack.io/#rnorth/visible-assertions/040134e667 to overcome dependency issue with `visible-assertions`:

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.816s
[INFO] Finished at: Thu Apr 28 14:32:30 UTC 2016
[INFO] Final Memory: 12M/143M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal on project testcontainers-parent: Could not resolve dependencies for project org.testcontainers:testcontainers-parent:pom:1.0.5-SNAPSHOT: Failed to collect dependencies at org.rnorth.visible-assertions:visible-assertions:jar:1.0.2 -> org.fusesource.jansi:jansi:jar:[,1.11): No versions available for org.fusesource.jansi:jansi:jar:[,1.11) within specified range -> [Help 1]
```