### PR TITLE
Note about JDBC driver

### DIFF
--- a/docs/usage/database_containers.md
+++ b/docs/usage/database_containers.md
@@ -48,8 +48,10 @@ Examples/Tests:
 ### JDBC URL
 
 As long as you have TestContainers and the appropriate JDBC driver on your classpath, you can simply modify regular JDBC connection URLs to get a fresh containerized instance of the database each time your application starts up.
+
+_N.B:_
 * _TC needs to be on your application's classpath at runtime for this to work_
-* _JDBC driver needs to be set to `org.testcontainers.jdbc.ContainerDatabaseDriver`_
+* _For Spring Boot you need to specify the driver manually `spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver`_
 
 **Original URL**: `jdbc:mysql://somehostname:someport/databasename`
 

--- a/docs/usage/database_containers.md
+++ b/docs/usage/database_containers.md
@@ -48,8 +48,8 @@ Examples/Tests:
 ### JDBC URL
 
 As long as you have TestContainers and the appropriate JDBC driver on your classpath, you can simply modify regular JDBC connection URLs to get a fresh containerized instance of the database each time your application starts up.
-
-_N.B: TC needs to be on your application's classpath at runtime for this to work_
+* _TC needs to be on your application's classpath at runtime for this to work_
+* _JDBC driver needs to be set to `org.testcontainers.jdbc.ContainerDatabaseDriver`_
 
 **Original URL**: `jdbc:mysql://somehostname:someport/databasename`
 


### PR DESCRIPTION
For me it did not work with Spring Boot until I changed the driver:
`spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver`

Not sure if this is needed in general.

PS: ignore line 115, seems like a glitch :)