### PR TITLE
Allow environment variables to be added from a map

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -146,6 +146,14 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     SELF withEnv(String key, String value);
 
     /**
+     * Add environment variables to be passed to the container.
+     *
+     * @param env map of environment variables
+     * @return this
+     */
+    SELF withEnv(Map<String, String> env);
+
+    /**
      * Set the command that should be run in the container
      *
      * @param cmd a command in single string format (will automatically be split on spaces)

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -490,6 +490,15 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * {@inheritDoc}
      */
     @Override
+    public SELF withEnv(Map<String, String> env) {
+        env.forEach(this::addEnv);
+        return self();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public SELF withCommand(String cmd) {
         this.setCommand(cmd);
         return self();


### PR DESCRIPTION
Adds `withEnv(Map<String, String>)` to the `Container` interface, so that a bunch of environment variables from another source can be added at once.