### PR TITLE
Load jdbc driver with current classloader instead of system

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -93,7 +93,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
         synchronized (DRIVER_LOAD_MUTEX) {
             if (driver == null) {
                 try {
-                    driver = (Driver) ClassLoader.getSystemClassLoader().loadClass(this.getDriverClassName()).newInstance();
+                    driver = (Driver) Class.forName(this.getDriverClassName()).newInstance();
                 } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
                     throw new RuntimeException("Could not get Driver", e);
                 }


### PR DESCRIPTION
Load jdbc driver with current classloader instead of system classloader. When running tests in SBT system classloader does not contain jdbc driver - SBT uses separate URLClassloader.

Maybe there are some reasons to use system classloader instead of current one, that I'm not aware of? With this fix tests run well in SBT with scalatest.