### PR TITLE
[WIP] Switch to shared docker client instance

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -204,11 +204,13 @@
                         <phase>package</phase>
                         <configuration>
                             <target>
-                                <echo message="unjar" />
-                                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar" dest="${project.build.directory}/exploded/" />
+                                <echo message="unjar"/>
+                                <unzip src="${project.build.directory}/${project.artifactId}-${project.version}.jar"
+                                       dest="${project.build.directory}/exploded/"/>
                                 <move file="${project.build.directory}/exploded/META-INF/native/libnetty-transport-native-epoll.so"
-                                      tofile="${project.build.directory}/exploded/META-INF/native/liborg-testcontainers-shaded-netty-transport-native-epoll.so" />
-                                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar" basedir="${project.build.directory}/exploded" />
+                                      tofile="${project.build.directory}/exploded/META-INF/native/liborg-testcontainers-shaded-netty-transport-native-epoll.so"/>
+                                <jar destfile="${project.build.directory}/${project.artifactId}-${project.version}.jar"
+                                     basedir="${project.build.directory}/exploded"/>
                             </target>
                         </configuration>
                         <goals>

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -70,22 +70,14 @@ public class DockerClientFactory {
      *
      * @return a new initialized Docker client
      */
-    public DockerClient client() {
-        return client(true);
-    }
-
-    /**
-     *
-     * @param failFast fail if client fails to ping Docker daemon
-     * @return a new initialized Docker client
-     */
     @Synchronized
-    public DockerClient client(boolean failFast) {
+    public DockerClient client() {
 
-        if (strategy == null) {
-            strategy = DockerClientProviderStrategy.getFirstValidStrategy(CONFIGURATION_STRATEGIES);
+        if (strategy != null) {
+            return strategy.getClient();
         }
 
+        strategy = DockerClientProviderStrategy.getFirstValidStrategy(CONFIGURATION_STRATEGIES);
         DockerClient client = strategy.getClient();
 
         if (!preconditionsChecked) {
@@ -102,11 +94,6 @@ public class DockerClientFactory {
             checkVersion(version.getVersion());
             checkDiskSpaceAndHandleExceptions(client);
             preconditionsChecked = true;
-        }
-
-        if (failFast) {
-            // Ping, to fail fast if our docker environment has gone away
-            client.pingCmd().exec();
         }
 
         return client;
@@ -197,7 +184,7 @@ public class DockerClientFactory {
      */
     public String getActiveApiVersion() {
         if (!preconditionsChecked) {
-            client(true);
+            client();
         }
         return activeApiVersion;
     }
@@ -207,7 +194,7 @@ public class DockerClientFactory {
      */
     public String getActiveExecutionDriver() {
         if (!preconditionsChecked) {
-            client(true);
+            client();
         }
         return activeExecutionDriver;
     }

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -261,12 +261,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         }
 
         ResourceReaper.instance().stopAndRemoveContainer(containerId, imageName);
-
-        try {
-            dockerClient.close();
-        } catch (IOException e) {
-            logger().debug("Failed to close docker client");
-        }
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
  */
 public abstract class DockerClientProviderStrategy {
 
+    protected DockerClient client;
     protected DockerClientConfig config;
 
     private static final RateLimiter PING_RATE_LIMITER = RateLimiterBuilder.newBuilder()
@@ -93,7 +94,7 @@ public abstract class DockerClientProviderStrategy {
      * @return a usable, tested, Docker client configuration for the host system environment
      */
     public DockerClient getClient() {
-        return getClientForConfig(config);
+        return client;
     }
 
     protected DockerClient getClientForConfig(DockerClientConfig config) {
@@ -114,7 +115,7 @@ public abstract class DockerClientProviderStrategy {
     }
 
     public String getDockerHostIpAddress() {
-        return DockerClientConfigUtils.getDockerHostIpAddress(config);
+        return DockerClientConfigUtils.getDockerHostIpAddress(this.config);
     }
 
 

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerMachineClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerMachineClientProviderStrategy.java
@@ -1,6 +1,5 @@
 package org.testcontainers.dockerclient;
 
-import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DockerClientConfig;
 import org.testcontainers.utility.CommandLine;
 import org.testcontainers.utility.DockerMachineClient;
@@ -17,8 +16,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class DockerMachineClientProviderStrategy extends DockerClientProviderStrategy {
     @Override
     public void test() throws InvalidConfigurationException {
-
-        DockerClient client;
 
         try {
             boolean installed = DockerMachineClient.instance().isInstalled();

--- a/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
@@ -1,6 +1,5 @@
 package org.testcontainers.dockerclient;
 
-import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DockerClientConfig;
 
 /**
@@ -15,7 +14,7 @@ public class EnvironmentAndSystemPropertyClientProviderStrategy extends DockerCl
         try {
             // Try using environment variables
             config = DockerClientConfig.createDefaultConfigBuilder().build();
-            DockerClient client = getClientForConfig(config);
+            client = getClientForConfig(config);
 
             ping(client, 1);
         } catch (Exception e) {
@@ -38,13 +37,11 @@ public class EnvironmentAndSystemPropertyClientProviderStrategy extends DockerCl
         }
 
         return  "    dockerHost=" + config.getDockerHost() + "\n" +
-                "    dockerCertPath='" + config.getDockerCertPath() + "'\n" +
-                "    dockerTlsVerify='" + config.getDockerTlsVerify() + "'\n" +
                 "    apiVersion='" + config.getApiVersion() + "'\n" +
                 "    registryUrl='" + config.getRegistryUrl() + "'\n" +
                 "    registryUsername='" + config.getRegistryUsername() + "'\n" +
                 "    registryPassword='" + config.getRegistryPassword() + "'\n" +
                 "    registryEmail='" + config.getRegistryEmail() + "'\n" +
-                "    dockerConfig='" + config.getDockerConfig() + "'\n";
+                "    dockerConfig='" + config.toString() + "'\n";
     }
 }

--- a/core/src/main/java/org/testcontainers/dockerclient/UnixSocketClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/UnixSocketClientProviderStrategy.java
@@ -1,6 +1,5 @@
 package org.testcontainers.dockerclient;
 
-import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DockerClientConfig;
 import org.jetbrains.annotations.NotNull;
 
@@ -46,12 +45,11 @@ public class UnixSocketClientProviderStrategy extends DockerClientProviderStrate
             throw new InvalidConfigurationException("Found docker unix domain socket but file mode was not as expected (expected: srwxr-xr-x). This problem is possibly due to occurrence of this issue in the past: https://github.com/docker/docker/issues/13121");
         }
 
-        DockerClientConfig config;
-        config = new DockerClientConfig.DockerClientConfigBuilder()
+        config = DockerClientConfig.createDefaultConfigBuilder()
                 .withDockerHost(dockerHost)
                 .withDockerTlsVerify(false)
                 .build();
-        DockerClient client = getClientForConfig(config);
+        client = getClientForConfig(config);
 
         ping(client, 3);
 

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -1,6 +1,7 @@
 package org.testcontainers.images;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.core.command.PullImageResultCallback;
 import lombok.NonNull;
@@ -12,7 +13,6 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.LazyFuture;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -40,7 +40,8 @@ public class RemoteDockerImage extends LazyFuture<String> {
         profiler.setLogger(logger);
 
         Profiler nested = profiler.startNested("Obtaining client");
-        try (DockerClient dockerClient = DockerClientFactory.instance().client(false)) {
+        DockerClient dockerClient = DockerClientFactory.instance().client();
+        try {
             nested.stop();
 
             profiler.start("Check local images");
@@ -88,7 +89,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
             }
 
             return dockerImageName;
-        } catch (IOException e) {
+        } catch (DockerClientException e) {
             throw new ContainerFetchException("Failed to get Docker client for " + dockerImageName, e);
         } finally {
             profiler.stop().log();

--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -2,6 +2,7 @@ package org.testcontainers.images.builder;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.BuildImageCmd;
+import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.BuildResponseItem;
 import com.github.dockerjava.core.command.BuildImageResultCallback;
 import com.google.common.collect.Sets;
@@ -39,7 +40,8 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
 
     static {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            try (DockerClient dockerClientForCleaning = DockerClientFactory.instance().client(false)) {
+            DockerClient dockerClientForCleaning = DockerClientFactory.instance().client();
+            try {
                 for (String dockerImageName : imagesToDelete) {
                     log.info("Removing image tagged {}", dockerImageName);
                     try {
@@ -48,7 +50,7 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
                         log.warn("Unable to delete image " + dockerImageName, e);
                     }
                 }
-            } catch (IOException e) {
+            } catch (DockerClientException e) {
                 throw new RuntimeException(e);
             }
         }));
@@ -91,7 +93,8 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
         Profiler profiler = new Profiler("Rule creation - build image");
         profiler.setLogger(logger);
 
-        try (DockerClient dockerClient = DockerClientFactory.instance().client(false)) {
+        DockerClient dockerClient = DockerClientFactory.instance().client();
+        try {
             if (deleteOnExit) {
                 imagesToDelete.add(dockerImageName);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
Netty client should be thread-safe, so the reasons for using one client per container have gone away.
This should help with #110.