### PR TITLE
closes #182 set mode on tarEntry from transferable

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -278,6 +278,17 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      */
     void followOutput(Consumer<OutputFrame> consumer, OutputFrame.OutputType... types);
 
+
+    /**
+     * Attach an output consumer at container startup, enabling stdout and stderr to be followed, waited on, etc.
+     * <p>
+     * More than one consumer may be registered.
+     *
+     * @param consumer consumer that output frames should be sent to
+     * @return this
+     */
+    SELF withLogConsumer(Consumer<OutputFrame> consumer);
+
     Info fetchDockerDaemonInfo() throws IOException;
 
     /**

--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -128,6 +128,7 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
                     TarArchiveEntry tarEntry = new TarArchiveEntry(entry.getKey());
                     Transferable transferable = entry.getValue();
                     tarEntry.setSize(transferable.getSize());
+                    tarEntry.setMode(transferable.getFileMode());
 
                     tarArchive.putArchiveEntry(tarEntry);
                     transferable.transferTo(tarArchive);

--- a/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
@@ -2,15 +2,26 @@ package org.testcontainers.junit;
 
 import com.github.dockerjava.api.command.BuildImageCmd;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.WaitingConsumer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.images.builder.Transferable;
 
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.pass;
+import static org.testcontainers.containers.output.OutputFrame.OutputType.STDOUT;
 
 public class DockerfileTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DockerfileTest.class);
 
     @Test
     public void simpleDockerfileWorks() {
@@ -59,6 +70,47 @@ public class DockerfileTest {
                 );
 
         verifyImage(image);
+    }
+
+    @Test
+    public void filePermissions() throws TimeoutException {
+
+        WaitingConsumer consumer = new WaitingConsumer();
+
+        ImageFromDockerfile image = new ImageFromDockerfile()
+                .withFileFromTransferable("/someFile.txt", new Transferable() {
+                    @Override
+                    public long getSize() {
+                        return 0;
+                    }
+
+                    @Override
+                    public int getFileMode() {
+                        return 0123;
+                    }
+
+                    @Override
+                    public void transferTo(OutputStream outputStream) {
+
+                    }
+                })
+                .withDockerfileFromBuilder(builder -> builder
+                        .from("alpine:3.2")
+                        .copy("someFile.txt", "/someFile.txt")
+                        .cmd("stat -c \"%a\" /someFile.txt")
+                );
+
+        GenericContainer container = new GenericContainer(image)
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+                .withLogConsumer(consumer);
+
+        try {
+            container.start();
+
+            consumer.waitUntil(frame -> frame.getType() == STDOUT && frame.getUtf8String().contains("123"), 5, TimeUnit.SECONDS);
+        } finally {
+            container.stop();
+        }
     }
 
     protected void verifyImage(ImageFromDockerfile image) {


### PR DESCRIPTION
This is a fix for a case from @ldoguin (reported in Slack)

Looks like I forgot to use `getFileMode` in `ImageFromDockerfile` and executable files from Dockerfile-based builds were not executable inside a container.