### PR TITLE
Fix alpine socket bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
       -v /var/run/docker.sock:/var/run/docker.sock \
       -v "$(pwd)":"$(pwd)" \
       -w "$(pwd)" \
-      joepjoosten/openjdk-alpine-bash \
+      kiview/openjdk-alpine-bash:8u111 \
       ./mvnw -B -pl core test -Dtest=*GenericContainerRuleTest
   - mvn -B test -f shade-test/pom.xml
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,15 @@ script:
       -w "$(pwd)" \
       openjdk:8-jre \
       ./mvnw -B -pl core test -Dtest=*GenericContainerRuleTest
+  # Run Docker-in-Docker tests inside Alpine
+  - |
+      DOCKER_HOST=unix:///var/run/docker.sock DOCKER_TLS_VERIFY= docker run --rm \
+      -v "$HOME/.m2":/root/.m2/ \
+      -v /var/run/docker.sock:/var/run/docker.sock \
+      -v "$(pwd)":"$(pwd)" \
+      -w "$(pwd)" \
+      joepjoosten/openjdk-alpine-bash \
+      ./mvnw -B -pl core test -Dtest=*GenericContainerRuleTest
   - mvn -B test -f shade-test/pom.xml
 
 cache:

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -38,8 +38,8 @@ public class DockerClientFactory {
 
     private static final List<DockerClientProviderStrategy> CONFIGURATION_STRATEGIES =
             asList(new EnvironmentAndSystemPropertyClientProviderStrategy(),
-                    new ProxiedUnixSocketClientProviderStrategy(),
                     new UnixSocketClientProviderStrategy(),
+                    new ProxiedUnixSocketClientProviderStrategy(),
                     new DockerMachineClientProviderStrategy());
     private String activeApiVersion;
     private String activeExecutionDriver;

--- a/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
@@ -33,7 +33,7 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
         Callable<Boolean> checkStrategy;
 
         // Special case for Docker for Mac, see #160
-        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+        if (isUsingSocketProxyOnMac()) {
             List<Integer> exposedPorts = container.getExposedPorts();
 
             Integer exposedPort = exposedPorts.stream()
@@ -89,5 +89,10 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
             throw new ContainerLaunchException("Timed out waiting for container port to open (" +
                     container.getContainerIpAddress() + ":" + port + " should be listening)");
         }
+    }
+
+    private boolean isUsingSocketProxyOnMac() {
+        return DockerClientFactory.instance().isUsing(ProxiedUnixSocketClientProviderStrategy.class)
+                && System.getProperty("os.name").toLowerCase().contains("mac");
     }
 }

--- a/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
@@ -33,7 +33,7 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
         Callable<Boolean> checkStrategy;
 
         // Special case for Docker for Mac, see #160
-        if (DockerClientFactory.instance().isUsing(ProxiedUnixSocketClientProviderStrategy.class)) {
+        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
             List<Integer> exposedPorts = container.getExposedPorts();
 
             Integer exposedPort = exposedPorts.stream()

--- a/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
@@ -21,7 +21,7 @@ public class EnvironmentAndSystemPropertyClientProviderStrategy extends DockerCl
 
             final int timeout = Integer.parseInt(System.getProperty(PING_TIMEOUT_PROPERTY_NAME, PING_TIMEOUT_DEFAULT));
             ping(client, timeout);
-        } catch (Exception e) {
+        } catch (Exception | UnsatisfiedLinkError e) {
             LOGGER.error("ping failed with configuration {} due to {}", getDescription(), e.toString(), e);
             throw new InvalidConfigurationException("ping failed");
         }

--- a/core/src/main/java/org/testcontainers/dockerclient/ProxiedUnixSocketClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/ProxiedUnixSocketClientProviderStrategy.java
@@ -9,8 +9,9 @@ public class ProxiedUnixSocketClientProviderStrategy extends UnixSocketClientPro
     @Override
     public void test() throws InvalidConfigurationException {
 
-        if (!System.getProperty("os.name").toLowerCase().contains("mac")) {
-            throw new InvalidConfigurationException("this strategy is only applicable to OS X");
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (!osName.contains("mac") && !osName.contains("linux")) {
+            throw new InvalidConfigurationException("this strategy is only applicable to OS X and Linux");
         }
 
         TcpToUnixSocketProxy proxy = new TcpToUnixSocketProxy(new File(DOCKER_SOCK_PATH));
@@ -20,7 +21,7 @@ public class ProxiedUnixSocketClientProviderStrategy extends UnixSocketClientPro
 
             config = tryConfiguration("tcp://localhost:" + proxyPort);
 
-            LOGGER.info("Accessing Docker for Mac unix domain socket via TCP proxy (" + DOCKER_SOCK_PATH + " via localhost:" + proxyPort + ")");
+            LOGGER.info("Accessing unix domain socket via TCP proxy (" + DOCKER_SOCK_PATH + " via localhost:" + proxyPort + ")");
         } catch (Exception e) {
 
             proxy.stop();

--- a/core/src/main/java/org/testcontainers/dockerclient/UnixSocketClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/UnixSocketClientProviderStrategy.java
@@ -28,7 +28,7 @@ public class UnixSocketClientProviderStrategy extends DockerClientProviderStrate
         try {
             config = tryConfiguration(SOCKET_LOCATION);
             LOGGER.info("Accessing docker with local Unix socket");
-        } catch (Exception e) {
+        } catch (Exception | UnsatisfiedLinkError e) {
             throw new InvalidConfigurationException("ping failed", e);
         }
     }


### PR DESCRIPTION
In case of an UnsatisfiedLinkError (which will happen if needed system libraries are missing) when trying to access Docker via Unix socket, a proxied Unix socket is used as a fallback on Linux instead. In addition, the check for determining the concrete HostPortWaitStrategy behavior now depends on mac as an OS.

However please note, that the existing mac workaround might not work if using images that don't contain bash or sh.