### PR TITLE
Upgrade to v2.0.0 of Visible Assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Fixed
 - Worked around incompatibility between Netty's Unix socket support and OS X 10.11. Reinstated use of TCP-Unix Socket proxy when running on OS X prior to v10.12. (Fixes #402)
+- Changed to use version 2.0 of the Visible Assertions library for startup pre-flight checks. This no longer has a dependency on Jansi, and is intended to resolve a JVM crash issue apparently caused by native lib version conflicts (#395). Please note that the newer ANSI code is less mature and thus has had less testing, particularly in interesting terminal environments such as Windows. If issues are encountered, coloured assertion output may be disabled by setting the system property `visibleassertions.ansi.enabled` to `true`.
 
 ### Changed
 - Removed Guava usage from `jdbc` module (#401)

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>org.rnorth.visible-assertions</groupId>
             <artifactId>visible-assertions</artifactId>
-            <version>1.0.5</version>
+            <version>2.0.0</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
Removes usage of Jansi - fixes #395 

This newer version of Visible Assertions does not use Jansi, and instead includes basic ANSI output formatting. It does, however, still require a native lib to access the TTY status of stdout - I'm using jnr-posix for this, which seems to be reliable and cross-platform.

I do want to do further checks before merging, though. Specifically, further checks:

- [x] On a Windows machine
- [ ] With a Gradle build

Until I've done these checks I think we need to be cautious and not merge.