### PR TITLE
#323 Fix for missed TINY_IMAGE during DockerClient initialization

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -98,17 +98,24 @@ public class DockerClientFactory {
 
             checkVersion(version.getVersion());
 
-            List<Image> images = client.listImagesCmd().exec();
             // Pull the image we use to perform some checks
-            if (images.stream().noneMatch(it -> it.getRepoTags() != null && asList(it.getRepoTags()).contains(TINY_IMAGE))) {
-                client.pullImageCmd(TINY_IMAGE).exec(new PullImageResultCallback()).awaitSuccess();
-            }
+            checkAndPullImage(client, TINY_IMAGE);
 
             checkDiskSpaceAndHandleExceptions(client);
             preconditionsChecked = true;
         }
 
         return client;
+    }
+
+  /**
+   * Check whether the image is available locally and pull it otherwise
+   */
+    private void checkAndPullImage(DockerClient client, String image) {
+        List<Image> images = client.listImagesCmd().withImageNameFilter(image).exec();
+        if (images.isEmpty()) {
+            client.pullImageCmd(image).exec(new PullImageResultCallback()).awaitSuccess();
+        }
     }
 
     /**
@@ -168,6 +175,7 @@ public class DockerClientFactory {
     }
 
     private <T> T runInsideDocker(DockerClient client, Consumer<CreateContainerCmd> createContainerCmdConsumer, BiFunction<DockerClient, String, T> block) {
+        checkAndPullImage(client, TINY_IMAGE);
         CreateContainerCmd createContainerCmd = client.createContainerCmd(TINY_IMAGE);
         createContainerCmdConsumer.accept(createContainerCmd);
         String id = createContainerCmd.exec().getId();

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -97,10 +97,6 @@ public class DockerClientFactory {
                     "  Total Memory: " + dockerInfo.getMemTotal() / (1024 * 1024) + " MB");
 
             checkVersion(version.getVersion());
-
-            // Pull the image we use to perform some checks
-            checkAndPullImage(client, TINY_IMAGE);
-
             checkDiskSpaceAndHandleExceptions(client);
             preconditionsChecked = true;
         }

--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -1,0 +1,46 @@
+package org.testcontainers;
+
+import org.junit.Test;
+import org.testcontainers.dockerclient.LogToStringContainerCallback;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created mgorelikov on 05/04/2017
+ * Test for {@link DockerClientFactory}.
+ */
+public class DockerClientFactoryTest {
+
+  private static final String SUCCESS = "SUCCESS";
+
+  @Test
+  public void runCommandInsideDockerShouldPullImageIfItDoesNotExistsLocally() {
+
+    final DockerClientFactory dockFactory = DockerClientFactory.instance();
+    final String imageName = TestcontainersConfiguration.getInstance().getTinyImage();
+    //remove tiny image, so it will be pulled during next command run
+    dockFactory.client()
+        .removeImageCmd(imageName)
+        .withForce(true).exec();
+
+    String result = dockFactory.runInsideDocker(
+        cmd -> cmd.withCmd("sh", "-c", "echo '" + SUCCESS + "'"),
+        (client, id) ->
+            client.logContainerCmd(id)
+                .withStdOut(true)
+                .exec(new LogToStringContainerCallback())
+                .toString()
+    );
+    //check local image availability
+    assertTrue(isImageAvailable(dockFactory, imageName));
+    assertEquals(SUCCESS + '\n', result);
+  }
+
+  private boolean isImageAvailable(DockerClientFactory dockFactory, String imageName) {
+    return !dockFactory.client().listImagesCmd()
+          .withImageNameFilter(imageName)
+          .exec().isEmpty();
+  }
+}

--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -4,43 +4,27 @@ import org.junit.Test;
 import org.testcontainers.dockerclient.LogToStringContainerCallback;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 /**
- * Created mgorelikov on 05/04/2017
  * Test for {@link DockerClientFactory}.
  */
 public class DockerClientFactoryTest {
 
-  private static final String SUCCESS = "SUCCESS";
-
   @Test
-  public void runCommandInsideDockerShouldPullImageIfItDoesNotExistsLocally() {
+  public void runCommandInsideDockerShouldNotFailIfImageDoesNotExistsLocally() {
 
     final DockerClientFactory dockFactory = DockerClientFactory.instance();
-    final String imageName = TestcontainersConfiguration.getInstance().getTinyImage();
     //remove tiny image, so it will be pulled during next command run
     dockFactory.client()
-        .removeImageCmd(imageName)
+        .removeImageCmd(TestcontainersConfiguration.getInstance().getTinyImage())
         .withForce(true).exec();
 
-    String result = dockFactory.runInsideDocker(
-        cmd -> cmd.withCmd("sh", "-c", "echo '" + SUCCESS + "'"),
+    dockFactory.runInsideDocker(
+        cmd -> cmd.withCmd("sh", "-c", "echo 'SUCCESS'"),
         (client, id) ->
             client.logContainerCmd(id)
                 .withStdOut(true)
                 .exec(new LogToStringContainerCallback())
                 .toString()
     );
-    //check local image availability
-    assertTrue(isImageAvailable(dockFactory, imageName));
-    assertEquals(SUCCESS + '\n', result);
-  }
-
-  private boolean isImageAvailable(DockerClientFactory dockFactory, String imageName) {
-    return !dockFactory.client().listImagesCmd()
-          .withImageNameFilter(imageName)
-          .exec().isEmpty();
   }
 }


### PR DESCRIPTION
Fix for `No such image: alpine:3.5 #323`
@bsideup 