### PR TITLE
use container.getContainerIpAddress() in children of GenericContainer.AbstractWaitStrategy

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
@@ -23,7 +23,7 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
             return;
         }
 
-        final String ipAddress = DockerClientFactory.instance().dockerHostIpAddress();
+        final String ipAddress = container.getContainerIpAddress();
         try {
             Unreliables.retryUntilSuccess((int) startupTimeout.getSeconds(), TimeUnit.SECONDS, () -> {
                 getRateLimiter().doWhenReady(() -> {

--- a/core/src/main/java/org/testcontainers/containers/wait/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HttpWaitStrategy.java
@@ -135,7 +135,7 @@ public class HttpWaitStrategy extends GenericContainer.AbstractWaitStrategy {
      */
     private URI buildLivenessUri(int livenessCheckPort) {
         final String scheme = (tlsEnabled ? "https" : "http") + "://";
-        final String host = DockerClientFactory.instance().dockerHostIpAddress();
+        final String host = container.getContainerIpAddress();
 
         final String portSuffix;
         if ((tlsEnabled && 443 == livenessCheckPort) || (!tlsEnabled && 80 == livenessCheckPort)) {


### PR DESCRIPTION
This allows the wait strategies to work with container types that inherit from GenericContainer and override getContainerIpAddress.

This helps pave the way for some code to address https://github.com/testcontainers/testcontainers-java/issues/134