### PR TITLE
Fix NPE when host has untagged images.

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -130,7 +130,7 @@ public class DockerClientFactory {
     private void checkDiskSpace(DockerClient client) {
 
         List<Image> images = client.listImagesCmd().exec();
-        if (!images.stream().anyMatch(it -> asList(it.getRepoTags()).contains("alpine:3.2"))) {
+        if (!images.stream().anyMatch(it -> it.getRepoTags() != null && asList(it.getRepoTags()).contains("alpine:3.2"))) {
             PullImageResultCallback callback = client.pullImageCmd("alpine:3.2").exec(new PullImageResultCallback());
             callback.awaitSuccess();
         }


### PR DESCRIPTION
When the docker host has untagged images the checkDiskSpace() method will throw a NullPointerException due to getRepoTags() returning null.

This simply adds a null check to avoid this situation.