### PR TITLE
Add audit logging

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -429,6 +429,8 @@ class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCom
             Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
         }
         logger().info("Docker Compose has finished running");
+
+        AuditLogger.doComposeLog(this.getCommandParts(), this.getEnv());
     }
 }
 

--- a/core/src/main/java/org/testcontainers/dockerclient/AuditLoggingDockerClient.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/AuditLoggingDockerClient.java
@@ -1,0 +1,121 @@
+package org.testcontainers.dockerclient;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.*;
+import lombok.experimental.Delegate;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.Proxy;
+import java.util.function.BiConsumer;
+
+import static org.testcontainers.utility.AuditLogger.doLog;
+
+/**
+ * Wrapper for {@link DockerClient} to facilitate 'audit logging' of potentially destruction actions using
+ * {@link org.testcontainers.utility.AuditLogger}.
+ */
+@Slf4j
+@SuppressWarnings("unchecked")
+public class AuditLoggingDockerClient implements DockerClient {
+
+    @Delegate(excludes = InterceptedMethods.class)
+    private final DockerClient wrappedClient;
+
+    public AuditLoggingDockerClient(DockerClient wrappedClient) {
+        this.wrappedClient = wrappedClient;
+    }
+
+    @Override
+    public CreateContainerCmd createContainerCmd(@NotNull String image) {
+        return wrappedCommand(CreateContainerCmd.class,
+                wrappedClient.createContainerCmd(image),
+                (cmd, res) -> doLog("CREATE", image, res.getId(), cmd),
+                (cmd, e) -> doLog("CREATE", image, null, cmd, e));
+
+    }
+
+    @Override
+    public StartContainerCmd startContainerCmd(@NotNull String containerId) {
+        return wrappedCommand(StartContainerCmd.class,
+                wrappedClient.startContainerCmd(containerId),
+                (cmd, res) -> doLog("START", null, containerId, cmd),
+                (cmd, e) -> doLog("START", null, containerId, cmd, e));
+    }
+
+    @Override
+    public RemoveContainerCmd removeContainerCmd(@NotNull String containerId) {
+        return wrappedCommand(RemoveContainerCmd.class,
+                wrappedClient.removeContainerCmd(containerId),
+                (cmd, res) -> doLog("REMOVE", null, containerId, cmd),
+                (cmd, e) -> doLog("REMOVE", null, containerId, cmd, e));
+    }
+
+    @Override
+    public StopContainerCmd stopContainerCmd(@NotNull String containerId) {
+        return wrappedCommand(StopContainerCmd.class,
+                wrappedClient.stopContainerCmd(containerId),
+                (cmd, res) -> doLog("STOP", null, containerId, cmd),
+                (cmd, e) -> doLog("STOP", null, containerId, cmd, e));
+    }
+
+    @Override
+    public KillContainerCmd killContainerCmd(@NotNull String containerId) {
+        return wrappedCommand(KillContainerCmd.class,
+                wrappedClient.killContainerCmd(containerId),
+                (cmd, res) -> doLog("KILL", null, containerId, cmd),
+                (cmd, e) -> doLog("KILL", null, containerId, cmd, e));
+    }
+
+    @Override
+    public CreateNetworkCmd createNetworkCmd() {
+        return wrappedCommand(CreateNetworkCmd.class,
+                wrappedClient.createNetworkCmd(),
+                (cmd, res) -> doLog("CREATE_NETWORK", null, null, cmd),
+                (cmd, e) -> doLog("CREATE_NETWORK", null, null, cmd, e));
+    }
+
+    @Override
+    public RemoveNetworkCmd removeNetworkCmd(@NotNull String networkId) {
+        return wrappedCommand(RemoveNetworkCmd.class,
+                wrappedClient.removeNetworkCmd(networkId),
+                (cmd, res) -> doLog("REMOVE_NETWORK", null, null, cmd),
+                (cmd, e) -> doLog("REMOVE_NETWORK", null, null, cmd, e));
+    }
+
+    private <T extends SyncDockerCmd<R>, R> T wrappedCommand(Class<T> clazz,
+                                                             T cmd,
+                                                             BiConsumer<T, R> successConsumer,
+                                                             BiConsumer<T, Exception> failureConsumer) {
+
+        return (T) Proxy.newProxyInstance(
+                clazz.getClassLoader(),
+                new Class<?>[]{clazz},
+                (proxy, method, args) -> {
+
+                    if (method.getName().equals("exec")) {
+                        try {
+                            R r = (R) method.invoke(cmd, args);
+                            successConsumer.accept(cmd, r);
+                            return r;
+                        } catch (Exception e) {
+                            failureConsumer.accept(cmd, e);
+                            throw e;
+                        }
+                    } else {
+                        return method.invoke(cmd, args);
+                    }
+                });
+    }
+
+    @SuppressWarnings("unused")
+    private interface InterceptedMethods {
+        CreateContainerCmd createContainerCmd(String image);
+        StartContainerCmd startContainerCmd(String containerId);
+        RemoveContainerCmd removeContainerCmd(String containerId);
+        StopContainerCmd stopContainerCmd(String containerId);
+        KillContainerCmd killContainerCmd(String containerId);
+        CreateNetworkCmd createNetworkCmd();
+        RemoveNetworkCmd removeNetworkCmd(String networkId);
+    }
+}

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -94,7 +94,7 @@ public abstract class DockerClientProviderStrategy {
      * @return a usable, tested, Docker client configuration for the host system environment
      */
     public DockerClient getClient() {
-        return client;
+        return new AuditLoggingDockerClient(client);
     }
 
     protected DockerClient getClientForConfig(DockerClientConfig config) {

--- a/core/src/main/java/org/testcontainers/utility/AuditLogger.java
+++ b/core/src/main/java/org/testcontainers/utility/AuditLogger.java
@@ -1,0 +1,67 @@
+package org.testcontainers.utility;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.command.DockerCmd;
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.MDC;
+
+import java.util.List;
+
+/**
+ * Logger for tracking potentially destructive actions, intended for usage in a shared Docker environment where
+ * traceability is needed. This class uses SLF4J, logging at TRACE level and capturing common fields as MDC fields.
+ * <p>
+ * Users should configure their test logging to apply appropriate filters/storage so that these logs are
+ * captured appropriately.
+ */
+@Slf4j
+@UtilityClass
+public class AuditLogger {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String MDC_PREFIX = AuditLogger.class.getCanonicalName();
+
+    public static void doLog(String action, String image, String containerId, DockerCmd<?> cmd) {
+        doLog(action, image, containerId, cmd, null);
+    }
+
+    public static void doLog(String action, String image, String containerId, DockerCmd<?> cmd, @Nullable Exception e) {
+        MDC.put(MDC_PREFIX + ".Action", action);
+        MDC.put(MDC_PREFIX + ".Image", image);
+        MDC.put(MDC_PREFIX + ".ContainerId", containerId);
+        try {
+            MDC.put(MDC_PREFIX + ".Command", objectMapper.writeValueAsString(cmd));
+        } catch (JsonProcessingException ignored) {
+        }
+
+        if (e != null) {
+            MDC.put(MDC_PREFIX + ".Exception", e.getLocalizedMessage());
+            log.trace("{} action with image: {}, containerId: {}", action, image, containerId, e);
+        } else {
+            log.trace("{} action with image: {}, containerId: {}", action, image, containerId);
+        }
+
+        MDC.remove(MDC_PREFIX + ".Action");
+        MDC.remove(MDC_PREFIX + ".Image");
+        MDC.remove(MDC_PREFIX + ".ContainerId");
+        MDC.remove(MDC_PREFIX + ".Command");
+        MDC.remove(MDC_PREFIX + ".Exception");
+    }
+
+    public static void doComposeLog(String[] commandParts, List<String> env) {
+        MDC.put(MDC_PREFIX + ".Action", "COMPOSE");
+        final String command = StringUtils.join(commandParts, ' ');
+        MDC.put(MDC_PREFIX + ".Compose.Command", command);
+        MDC.put(MDC_PREFIX + ".Compose.Env", env.toString());
+
+        log.trace("COMPOSE action with command: {}, env: {}", command, env);
+
+        MDC.remove(MDC_PREFIX + ".Action");
+        MDC.remove(MDC_PREFIX + ".Compose.Command");
+        MDC.remove(MDC_PREFIX + ".Compose.Env");
+    }
+}


### PR DESCRIPTION
... to capture structured information about important actions via SLF4J. This is intended for use in environments where docker daemons are shared between large numbers of test executions, and where there is a need to collect logs to diagnose faults.

Context: at my work we have a large number of CI jobs running at any given time using Drone CI, on a CI cluster shared across the company. There is a desire for Testcontainers to log anything that is potentially destructive, particularly as it could _theoretically_ stomp over unrelated build jobs in a Drone environment.