### PR TITLE
Improve reliability of HostPortWaitStrategyTest

### DIFF
--- a/core/src/test/java/org/testcontainers/junit/wait/HostPortWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/HostPortWaitStrategyTest.java
@@ -18,7 +18,7 @@ public class HostPortWaitStrategyTest extends AbstractWaitStrategyTest<HostPortW
      */
     @Test
     public void testWaitUntilReady_Success() {
-        waitUntilReadyAndSucceed("nc -lp 8080");
+        waitUntilReadyAndSucceed("while true; do nc -lp 8080; done");
     }
 
     /**

--- a/core/src/test/java/org/testcontainers/junit/wait/HttpWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/HttpWaitStrategyTest.java
@@ -23,7 +23,7 @@ public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrat
      */
     @Test
     public void testWaitUntilReady_Success() {
-        waitUntilReadyAndSucceed("echo -e \"HTTP/1.1 200 OK" + DOUBLE_NEWLINE + "\" | nc -lp 8080");
+        waitUntilReadyAndSucceed("while true; do echo -e \"HTTP/1.1 200 OK" + DOUBLE_NEWLINE + "\" | nc -lp 8080; done");
     }
 
     /**
@@ -32,7 +32,7 @@ public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrat
      */
     @Test
     public void testWaitUntilReady_Timeout() {
-        waitUntilReadyAndTimeout("echo -e \"HTTP/1.1 400 Bad Request" + DOUBLE_NEWLINE + "\" | nc -lp 8080");
+        waitUntilReadyAndTimeout("while true; do echo -e \"HTTP/1.1 400 Bad Request" + DOUBLE_NEWLINE + "\" | nc -lp 8080; done");
     }
 
     /**


### PR DESCRIPTION
After painstaking effort to determine the cause of these test failures, it seems that `nc -lp 8080` inside the container was failing intermittently and exiting. This simple change works around this problem.