### PR TITLE
use version 1.2.3 of logback-classic to stay up to date

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
-            <version>1.7.2</version>
+            <version>1.7.25</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.2</version>
+            <version>1.2.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.7</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
yet another dependency bump to keep up.  See https://logback.qos.ch/news.html for background and https://docs.google.com/spreadsheets/d/1cpb5D7qnyye4W0RTlHUnXedYK98catNZytYIu5D91m0/edit#gid=0 for performance changes.