### PR TITLE
favor ".exe" extension for Windows executables

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/CommandLine.java
+++ b/core/src/main/java/org/testcontainers/utility/CommandLine.java
@@ -23,7 +23,7 @@ public class CommandLine {
 
     private static final Logger LOGGER = getLogger(CommandLine.class);
 
-    private static String OS = System.getProperty("os.name").toLowerCase();
+    private static final String OS = System.getProperty("os.name").toLowerCase();
 
     /**
      * Run a shell command synchronously.

--- a/core/src/main/java/org/testcontainers/utility/CommandLine.java
+++ b/core/src/main/java/org/testcontainers/utility/CommandLine.java
@@ -23,6 +23,8 @@ public class CommandLine {
 
     private static final Logger LOGGER = getLogger(CommandLine.class);
 
+    private static String OS = System.getProperty("os.name").toLowerCase();
+
     /**
      * Run a shell command synchronously.
      *
@@ -57,15 +59,19 @@ public class CommandLine {
      */
     public static boolean executableExists(String executable) {
 
+        String winExecutable = executable + ".exe";
+
         // First check if we've been given the full path already
         File directFile = new File(executable);
-        if (directFile.exists() && directFile.canExecute()) {
+        File windowsExeFile = new File(winExecutable);
+        if ((directFile.exists() && directFile.canExecute()) || (isWindows() && windowsExeFile.exists() && windowsExeFile.canExecute())) {
             return true;
         }
 
         for (String pathString : getSystemPath()) {
             Path path = Paths.get(pathString);
-            if (Files.exists(path.resolve(executable)) && Files.isExecutable(path.resolve(executable))) {
+            if ((Files.exists(path.resolve(executable)) && Files.isExecutable(path.resolve(executable)))
+                    || (isWindows() && Files.exists(path.resolve(winExecutable)) && Files.isExecutable(path.resolve(winExecutable)))) {
                 return true;
             }
         }
@@ -76,6 +82,10 @@ public class CommandLine {
     @NotNull
     public static String[] getSystemPath() {
         return System.getenv("PATH").split(Pattern.quote(File.pathSeparator));
+    }
+
+    private static boolean isWindows() {
+        return OS.startsWith("windows");
     }
 
     private static class ShellCommandException extends RuntimeException {

--- a/core/src/main/java/org/testcontainers/utility/CommandLine.java
+++ b/core/src/main/java/org/testcontainers/utility/CommandLine.java
@@ -59,19 +59,22 @@ public class CommandLine {
      */
     public static boolean executableExists(String executable) {
 
-        String winExecutable = executable + ".exe";
+        String fullExecutableName;
+        if (isWindows() && !executable.endsWith(".exe")) {
+            fullExecutableName = executable + ".exe";
+        } else {
+            fullExecutableName = executable;
+        }
 
         // First check if we've been given the full path already
-        File directFile = new File(executable);
-        File windowsExeFile = new File(winExecutable);
-        if ((directFile.exists() && directFile.canExecute()) || (isWindows() && windowsExeFile.exists() && windowsExeFile.canExecute())) {
+        File directFile = new File(fullExecutableName);
+        if (directFile.exists() && directFile.canExecute()) {
             return true;
         }
 
         for (String pathString : getSystemPath()) {
             Path path = Paths.get(pathString);
-            if ((Files.exists(path.resolve(executable)) && Files.isExecutable(path.resolve(executable)))
-                    || (isWindows() && Files.exists(path.resolve(winExecutable)) && Files.isExecutable(path.resolve(winExecutable)))) {
+            if (Files.exists(path.resolve(executable)) && Files.isExecutable(path.resolve(executable))) {
                 return true;
             }
         }


### PR DESCRIPTION
CommandLine.executableExists fails to locate local "docker-compose" executable (LocalDockerCompose.COMPOSE_EXECUTABLE) on Windows as a valid windows name is "docker-compose.exe" not just "docker-compose".
The suggested fix try to check both "name" and "name.exe" on Windows.
(P.S. for running an executable ".exe"-extension is not required, only for presence check)