### PR TITLE
Add support for Docker networks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ cache:
 install:
   - echo "MAVEN_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1'" > ~/.mavenrc
   - sudo apt-get update -qq
-  - sudo apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew install docker-engine
+  - sudo apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew install docker-ce
   - docker info
   # Update env vars required by testcontainers
   - export DOCKER_HOST=tcp://127.0.0.1:2375

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 - Added pre-flight checks (can be disabled with `checks.disable` configuration property) (#363)
 - Removed unused Jersey dependencies (#361)
 - Fixed non-POSIX fallback for file attribute reading (#371)
-- Added support for the Docker networks (#372)
+- Added support for Docker networks (#372)
 
 ## [1.3.0] - 2017-06-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Changed
+- Added support for Docker networks (#372)
 
 ## [1.3.1] - 2017-06-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Added `TC_DAEMON` JDBC URL flag to prevent `ContainerDatabaseDriver` from shutting down containers at the time all connections are closed. (#359, #360)
 - Removed unused Jersey dependencies (#361)
+- Added support for the Docker networks (#372)
 
 ## [1.3.0] - 2017-06-05
 ### Fixed

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -197,6 +197,24 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     SELF withNetworkMode(String networkMode);
 
     /**
+     * Set the network for this container, similar to the <code>--network &lt;name&gt;</code>
+     * option on the docker CLI.
+     *
+     * @param network the instance of {@link Network}
+     * @return this
+     */
+    SELF withNetwork(Network network);
+
+    /**
+     * Set the network aliases for this container, similar to the <code>--network-alias &lt;my-service&gt;</code>
+     * option on the docker CLI.
+     *
+     * @param aliases the list of aliases
+     * @return this
+     */
+    SELF withNetworkAliases(String... aliases);
+
+    /**
      * Map a resource (file or directory) on the classpath to a path inside the container.
      * This will only work if you are running your tests outside a Docker container.
      *

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -419,11 +419,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         createCommand.withExtraHosts(extraHostsArray);
 
         if (network != null) {
-            if (!network.isCreated()) {
-                throw new ContainerLaunchException("Aborting attempt to use non-existing network " + network.getName());
-            }
-
-            createCommand.withNetworkMode(network.getName());
+            createCommand.withNetworkMode(network.getId());
             createCommand.withAliases(this.networkAliases);
         } else if (networkMode != null) {
             createCommand.withNetworkMode(networkMode);

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -76,6 +76,12 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     private String networkMode;
 
     @NonNull
+    private Network network;
+
+    @NonNull
+    private List<String> networkAliases = new ArrayList<>();
+
+    @NonNull
     private Future<String> image;
 
     @NonNull
@@ -412,7 +418,14 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 .toArray(String[]::new);
         createCommand.withExtraHosts(extraHostsArray);
 
-        if (networkMode != null) {
+        if (network != null) {
+            if (!network.isCreated()) {
+                throw new ContainerLaunchException("Aborting attempt to use non-existing network " + network.getName());
+            }
+
+            createCommand.withNetworkMode(network.getName());
+            createCommand.withAliases(this.networkAliases);
+        } else if (networkMode != null) {
             createCommand.withNetworkMode(networkMode);
         }
 
@@ -612,6 +625,18 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withNetworkMode(String networkMode) {
         this.networkMode = networkMode;
+        return self();
+    }
+
+    @Override
+    public SELF withNetwork(Network network) {
+        this.network = network;
+        return self();
+    }
+
+    @Override
+    public SELF withNetworkAliases(String... aliases) {
+        Collections.addAll(this.networkAliases, aliases);
         return self();
     }
 

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -32,6 +32,7 @@ public interface Network extends AutoCloseable, TestRule {
     }
 
     @Builder
+    @Getter
     class NetworkImpl extends ExternalResource implements Network {
 
         private final String name = UUID.randomUUID().toString();

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -3,7 +3,6 @@ package org.testcontainers.containers;
 import com.github.dockerjava.api.command.CreateNetworkCmd;
 import lombok.*;
 import lombok.experimental.Delegate;
-import lombok.experimental.FieldDefaults;
 import org.junit.rules.ExternalResource;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.utility.ResourceReaper;
@@ -47,17 +46,16 @@ public interface Network extends AutoCloseable {
 
     @Builder
     @Getter
-    @FieldDefaults(level = AccessLevel.PRIVATE)
     class NetworkImpl implements Network {
 
-        final String name = UUID.randomUUID().toString();
+        private final String name = UUID.randomUUID().toString();
 
-        Boolean enableIpv6;
+        private Boolean enableIpv6;
 
-        String driver;
+        private String driver;
 
         @Singular
-        Set<Consumer<CreateNetworkCmd>> createNetworkCmdModifiers = new LinkedHashSet<>();
+        private Set<Consumer<CreateNetworkCmd>> createNetworkCmdModifiers = new LinkedHashSet<>();
 
         @Override
         public boolean isCreated() {

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -1,0 +1,147 @@
+package org.testcontainers.containers;
+
+import com.github.dockerjava.api.command.CreateNetworkCmd;
+import lombok.*;
+import lombok.experimental.Delegate;
+import org.junit.rules.ExternalResource;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.utility.ResourceReaper;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+public interface Network extends AutoCloseable {
+
+    String getName();
+
+    Boolean getEnableIpv6();
+
+    String getDriver();
+
+    boolean isCreated();
+
+    @Override
+    default void close() {
+        if (isCreated()) {
+            ResourceReaper.instance().removeNetworks(getName());
+        }
+    }
+
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    default <T extends Network> T as(Class<T> type) {
+        return type.getDeclaredConstructor(Network.class).newInstance(this);
+    }
+
+    static Network newNetwork() {
+        return builder().build();
+    }
+
+    static NetworkImpl.NetworkImplBuilder builder() {
+        return NetworkImpl.builder();
+    }
+
+    @Builder
+    @Getter
+    class NetworkImpl implements Network {
+
+        final String name = UUID.randomUUID().toString();
+
+        Boolean enableIpv6;
+
+        String driver;
+
+        @Singular
+        Set<Consumer<CreateNetworkCmd>> createNetworkCmdModifiers = new LinkedHashSet<>();
+
+        @Override
+        public boolean isCreated() {
+            return false;
+        }
+    }
+
+    @RequiredArgsConstructor
+    class Runnable implements Network, java.lang.Runnable {
+
+        @Delegate(excludes = Excludes.class)
+        protected final Network network;
+
+        private final AtomicBoolean created = new AtomicBoolean(false);
+
+        @Override
+        public void run() {
+            if (!created.getAndSet(true)) {
+                ResourceReaper.instance().registerNetworkForCleanup(getName());
+
+                CreateNetworkCmd createNetworkCmd = DockerClientFactory.instance().client().createNetworkCmd();
+
+                createNetworkCmd.withName(getName());
+                createNetworkCmd.withCheckDuplicate(true);
+
+                if (getEnableIpv6() != null) {
+                    createNetworkCmd.withEnableIpv6(getEnableIpv6());
+                }
+
+                if (getDriver() != null) {
+                    createNetworkCmd.withDriver(getDriver());
+                }
+
+                if (network instanceof NetworkImpl) {
+                    for (Consumer<CreateNetworkCmd> consumer : ((NetworkImpl) network).getCreateNetworkCmdModifiers()) {
+                        consumer.accept(createNetworkCmd);
+                    }
+                }
+
+                createNetworkCmd.exec();
+            }
+        }
+
+        @Override
+        public boolean isCreated() {
+            return created.get();
+        }
+    }
+
+    class AutoCreated implements Network {
+
+        @Delegate(excludes = Excludes.class)
+        protected final Network network;
+
+        public AutoCreated(Network network) {
+            this.network = network;
+            as(Runnable.class).run();
+        }
+
+        @Override
+        public boolean isCreated() {
+            return true;
+        }
+    }
+
+    class JUnitRule extends ExternalResource implements Network {
+
+        @Delegate(types = Network.class)
+        protected final Network.Runnable network;
+
+        public JUnitRule(Network network) {
+            this.network = network.as(Runnable.class);
+        }
+
+        @Override
+        protected void before() throws Throwable {
+            network.run();
+        }
+
+        @Override
+        protected void after() {
+            network.close();
+        }
+    }
+
+    interface Excludes {
+        boolean isCreated();
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -3,6 +3,7 @@ package org.testcontainers.containers;
 import com.github.dockerjava.api.command.CreateNetworkCmd;
 import lombok.*;
 import lombok.experimental.Delegate;
+import lombok.experimental.FieldDefaults;
 import org.junit.rules.ExternalResource;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.utility.ResourceReaper;
@@ -46,6 +47,7 @@ public interface Network extends AutoCloseable {
 
     @Builder
     @Getter
+    @FieldDefaults(level = AccessLevel.PRIVATE)
     class NetworkImpl implements Network {
 
         final String name = UUID.randomUUID().toString();

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -109,17 +109,12 @@ public interface Network extends AutoCloseable {
 
     class AutoCreated implements Network {
 
-        @Delegate(excludes = Excludes.class)
-        protected final Network network;
+        @Delegate(types = Network.class)
+        protected final Network.Runnable network;
 
         public AutoCreated(Network network) {
-            this.network = network;
-            as(Runnable.class).run();
-        }
-
-        @Override
-        public boolean isCreated() {
-            return true;
+            this.network = network.as(Runnable.class);
+            this.network.run();
         }
     }
 

--- a/core/src/test/java/org/testcontainers/containers/NetworkTest.java
+++ b/core/src/test/java/org/testcontainers/containers/NetworkTest.java
@@ -18,7 +18,7 @@ public class NetworkTest {
         @Test
         public void testNetworkSupport() throws Exception {
             try (
-                    Network network = Network.newNetwork().as(Network.AutoCreated.class);
+                    Network network = newNetwork().as(Network.AutoCreated.class);
 
                     GenericContainer foo = new GenericContainer()
                             .withNetwork(network)
@@ -45,7 +45,7 @@ public class NetworkTest {
                             .build()
                             .as(Network.AutoCreated.class);
             ) {
-                VisibleAssertions.assertEquals(
+                assertEquals(
                         "Flag is set",
                         "macvlan",
                         DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(network.getName()).exec().getDriver()
@@ -61,7 +61,7 @@ public class NetworkTest {
                             .build()
                             .as(Network.AutoCreated.class);
             ) {
-                VisibleAssertions.assertEquals(
+                assertEquals(
                         "Flag is set",
                         "macvlan",
                         DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(network.getName()).exec().getDriver()

--- a/core/src/test/java/org/testcontainers/containers/NetworkTest.java
+++ b/core/src/test/java/org/testcontainers/containers/NetworkTest.java
@@ -1,0 +1,95 @@
+package org.testcontainers.containers;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.rnorth.visibleassertions.VisibleAssertions;
+import org.testcontainers.DockerClientFactory;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.testcontainers.containers.Network.newNetwork;
+
+@RunWith(Enclosed.class)
+public class NetworkTest {
+
+    public static class WithoutRules {
+
+        @Test
+        public void testNetworkSupport() throws Exception {
+            try (
+                    Network network = Network.newNetwork().as(Network.AutoCreated.class);
+
+                    GenericContainer foo = new GenericContainer()
+                            .withNetwork(network)
+                            .withNetworkAliases("foo")
+                            .withCommand("/bin/sh", "-c", "while true ; do printf 'HTTP/1.1 200 OK\\n\\nyay' | nc -l -p 8080; done");
+
+                    GenericContainer bar = new GenericContainer()
+                            .withNetwork(network)
+                            .withCommand("top")
+            ) {
+                foo.start();
+                bar.start();
+
+                String response = bar.execInContainer("wget", "-O", "-", "http://foo:8080").getStdout();
+                assertEquals("received response", "yay", response);
+            }
+        }
+
+        @Test
+        public void testBuilder() throws Exception {
+            try (
+                    Network network = Network.builder()
+                            .driver("macvlan")
+                            .build()
+                            .as(Network.AutoCreated.class);
+            ) {
+                VisibleAssertions.assertEquals(
+                        "Flag is set",
+                        "macvlan",
+                        DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(network.getName()).exec().getDriver()
+                );
+            }
+        }
+
+        @Test
+        public void testModifiers() throws Exception {
+            try (
+                    Network network = Network.builder()
+                            .createNetworkCmdModifier(cmd -> cmd.withDriver("macvlan"))
+                            .build()
+                            .as(Network.AutoCreated.class);
+            ) {
+                VisibleAssertions.assertEquals(
+                        "Flag is set",
+                        "macvlan",
+                        DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(network.getName()).exec().getDriver()
+                );
+            }
+        }
+    }
+
+    public static class WithRules {
+
+        @Rule
+        public Network.JUnitRule network = newNetwork().as(Network.JUnitRule.class);
+
+        @Rule
+        public GenericContainer foo = new GenericContainer()
+                .withNetwork(network)
+                .withNetworkAliases("foo")
+                .withCommand("/bin/sh", "-c", "while true ; do printf 'HTTP/1.1 200 OK\\n\\nyay' | nc -l -p 8080; done");
+
+        @Rule
+        public GenericContainer bar = new GenericContainer()
+                .withNetwork(network)
+                .withCommand("top");
+
+        @Test
+        public void testNetworkSupport() throws Exception {
+            String response = bar.execInContainer("wget", "-O", "-", "http://foo:8080").getStdout();
+            assertEquals("received response", "yay", response);
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/containers/NetworkTest.java
+++ b/core/src/test/java/org/testcontainers/containers/NetworkTest.java
@@ -66,11 +66,11 @@ public class NetworkTest {
                             .driver("macvlan")
                             .build();
             ) {
-                network.create();
+                String id = network.getId();
                 assertEquals(
                         "Flag is set",
                         "macvlan",
-                        DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(network.getName()).exec().getDriver()
+                        DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(id).exec().getDriver()
                 );
             }
         }
@@ -82,23 +82,12 @@ public class NetworkTest {
                             .createNetworkCmdModifier(cmd -> cmd.withDriver("macvlan"))
                             .build();
             ) {
-                network.create();
+                String id = network.getId();
                 assertEquals(
                         "Flag is set",
                         "macvlan",
-                        DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(network.getName()).exec().getDriver()
+                        DockerClientFactory.instance().client().inspectNetworkCmd().withNetworkId(id).exec().getDriver()
                 );
-            }
-        }
-
-        @Test
-        public void testLaziness() throws Exception {
-            try (
-                    Network network = newNetwork()
-            ) {
-                assertFalse("Not created by default", network.isCreated());
-                assertNotNull("Returns an id", network.getId());
-                assertTrue("Is created after id request", network.isCreated());
             }
         }
     }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
@@ -24,14 +24,14 @@ public class LinkedContainerTest {
 
     private static File contentFolder = new File(System.getProperty("user.home") + "/.tmp-test-container");
 
-    Network.JUnitRule network = Network.newNetwork().as(Network.JUnitRule.class);
+    private Network.JUnitRule network = Network.newNetwork().as(Network.JUnitRule.class);
 
-    NginxContainer nginx = new NginxContainer<>()
+    private NginxContainer nginx = new NginxContainer<>()
             .withNetwork(network)
             .withNetworkAliases("nginx")
             .withCustomContent(contentFolder.toString());
 
-    BrowserWebDriverContainer chrome = new BrowserWebDriverContainer<>()
+    private BrowserWebDriverContainer chrome = new BrowserWebDriverContainer<>()
             .withNetwork(network)
             .withDesiredCapabilities(DesiredCapabilities.chrome());
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
@@ -4,7 +4,6 @@ import lombok.Cleanup;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.RuleChain;
 import org.openqa.selenium.By;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -24,21 +23,19 @@ public class LinkedContainerTest {
 
     private static File contentFolder = new File(System.getProperty("user.home") + "/.tmp-test-container");
 
-    private Network.JUnitRule network = Network.newNetwork().as(Network.JUnitRule.class);
+    @Rule
+    public Network network = Network.newNetwork();
 
-    private NginxContainer nginx = new NginxContainer<>()
+    @Rule
+    public NginxContainer nginx = new NginxContainer<>()
             .withNetwork(network)
             .withNetworkAliases("nginx")
             .withCustomContent(contentFolder.toString());
 
-    private BrowserWebDriverContainer chrome = new BrowserWebDriverContainer<>()
+    @Rule
+    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer<>()
             .withNetwork(network)
             .withDesiredCapabilities(DesiredCapabilities.chrome());
-
-    @Rule
-    public RuleChain chain = RuleChain.outerRule(network)
-            .around(nginx)
-            .around(chrome);
 
     @BeforeClass
     public static void setupContent() throws FileNotFoundException {


### PR DESCRIPTION
Hi.

One of the highly requested features, especially from users who wanted to run a fleet of containers, i.e. Hazelcast (hey @gAmUssA :D )

Also very helpful for Selenium + container-under-the-test scenario

As you can see, I experimented a bit with DSL, and it seems very usable :)