### PR TITLE
Corrects depreciated method getIpAddress in the docs

### DIFF
--- a/docs/usage/generic_containers.md
+++ b/docs/usage/generic_containers.md
@@ -40,10 +40,10 @@ tests have run.
 
 The class rule provides methods for discovering how your tests can interact with the containers:
 
-* `getIpAddress()` returns the IP address where the container is listening
+* `getContainerIpAddress()` returns the IP address where the container is listening
 * `getMappedPort(...)` returns the Docker mapped port for a port that has been exposed on the container
 
 For example, with the Redis example above, the following will allow your tests to access the Redis service:
 ```java
-String redisUrl = redis.getIpAddress() + ":" + redis.getMappedPort(6379);
+String redisUrl = redis.getContainerIpAddress() + ":" + redis.getMappedPort(6379);
 ```


### PR DESCRIPTION
The method `getIpAddress()` is depreciated in favour of `getContainerIpAddress()`. This commit corrects the documentation to the latter.