### PR TITLE
Issue 247: Add support for $HOME/.docker/config.json

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>3.0.5</version>
+            <version>3.0.7</version>
             <exclusions>
                 <!-- replace with junixsocket -->
                 <exclusion>


### PR DESCRIPTION
As described in issue https://github.com/testcontainers/testcontainers-java/issues/247, **docker-java**, up to version **3.0.6**, hardcoded the private registry authentication file to use ($HOME/.docker/.dockercfg).
I updated docker-java to support both config.json and .dockercfg (https://github.com/docker-java/docker-java/pull/756), which has been released in version 3.0.7.

This commit upgrades docker-java's version to 3.0.7