### PR TITLE
Adding fluent builder withLink for addLink method

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -100,7 +100,8 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     void addFileSystemBind(String hostPath, String containerPath, BindMode mode, SelinuxContext selinuxContext);
 
     /**
-     * Add a link to another container.
+     * Add a link to another container. Consider using {@link #withLink(LinkableContainer, String)}
+     * for building a container in a fluent style.
      *
      * @param otherContainer the other container object to link to
      * @param alias the alias (for the other container) that this container should be able to use
@@ -150,6 +151,14 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @return this
      */
     SELF withVolumesFrom(Container container, BindMode mode);
+
+    /**
+     * Add a link to another container.
+     *
+     * @param otherContainer the other container object to link to
+     * @param alias the alias (for the other container) that this container should be able to use
+     */
+    SELF withLink(LinkableContainer otherContainer, String alias);
 
     /**
      * Set the ports that this container listens on

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -518,6 +518,12 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         return self();
     }
 
+    @Override
+    public SELF withLink(LinkableContainer otherContainer, String alias) {
+        addLink(otherContainer, alias);
+        return self();
+    }
+
     private void addVolumesFrom(Container container, BindMode mode) {
         volumesFroms.add(new VolumesFrom(container.getContainerName(), mode.accessMode));
     }


### PR DESCRIPTION
It would be very convenient to add links to another containers using fluent builder. Currently `addLink` method has no fluent alternative. This PR introduces one: `withLink`. 