### PR TITLE
Shade jersey dependencies in JDBC to avoid conflicts with jersey-test.

### DIFF
--- a/modules/jdbc/pom.xml
+++ b/modules/jdbc/pom.xml
@@ -40,10 +40,28 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <transformers>
+                        <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer"/>
+                        <transformer
+                            implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                     <relocations>
                         <relocation>
                             <pattern>com.google.common</pattern>
                             <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>org.glassfish</pattern>
+                            <shadedPattern>org.testcontainers.shaded.org.glassfish</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>javax.ws.rs</pattern>
+                            <shadedPattern>org.testcontainers.shaded.javax.ws.rs</shadedPattern>
+                        </relocation>
+                        <relocation>
+                            <pattern>com.fasterxml.jackson</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.fasterxml.jackson</shadedPattern>
                         </relocation>
                     </relocations>
                     <filters>
@@ -55,10 +73,22 @@
                                 <exclude>META-INF/*.RSA</exclude>
                             </excludes>
                         </filter>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/services/com.fasterxml.jackson.core.*</exclude>
+                                <exclude>META-INF/services/com.github.dockerjava.api.command.*</exclude>
+                                <exclude>META-INF/services/javax.ws.rs.ext.*</exclude>
+                                <exclude>META-INF/services/org.glassfish.hk2.extension.*</exclude>
+                                <exclude>META-INF/services/org.jvnet.hk2.external.generator.*</exclude>
+                                <exclude>META-INF/services/org.glassfish.jersey.internal.spi.*</exclude>
+                            </excludes>
+                        </filter>
                     </filters>
                     <artifactSet>
                         <excludes>
                             <exclude>com.google.guava:*</exclude>
+                            <exclude>org.glassfish.*:*</exclude>
                         </excludes>
                     </artifactSet>
                     <promoteTransitiveDependencies>true</promoteTransitiveDependencies>


### PR DESCRIPTION
Should resolve #196 

Symptoms I encountered were a NoSuchMethod error on `RankedProvider.getContractTypes()`

It appeared that the jdbc module included both shaded and non-shaded Jersey dependencies. This should ensure that the packaged classes are shaded.