### PR TITLE
Cleanup if start failed

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -46,7 +46,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
     private final String identifier;
     private final Map<String, AmbassadorContainer> ambassadorContainers = new HashMap<>();
     private final List<File> composeFiles;
-    private Set<String> spawnedContainerIds;
+    private Set<String> spawnedContainerIds = Collections.emptySet();
     private Map<String, Integer> scalingPreferences = new HashMap<>();
     private DockerClient dockerClient;
     private boolean localCompose;

--- a/core/src/main/java/org/testcontainers/containers/FailureDetectingExternalResource.java
+++ b/core/src/main/java/org/testcontainers/containers/FailureDetectingExternalResource.java
@@ -25,9 +25,8 @@ public class FailureDetectingExternalResource implements TestRule {
 
                 List<Throwable> errors = new ArrayList<Throwable>();
 
-                starting(description);
-
                 try {
+                    starting(description);
                     base.evaluate();
                     succeeded(description);
                 } catch (Throwable e) {

--- a/core/src/test/java/org/testcontainers/containers/FailureDetectingExternalResourceTest.java
+++ b/core/src/test/java/org/testcontainers/containers/FailureDetectingExternalResourceTest.java
@@ -1,0 +1,28 @@
+package org.testcontainers.containers;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+public class FailureDetectingExternalResourceTest {
+
+    @Test
+    public void finishedIsCalledForCleanupIfStartingThrows() throws Throwable {
+        FailureDetectingExternalResource res = spy(FailureDetectingExternalResource.class);
+        Statement stmt = res.apply(mock(Statement.class), Description.EMPTY);
+        doThrow(new RuntimeException()).when(res).starting(any());
+        try {
+            stmt.evaluate();
+        } catch (Throwable t) {
+            // ignore
+        }
+        verify(res).starting(any());
+        verify(res).finished(any());
+    }
+
+}


### PR DESCRIPTION
This is a proposed fix for #335.
The test suites reported no errors after this change.