### PR TITLE
Remove deprecated wrongly generated setters from GenericContainer

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -388,35 +388,5 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     void setLinkedContainers(Map<String, LinkableContainer> linkedContainers);
 
-    /**
-     * @deprecated set by GenericContainer and should never be set outside
-     */
-    @Deprecated
-    void setDockerClient(DockerClient dockerClient);
-
-    /**
-     * @deprecated set by GenericContainer and should never be set outside
-     */
-    @Deprecated
-    void setDockerDaemonInfo(Info dockerDaemonInfo);
-
-    /**
-     * @deprecated set by GenericContainer and should never be set outside
-     */
-    @Deprecated
-    void setContainerId(String containerId);
-
-    /**
-     * @deprecated set by GenericContainer and should never be set outside
-     */
-    @Deprecated
-    void setContainerName(String containerName);
-
     void setWaitStrategy(WaitStrategy waitStrategy);
-
-    /**
-     * @deprecated set by GenericContainer and should never be set outside
-     */
-    @Deprecated
-    void setContainerInfo(InspectContainerResponse containerInfo);
 }

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -8,9 +8,7 @@ import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.*;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NonNull;
+import lombok.*;
 import org.jetbrains.annotations.Nullable;
 import org.junit.runner.Description;
 import org.rnorth.ducttape.ratelimits.RateLimiter;
@@ -108,17 +106,22 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     /*
      * Unique instance of DockerClient for use by this container object.
      */
+    @Setter(AccessLevel.NONE)
     protected DockerClient dockerClient = DockerClientFactory.instance().client();
 
     /*
      * Info about the Docker server; lazily fetched.
      */
+    @Setter(AccessLevel.NONE)
     protected Info dockerDaemonInfo = null;
 
     /*
      * Set during container startup
      */
+    @Setter(AccessLevel.NONE)
     protected String containerId;
+
+    @Setter(AccessLevel.NONE)
     protected String containerName;
 
     /**
@@ -128,6 +131,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     protected WaitStrategy waitStrategy = Wait.defaultWaitStrategy();
 
     @Nullable
+    @Setter(AccessLevel.NONE)
     private InspectContainerResponse containerInfo;
 
     private List<Consumer<OutputFrame>> logConsumers = new ArrayList<>();


### PR DESCRIPTION
This PR removes wrongly generated setters from GenericContainer. 
They didn't work anyway and were marked as `@Deprecated` a few releases ago :)