### PR TITLE
Change PostgreSQLContainer wait behaviour (fix #317)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/output/OutputFrame.java
+++ b/core/src/main/java/org/testcontainers/containers/output/OutputFrame.java
@@ -30,7 +30,7 @@ public class OutputFrame {
     public String getUtf8String() {
 
         if (bytes == null) {
-            return null;
+            return "";
         }
 
         return new String(bytes, Charsets.UTF_8);

--- a/modules/jdbc-test/pom.xml
+++ b/modules/jdbc-test/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.3-1101-jdbc41</version>
+            <version>42.0.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I've changed the `PostgreSQLContainer` to use the `WaitingConsumer` for waiting for Log output, instead of performing SQL queries. It's basically the same code as in `LogWaitStrategy`, but I've figured we'll refactor the `JdbcDatabaseContainers` at a later stage, to make use of a `WaitingStrategy`?

This fixes #317 