### PR TITLE
#444 'MountableFile path on Windows' - added separate filesystem path for file source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Fixed
 - Fixed local Docker Compose executable name resolution on Windows (#416)
+- Added workaround to make MountableFile host path work on Windows (#444)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Fixed
 - Fixed local Docker Compose executable name resolution on Windows (#416)
-- Added workaround to make MountableFile host path work on Windows (#444)
+- Made tar composing work on Windows as well (#444)
 
 ### Changed
 

--- a/core/src/main/java/org/testcontainers/images/builder/traits/ClasspathTrait.java
+++ b/core/src/main/java/org/testcontainers/images/builder/traits/ClasspathTrait.java
@@ -13,6 +13,6 @@ public interface ClasspathTrait<SELF extends ClasspathTrait<SELF> & BuildContext
     default SELF withFileFromClasspath(String path, String resourcePath) {
         final MountableFile mountableFile = MountableFile.forClasspathResource(resourcePath);
 
-        return ((SELF) this).withFileFromPath(path, Paths.get(mountableFile.getResolvedPath()));
+        return ((SELF) this).withFileFromPath(path, Paths.get(mountableFile.getFilesystemPath()));
     }
 }

--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -74,8 +74,8 @@ public class MountableFileTest {
 
     private void performChecks(final MountableFile mountableFile) {
         final String mountablePath = mountableFile.getFilesystemPath();
-        assertTrue("The resolved path can be found", new File(mountablePath).exists());
-        assertFalse("The resolved path does not contain any URL escaping", mountablePath.contains("%20"));
+        assertTrue("The filesystem path '" + mountablePath + "' can be found", new File(mountablePath).exists());
+        assertFalse("The filesystem path '" + mountablePath + "' does not contain any URL escaping", mountablePath.contains("%20"));
     }
 
 }

--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -60,10 +60,6 @@ public class MountableFileTest {
         assertFalse("The resolved path does not contain an escaped space", mountableFile.getResolvedPath().contains("\\ "));
     }
 
-    /*
-     *
-     */
-
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @NotNull
     private Path createTempFile(final String name) throws IOException {
@@ -77,7 +73,7 @@ public class MountableFileTest {
     }
 
     private void performChecks(final MountableFile mountableFile) {
-        final String mountablePath = mountableFile.getResolvedPath();
+        final String mountablePath = mountableFile.getFilesystemPath();
         assertTrue("The resolved path can be found", new File(mountablePath).exists());
         assertFalse("The resolved path does not contain any URL escaping", mountablePath.contains("%20"));
     }


### PR DESCRIPTION
Not sure if this is the only and correct way, so comments are more then welcome.
tar adding function checks if new File(resolvedPath).isFile(). 
getResolvedPath() on windows returns mingwfied path, which does not work with File API, so content of file is never copied into tar archive (but header is created, resulting in 0-bytes file inside container).

Same issue with using getResolvedPath() affects many other parts (i.e. docker-compose flows), but for now trying to solve it for copy() functionality inside dockerfile builder.

Also as I cannot run *nix tests for now, will take a look at CI results.