### PR TITLE
DockerClientProviderStrategy.getDescription() should be called after …

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -51,8 +51,8 @@ public abstract class DockerClientProviderStrategy {
 
         for (DockerClientProviderStrategy strategy : strategies) {
             try {
-                LOGGER.info("Looking for Docker environment. Trying {}", strategy.getDescription());
                 strategy.test();
+                LOGGER.info("Looking for Docker environment. Tried {}", strategy.getDescription());
                 return strategy;
             } catch (Exception | ExceptionInInitializerError | NoClassDefFoundError e) {
                 @Nullable String throwableMessage = e.getMessage();


### PR DESCRIPTION
When using testcontainers 1.1.0+ I get the following

```
Looking for Docker environment. Trying Environment variables, system properties and defaults. Resolved:

```

In the refactoring that happened for 1.1.0+ the DockerClientProviderStrategy logs strategy.getDescription() before the config is initialized, which is why for Environment strategy the values are empty. This simply reverses the logging order to after test() has been called and config is populated.