### PR TITLE
Updating tests to create temporary files in temp dir instead of user dir

### DIFF
--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -46,7 +46,7 @@ public class GenericContainerRuleTest {
      */
     @BeforeClass
     public static void setupContent() throws FileNotFoundException {
-        File contentFolder = new File(System.getProperty("user.home") + "/.tmp-test-container");
+        File contentFolder = new File(System.getProperty("java.io.tmpdir") + "/.tmp-test-container");
         contentFolder.mkdir();
         writeStringToFile(contentFolder, "file", "Hello world!");
     }

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -17,7 +17,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.*;
  */
 public class SimpleNginxTest {
 
-    private static File contentFolder = new File(System.getProperty("user.home") + "/.tmp-test-container");
+    private static File contentFolder = new File(System.getProperty("java.io.tmpdir") + "/.tmp-test-container");
 
     @Rule
     public NginxContainer nginx = new NginxContainer()

--- a/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
@@ -21,7 +21,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.*;
  */
 public class LinkedContainerTest {
 
-    private static File contentFolder = new File(System.getProperty("user.home") + "/.tmp-test-container");
+    private static File contentFolder = new File(System.getProperty("java.io.tmpdir") + "/.tmp-test-container");
 
     @Rule
     public Network network = Network.newNetwork();


### PR DESCRIPTION
I've noticed that unit tests create a temporary folder `.tmp-test-container` in my user directory. I don't believe that this is the best choice. Temporary directory is usually a better choice to create temp files. 

This PR suggests to use `java.io.tmpdir` instead of `user.home` in tests.  