### PR TITLE
Add support for https://docs.docker.com/compose/extends/

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -85,8 +85,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
         this.dockerClient = DockerClientFactory.instance().client();
     }
 
-    @Override
-    @VisibleForTesting
+    @Override @VisibleForTesting
     public void starting(Description description) {
         final Profiler profiler = new Profiler("Docker compose container rule");
         profiler.setLogger(logger());
@@ -198,8 +197,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
         return LoggerFactory.getLogger(DockerComposeContainer.class);
     }
 
-    @Override
-    @VisibleForTesting
+    @Override @VisibleForTesting
     public void finished(Description description) {
 
         // shut down all the ambassador containers

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -304,11 +304,11 @@ class DockerCompose extends GenericContainer<DockerCompose> {
         composeFilesIterator.next();
         while(composeFilesIterator.hasNext()) {
             File composeFileOverride = composeFilesIterator.next();
-            composeFileEnvVariable.append(File.separator + pwd + "/" + composeFileOverride.getAbsoluteFile().getName());
+            composeFileEnvVariable.append(File.pathSeparator + pwd + "/" + composeFileOverride.getAbsoluteFile().getName());
         }
 
         String composeFileEnvVariableString = composeFileEnvVariable.toString();
-        logger().info("Settings COMPOSE_FILE={}", composeFileEnvVariableString);
+        logger().info("Set env COMPOSE_FILE={}", composeFileEnvVariableString);
         addEnv("COMPOSE_FILE", composeFileEnvVariableString);
 
         addFileSystemBind(pwd, pwd, READ_ONLY);


### PR DESCRIPTION
It is possible to pass more then one docker-compose file to the docker-compose comand as decribed here https://docs.docker.com/compose/extends/

To make this feature available in testcontainers a list of docker-compose files ahs to be passed to DockerComposeContainer.

The files have to be concatenated in the COMPOSE_FILE env variable as described here https://docs.docker.com/compose/reference/envvars/