### PR TITLE
Add ability to override DockerClientFactory.TINY_IMAGE in testcontainers.properties

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -12,6 +12,7 @@ import com.github.dockerjava.core.command.PullImageResultCallback;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.dockerclient.*;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,7 +29,7 @@ import static java.util.Arrays.asList;
 @Slf4j
 public class DockerClientFactory {
 
-    private static final String TINY_IMAGE = "alpine:3.2";
+    private static final String TINY_IMAGE = TestcontainersConfiguration.getInstance().getTinyImage();
     private static DockerClientFactory instance;
 
     // Cached client configuration

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -43,7 +43,7 @@ public class TestcontainersConfiguration {
 
                 config.ambassadorContainerImage = properties.getProperty("ambassador.container.image", config.ambassadorContainerImage);
                 config.vncRecordedContainerImage = properties.getProperty("vncrecorder.container.image", config.vncRecordedContainerImage);
-                config.tinyImage = properties.getProperty("tinyimage.container.image", config.vncRecordedContainerImage);
+                config.tinyImage = properties.getProperty("tinyimage.container.image", config.tinyImage);
 
                 log.debug("Testcontainers configuration overrides loaded from {}: {}", configOverrides, config);
 

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -24,6 +24,7 @@ public class TestcontainersConfiguration {
 
     private String ambassadorContainerImage = "richnorth/ambassador:latest";
     private String vncRecordedContainerImage = "richnorth/vnc-recorder:latest";
+    private String tinyImage = "alpine:3.2";
 
     private static TestcontainersConfiguration loadConfiguration() {
         final TestcontainersConfiguration config = new TestcontainersConfiguration();
@@ -42,6 +43,7 @@ public class TestcontainersConfiguration {
 
                 config.ambassadorContainerImage = properties.getProperty("ambassador.container.image", config.ambassadorContainerImage);
                 config.vncRecordedContainerImage = properties.getProperty("vncrecorder.container.image", config.vncRecordedContainerImage);
+                config.tinyImage = properties.getProperty("tinyimage.container.image", config.vncRecordedContainerImage);
 
                 log.debug("Testcontainers configuration overrides loaded from {}: {}", configOverrides, config);
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,9 +109,12 @@ Testcontainers uses additional docker images under some modes of execution:
 
 > *N.B.:* both these images use the 'latest' tag, which could potentially affect repeatability of tests and compatibility with Testcontainers _if the image is ever changed_. This is a [known issue](https://github.com/testcontainers/testcontainers-java/issues/276) which will be addressed in the future. The current 'latest' version of these images will never be changed until they are replaced by a new image altogether.
 
+Last but not least, `alpine:3.2` image is used for Docker host IP address detection in some special cases.
+
 If it is necessary to override these image names (e.g. when using a private registry), you should create a file named `testcontainers.properties` and place it on the classpath with the following content:
 
 ```properties
 ambassador.container.image=replacement image name here
 vncrecorder.container.image=replacement image name here
+tinyimage.container.image=replacement image name here
 ```


### PR DESCRIPTION
This fixes #281.