### PR TITLE
Mark link-related APIs as deprecated pending future removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Make Network instances reusable (i.e. work with `@ClassRule`) ([\#469](https://github.com/testcontainers/testcontainers-java/issues/469))
 - Added support for explicitly setting file mode when copying file into container ([\#446](https://github.com/testcontainers/testcontainers-java/issues/446), [\#467](https://github.com/testcontainers/testcontainers-java/issues/467)) 
+- Mark all links functionality as deprecated. This is pending removal in a later release. Please see [\#465](https://github.com/testcontainers/testcontainers-java/issues/465). {@link Network} features should be used instead.
 
 ## [1.4.3] - 2017-10-14
 ### Fixed

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -104,7 +104,9 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      *
      * @param otherContainer the other container object to link to
      * @param alias the alias (for the other container) that this container should be able to use
+     * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
      */
+    @Deprecated
     void addLink(LinkableContainer otherContainer, String alias);
 
     /**
@@ -420,6 +422,10 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     List<Bind> getBinds();
 
+    /**
+     * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
+     */
+    @Deprecated
     Map<String, LinkableContainer> getLinkedContainers();
 
     DockerClient getDockerClient();
@@ -446,6 +452,10 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     void setBinds(List<Bind> binds);
 
+    /**
+     * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
+     */
+    @Deprecated
     void setLinkedContainers(Map<String, LinkableContainer> linkedContainers);
 
     void setWaitStrategy(WaitStrategy waitStrategy);

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -99,7 +99,11 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @NonNull
     private List<VolumesFrom> volumesFroms = new ArrayList<>();
 
+    /**
+     * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
+     */
     @NonNull
+    @Deprecated
     private Map<String, LinkableContainer> linkedContainers = new HashMap<>();
 
     private StartupCheckStrategy startupCheckStrategy = new IsRunningStartupCheckStrategy();
@@ -522,6 +526,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         volumesFroms.add(new VolumesFrom(container.getContainerName(), mode.accessMode));
     }
 
+    /**
+     * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
+     */
+    @Deprecated
     @Override
     public void addLink(LinkableContainer otherContainer, String alias) {
         this.linkedContainers.put(alias, otherContainer);

--- a/core/src/main/java/org/testcontainers/containers/traits/LinkableContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/traits/LinkableContainer.java
@@ -2,7 +2,10 @@ package org.testcontainers.containers.traits;
 
 /**
  * A container which can be linked to by other containers.
+ *
+ * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link org.testcontainers.containers.Network} features instead.
  */
+@Deprecated
 public interface LinkableContainer {
 
     String getContainerName();

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -229,7 +229,10 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      * @param otherContainer the container rule to link to
      * @param alias          the alias (hostname) that this other container should be referred to by
      * @return this
+     *
+     * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
      */
+    @Deprecated
     public SELF withLinkToContainer(LinkableContainer otherContainer, String alias) {
         addLink(otherContainer, alias);
         return self();


### PR DESCRIPTION
See #465