### PR TITLE
Added `getFirstMappedPort` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Changed
-- Added no-args `getMappedPort` overloaded method
+- Added `getFirstMappedPort` method
 
 ## [1.3.1] - 2017-06-22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 ### Changed
+- Added no-args `getMappedPort` overloaded method
 
 ## [1.3.1] - 2017-06-22
 ### Fixed

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -287,6 +287,20 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     Boolean isRunning();
 
     /**
+     * Get the actual mapped port for a first port exposed by the container.
+     *
+     * @return the port that the exposed port is mapped to
+     * @throws IllegalStateException if there are no exposed ports
+     */
+    default Integer getFirstMappedPort() {
+        return getExposedPorts()
+                .stream()
+                .findFirst()
+                .map(this::getMappedPort)
+                .orElseThrow(() -> new IllegalStateException("Container doesn't expose any ports"));
+    }
+
+    /**
      * Get the actual mapped port for a given port exposed by the container.
      *
      * @param originalPort the original TCP port that is exposed

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -325,7 +325,7 @@ public class GenericContainerRuleTest {
         return Unreliables.retryUntilSuccess(10, TimeUnit.SECONDS, () -> {
             Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
 
-            Socket socket = new Socket(container.getContainerIpAddress(), container.getMappedPort(80));
+            Socket socket = new Socket(container.getContainerIpAddress(), container.getFirstMappedPort());
             return new BufferedReader(new InputStreamReader(socket.getInputStream()));
         });
     }


### PR DESCRIPTION
This change simplifies the usage for 90% cases where users have something like:
```java
@Rule
GenericContainer container = new GenericContainer().withExposedPorts(1234)

// ...

container.getMappedPort(1234)
```

by introducing new method:
```java
container.getFirstMappedPort()
```

and it is just a safer version of:
```java
container.getMappedPort(container.getExposedPorts().get(0))
```

It helps to remove some boilerplate, as well as "magic number" duplication.