### PR TITLE
Do not run "docker ps -a" in ResourceReaper to avoid TooLongFrameException from Netty

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -85,14 +85,6 @@ public final class ResourceReaper {
     }
 
     private void stopContainer(String containerId, String imageName) {
-
-        List<Container> allContainers = dockerClient.listContainersCmd().withShowAll(true).exec();
-
-        if (allContainers.stream().map(Container::getId).noneMatch(containerId::equals)) {
-            LOGGER.trace("Was going to clean up container but it apparently no longer exists: {}");
-            return;
-        }
-
         boolean running;
         try {
             InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(containerId).exec();


### PR DESCRIPTION
`dockerClient.listContainersCmd().withShowAll(true).exec()` fails with `TooLongFrameException` from Netty ( see https://github.com/docker-java/docker-java/issues/603 ) if host has a lot of different containers, including stopped ones. 

We inspect later, so `listContainersCmd` is not needed and must be removed to avoid the performance penalty. 