### PR TITLE
add container arguments to specify SELinux contexts for mounts

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -80,11 +80,24 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * Adds a file system binding. Consider using {@link #withFileSystemBind(String, String, BindMode)}
      * for building a container in a fluent style.
      *
-     * @param hostPath the file system path on the host
+     * @param hostPath      the file system path on the host
      * @param containerPath the file system path inside the container
-     * @param mode the bind mode
+     * @param mode          the bind mode
      */
-    void addFileSystemBind(String hostPath, String containerPath, BindMode mode);
+    default void addFileSystemBind(final String hostPath, final String containerPath, final BindMode mode) {
+        addFileSystemBind(hostPath, containerPath, mode, SelinuxContext.NONE);
+    }
+
+    /**
+     * Adds a file system binding. Consider using {@link #withFileSystemBind(String, String, BindMode)}
+     * for building a container in a fluent style.
+     *
+     * @param hostPath      the file system path on the host
+     * @param containerPath the file system path inside the container
+     * @param mode          the bind mode
+     * @param selinuxContext selinux context argument to use for this file
+     */
+    void addFileSystemBind(String hostPath, String containerPath, BindMode mode, SelinuxContext selinuxContext);
 
     /**
      * Add a link to another container.
@@ -205,7 +218,22 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @param mode          access mode for the file
      * @return this
      */
-    SELF withClasspathResourceMapping(String resourcePath, String containerPath, BindMode mode);
+    default SELF withClasspathResourceMapping(final String resourcePath, final String containerPath, final BindMode mode) {
+        withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.NONE);
+        return self();
+    }
+
+    /**
+     * Map a resource (file or directory) on the classpath to a path inside the container.
+     * This will only work if you are running your tests outside a Docker container.
+     *
+     * @param resourcePath   path to the resource on the classpath (relative to the classpath root; should not start with a leading slash)
+     * @param containerPath  path this should be mapped to inside the container
+     * @param mode           access mode for the file
+     * @param selinuxContext selinux context argument to use for this file
+     * @return this
+     */
+    SELF withClasspathResourceMapping(String resourcePath, String containerPath, BindMode mode, SelinuxContext selinuxContext);
 
     /**
      * Set the duration of waiting time until container treated as started.

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -481,10 +481,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * {@inheritDoc}
      */
     @Override
-    public void addFileSystemBind(String hostPath, String containerPath, BindMode mode) {
+    public void addFileSystemBind(final String hostPath, final String containerPath, final BindMode mode, final SelinuxContext selinuxContext) {
 
         final MountableFile mountableFile = MountableFile.forHostPath(hostPath);
-        binds.add(new Bind(mountableFile.getResolvedPath(), new Volume(containerPath), mode.accessMode));
+        binds.add(new Bind(mountableFile.getResolvedPath(), new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
     }
 
     /**
@@ -615,10 +615,18 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * {@inheritDoc}
      */
     @Override
-    public SELF withClasspathResourceMapping(String resourcePath, String containerPath, BindMode mode) {
+    public SELF withClasspathResourceMapping(final String resourcePath, final String containerPath, final BindMode mode) {
+        return withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.NONE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SELF withClasspathResourceMapping(final String resourcePath, final String containerPath, final BindMode mode, final SelinuxContext selinuxContext) {
         final MountableFile mountableFile = MountableFile.forClasspathResource(resourcePath);
 
-        this.addFileSystemBind(mountableFile.getResolvedPath(), containerPath, mode);
+        this.addFileSystemBind(mountableFile.getResolvedPath(), containerPath, mode, selinuxContext);
 
         return self();
     }

--- a/core/src/main/java/org/testcontainers/containers/SelinuxContext.java
+++ b/core/src/main/java/org/testcontainers/containers/SelinuxContext.java
@@ -1,16 +1,17 @@
 package org.testcontainers.containers;
 
 import com.github.dockerjava.api.model.SELContext;
+import lombok.AllArgsConstructor;
 
 /**
  * Possible contexts for use with SELinux
  */
+@AllArgsConstructor
 public enum SelinuxContext {
-    SHARED(SELContext.shared), SINGLE(SELContext.single), NONE(SELContext.none);
+    SHARED(SELContext.shared),
+    SINGLE(SELContext.single),
+    NONE(SELContext.none);
 
     public final SELContext selContext;
 
-    SelinuxContext(final SELContext selContext) {
-        this.selContext = selContext;
-    }
 }

--- a/core/src/main/java/org/testcontainers/containers/SelinuxContext.java
+++ b/core/src/main/java/org/testcontainers/containers/SelinuxContext.java
@@ -1,0 +1,16 @@
+package org.testcontainers.containers;
+
+import com.github.dockerjava.api.model.SELContext;
+
+/**
+ * Possible contexts for use with SELinux
+ */
+public enum SelinuxContext {
+    SHARED(SELContext.shared), SINGLE(SELContext.single), NONE(SELContext.none);
+
+    public final SELContext selContext;
+
+    SelinuxContext(final SELContext selContext) {
+        this.selContext = selContext;
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -107,7 +107,7 @@ public class GenericContainerRuleTest {
      * Map a file on the classpath to a file in the container, and then expose the content for testing.
      */
     @ClassRule
-    public static GenericContainer alpineClasspathResourceSelinx = new GenericContainer("alpine:3.2")
+    public static GenericContainer alpineClasspathResourceSelinux = new GenericContainer("alpine:3.2")
             .withExposedPorts(80)
             .withClasspathResourceMapping("mappable-resource/test-resource.txt", "/content.txt", READ_WRITE, SHARED)
             .withCommand("/bin/sh", "-c", "while true; do cat /content.txt | nc -l -p 80; done");
@@ -216,10 +216,7 @@ public class GenericContainerRuleTest {
 
     @Test
     public void customClasspathResourceMappingWithSelinuxTest() throws IOException {
-        // Note: This functionality doesn't work if you are running your build inside a Docker container;
-        // in that case this test will fail.
-        String line = getReaderForContainerPort80(alpineClasspathResourceSelinx).readLine();
-
+        String line = getReaderForContainerPort80(alpineClasspathResourceSelinux).readLine();
         assertEquals("Resource on the classpath can be mapped using calls to withClasspathResourceMappingSelinux", "FOOBAR", line);
     }
 

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -11,7 +11,6 @@ import org.junit.*;
 import org.rnorth.ducttape.RetryCountExceededException;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.TestEnvironment;
 


### PR DESCRIPTION
I wanted to use the :z/Z mount options with SELinux and saw where they were not exposed.  Just a small patch that will expose these from the underlying library.