### PR TITLE
Switch browser containers to use LogMessageWaitStrategy

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -18,7 +18,8 @@
         <dependency>
             <groupId>com.github.docker-java</groupId>
             <artifactId>docker-java</artifactId>
-            <version>3.0.9</version>
+            <version>${docker-java.version}</version>
+            <scope>compile</scope>
             <exclusions>
                 <!-- replace with junixsocket -->
                 <exclusion>
@@ -150,10 +151,6 @@
                         <relocation>
                             <pattern>com.fasterxml.jackson</pattern>
                             <shadedPattern>org.testcontainers.shaded.com.fasterxml.jackson</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>com.github.dockerjava</pattern>
-                            <shadedPattern>org.testcontainers.shaded.com.github.dockerjava</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>jersey.repackaged</pattern>

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -867,8 +867,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      *
      * @param attempts number of attempts
      */
-    public void withStartupAttempts(int attempts) {
+    public SELF withStartupAttempts(int attempts) {
         this.startupAttempts = attempts;
+        return self();
     }
 
     @Override

--- a/core/src/main/java/org/testcontainers/containers/output/WaitingConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/WaitingConsumer.java
@@ -86,7 +86,8 @@ public class WaitingConsumer implements Consumer<OutputFrame> {
                 OutputFrame frame = frames.pollLast(100, TimeUnit.MILLISECONDS);
 
                 if (frame != null) {
-                    LOGGER.debug("{}: {}", frame.getType(), frame.getUtf8String());
+                    final String trimmedFrameText = frame.getUtf8String().replaceFirst("\n$", "");
+                    LOGGER.debug("{}: {}", frame.getType(), trimmedFrameText);
 
                     if (predicate.test(frame)) {
                         numberOfMatches++;

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -17,6 +18,12 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java</artifactId>
+            <version>${docker-java.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -39,6 +46,7 @@
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>jetty</artifactId>
             <version>6.1.25</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
@@ -1,0 +1,27 @@
+package org.testcontainers.junit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+
+import java.io.IOException;
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+/**
+ *
+ */
+public class CustomWaitTimeoutWebDriverContainerTest extends BaseWebDriverContainerTest {
+
+    @Rule
+    public BrowserWebDriverContainer chromeWithCustomTimeout = new BrowserWebDriverContainer<>()
+            .withDesiredCapabilities(DesiredCapabilities.chrome())
+            .withStartupTimeout(Duration.of(30, SECONDS));
+
+    @Test
+    public void simpleTest() throws IOException {
+        doSimpleWebdriverTest(chromeWithCustomTimeout);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <docker-java.version>3.0.9</docker-java.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Reduces default browser container startup timeout to 15s, down from an
unnecessarily high 120s.

This also replaces inheritance-based `waitUntilContainerStarted` with
composition-based `WaitStrategy`. The new `LogMessageWaitStrategy` allows
us to wait based upon the Selenium container log output, rather than the
 relatively expensive process of repeatedly trying to create and connect
 a `RemoteWebDriver` instance.