### PR TITLE
Fixed regression in 1.4.3 when using Docker Compose on Windows, Fixes #439

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
-_No changes yet_
+### Fixed
+- Fixed regression in 1.4.3 when using Docker Compose on Windows ([\#439](https://github.com/testcontainers/testcontainers-java/issues/439))
+
+### Changed
 
 ## [1.4.3] - 2017-10-14
 ### Fixed

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -494,7 +494,7 @@ class LocalDockerCompose implements DockerCompose {
     @Override
     public void invoke() {
         // bail out early
-        if (!dockerComposeExecutableExists()) {
+        if (!CommandLine.executableExists(COMPOSE_EXECUTABLE)) {
             throw new ContainerLaunchException("Local Docker Compose not found. Is " + COMPOSE_EXECUTABLE + " on the PATH?");
         }
 
@@ -528,14 +528,6 @@ class LocalDockerCompose implements DockerCompose {
 
         } catch (Exception e) {
             throw new ContainerLaunchException("Error running local Docker Compose command: " + cmd, e);
-        }
-    }
-
-    private boolean dockerComposeExecutableExists() {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            return CommandLine.executableExists(COMPOSE_EXECUTABLE + ".exe");
-        } else {
-            return CommandLine.executableExists(COMPOSE_EXECUTABLE);
         }
     }
 


### PR DESCRIPTION
Fixed regression in 1.4.3 when using Docker Compose on Windows
Fixes #439 

#437 and #461 tried to solve similar problems around the same time and stepped on each others toes.