### PR TITLE
Improve cleanup for docker-compose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Fixed leakage of Vibur and Tomcat JDBC test dependencies in `jdbc-test` and `mysql` modules (#382)
 - Added timeout and retries for creation of `RemoteWebDriver` (#381, #373, #257)
 - Fixed various shading issues
+- Improved removal of containers/networks when using Docker Compose, eliminating irrelevant errors during cleanup (#342, #394)
 
 ### Changed
 - Added support for Docker networks (#372)

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -250,16 +250,16 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
 
                 // If we reach here then docker-compose down has cleared networks and containers;
                 //  we can unregister from ResourceReaper
-                spawnedNetworkIds.forEach(id -> ResourceReaper.instance().unregisterNetwork(identifier));
                 spawnedContainerIds.forEach(id -> ResourceReaper.instance().unregisterContainer(id));
+                spawnedNetworkIds.forEach(id -> ResourceReaper.instance().unregisterNetwork(identifier));
             } catch (ContainerLaunchException e) {
                 // docker-compose down failed; use ResourceReaper to ensure cleanup
 
-                // remove the networks before removing the containers
-                spawnedNetworkIds.forEach(id -> ResourceReaper.instance().removeNetworks(identifier));
-
                 // kill the spawned service containers
                 spawnedContainerIds.forEach(id -> ResourceReaper.instance().stopAndRemoveContainer(id));
+
+                // remove the networks after removing the containers
+                spawnedNetworkIds.forEach(id -> ResourceReaper.instance().removeNetworks(identifier));
             }
 
             spawnedContainerIds.clear();

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -20,7 +20,7 @@ public interface Network extends AutoCloseable, TestRule {
 
     @Override
     default void close() {
-        ResourceReaper.instance().removeNetworks(getId());
+        ResourceReaper.instance().removeNetworkById(getId());
     }
 
     static Network newNetwork() {
@@ -66,7 +66,7 @@ public interface Network extends AutoCloseable, TestRule {
             }
 
             String id = createNetworkCmd.exec().getId();
-            ResourceReaper.instance().registerNetworkForCleanup(id);
+            ResourceReaper.instance().registerNetworkIdForCleanup(id);
             return id;
         }
 

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -130,28 +130,28 @@ public final class ResourceReaper {
     /**
      * Register a network to be cleaned up at JVM shutdown.
      *
-     * @param networkName   the image name of the network
+     * @param id   the ID of the network
      */
-    public void registerNetworkForCleanup(String networkName) {
-        registeredNetworks.add(networkName);
+    public void registerNetworkIdForCleanup(String id) {
+        registeredNetworks.add(id);
     }
 
     /**
      * Removes any networks that contain the identifier.
-     * @param identifier
+     * @param id
      */
-    public void removeNetworks(String identifier) {
-      removeNetwork(identifier);
+    public void removeNetworkById(String id) {
+      removeNetwork(id);
     }
 
-    private void removeNetwork(String networkName) {
+    private void removeNetwork(String id) {
         try {
             List<Network> networks;
             try {
-                // Then try to list all networks with the same name
-                networks = dockerClient.listNetworksCmd().withNameFilter(networkName).exec();
+                // Try to find the network if it still exists
+                networks = dockerClient.listNetworksCmd().withIdFilter(id).exec();
             } catch (Exception e) {
-                LOGGER.trace("Error encountered when looking up network for removal (name: {}) - it may not have been removed", networkName);
+                LOGGER.trace("Error encountered when looking up network for removal (name: {}) - it may not have been removed", id);
                 return;
             }
 
@@ -159,13 +159,13 @@ public final class ResourceReaper {
                 try {
                     dockerClient.removeNetworkCmd(network.getId()).exec();
                     registeredNetworks.remove(network.getId());
-                    LOGGER.debug("Removed network: {}", networkName);
+                    LOGGER.debug("Removed network: {}", id);
                 } catch (Exception e) {
                     LOGGER.trace("Error encountered removing network (name: {}) - it may not have been removed", network.getName());
                 }
             }
         } finally {
-            registeredNetworks.remove(networkName);
+            registeredNetworks.remove(id);
         }
     }
 

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -10,7 +10,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
@@ -143,13 +146,6 @@ public final class ResourceReaper {
 
     private void removeNetwork(String networkName) {
         try {
-            try {
-                // First try to remove by name
-                dockerClient.removeNetworkCmd(networkName).exec();
-            } catch (Exception e) {
-                LOGGER.trace("Error encountered removing network by name ({}) - it may not have been removed", networkName);
-            }
-
             List<Network> networks;
             try {
                 // Then try to list all networks with the same name
@@ -171,5 +167,13 @@ public final class ResourceReaper {
         } finally {
             registeredNetworks.remove(networkName);
         }
+    }
+
+    public void unregisterNetwork(String identifier) {
+        registeredNetworks.remove(identifier);
+    }
+
+    public void unregisterContainer(String identifier) {
+        registeredContainers.remove(identifier);
     }
 }


### PR DESCRIPTION
Reduce unnecessary cleanup attempts which cause errors to be logged.
docker-compose down is now trusted to have cleanup up properly if it
exits with a 0 status code.

I hope we can squeeze this in to 1.4.0!