### PR TITLE
Expose low level API

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -388,15 +388,35 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     void setLinkedContainers(Map<String, LinkableContainer> linkedContainers);
 
+    /**
+     * @deprecated set by GenericContainer and should never be set outside
+     */
+    @Deprecated
     void setDockerClient(DockerClient dockerClient);
 
+    /**
+     * @deprecated set by GenericContainer and should never be set outside
+     */
+    @Deprecated
     void setDockerDaemonInfo(Info dockerDaemonInfo);
 
+    /**
+     * @deprecated set by GenericContainer and should never be set outside
+     */
+    @Deprecated
     void setContainerId(String containerId);
 
+    /**
+     * @deprecated set by GenericContainer and should never be set outside
+     */
+    @Deprecated
     void setContainerName(String containerName);
 
     void setWaitStrategy(WaitStrategy waitStrategy);
 
+    /**
+     * @deprecated set by GenericContainer and should never be set outside
+     */
+    @Deprecated
     void setContainerInfo(InspectContainerResponse containerInfo);
 }

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -134,7 +134,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     private List<Consumer<OutputFrame>> logConsumers = new ArrayList<>();
 
-    private final Set<Consumer<CreateContainerCmd>> createContainerCmdMidifiers = new LinkedHashSet<>();
+    private final Set<Consumer<CreateContainerCmd>> createContainerCmdModifiers = new LinkedHashSet<>();
 
     private static final Set<String> AVAILABLE_IMAGE_NAME_CACHE = new HashSet<>();
     private static final RateLimiter DOCKER_CLIENT_RATE_LIMITER = RateLimiterBuilder
@@ -193,7 +193,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             profiler.start("Create container");
             CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName);
             applyConfiguration(createCommand);
-            createContainerCmdMidifiers.forEach(hook -> hook.accept(createCommand));
+            createContainerCmdModifiers.forEach(hook -> hook.accept(createCommand));
 
             containerId = createCommand.exec().getId();
             ResourceReaper.instance().registerContainerForCleanup(containerId, dockerImageName);
@@ -898,7 +898,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * @return this
      */
     public SELF withCreateContainerCmdModifier(Consumer<CreateContainerCmd> modifier) {
-        createContainerCmdMidifiers.add(modifier);
+        createContainerCmdModifiers.add(modifier);
         return self();
     }
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -134,7 +134,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     private List<Consumer<OutputFrame>> logConsumers = new ArrayList<>();
 
-    private final Set<Consumer<CreateContainerCmd>> createContainerCmdMidifiers = new HashSet<>();
+    private final Set<Consumer<CreateContainerCmd>> createContainerCmdMidifiers = new LinkedHashSet<>();
 
     private static final Set<String> AVAILABLE_IMAGE_NAME_CACHE = new HashSet<>();
     private static final RateLimiter DOCKER_CLIENT_RATE_LIMITER = RateLimiterBuilder

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -290,11 +290,11 @@ public class GenericContainerRuleTest {
         try(
                 GenericContainer container = new GenericContainer<>("redis:3.0.2")
                         .withCommand("redis-server", "--help")
-                        .withCustomizer(cmd -> cmd.withName("overrideMe"))
+                        .withCreateContainerCmdModifier(cmd -> cmd.withName("overrideMe"))
                         // Preserves the order
-                        .withCustomizer(cmd -> cmd.withName(randomName))
+                        .withCreateContainerCmdModifier(cmd -> cmd.withName(randomName))
                         // Allows to override pre-configured values by GenericContainer
-                        .withCustomizer(cmd -> cmd.withCmd("redis-server", "--port", "6379"))
+                        .withCreateContainerCmdModifier(cmd -> cmd.withCmd("redis-server", "--port", "6379"))
         ) {
             container.start();
 


### PR DESCRIPTION
Makes it possible to override unsupported CreateContainerCmd properties without waiting until TestContainers adds support for it.