### PR TITLE
Modify Selenium container startup detection

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -56,7 +56,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      */
     public BrowserWebDriverContainer() {
         this.waitStrategy = new LogMessageWaitStrategy()
-                .withRegEx(".*Selenium Server is up and running.*\n")
+                .withRegEx(".*(RemoteWebDriver instances should connect to|Selenium Server is up and running).*\n")
                 .withStartupTimeout(Duration.of(15, SECONDS));
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -56,7 +56,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      */
     public BrowserWebDriverContainer() {
         this.waitStrategy = new LogMessageWaitStrategy()
-                .withRegEx(".*(RemoteWebDriver instances should connect to|Selenium Server is up and running).*\n")
+                .withRegEx(".*Selenium Server is up and running.*\n")
                 .withStartupTimeout(Duration.of(15, SECONDS));
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -56,7 +56,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      */
     public BrowserWebDriverContainer() {
         this.waitStrategy = new LogMessageWaitStrategy()
-                .withRegEx(".*RemoteWebDriver instances should connect to.*\n")
+                .withRegEx(".*(RemoteWebDriver instances should connect to|Selenium Server is up and running).*\n")
                 .withStartupTimeout(Duration.of(15, SECONDS));
     }
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
@@ -1,0 +1,33 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+
+/**
+ * Simple test to check that readiness detection works correctly across major versions of the containers.
+ */
+@RunWith(Parameterized.class)
+public class Selenium3xTest extends BaseWebDriverContainerTest {
+
+    @Parameterized.Parameters(name = "tag: {0}")
+    public static String[] data() {
+        return new String[] { "3.4.0", "2.53.0" };
+    }
+
+    @Parameterized.Parameter()
+    public String tag;
+
+    @Test
+    public void testAdditionalStartupString() {
+        BrowserWebDriverContainer chrome = new BrowserWebDriverContainer("selenium/standalone-chrome-debug:" + tag)
+                .withDesiredCapabilities(DesiredCapabilities.chrome());
+        try {
+            chrome.start();
+        } finally {
+            chrome.stop();
+        }
+    }
+}

--- a/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
@@ -10,11 +10,11 @@ import org.testcontainers.containers.BrowserWebDriverContainer;
  * Simple test to check that readiness detection works correctly across major versions of the containers.
  */
 @RunWith(Parameterized.class)
-public class Selenium3xTest extends BaseWebDriverContainerTest {
+public class Selenium3xTest {
 
     @Parameterized.Parameters(name = "tag: {0}")
     public static String[] data() {
-        return new String[] { "3.4.0", "2.53.0" };
+        return new String[]{"3.4.0", "2.53.0", "2.45.0"};
     }
 
     @Parameterized.Parameter()
@@ -22,12 +22,9 @@ public class Selenium3xTest extends BaseWebDriverContainerTest {
 
     @Test
     public void testAdditionalStartupString() {
-        BrowserWebDriverContainer chrome = new BrowserWebDriverContainer("selenium/standalone-chrome-debug:" + tag)
-                .withDesiredCapabilities(DesiredCapabilities.chrome());
-        try {
+        try (BrowserWebDriverContainer chrome = new BrowserWebDriverContainer("selenium/standalone-chrome-debug:" + tag)
+                .withDesiredCapabilities(DesiredCapabilities.chrome())) {
             chrome.start();
-        } finally {
-            chrome.stop();
         }
     }
 }


### PR DESCRIPTION
... using alternative readiness string observed in v3.x of Selenium containers.

It seems that somewhere along the line the string that the selenium containers use to signal readiness has changed. This commit fixes that issue by allowing either string to be detected. The test tries two tag versions with differing outputs.

FYI @bsideup @kiview 