### PR TITLE
Improved disk space validation error message

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -166,7 +166,7 @@ public class DockerClientFactory {
         DiskSpaceUsage df = parseAvailableDiskSpace(outputStream.toString());
 
         VisibleAssertions.assertTrue(
-                "Docker environment has more than 2GB free",
+                "Docker environment has less than 2GB free",
                 df.availableMB.map(it -> it >= 2048).orElse(true)
         );
     }


### PR DESCRIPTION
Before it was reporting that Docker environment has MORE than 2GB when in reality it had LESS then 2GB. Error message was a bit confusing.