### PR TITLE
Docker for Windows: Use command-based port checker

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/HostPortWaitStrategy.java
@@ -33,7 +33,7 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
 
         Callable<Boolean> checkStrategy;
 
-        if (isApplicable()) {
+        if (shouldCheckWithCommand()) {
             List<Integer> exposedPorts = container.getExposedPorts();
 
             Integer exposedPort = exposedPorts.stream()
@@ -91,7 +91,7 @@ public class HostPortWaitStrategy extends GenericContainer.AbstractWaitStrategy 
         }
     }
 
-    private boolean isApplicable() {
+    private boolean shouldCheckWithCommand() {
         // Special case for Docker for Mac, see #160
         if(DockerClientFactory.instance().isUsing(ProxiedUnixSocketClientProviderStrategy.class)
                 && System.getProperty("os.name").toLowerCase().contains("mac")) {


### PR DESCRIPTION
It seems like Docker for Windows has the same port forwarding issue as Docker for Mac