### PR TITLE
Upgrading Jackson

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -30,6 +30,10 @@
                     <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
@@ -115,6 +119,15 @@
             <artifactId>fakejar</artifactId>
             <version>0</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,21 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -168,6 +183,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker-java.version>3.0.12</docker-java.version>
+        <jackson.version>2.8.9</jackson.version>
     </properties>
 
     <modules>

--- a/shade-test/clashing-deps-jackson/pom.xml
+++ b/shade-test/clashing-deps-jackson/pom.xml
@@ -26,7 +26,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.6.3</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Upgrading Jackson

What brought this up was an issue I was facing using testcontainers. I was using an object mappers from a newer version of Jackson which was configured to use ```findAndRegisterModules```. Not only going it's going to discover Java8 Modules but also it discovers other modules even belonging to the old version of jackson causing trouble even though Jackson is being shaded. 

I'll have to make a PR on jackson-databind as well but I thought while I'm at it, I could upgrade the jackson version here as well. Not sure it's useful for you guys now @rnorth ? 