### PR TITLE
Adds the ability to tail child container logs.

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.command.LogContainerCmd;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.*;
 import com.google.common.base.Preconditions;
@@ -757,17 +756,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      */
     @Override
     public void followOutput(Consumer<OutputFrame> consumer, OutputFrame.OutputType... types) {
-        LogContainerCmd cmd = dockerClient.logContainerCmd(containerId)
-                .withFollowStream(true);
-
-        FrameConsumerResultCallback callback = new FrameConsumerResultCallback();
-        for (OutputFrame.OutputType type : types) {
-            callback.addConsumer(type, consumer);
-            if (type == STDOUT) cmd.withStdOut(true);
-            if (type == STDERR) cmd.withStdErr(true);
-        }
-
-        cmd.exec(callback);
+        LogUtils.followOutput(dockerClient, containerId, consumer, types);
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/utility/LogUtils.java
+++ b/core/src/main/java/org/testcontainers/utility/LogUtils.java
@@ -1,0 +1,37 @@
+package org.testcontainers.utility;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.LogContainerCmd;
+import lombok.experimental.UtilityClass;
+import org.testcontainers.containers.output.FrameConsumerResultCallback;
+import org.testcontainers.containers.output.OutputFrame;
+
+import java.util.function.Consumer;
+
+import static org.testcontainers.containers.output.OutputFrame.OutputType.STDERR;
+import static org.testcontainers.containers.output.OutputFrame.OutputType.STDOUT;
+
+/**
+ * Provides utility methods for logging.
+ */
+@UtilityClass
+public class LogUtils {
+    /**
+     * {@inheritDoc}
+     */
+    public void followOutput(DockerClient dockerClient, String containerId,
+                             Consumer<OutputFrame> consumer, OutputFrame.OutputType... types) {
+
+        final LogContainerCmd cmd = dockerClient.logContainerCmd(containerId)
+                .withFollowStream(true);
+
+        final FrameConsumerResultCallback callback = new FrameConsumerResultCallback();
+        for (OutputFrame.OutputType type : types) {
+            callback.addConsumer(type, consumer);
+            if (type == STDOUT) cmd.withStdOut(true);
+            if (type == STDERR) cmd.withStdErr(true);
+        }
+
+        cmd.exec(callback);
+    }
+}


### PR DESCRIPTION
## Purpose

See #158.
## This PR
- Adds the ability to tail child container logs.
- Adds the option to enable/disable pulling of images before starting Compose services. This is useful when images have a repository as part of their image identifier, but have not been pushed (such as when they are being built/tested locally).
