### PR TITLE
Fix for issue 419

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -183,8 +183,8 @@ public class MountableFile implements Transferable {
 
         if (!entry.isDirectory()) {
             // Create parent directories
-            newFile.mkdirs();
-            newFile.delete();
+            Path parent = newFile.getAbsoluteFile().toPath().getParent();
+            parent.toFile().mkdirs();
             newFile.deleteOnExit();
 
             try (InputStream is = jarFile.getInputStream(entry)) {


### PR DESCRIPTION
I've modified the code generating the parent directories to avoid creating a directory that is subsequently deleted. This was causing a FileAlreadyExistsException exception when generating the actual temporary file, as the directory fails to be deleted in some circumstances.