### PR TITLE
Reap docker-compose networks after each test

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -121,6 +121,14 @@ public final class ResourceReaper {
         registeredNetworks.add(networkName);
     }
 
+    /**
+     * Removes any networks that contain the identifier.
+     * @param identifier
+     */
+    public void removeNetworks(String identifier) {
+      removeNetwork(identifier);
+    }
+
     private void removeNetwork(String networkName) {
         List<Network> networks;
         try {
@@ -133,6 +141,7 @@ public final class ResourceReaper {
         for (Network network : networks) {
             try {
                 dockerClient.removeNetworkCmd(network.getId()).exec();
+                registeredNetworks.remove(network.getId());
                 LOGGER.debug("Removed network: {}", networkName);
             } catch (DockerException e) {
                 LOGGER.trace("Error encountered removing network (name: {}) - it may not have been removed", network.getName());

--- a/core/src/test/java/org/testcontainers/junit/BaseDockerComposeTest.java
+++ b/core/src/test/java/org/testcontainers/junit/BaseDockerComposeTest.java
@@ -1,18 +1,23 @@
 package org.testcontainers.junit;
 
+import com.github.dockerjava.api.model.Network;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assume;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.utility.TestEnvironment;
 import redis.clients.jedis.Jedis;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 
 /**
  * Created by rnorth on 21/05/2016.
@@ -22,6 +27,8 @@ public abstract class BaseDockerComposeTest {
     protected static final int REDIS_PORT = 6379;
 
     protected abstract DockerComposeContainer getEnvironment();
+
+    private List<String> existingNetworks = new ArrayList<>();
 
     @BeforeClass
     public static void checkVersion() {
@@ -57,6 +64,23 @@ public abstract class BaseDockerComposeTest {
         assertEquals("Tests use fresh container instances", "3", jedis.get("test"));
         // if these end up using the same container one of the test methods will fail.
         // However, @Rule creates a separate DockerComposeContainer instance per test, so this just shouldn't happen
+    }
+
+    @Before
+    public void captureNetworks() {
+      existingNetworks.addAll(findAllNetworks());
+    }
+
+    @After
+    public void verifyNoNetworks() {
+      assertThat("The networks", findAllNetworks(), is(existingNetworks));
+    }
+
+    private List<String> findAllNetworks() {
+      return DockerClientFactory.instance().client().listNetworksCmd().exec().stream()
+        .map(Network::getName)
+        .sorted()
+        .collect(Collectors.toList());
     }
 
     @NotNull

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeV2WithNetworkTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeV2WithNetworkTest.java
@@ -1,0 +1,21 @@
+package org.testcontainers.junit;
+
+import java.io.File;
+
+import org.junit.Rule;
+import org.testcontainers.containers.DockerComposeContainer;
+
+public class DockerComposeV2WithNetworkTest extends BaseDockerComposeTest {
+
+    @Rule
+    public DockerComposeContainer environment = new DockerComposeContainer(new File("src/test/resources/v2-compose-test-with-network.yml"))
+            .withExposedService("redis_1", REDIS_PORT);
+
+    @Override
+    protected DockerComposeContainer getEnvironment() {
+        return environment;
+    }
+
+
+
+}

--- a/core/src/test/resources/v2-compose-test-with-network.yml
+++ b/core/src/test/resources/v2-compose-test-with-network.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  redis:
+    image: redis
+    networks:
+      - redis-net
+
+networks:
+  redis-net:


### PR DESCRIPTION
For docker-compose instances with custom networks, these need
to be reaped after each test as they could potentially define
overlapping subnets.