### PR TITLE
Improve docker-compose handling of startup...

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -16,7 +16,7 @@ import org.slf4j.profiler.Profiler;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.containers.startupcheck.IndefiniteWaitOneShotStartupCheckStrategy;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.ResourceReaper;
 
@@ -281,7 +281,7 @@ class DockerCompose extends GenericContainer<DockerCompose> {
         //  we map the socket file outside of /var/run, as just /docker.sock
         addFileSystemBind("/var/run/docker.sock", "/docker.sock", READ_WRITE);
         addEnv("DOCKER_HOST", "unix:///docker.sock");
-        setStartupCheckStrategy(new OneShotStartupCheckStrategy());
+        setStartupCheckStrategy(new IndefiniteWaitOneShotStartupCheckStrategy());
     }
 
     @Override

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -204,6 +204,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 resultCallback.addConsumer(STDERR, new Slf4jLogConsumer(logger()));
                 dockerClient.logContainerCmd(containerId).withStdOut(true).withStdErr(true).exec(resultCallback);
 
+                // Ensure that container log output is shown before proceeding
+                resultCallback.getCompletionLatch().await();
+
                 // Bail out, don't wait for the port to start listening.
                 // (Exception thrown here will be caught below and wrapped)
                 throw new IllegalStateException("Container did not start correctly.");

--- a/core/src/main/java/org/testcontainers/containers/output/FrameConsumerResultCallback.java
+++ b/core/src/main/java/org/testcontainers/containers/output/FrameConsumerResultCallback.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Consumer;
 
 /**
@@ -20,6 +21,8 @@ public class FrameConsumerResultCallback extends ResultCallbackTemplate<FrameCon
     private final static Logger LOGGER = LoggerFactory.getLogger(FrameConsumerResultCallback.class);
 
     private Map<OutputFrame.OutputType, Consumer<OutputFrame>> consumers;
+
+    private CountDownLatch completionLatch = new CountDownLatch(1);
 
     public FrameConsumerResultCallback() {
         consumers = new HashMap<>();
@@ -57,5 +60,14 @@ public class FrameConsumerResultCallback extends ResultCallbackTemplate<FrameCon
             consumer.accept(OutputFrame.END);
         }
         super.close();
+
+        completionLatch.countDown();
+    }
+
+    /**
+     * @return a {@link CountDownLatch} that may be used to wait until {@link #close()} has been called.
+     */
+    public CountDownLatch getCompletionLatch() {
+        return completionLatch;
     }
 }

--- a/core/src/main/java/org/testcontainers/containers/startupcheck/IndefiniteWaitOneShotStartupCheckStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/startupcheck/IndefiniteWaitOneShotStartupCheckStrategy.java
@@ -1,0 +1,23 @@
+package org.testcontainers.containers.startupcheck;
+
+import com.github.dockerjava.api.DockerClient;
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Variant of {@link OneShotStartupCheckStrategy} that does not impose a timeout.
+ * Intended for situation such as when a long running task forms part of container startup.
+ * <p>
+ * It has to be assumed that the container will stop of its own accord, either with a success or failure exit code.
+ */
+public class IndefiniteWaitOneShotStartupCheckStrategy extends OneShotStartupCheckStrategy {
+    @Override
+    public boolean waitUntilStartupSuccessful(DockerClient dockerClient, String containerId) {
+        while (checkStartupState(dockerClient, containerId) == StartupStatus.NOT_YET_KNOWN) {
+            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
+        }
+
+        return checkStartupState(dockerClient, containerId) == StartupStatus.SUCCESSFUL;
+    }
+}


### PR DESCRIPTION
... especially when a large image pull is involved.

Set startup checks for docker-compose to wait indefinitely (until compose terminates).
Improve logging on container startup failure by ensuring that all logs have been fetched before the test terminates.

Helps with #172