### PR TITLE
fix: use pwd as mounting point for docker compose

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -273,8 +273,9 @@ class DockerCompose extends GenericContainer<DockerCompose> {
         super("dduportal/docker-compose:1.7.1");
         addEnv("COMPOSE_PROJECT_NAME", identifier);
         // Map the docker compose file into the container
-        addEnv("COMPOSE_FILE", "/compose/" + composeFile.getAbsoluteFile().getName());
-        addFileSystemBind(composeFile.getAbsoluteFile().getParentFile().getAbsolutePath(), "/compose", READ_ONLY);
+        String pwd = composeFile.getAbsoluteFile().getParentFile().getAbsolutePath();
+        addEnv("COMPOSE_FILE", pwd + "/" + composeFile.getAbsoluteFile().getName());
+        addFileSystemBind(pwd, pwd, READ_ONLY);
         // Ensure that compose can access docker. Since the container is assumed to be running on the same machine
         //  as the docker daemon, just mapping the docker control socket is OK.
         // As there seems to be a problem with mapping to the /var/run directory in certain environments (e.g. CircleCI)
@@ -282,7 +283,7 @@ class DockerCompose extends GenericContainer<DockerCompose> {
         addFileSystemBind("/var/run/docker.sock", "/docker.sock", READ_WRITE);
         addEnv("DOCKER_HOST", "unix:///docker.sock");
         setStartupCheckStrategy(new IndefiniteWaitOneShotStartupCheckStrategy());
-        setWorkingDirectory("/compose");
+        setWorkingDirectory(pwd);
     }
 
     @Override


### PR DESCRIPTION
use pwd as mounting point for docker compose to make relative paths work within docker-compose.yml