### PR TITLE
Reverse over-optimisation of MySQL/MariaDB thread_stack size setting

### DIFF
--- a/modules/mysql/src/main/resources/mysql-default-conf/my.cnf
+++ b/modules/mysql/src/main/resources/mysql-default-conf/my.cnf
@@ -11,7 +11,6 @@ sort_buffer_size = 64K
 read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K
-thread_stack = 128K
 skip-host-cache
 skip-name-resolve
 


### PR DESCRIPTION
The default value has now been removed to allow DB default to be used (typically 192K)
Refs #347