### PR TITLE
Remove Jersey dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Changed
 - Added `TC_DAEMON` JDBC URL flag to prevent `ContainerDatabaseDriver` from shutting down containers at the time all connections are closed. (#359, #360)
+- Removed unused Jersey dependencies (#361)
 
 ## [1.3.0] - 2017-06-05
 ### Fixed

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,7 +26,21 @@
                     <groupId>de.gesellix</groupId>
                     <artifactId>unix-socket-factory</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.connectors</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.0.1</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Since we use Netty, it's pointless to depend on Jersey (comes from docker-java)