### PR TITLE
#371 'posix fallback bug' - added fallback in case of UnsupportedOperationException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Added `TC_DAEMON` JDBC URL flag to prevent `ContainerDatabaseDriver` from shutting down containers at the time all connections are closed. (#359, #360)
 - Added pre-flight checks (can be disabled with `checks.disable` configuration property) (#363)
 - Removed unused Jersey dependencies (#361)
+- Fixed non-POSIX fallback for file attribute reading (#371)
 
 ## [1.3.0] - 2017-06-05
 ### Fixed

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -267,7 +267,7 @@ public class MountableFile implements Transferable {
         final Path path = Paths.get(pathAsString);
         try {
             return (int) Files.getAttribute(path, "unix:mode");
-        } catch (IOException e) {
+        } catch (IOException | UnsupportedOperationException e) {
             // fallback for non-posix environments
             int mode = DEFAULT_FILE_MODE;
             if (Files.isDirectory(path)) {


### PR DESCRIPTION
Added additional exception type to fallback catch clause, as Windows env throws UnsupportedOperationException when trying to get not-existing file attribute