### PR TITLE
Jdbc containers with user, passwd, and db customizations

### DIFF
--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/CustomizableMysqlTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/CustomizableMysqlTest.java
@@ -1,0 +1,47 @@
+package org.testcontainers.junit;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+
+public class CustomizableMysqlTest {
+    private static final String DB_NAME = "foo";
+    private static final String USER = "bar";
+    private static final String PWD = "baz";
+
+    // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
+    @Rule
+    public MySQLContainer mysql = (MySQLContainer) new MySQLContainer("mysql:5.5")
+            .withDatabaseName(DB_NAME)
+            .withUsername(USER)
+            .withPassword(PWD)
+            .withEnv("MYSQL_ROOT_HOST", "%");
+
+    @Test
+    public void testSimple() throws SQLException {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl("jdbc:mysql://"
+                + mysql.getContainerIpAddress()
+                + ":" + mysql.getMappedPort(MySQLContainer.MYSQL_PORT)
+                + "/" + DB_NAME);
+        hikariConfig.setUsername(USER);
+        hikariConfig.setPassword(PWD);
+
+        HikariDataSource ds = new HikariDataSource(hikariConfig);
+        Statement statement = ds.getConnection().createStatement();
+        statement.execute("SELECT 1");
+        ResultSet resultSet = statement.getResultSet();
+
+        assertEquals("There is a result", resultSet.next(), true);
+        int resultSetInt = resultSet.getInt(1);
+        assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+    }
+}

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -60,6 +60,19 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
      */
     protected abstract String getTestQueryString();
 
+    public SELF withUsername(String username) {
+        throw new UnsupportedOperationException();
+    }
+
+    public SELF withPassword(String password){
+        throw new UnsupportedOperationException();
+    }
+
+    public SELF withDatabaseName(String dbName) {
+        throw new UnsupportedOperationException();
+
+    }
+
     @Override
     protected void waitUntilContainerStarted() {
         // Repeatedly try and open a connection to the DB and execute a test query

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -8,7 +8,10 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     public static final String NAME = "mysql";
     public static final String IMAGE = "mysql";
     private static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "TC_MY_CNF";
-    private static final Integer MYSQL_PORT = 3306;
+    public static final Integer MYSQL_PORT = 3306;
+    private String databaseName = "test";
+    private String username = "test";
+    private String password = "test";
 
     public MySQLContainer() {
         super(IMAGE + ":latest");
@@ -28,9 +31,9 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         optionallyMapResourceParameterAsVolume(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/conf.d", "mysql-default-conf");
 
         addExposedPort(3306);
-        addEnv("MYSQL_DATABASE", "test");
-        addEnv("MYSQL_USER", "test");
-        addEnv("MYSQL_PASSWORD", "test");
+        addEnv("MYSQL_DATABASE", databaseName);
+        addEnv("MYSQL_USER", username);
+        addEnv("MYSQL_PASSWORD", password);
         addEnv("MYSQL_ROOT_PASSWORD", "test");
         setCommand("mysqld");
         setStartupAttempts(3);
@@ -43,17 +46,17 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:mysql://" + getContainerIpAddress() + ":" + getMappedPort(MYSQL_PORT) + "/test";
+        return "jdbc:mysql://" + getContainerIpAddress() + ":" + getMappedPort(MYSQL_PORT) + "/" + databaseName;
     }
 
     @Override
     public String getUsername() {
-        return "test";
+        return username;
     }
 
     @Override
     public String getPassword() {
-        return "test";
+        return password;
     }
 
     @Override
@@ -63,6 +66,24 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
     public SELF withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
+        return self();
+    }
+
+    @Override
+    public SELF withDatabaseName(final String databaseName) {
+        this.databaseName = databaseName;
+        return self();
+    }
+
+    @Override
+    public SELF withUsername(final String username) {
+        this.username = username;
+        return self();
+    }
+
+    @Override
+    public SELF withPassword(final String password) {
+        this.password = password;
         return self();
     }
 }

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -69,16 +69,19 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
         return "SELECT 1";
     }
 
+    @Override
     public SELF withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
+    @Override
     public SELF withUsername(final String username) {
         this.username = username;
         return self();
     }
 
+    @Override
     public SELF withPassword(final String password) {
         this.password = password;
         return self();


### PR DESCRIPTION
Based on our conversation in #354, all jdbc containers will allow customizations to the db, user, and password (or else throw an exception).

Since this is a different design than #354, I opened a new PR.

Closes #354