### PR TITLE
Fix apparent race condition in test, observed in docker-machine on Mac

### DIFF
--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -147,7 +147,7 @@ public class GenericContainerRuleTest {
 
     @Test
     public void testIsRunning() {
-        try (GenericContainer container = new GenericContainer().withCommand("sleep 60")) {
+        try (GenericContainer container = new GenericContainer().withCommand("top")) {
             assertFalse("Container is not started and not running", container.isRunning());
             container.start();
             assertTrue("Container is started and running", container.isRunning());

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -147,7 +147,7 @@ public class GenericContainerRuleTest {
 
     @Test
     public void testIsRunning() {
-        try (GenericContainer container = new GenericContainer()) {
+        try (GenericContainer container = new GenericContainer().withCommand("sleep 60")) {
             assertFalse("Container is not started and not running", container.isRunning());
             container.start();
             assertTrue("Container is started and running", container.isRunning());


### PR DESCRIPTION
Startup success detection appeared to be seeing container as having exited already
For the purposes of this test, all we need is a positive `isRunning` state, so
a container sleep command of reasonable length is sufficient to achieve this