### PR TITLE
Correct shading for netty native linux lib; add guava shading and fix bouncycastle certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2016-07-19
+### Fixed
+- Fix shading of netty Linux native libs
+
+### Changed
+- Shade guava artifacts to prevent classloader conflicts
+
 ## [1.1.1] - 2016-07-17
 ### Fixed
 - Improve shutdown of unnecessary docker clients (#170)
@@ -153,6 +160,7 @@ All notable changes to this project will be documented in this file.
 ## [0.9] - 2015-04-29
 Initial release
 
+[1.1.2]: https://github.com/testcontainers/testcontainers-java/releases/tag/testcontainers-1.1.2
 [1.1.1]: https://github.com/testcontainers/testcontainers-java/releases/tag/testcontainers-1.1.1
 [1.1.0]: https://github.com/testcontainers/testcontainers-java/releases/tag/testcontainers-1.1.0
 [1.0.5]: https://github.com/testcontainers/testcontainers-java/releases/tag/testcontainers-1.0.5

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,8 +149,16 @@
                             <shadedPattern>org.testcontainers.shaded.jersey.repackaged</shadedPattern>
                         </relocation>
                         <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                        <relocation>
                             <pattern>io.netty</pattern>
                             <shadedPattern>org.testcontainers.shaded.io.netty</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.bouncycastle</pattern>
+                            <shadedPattern>org.testcontainers.shaded.org.bouncycastle</shadedPattern>
                         </relocation>
                     </relocations>
                     <artifactSet>
@@ -162,7 +170,9 @@
                             <include>javax.ws.rs:*</include>
                             <include>com.fasterxml.*:*</include>
                             <include>com.github.docker-java:*</include>
+                            <include>com.google.guava:*</include>
                             <include>io.netty:*</include>
+                            <include>org.bouncycastle:*</include>
                         </includes>
                     </artifactSet>
                     <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
@@ -183,6 +193,29 @@
                         </filter>
                     </filters>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.7</version>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>package</phase>
+                        <configuration>
+                            <target>
+                                <echo message="unjar" />
+                                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar" dest="${project.build.directory}/exploded/" />
+                                <move file="${project.build.directory}/exploded/META-INF/native/libnetty-transport-native-epoll.so"
+                                      tofile="${project.build.directory}/exploded/META-INF/native/liborg-testcontainers-shaded-netty-transport-native-epoll.so" />
+                                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar" basedir="${project.build.directory}/exploded" />
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -65,6 +65,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     public static final int CONTAINER_RUNNING_TIMEOUT_SEC = 30;
 
+    static {
+        System.setProperty("org.testcontainers.shaded.io.netty.packagePrefix", "org.testcontainers.shaded.");
+    }
+
     /*
      * Default settings
      */

--- a/modules/jdbc/pom.xml
+++ b/modules/jdbc/pom.xml
@@ -18,5 +18,43 @@
             <artifactId>testcontainers</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>com.google.guava:*</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/jdbc/pom.xml
+++ b/modules/jdbc/pom.xml
@@ -46,6 +46,16 @@
                             <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
                         </relocation>
                     </relocations>
+                    <filters>
+                        <filter>
+                            <artifact>org.bouncycastle:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <artifactSet>
                         <excludes>
                             <exclude>com.google.guava:*</exclude>

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -19,6 +19,13 @@
             <version>${project.version}</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- WebDriver dependency as 'provided' scope -->
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
@@ -34,4 +41,36 @@
             <version>6.1.25</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>2.4.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <relocations>
+                        <relocation>
+                            <pattern>com.google.common</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <artifactSet>
+                        <excludes>
+                            <exclude>com.google.guava:*</exclude>
+                        </excludes>
+                    </artifactSet>
+                    <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                    <shadedArtifactAttached>false</shadedArtifactAttached>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -62,6 +62,16 @@
                             <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
                         </relocation>
                     </relocations>
+                    <filters>
+                        <filter>
+                            <artifact>org.bouncycastle:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
                     <artifactSet>
                         <excludes>
                             <exclude>com.google.guava:*</exclude>


### PR DESCRIPTION
This picks up from #180 where the majority of the work was done to address #178 and #179.

If this looks good to people (please test in other environments!) this will become 1.1.2. 

I've tested locally on Mac (docker-machine) and Ubuntu (local docker). 