### PR TITLE
Traits

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/traits/ClasspathBind.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/ClasspathBind.java
@@ -1,16 +1,16 @@
 package org.testcontainers.containers.traits;
 
 import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.TestContainer;
 import org.testcontainers.utility.SelfReference;
 
 import java.net.URL;
 import java.util.Optional;
 
-public class ClasspathBind<SELF extends TestContainer<SELF>> extends FileSystemBind<SELF> {
+public class ClasspathBind<SELF extends Container<SELF>> extends FileSystemBind<SELF> {
 
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
 
         /**
          * Map a resource (file or directory) on the classpath to a path inside the container.

--- a/core/src/main/java/org/testcontainers/containers/traits/ClasspathBind.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/ClasspathBind.java
@@ -1,0 +1,39 @@
+package org.testcontainers.containers.traits;
+
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.net.URL;
+import java.util.Optional;
+
+public class ClasspathBind<SELF extends TestContainer<SELF>> extends FileSystemBind<SELF> {
+
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+
+        /**
+         * Map a resource (file or directory) on the classpath to a path inside the container.
+         * This will only work if you are running your tests outside a Docker container.
+         *
+         * @param resourcePath  path to the resource on the classpath (relative to the classpath root; should not start with a leading slash)
+         * @param containerPath path this should be mapped to inside the container
+         * @param mode          access mode for the file
+         * @return this
+         */
+        default SELF withClasspathResourceMapping(String resourcePath, String containerPath, BindMode mode) {
+            return self().with(new ClasspathBind<>(resourcePath, containerPath, mode));
+        }
+    }
+
+    public ClasspathBind(String resourcePath, String containerPath, BindMode mode) {
+        // We have to use Optional.ofNullable here because you can't do anything before super() statement :(
+        super(
+                Optional.ofNullable(GenericContainer.class.getClassLoader().getResource(resourcePath))
+                        .map(URL::getFile)
+                        .orElseThrow(() -> new IllegalArgumentException("Could not find classpath resource at provided path: " + resourcePath)),
+                containerPath,
+                mode
+        );
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/Command.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Command.java
@@ -2,22 +2,23 @@ package org.testcontainers.containers.traits;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import lombok.*;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 @Data
 @AllArgsConstructor
-public class Command<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+public class Command<SELF extends Container<SELF>> implements Trait<SELF> {
 
     /**
      * This trait extension is required for backward compatibility
      *
      * @param <SELF>
      */
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
 
         /**
-         * Set the command that should be run in the container
+         * Set the command that should be run in the container. Consider using {@link #withCommand(String)}
+         * for building a container in a fluent style.
          *
          * @param command a command in single string format (will automatically be split on spaces)
          */
@@ -26,7 +27,8 @@ public class Command<SELF extends TestContainer<SELF>> implements Trait<SELF> {
         }
 
         /**
-         * Set the command that should be run in the container
+         * Set the command that should be run in the container. Consider using {@link #withCommand(String...)}
+         * for building a container in a fluent style.
          *
          * @param commandParts a command as an array of string parts
          */

--- a/core/src/main/java/org/testcontainers/containers/traits/Command.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Command.java
@@ -1,0 +1,79 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import lombok.*;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+@Data
+@AllArgsConstructor
+public class Command<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+
+    /**
+     * This trait extension is required for backward compatibility
+     *
+     * @param <SELF>
+     */
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+
+        /**
+         * Set the command that should be run in the container
+         *
+         * @param command a command in single string format (will automatically be split on spaces)
+         */
+        default void setCommand(@NonNull String command) {
+            setCommand(command.split(" "));
+        }
+
+        /**
+         * Set the command that should be run in the container
+         *
+         * @param commandParts a command as an array of string parts
+         */
+        default void setCommand(@NonNull String... commandParts) {
+            Command command = self().computeTraitIfAbsent(Command.class, traitClass -> new Command<>(null));
+
+            command.setCommandParts(commandParts);
+        }
+
+        /**
+         * Set the command that should be run in the container
+         *
+         * @param cmd a command in single string format (will automatically be split on spaces)
+         * @return this
+         */
+        default SELF withCommand(String cmd) {
+            setCommand(cmd);
+            return self();
+        }
+
+        /**
+         * Set the command that should be run in the container
+         *
+         * @param commandParts a command as an array of string parts
+         * @return this
+         */
+        default SELF withCommand(String... commandParts) {
+            setCommand(commandParts);
+
+            return self();
+        }
+
+        default String[] getCommandParts() {
+            return self().getTrait(Command.class).map(Command::getCommandParts).orElse(null);
+        }
+
+        default void setCommandParts(String[] commandParts) {
+            setCommand(commandParts);
+        }
+    }
+
+    protected String[] commandParts = null;
+
+    @Override
+    public void configure(SELF container, CreateContainerCmd createContainerCmd) {
+        if (commandParts != null) {
+            createContainerCmd.withCmd(commandParts);
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/Env.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Env.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.collect.ObjectArrays;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 import java.util.List;
@@ -13,12 +13,13 @@ import java.util.stream.Stream;
 
 @Data
 @RequiredArgsConstructor
-public class Env<SELF extends TestContainer<SELF>> implements Trait<SELF>  {
+public class Env<SELF extends Container<SELF>> implements Trait<SELF>  {
 
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
 
         /**
-         * Add an environment variable to be passed to the container.
+         * Add an environment variable to be passed to the container. Consider using {@link #withEnv(String, String)}
+         * for building a container in a fluent style.
          *
          * @param key   environment variable key
          * @param value environment variable value

--- a/core/src/main/java/org/testcontainers/containers/traits/Env.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Env.java
@@ -1,0 +1,65 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.google.common.collect.ObjectArrays;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@RequiredArgsConstructor
+public class Env<SELF extends TestContainer<SELF>> implements Trait<SELF>  {
+
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+
+        /**
+         * Add an environment variable to be passed to the container.
+         *
+         * @param key   environment variable key
+         * @param value environment variable value
+         */
+        default void addEnv(String key, String value) {
+            self().with(new Env<>(key + "=" + value));
+        }
+
+        /**
+         * Add an environment variable to be passed to the container.
+         *
+         * @param key   environment variable key
+         * @param value environment variable value
+         * @return this
+         */
+        default SELF withEnv(String key, String value) {
+            addEnv(key, value);
+
+            return self();
+        }
+
+        default List<String> getEnv() {
+            Stream<Env> traits = self().getTraits(Env.class);
+            return traits.map(Env::getValue).collect(Collectors.toList());
+        }
+
+        default void setEnv(List<String> env) {
+            self().replaceTraits(Env.class, env.stream().map(Env::new));
+        }
+    }
+
+    protected final String value;
+
+    @Override
+    public void configure(SELF container, CreateContainerCmd createContainerCmd) {
+        String[] env = createContainerCmd.getEnv();
+
+        if (env == null) {
+            env = new String[] {};
+        }
+
+        createContainerCmd.withEnv(ObjectArrays.concat(env, value));
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/ExposedPort.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/ExposedPort.java
@@ -1,0 +1,68 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.google.common.collect.ObjectArrays;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@RequiredArgsConstructor
+public class ExposedPort<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+        default void addExposedPort(Integer port) {
+            self().with(new ExposedPort<>(port));
+        }
+
+        default void addExposedPorts(Integer... ports) {
+            for (int port : ports) {
+                addExposedPort(port);
+            }
+        }
+
+        /**
+         * Set the ports that this container listens on
+         *
+         * @param ports an array of TCP ports
+         * @return this
+         */
+        default SELF withExposedPorts(Integer... ports) {
+            addExposedPorts(ports);
+
+            return self();
+        }
+
+        default List<Integer> getExposedPorts() {
+            Stream<ExposedPort> traits = self().getTraits(ExposedPort.class);
+            return traits.map(exposedPort -> exposedPort.getExposedPort().getPort()).collect(Collectors.toList());
+        }
+
+        default void setExposedPorts(List<Integer> exposedPorts) {
+            self().replaceTraits(ExposedPort.class, exposedPorts.stream().map(ExposedPort::new));
+        }
+    }
+
+    protected final com.github.dockerjava.api.model.ExposedPort exposedPort;
+
+    public ExposedPort(int port) {
+        this(new com.github.dockerjava.api.model.ExposedPort(port));
+    }
+
+    @Override
+    public void configure(SELF container, CreateContainerCmd createContainerCmd) {
+        com.github.dockerjava.api.model.ExposedPort[] currentExposedPorts = createContainerCmd.getExposedPorts();
+
+        if (currentExposedPorts == null) {
+            currentExposedPorts = new com.github.dockerjava.api.model.ExposedPort[] {};
+        }
+
+        // Set up exposed ports (where there are no host port bindings defined)
+        createContainerCmd.withExposedPorts(ObjectArrays.concat(currentExposedPorts, exposedPort));
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/ExposedPort.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/ExposedPort.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.collect.ObjectArrays;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 import java.util.List;
@@ -13,13 +13,26 @@ import java.util.stream.Stream;
 
 @Data
 @RequiredArgsConstructor
-public class ExposedPort<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+public class ExposedPort<SELF extends Container<SELF>> implements Trait<SELF> {
 
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
+
+        /**
+         * Add an exposed port. Consider using {@link #withExposedPorts(Integer...)}
+         * for building a container in a fluent style.
+         *
+         * @param port a TCP port
+         */
         default void addExposedPort(Integer port) {
             self().with(new ExposedPort<>(port));
         }
 
+        /**
+         * Add exposed ports. Consider using {@link #withExposedPorts(Integer...)}
+         * for building a container in a fluent style.
+         *
+         * @param ports an array of TCP ports
+         */
         default void addExposedPorts(Integer... ports) {
             for (int port : ports) {
                 addExposedPort(port);

--- a/core/src/main/java/org/testcontainers/containers/traits/ExtraHost.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/ExtraHost.java
@@ -1,0 +1,56 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.google.common.collect.ObjectArrays;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@RequiredArgsConstructor
+public class ExtraHost<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+
+        /**
+         * Add an extra host entry to be passed to the container
+         * @param hostname
+         * @param ipAddress
+         * @return this
+         */
+        default SELF withExtraHost(String hostname, String ipAddress) {
+            return self().with(new ExtraHost<>(hostname, ipAddress));
+        }
+
+        default List<String> getExtraHosts() {
+            Stream<ExtraHost> traits = self().getTraits(ExtraHost.class);
+            return traits.map(ExtraHost::getValue).collect(Collectors.toList());
+        }
+
+        default void setExtraHosts(List<String> extraHosts) {
+            self().replaceTraits(ExtraHost.class, extraHosts.stream().map(ExtraHost::new));
+        }
+    }
+
+    protected final String value;
+
+    public ExtraHost(String hostname, String ipAddress) {
+        this(String.format("%s:%s", hostname, ipAddress));
+    }
+
+    @Override
+    public void configure(SELF container, CreateContainerCmd createContainerCmd) {
+        String[] extraHosts = createContainerCmd.getExtraHosts();
+
+        if (extraHosts == null) {
+            extraHosts = new String[] {};
+        }
+
+        createContainerCmd.withExtraHosts(ObjectArrays.concat(extraHosts, value));
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/ExtraHost.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/ExtraHost.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.collect.ObjectArrays;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 import java.util.List;
@@ -13,9 +13,9 @@ import java.util.stream.Stream;
 
 @Data
 @RequiredArgsConstructor
-public class ExtraHost<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+public class ExtraHost<SELF extends Container<SELF>> implements Trait<SELF> {
 
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
 
         /**
          * Add an extra host entry to be passed to the container

--- a/core/src/main/java/org/testcontainers/containers/traits/FileSystemBind.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/FileSystemBind.java
@@ -1,0 +1,69 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Volume;
+import com.google.common.collect.ObjectArrays;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@RequiredArgsConstructor
+public class FileSystemBind<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+
+        /**
+         * Adds a file system binding.
+         *
+         * @param hostPath      the file system path on the host
+         * @param containerPath the file system path inside the container
+         * @param mode          the bind mode
+         */
+        default void addFileSystemBind(String hostPath, String containerPath, BindMode mode) {
+            self().with(new FileSystemBind<>(hostPath, containerPath, mode));
+        }
+
+        /**
+         * Adds a file system binding.
+         *
+         * @param hostPath      the file system path on the host
+         * @param containerPath the file system path inside the container
+         * @param mode          the bind mode
+         * @return this
+         */
+        default SELF withFileSystemBind(String hostPath, String containerPath, BindMode mode) {
+            addFileSystemBind(hostPath, containerPath, mode);
+
+            return self();
+        }
+
+        default List<Bind> getBinds() {
+            Stream<FileSystemBind> traits = self().getTraits(FileSystemBind.class);
+            return traits.map(FileSystemBind::getBind).collect(Collectors.toList());
+        }
+
+        default void setBinds(List<Bind> binds) {
+            self().replaceTraits(FileSystemBind.class, binds.stream().map(FileSystemBind::new));
+        }
+    }
+
+    protected final Bind bind;
+
+    public FileSystemBind(String hostPath, String containerPath, BindMode mode) {
+        this(new Bind(hostPath, new Volume(containerPath), mode.accessMode));
+    }
+
+    @Override
+    public void configure(SELF container, CreateContainerCmd createContainerCmd) {
+        Bind[] currentBinds = createContainerCmd.getBinds();
+        createContainerCmd.withBinds(ObjectArrays.concat(currentBinds, bind));
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/FileSystemBind.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/FileSystemBind.java
@@ -7,7 +7,7 @@ import com.google.common.collect.ObjectArrays;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 import java.util.List;
@@ -16,16 +16,17 @@ import java.util.stream.Stream;
 
 @Data
 @RequiredArgsConstructor
-public class FileSystemBind<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+public class FileSystemBind<SELF extends Container<SELF>> implements Trait<SELF> {
 
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
 
         /**
-         * Adds a file system binding.
+         * Adds a file system binding. Consider using {@link #withFileSystemBind(String, String, BindMode)}
+         * for building a container in a fluent style.
          *
-         * @param hostPath      the file system path on the host
+         * @param hostPath the file system path on the host
          * @param containerPath the file system path inside the container
-         * @param mode          the bind mode
+         * @param mode the bind mode
          */
         default void addFileSystemBind(String hostPath, String containerPath, BindMode mode) {
             self().with(new FileSystemBind<>(hostPath, containerPath, mode));
@@ -34,9 +35,9 @@ public class FileSystemBind<SELF extends TestContainer<SELF>> implements Trait<S
         /**
          * Adds a file system binding.
          *
-         * @param hostPath      the file system path on the host
+         * @param hostPath the file system path on the host
          * @param containerPath the file system path inside the container
-         * @param mode          the bind mode
+         * @param mode the bind mode
          * @return this
          */
         default SELF withFileSystemBind(String hostPath, String containerPath, BindMode mode) {

--- a/core/src/main/java/org/testcontainers/containers/traits/Link.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Link.java
@@ -1,0 +1,50 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.google.common.collect.ObjectArrays;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@RequiredArgsConstructor
+public class Link<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+
+        default void addLink(LinkableContainer otherContainer, String alias) {
+            self().getTraits().removeIf(trait -> trait instanceof Link && alias.equals(((Link) trait).getAlias()));
+
+            self().with(new Link<>(otherContainer, alias));
+        }
+
+        default Map<String, LinkableContainer> getLinkedContainers() {
+            Stream<Link> traits = self().getTraits(Link.class);
+            return traits.collect(Collectors.toMap(Link::getAlias, Link::getOtherContainer));
+        }
+
+        default void setLinkedContainers(Map<String, LinkableContainer> value) {
+            self().replaceTraits(Link.class, value.entrySet().stream().map(entry -> new Link(entry.getValue(), entry.getKey())));
+        }
+    }
+
+    protected final LinkableContainer otherContainer;
+
+    protected final String alias;
+
+    @Override
+    public void configure(SELF container, CreateContainerCmd createContainerCmd) {
+        com.github.dockerjava.api.model.Link[] links = createContainerCmd.getLinks();
+
+        if (links == null) {
+            links = new com.github.dockerjava.api.model.Link[] {};
+        }
+
+        createContainerCmd.withLinks(ObjectArrays.concat(links, new com.github.dockerjava.api.model.Link(otherContainer.getContainerName(), alias)));
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/Link.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Link.java
@@ -4,7 +4,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.google.common.collect.ObjectArrays;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 import java.util.Map;
@@ -13,10 +13,16 @@ import java.util.stream.Stream;
 
 @Data
 @RequiredArgsConstructor
-public class Link<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+public class Link<SELF extends Container<SELF>> implements Trait<SELF> {
 
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
 
+        /**
+         * Add a link to another container.
+         *
+         * @param otherContainer
+         * @param alias
+         */
         default void addLink(LinkableContainer otherContainer, String alias) {
             self().getTraits().removeIf(trait -> trait instanceof Link && alias.equals(((Link) trait).getAlias()));
 

--- a/core/src/main/java/org/testcontainers/containers/traits/PortBinding.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/PortBinding.java
@@ -3,7 +3,7 @@ package org.testcontainers.containers.traits;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 import java.util.List;
@@ -12,9 +12,9 @@ import java.util.stream.Stream;
 
 @Data
 @RequiredArgsConstructor
-public class PortBinding<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+public class PortBinding<SELF extends Container<SELF>> implements Trait<SELF> {
 
-    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+    public interface Support<SELF extends Container<SELF>> extends SelfReference<SELF> {
         default List<String> getPortBindings() {
             Stream<PortBinding> traits = self().getTraits(PortBinding.class);
             return traits.map(PortBinding::getBinding).collect(Collectors.toList());

--- a/core/src/main/java/org/testcontainers/containers/traits/PortBinding.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/PortBinding.java
@@ -1,0 +1,44 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Data
+@RequiredArgsConstructor
+public class PortBinding<SELF extends TestContainer<SELF>> implements Trait<SELF> {
+
+    public interface Support<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+        default List<String> getPortBindings() {
+            Stream<PortBinding> traits = self().getTraits(PortBinding.class);
+            return traits.map(PortBinding::getBinding).collect(Collectors.toList());
+        }
+
+        default void setPortBindings(List<String> newValues) {
+            self().replaceTraits(PortBinding.class, newValues.stream().map(PortBinding::new));
+        }
+    }
+
+    protected final String binding;
+
+    public PortBinding(int hostPort, int containerPort) {
+        this(String.format("%d:%d", hostPort, containerPort));
+    }
+
+
+    @Override
+    public void configure(SELF container, CreateContainerCmd createContainerCmd) {
+        Stream<PortBinding> traits = container.getTraits(PortBinding.class);
+        createContainerCmd.withPortBindings(
+                traits.map(PortBinding::getBinding)
+                        .map(com.github.dockerjava.api.model.PortBinding::parse)
+                        .toArray(com.github.dockerjava.api.model.PortBinding[]::new)
+        );
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/Trait.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Trait.java
@@ -1,9 +1,9 @@
 package org.testcontainers.containers.traits;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 
-public interface Trait<T extends TestContainer<T>> {
+public interface Trait<T extends Container<T>> {
 
     void configure(T container, CreateContainerCmd createContainerCmd);
 

--- a/core/src/main/java/org/testcontainers/containers/traits/Trait.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/Trait.java
@@ -1,0 +1,10 @@
+package org.testcontainers.containers.traits;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import org.testcontainers.containers.TestContainer;
+
+public interface Trait<T extends TestContainer<T>> {
+
+    void configure(T container, CreateContainerCmd createContainerCmd);
+
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/TraitsSupport.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/TraitsSupport.java
@@ -1,7 +1,7 @@
 package org.testcontainers.containers.traits;
 
 import lombok.NonNull;
-import org.testcontainers.containers.TestContainer;
+import org.testcontainers.containers.Container;
 import org.testcontainers.utility.SelfReference;
 
 import java.util.*;
@@ -9,7 +9,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public interface TraitsSupport<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+public interface TraitsSupport<SELF extends Container<SELF>> extends SelfReference<SELF> {
 
     Comparator<Trait> TRAIT_COMPARATOR = (obj1, obj2) -> {
         if (obj1 instanceof Comparable && obj2 instanceof Comparable) {

--- a/core/src/main/java/org/testcontainers/containers/traits/TraitsSupport.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/TraitsSupport.java
@@ -1,0 +1,71 @@
+package org.testcontainers.containers.traits;
+
+import lombok.NonNull;
+import org.testcontainers.containers.TestContainer;
+import org.testcontainers.utility.SelfReference;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public interface TraitsSupport<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
+
+    Comparator<Trait> TRAIT_COMPARATOR = (obj1, obj2) -> {
+        if (obj1 instanceof Comparable && obj2 instanceof Comparable)
+        {
+            Comparable cmp1 = (Comparable)obj1;
+            return cmp1.compareTo(obj2);
+        }
+
+        if (!(obj1 instanceof Comparable) && !(obj2 instanceof Comparable))
+        {
+            return 0;
+        }
+
+        if (!(obj1 instanceof Comparable))
+        {
+            return -1;
+        }
+
+        return 1;
+    };
+
+    List<Trait<SELF>> getTraits();
+
+    default <T extends Trait<SELF>> Stream<T> getTraits(Class<T> traitClass) {
+        return getTraits().stream().filter(traitClass::isInstance).map(traitClass::cast);
+    }
+
+    default <T extends Trait<SELF>> void replaceTraits(Class<T> traitClass, Stream<T> newValues) {
+        List<Trait<SELF>> traits = self().getTraits();
+
+        // Remove all other instances
+        traits.removeIf(traitClass::isInstance);
+
+        newValues.collect(Collectors.toCollection(() -> traits));
+    }
+
+    default <T extends Trait<SELF>> T computeTraitIfAbsent(Class<T> traitClass, Function<Class<T>, T> mappingFunction) {
+        return getTrait(traitClass).orElseGet(() -> {
+            T trait = mappingFunction.apply(traitClass);
+
+            with(trait);
+
+            return trait;
+        });
+    }
+
+    default <T extends Trait> Optional<T> getTrait(Class<T> traitClass) {
+        return getTraits().stream()
+                .filter(trait -> traitClass.isAssignableFrom(trait.getClass()))
+                .map(traitClass::cast)
+                .findAny();
+    }
+
+    default SELF with(@NonNull Trait<SELF> trait) {
+        getTraits().add(trait);
+
+        return self();
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/traits/TraitsSupport.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/TraitsSupport.java
@@ -12,19 +12,16 @@ import java.util.stream.Stream;
 public interface TraitsSupport<SELF extends TestContainer<SELF>> extends SelfReference<SELF> {
 
     Comparator<Trait> TRAIT_COMPARATOR = (obj1, obj2) -> {
-        if (obj1 instanceof Comparable && obj2 instanceof Comparable)
-        {
+        if (obj1 instanceof Comparable && obj2 instanceof Comparable) {
             Comparable cmp1 = (Comparable)obj1;
             return cmp1.compareTo(obj2);
         }
 
-        if (!(obj1 instanceof Comparable) && !(obj2 instanceof Comparable))
-        {
+        if (!(obj1 instanceof Comparable) && !(obj2 instanceof Comparable)) {
             return 0;
         }
 
-        if (!(obj1 instanceof Comparable))
-        {
+        if (!(obj1 instanceof Comparable)) {
             return -1;
         }
 

--- a/core/src/main/java/org/testcontainers/utility/SelfReference.java
+++ b/core/src/main/java/org/testcontainers/utility/SelfReference.java
@@ -2,6 +2,10 @@ package org.testcontainers.utility;
 
 public interface SelfReference<SELF extends SelfReference<SELF>> {
 
+    /**
+     * @return a reference to this container instance, cast to the expected generic type.
+     */
+    @SuppressWarnings("unchecked")
     default SELF self() {
         return (SELF) this;
     }

--- a/core/src/main/java/org/testcontainers/utility/SelfReference.java
+++ b/core/src/main/java/org/testcontainers/utility/SelfReference.java
@@ -1,0 +1,8 @@
+package org.testcontainers.utility;
+
+public interface SelfReference<SELF extends SelfReference<SELF>> {
+
+    default SELF self() {
+        return (SELF) this;
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/CustomTraitTest.java
+++ b/core/src/test/java/org/testcontainers/junit/CustomTraitTest.java
@@ -1,0 +1,43 @@
+package org.testcontainers.junit;
+
+import com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.commons.io.IOUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.traits.ExposedPort;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+
+public class CustomTraitTest {
+
+    @Rule
+    public GenericContainer container = new GenericContainer<>()
+            .with((container1, createContainerCmd) -> createContainerCmd.withHostName("some.domain.com"))
+            .with(new ExposedPort<>(80))
+            .withCommand("/bin/sh", "-c", "while true; do echo \"`hostname`\" | nc -l -p 80; done");
+
+    @Test
+    public void customTraitTest() throws IOException {
+        BufferedReader br = Unreliables.retryUntilSuccess(10, TimeUnit.SECONDS, () -> {
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+
+            Socket socket = new Socket(container.getContainerIpAddress(), container.getMappedPort(80));
+            return new BufferedReader(new InputStreamReader(socket.getInputStream()));
+        });
+
+        try  {
+            assertEquals("A container built with custom trait returns configured hostname",
+                    br.readLine(), "some.domain.com");
+        } finally {
+            IOUtils.closeQuietly(br);
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
@@ -20,7 +20,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 public class DockerfileContainerTest {
 
     @Rule
-    public GenericContainer dslContainer = new GenericContainer(
+    public GenericContainer dslContainer = new GenericContainer<>(
             new ImageFromDockerfile("tcdockerfile/nginx", false).withDockerfileFromBuilder(builder -> {
                     builder
                             .from("alpine:3.2")

--- a/core/src/test/java/org/testcontainers/junit/FixedHostPortContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/FixedHostPortContainerTest.java
@@ -23,7 +23,7 @@ public class FixedHostPortContainerTest {
     @Test
     public void testFixedHostPortMapping() throws IOException {
         // first find a free port on the docker host that will work for testing
-        GenericContainer portDiscoveryRedis = new GenericContainer("redis:3.0.2").withExposedPorts(REDIS_PORT);
+        GenericContainer portDiscoveryRedis = new GenericContainer<>("redis:3.0.2").withExposedPorts(REDIS_PORT);
         portDiscoveryRedis.start();
         Integer freePort = portDiscoveryRedis.getMappedPort(REDIS_PORT);
         portDiscoveryRedis.stop();

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -57,21 +57,21 @@ public class GenericContainerRuleTest {
      * Redis
      */
     @ClassRule
-    public static GenericContainer redis = new GenericContainer("redis:3.0.2")
+    public static GenericContainer redis = new GenericContainer<>("redis:3.0.2")
             .withExposedPorts(REDIS_PORT);
 
     /**
      * RabbitMQ
      */
     @ClassRule
-    public static GenericContainer rabbitMq = new GenericContainer("rabbitmq:3.5.3")
+    public static GenericContainer rabbitMq = new GenericContainer<>("rabbitmq:3.5.3")
             .withExposedPorts(RABBITMQ_PORT);
 
     /**
      * MongoDB
      */
     @ClassRule
-    public static GenericContainer mongo = new GenericContainer("mongo:3.1.5")
+    public static GenericContainer mongo = new GenericContainer<>("mongo:3.1.5")
             .withExposedPorts(MONGO_PORT);
 
     /**
@@ -79,7 +79,7 @@ public class GenericContainerRuleTest {
      * dirty way for testing.
      */
     @ClassRule
-    public static GenericContainer alpineEnvVar = new GenericContainer("alpine:3.2")
+    public static GenericContainer alpineEnvVar = new GenericContainer<>("alpine:3.2")
             .withExposedPorts(80)
             .withEnv("MAGIC_NUMBER", "42")
             .withCommand("/bin/sh", "-c", "while true; do echo \"$MAGIC_NUMBER\" | nc -l -p 80; done");
@@ -88,7 +88,7 @@ public class GenericContainerRuleTest {
      * Map a file on the classpath to a file in the container, and then expose the content for testing.
      */
     @ClassRule
-    public static GenericContainer alpineClasspathResource = new GenericContainer("alpine:3.2")
+    public static GenericContainer alpineClasspathResource = new GenericContainer<>("alpine:3.2")
             .withExposedPorts(80)
             .withClasspathResourceMapping("mappable-resource/test-resource.txt", "/content.txt", READ_ONLY)
             .withCommand("/bin/sh", "-c", "while true; do cat /content.txt | nc -l -p 80; done");
@@ -97,7 +97,7 @@ public class GenericContainerRuleTest {
      * Create a container with an extra host entry and expose the content of /etc/hosts for testing.
      */
     @ClassRule
-    public static GenericContainer alpineExtrahost = new GenericContainer("alpine:3.2")
+    public static GenericContainer alpineExtrahost = new GenericContainer<>("alpine:3.2")
             .withExposedPorts(80)
             .withExtraHost("somehost", "192.168.1.10")
             .withCommand("/bin/sh", "-c", "while true; do cat /etc/hosts | nc -l -p 80; done");
@@ -224,7 +224,7 @@ public class GenericContainerRuleTest {
     public void failFastWhenContainerHaltsImmediately() throws Exception {
 
         long startingTimeMs = System.currentTimeMillis();
-        final GenericContainer failsImmediately = new GenericContainer("alpine:3.2")
+        final GenericContainer failsImmediately = new GenericContainer<>("alpine:3.2")
               .withCommand("/bin/sh", "-c", "return false")
               .withMinimumRunningDuration(Duration.ofMillis(100));
 

--- a/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
+++ b/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
@@ -23,7 +23,7 @@ import static org.testcontainers.containers.output.OutputFrame.OutputType.STDOUT
 public class OutputStreamTest {
 
     @Rule
-    public GenericContainer container = new GenericContainer("alpine:3.2")
+    public GenericContainer container = new GenericContainer<>("alpine:3.2")
             .withCommand("ping -c 5 www.google.com");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OutputStreamTest.class);

--- a/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
@@ -29,7 +29,7 @@ public class ParameterizedDockerfileContainerTest {
     }
 
     public ParameterizedDockerfileContainerTest(String baseImage) {
-        container = new GenericContainer(new ImageFromDockerfile().withDockerfileFromBuilder(builder -> {
+        container = new GenericContainer<>(new ImageFromDockerfile().withDockerfileFromBuilder(builder -> {
                 builder
                         .from(baseImage)
                         .run("apk add --update nginx")

--- a/core/src/test/java/org/testcontainers/junit/wait/AbstractWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/AbstractWaitStrategyTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractWaitStrategyTest<W extends WaitStrategy> {
                 .withStartupTimeout(Duration.ofMillis(WAIT_TIMEOUT_MILLIS));
 
         // apply WaitStrategy to container
-        return new GenericContainer(IMAGE_NAME)
+        return new GenericContainer<>(IMAGE_NAME)
                 .withExposedPorts(8080)
                 .withCommand("sh", "-c", shellCommand)
                 .waitingFor(waitStrategy);

--- a/shade-test/clashing-deps-jackson/src/test/java/RedisJacksonBackedCacheTest.java
+++ b/shade-test/clashing-deps-jackson/src/test/java/RedisJacksonBackedCacheTest.java
@@ -16,7 +16,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.*;
 public class RedisJacksonBackedCacheTest {
 
     @Rule
-    public GenericContainer redis = new GenericContainer("redis:3.0.6")
+    public GenericContainer redis = new GenericContainer<>("redis:3.0.6")
                                             .withExposedPorts(6379);
     private Cache cache;
 

--- a/shade-test/clashing-deps-jersey/src/test/java/OldJerseyClientTest.java
+++ b/shade-test/clashing-deps-jersey/src/test/java/OldJerseyClientTest.java
@@ -11,7 +11,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 public class OldJerseyClientTest {
 
     @Rule
-    public GenericContainer httpd = new GenericContainer("httpd:2.4").withExposedPorts(80);
+    public GenericContainer httpd = new GenericContainer<>("httpd:2.4").withExposedPorts(80);
 
     @Test
     public void clientRequestTest() {


### PR DESCRIPTION
Depends on https://github.com/testcontainers/testcontainers-java/pull/144 , but could be merged instead since it's included.

This pretty huge change makes it possible to use **composition over inheritance** in TestContainers. All "withXXXX" code was extracted from GenericContainer to the separate traits. 

Unfortunately, because of Java limitations, **it breaks user's code a little bit** - they have to use `new GenericContainer<>(...)` now (note diamond generic notation). 

Motivation:
In our test system, we use "traits" to reuse some code to configure GenericContainer (currently, we have some base container which extends GenericContainer and adds support for a trait, but we want it in core).
For instance, we have a "recipe" to add the Java Agent, and we use it like:

``` java
new GenericContainer<>()
    .with(new XHubAgentTrait(some, opts, here))
    .with(new FakeTimeTrait(Duration.ofDays(-7)))
    .withExposedPorts(8080)
```

Thanks to traits, we don't have to use inheritance to extend our containers - we just apply multiple traits to it.

@rnorth WDYT?
