### PR TITLE
Expose reaper's trigger to public API

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -30,7 +30,7 @@ public final class ResourceReaper {
         dockerClient = DockerClientFactory.instance().client();
 
         // If the JVM stops without containers being stopped, try and stop the container.
-        Runtime.getRuntime().addShutdownHook(new Thread(this::perform));
+        Runtime.getRuntime().addShutdownHook(new Thread(this::performCleanup));
     }
 
     public synchronized static ResourceReaper instance() {
@@ -45,7 +45,7 @@ public final class ResourceReaper {
      * Perform a cleanup.
      *
      */
-    public synchronized void perform() {
+    public synchronized void performCleanup() {
         registeredContainers.forEach(this::stopContainer);
         registeredNetworks.forEach(this::removeNetwork);
     }

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -30,10 +30,7 @@ public final class ResourceReaper {
         dockerClient = DockerClientFactory.instance().client();
 
         // If the JVM stops without containers being stopped, try and stop the container.
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            registeredContainers.forEach(this::stopContainer);
-            registeredNetworks.forEach(this::removeNetwork);
-        }));
+        Runtime.getRuntime().addShutdownHook(new Thread(this::perform));
     }
 
     public synchronized static ResourceReaper instance() {
@@ -42,6 +39,15 @@ public final class ResourceReaper {
         }
 
         return instance;
+    }
+
+    /**
+     * Perform a cleanup.
+     *
+     */
+    public synchronized void perform() {
+        registeredContainers.forEach(this::stopContainer);
+        registeredNetworks.forEach(this::removeNetwork);
     }
 
     /**


### PR DESCRIPTION
Hi

Sometimes there is a need to trigger ResourceReaper, especially in non-JUnit environments (i.e. Cucumber-JVM)

Method is marked as `synchronized` to avoid concurrency access.
