### PR TITLE
changed shadowing scope of guava packages

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -149,8 +149,8 @@
                             <shadedPattern>org.testcontainers.shaded.jersey.repackaged</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>com.google.common</pattern>
-                            <shadedPattern>org.testcontainers.shaded.com.google.common</shadedPattern>
+                            <pattern>com.google</pattern>
+                            <shadedPattern>org.testcontainers.shaded.com.google</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>io.netty</pattern>


### PR DESCRIPTION
Guava `com.google.thirdparty` package was not shadowed. 

Before:
```
$ jar tvf testcontainers-1.1.9.jar | less
...
53288 Sun Feb 12 21:01:26 CET 2017 com/google/thirdparty/publicsuffix/PublicSuffixPatterns.class
2421 Sun Feb 12 21:01:26 CET 2017 com/google/thirdparty/publicsuffix/PublicSuffixType.class
4186 Sun Feb 12 21:01:26 CET 2017 com/google/thirdparty/publicsuffix/TrieParser.class
...
```
After:
```
$ jar tvf testcontainers-1.1.10-SNAPSHOT.jar | less
...
53392 Wed Feb 15 16:10:48 CET 2017 org/testcontainers/shaded/com/google/thirdparty/publicsuffix/PublicSuffixPatterns.class
2629 Wed Feb 15 16:10:48 CET 2017 org/testcontainers/shaded/com/google/thirdparty/publicsuffix/PublicSuffixType.class
4368 Wed Feb 15 16:10:48 CET 2017 org/testcontainers/shaded/com/google/thirdparty/publicsuffix/TrieParser.class
...
```
