### PR TITLE
Speed up Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,8 @@ cache:
   directories:
     - '$HOME/.m2'
 
-install:
+before_install:
   - echo "MAVEN_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1'" > ~/.mavenrc
-  - sudo apt-get update -qq
-  - sudo apt-get -y -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confnew install docker-ce
-  - docker info
-  # Update env vars required by testcontainers
-  - export DOCKER_HOST=tcp://127.0.0.1:2375
-  - export DOCKER_TLS_VERIFY=0
-  - env
-  - ./mvnw -T4 -DskipTests=true -Dmaven.javadoc.skip=true install
 
 jobs:
   include:
@@ -44,9 +36,10 @@ jobs:
     - env: [ NAME=modules ]
       script: ./mvnw -pl !core,!modules/selenium test
 
-    # Run Docker-in-Docker tests inside Alpine
-    - env: [ NAME=docker-in-alpine-docker ]
-      script: |
+    # Run Docker-in-Docker tests inside Alpine and shading tests
+    - env: [ NAME="docker-in-alpine-docker&shade" ]
+      script:
+        - |
                 DOCKER_HOST=unix:///var/run/docker.sock DOCKER_TLS_VERIFY= docker run -t --rm \
                 -v "$HOME/.m2":/root/.m2/ \
                 -v /var/run/docker.sock:/var/run/docker.sock \
@@ -55,10 +48,11 @@ jobs:
                 openjdk:8-jdk-alpine \
                 ./mvnw -pl core test -Dtest=*GenericContainerRuleTest
 
-    - env: [ NAME=shade ]
-      script: ./mvnw test -f shade-test/pom.xml
+        - ./mvnw test -f shade-test/pom.xml
 
     - stage: deploy
+      sudo: false
+      services: []
       install: skip
       script: skip
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ cache:
   directories:
     - '$HOME/.m2'
 
-before_install:
+install:
   - echo "MAVEN_OPTS='-XX:+TieredCompilation -XX:TieredStopAtLevel=1'" > ~/.mavenrc
+  - ./mvnw -T4 -DskipTests=true -Dmaven.javadoc.skip=true install
 
 jobs:
   include:


### PR DESCRIPTION
What I did:
- removed custom Docker installation (with the latest Travis release they have Docker 2017.03-ce)
- merged alpine + shade tests (-1 allocated node. Travis limits it to 5)
- removed "sudo" from deploy's stage (boot time dropped from 20-50s to 1-6s, see https://docs.travis-ci.com/user/ci-environment/ )
