### PR TITLE
Remember failure to ping docker daemon to reduce log garbage and reduce run time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
+### Changed
+- Added caching of failure to find a docker daemon, so that subsequent tests fail fast. This is likely to be a significant improvement in situations where there is no docker daemon available, dramatically reducing run time and log output when further attempts to find the docker daemon cannot succeed.
+
 ### Fixed
 - Fixed local Docker Compose executable name resolution on Windows (#416)
 - Made tar composing work on Windows as well (#444)

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -20,6 +20,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
 /**
@@ -34,6 +35,8 @@ public abstract class DockerClientProviderStrategy {
             .withRate(2, TimeUnit.SECONDS)
             .withConstantThroughput()
             .build();
+
+    private static final AtomicBoolean FAIL_FAST_ALWAYS = new AtomicBoolean(false);
 
     /**
      * @throws InvalidConfigurationException if this strategy fails
@@ -64,6 +67,11 @@ public abstract class DockerClientProviderStrategy {
      * @return a working DockerClientConfig, as determined by successful execution of a ping command
      */
     public static DockerClientProviderStrategy getFirstValidStrategy(List<DockerClientProviderStrategy> strategies) {
+
+        if (FAIL_FAST_ALWAYS.get()) {
+            throw new IllegalStateException("Previous attempts to find a Docker environment failed. Will not retry. Please see logs and check configuration");
+        }
+
         List<String> configurationFailures = new ArrayList<>();
 
         return Stream
@@ -134,6 +142,7 @@ public abstract class DockerClientProviderStrategy {
                     }
                     LOGGER.error("As no valid configuration was found, execution cannot continue");
 
+                    FAIL_FAST_ALWAYS.set(true);
                     return new IllegalStateException("Could not find a valid Docker environment. Please see logs and check configuration");
                 });
     }


### PR DESCRIPTION
This is just a simple one. I observed the following behaviour last night, which needs to be fixed:

* When there is no working Docker environment discoverable
* Running a test will go through the normal discovery process, trying each strategy in turn. For each strategy, there will be 5-30 seconds of pinging the docker daemon, accompanied by logs. (Netty is particularly noisy for most of the strategies, logging a stack trace for each ping).
* Unfortunately this is repeated for every test method in the test suite, adding up to thousands of failed pings.
* Obviously this takes a lot of time and produces a tonne of logs. I wonder if this might have caused the issue @asafm observed last week.

As a dumb but effective way to prevent this, I've added a static fail-fast flag, which is set the first time a total discovery failure occurs.