### PR TITLE
Command-based port check in HostPortWaitStrategy in case of Docker for Mac

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -817,7 +817,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 .execCreateCmd(this.containerId)
                 .withCmd(command);
 
-        logger().info("Running \"exec\" command: " + String.join(" ", command));
+        logger().debug("Running \"exec\" command: " + String.join(" ", command));
         final ExecCreateCmdResponse execCreateCmdResponse = dockerClient.execCreateCmd(this.containerId)
                 .withAttachStdout(true).withAttachStderr(true).withCmd(command).exec();
 

--- a/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
@@ -37,8 +37,7 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
             List<Integer> exposedPorts = container.getExposedPorts();
 
             Integer exposedPort = exposedPorts.stream()
-                    .map(container::getMappedPort)
-                    .filter(port::equals)
+                    .filter(it -> port.equals(container.getMappedPort(it)))
                     .findFirst()
                     .orElse(null);
 

--- a/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.rnorth.ducttape.TimeoutException;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.DockerClientFactory;
-import org.testcontainers.containers.Container;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.dockerclient.ProxiedUnixSocketClientProviderStrategy;
@@ -57,12 +56,7 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
             checkStrategy = () -> {
                 for (String[] command : commands) {
                     try {
-                        Container.ExecResult execResult = container.execInContainer(command);
-
-                        if (!execResult.getStderr().isEmpty()) {
-                            log.warn(execResult.getStderr());
-                        }
-                        if (execResult.getStdout().contains(SUCCESS_MARKER)) {
+                        if (container.execInContainer(command).getStdout().contains(SUCCESS_MARKER)) {
                             return true;
                         }
                     } catch (InterruptedException e) {


### PR DESCRIPTION
Fixes #160

I did a test run on my Mac with Docker for Mac, everything is green :)

Consider it as a temporary hack until the issue with port forwarding is fixed on Docker's side
