### PR TITLE
Properly shade Netty including its native adapters. Include Guava when shading dependencies.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,8 +149,16 @@
                             <shadedPattern>org.testcontainers.shaded.jersey.repackaged</shadedPattern>
                         </relocation>
                         <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                        <relocation>
                             <pattern>io.netty</pattern>
                             <shadedPattern>org.testcontainers.shaded.io.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.bouncycastle</pattern>
+                            <shadedPattern>org.testcontainers.shaded.org.bouncycastle</shadedPattern>
                         </relocation>
                     </relocations>
                     <artifactSet>
@@ -162,7 +170,9 @@
                             <include>javax.ws.rs:*</include>
                             <include>com.fasterxml.*:*</include>
                             <include>com.github.docker-java:*</include>
+                            <include>com.google.guava:*</include>
                             <include>io.netty:*</include>
+                            <include>org.bouncycastle:*</include>
                         </includes>
                     </artifactSet>
                     <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
@@ -183,6 +193,29 @@
                         </filter>
                     </filters>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <echo message="unjar" />
+                                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar" dest="${project.build.directory}/exploded/" />
+                                <move file="${project.build.directory}/exploded/META-INF/native/libnetty-transport-native-epoll.so"
+                                      tofile="${project.build.directory}/exploded/META-INF/native/liborg-testcontainers-shaded-netty-transport-native-epoll.so" />
+                                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar" basedir="${project.build.directory}/exploded" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -65,6 +65,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     public static final int CONTAINER_RUNNING_TIMEOUT_SEC = 30;
 
+    static {
+        System.setProperty("org.testcontainers.shaded.io.netty.packagePrefix", "org.testcontainers.shaded.");
+    }
+
     /*
      * Default settings
      */

--- a/modules/jdbc/pom.xml
+++ b/modules/jdbc/pom.xml
@@ -18,5 +18,43 @@
             <artifactId>testcontainers</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>com.google.guava:*</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -19,6 +19,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- WebDriver dependency as 'provided' scope -->
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -34,4 +41,36 @@
             <version>6.1.25</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>com.google.guava:*</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Fixes https://github.com/testcontainers/testcontainers-java/issues/178 and https://github.com/testcontainers/testcontainers-java/issues/178.

The system property must be set at the libraries natural entry point which I identified to be `GenericContainer`. If any of the shaded Netty dependencies is loaded before setting the system property, loading the native dependencies will fail.