### PR TITLE
Allows chaining when adding file system binds.

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -414,9 +414,28 @@ public class GenericContainer extends FailureDetectingExternalResource implement
         env.add(key + "=" + value);
     }
 
+    /**
+     * Adds a file system binding.
+     *
+     * @param hostPath the file system path on the host
+     * @param containerPath the file system path inside the container
+     * @param mode the bind mode
+     */
     public void addFileSystemBind(String hostPath, String containerPath, BindMode mode) {
-
         binds.add(new Bind(hostPath, new Volume(containerPath), mode.accessMode));
+    }
+
+    /**
+     * Adds a file system binding.
+     *
+     * @param hostPath the file system path on the host
+     * @param containerPath the file system path inside the container
+     * @param mode the bind mode
+     * @return this
+     */
+    public GenericContainer withFileSystemBind(String hostPath, String containerPath, BindMode mode) {
+        addFileSystemBind(hostPath, containerPath, mode);
+        return this;
     }
 
     public void addLink(LinkableContainer otherContainer, String alias) {


### PR DESCRIPTION
Impl note: rather than change the method name of `addFileSystemBind`, I have added a delegating method following the `with...` convention, used by other chaining methods.