### PR TITLE
Fix random test failure by removing dependency on Alpine package server.

### DIFF
--- a/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
@@ -16,16 +16,10 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 @RunWith(Parameterized.class)
 public class ParameterizedDockerfileContainerTest {
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Object[][] data() {
-        return new Object[][] {
-                { "alpine:3.2", "3.2"},
-                { "alpine:3.3", "3.3"},
-                { "alpine:3.4", "3.4"},
-                { "alpine:3.5", "3.5"},
-                { "alpine:3.6", "3.6"}
-        };
-    }
+    private final String expectedVersion;
+
+    @Rule
+    public GenericContainer container;
 
     public ParameterizedDockerfileContainerTest(String baseImage, String expectedVersion) {
         container = new GenericContainer(new ImageFromDockerfile().withDockerfileFromBuilder(builder -> {
@@ -38,10 +32,16 @@ public class ParameterizedDockerfileContainerTest {
         this.expectedVersion = expectedVersion;
     }
 
-    @Rule
-    public GenericContainer container;
-
-    private final String expectedVersion;
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[][] data() {
+        return new Object[][] {
+                { "alpine:3.2", "3.2"},
+                { "alpine:3.3", "3.3"},
+                { "alpine:3.4", "3.4"},
+                { "alpine:3.5", "3.5"},
+                { "alpine:3.6", "3.6"}
+        };
+    }
 
     @Test
     public void simpleTest() throws Exception {

--- a/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
@@ -1,21 +1,12 @@
 package org.testcontainers.junit;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
-import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 /**
@@ -26,39 +17,33 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 public class ParameterizedDockerfileContainerTest {
 
     @Parameterized.Parameters(name = "{0}")
-    public static Object[] data() {
-        return new Object[] { "alpine:3.2", "alpine:3.3" };
+    public static Object[][] data() {
+        return new Object[][] {
+                { "alpine:3.2", "3.2"},
+                { "alpine:3.3", "3.3"},
+                { "alpine:3.4", "3.4"}
+        };
     }
 
-    public ParameterizedDockerfileContainerTest(String baseImage) {
+    public ParameterizedDockerfileContainerTest(String baseImage, String expectedVersion) {
         container = new GenericContainer(new ImageFromDockerfile().withDockerfileFromBuilder(builder -> {
                 builder
                         .from(baseImage)
-                        .run("apk add --update nginx")
-                        .cmd("nginx", "-g", "daemon off;")
                         .build();
-            })).withExposedPorts(80);
+            })).withCommand("sleep", "30");
+        this.expectedVersion = expectedVersion;
     }
 
     @Rule
     public GenericContainer container;
 
+    private final String expectedVersion;
+
     @Test
-    public void simpleTest() throws IOException {
-        String address = String.format("http://%s:%s", container.getContainerIpAddress(), container.getMappedPort(80));
+    public void simpleTest() throws Exception {
+        final String release = container.execInContainer("cat", "/etc/alpine-release").getStdout();
 
-        CloseableHttpClient httpClient = HttpClientBuilder.create().build();
-        HttpGet get = new HttpGet(address);
-
-        Unreliables.retryUntilSuccess(5, TimeUnit.SECONDS, () -> {
-            try (CloseableHttpResponse response = httpClient.execute(get)) {
-                assertEquals("A container built from a dockerfile can run nginx as expected, and returns a good status code",
-                                200,
-                                response.getStatusLine().getStatusCode());
-                assertTrue("A container built from a dockerfile can run nginx as expected, and returns an expected Server header",
-                                response.getHeaders("Server")[0].getValue().contains("nginx"));
-            }
-            return true;
-        });
+        assertTrue("/etc/alpine-release starts with " + expectedVersion,
+                release.startsWith(expectedVersion));
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
@@ -21,7 +21,9 @@ public class ParameterizedDockerfileContainerTest {
         return new Object[][] {
                 { "alpine:3.2", "3.2"},
                 { "alpine:3.3", "3.3"},
-                { "alpine:3.4", "3.4"}
+                { "alpine:3.4", "3.4"},
+                { "alpine:3.5", "3.5"},
+                { "alpine:3.6", "3.6"}
         };
     }
 
@@ -29,8 +31,10 @@ public class ParameterizedDockerfileContainerTest {
         container = new GenericContainer(new ImageFromDockerfile().withDockerfileFromBuilder(builder -> {
                 builder
                         .from(baseImage)
+                        // Could potentially customise the image here, e.g. adding files, running
+                        //  commands, etc.
                         .build();
-            })).withCommand("sleep", "30");
+            })).withCommand("top");
         this.expectedVersion = expectedVersion;
     }
 


### PR DESCRIPTION
This fixes an occasional random failure during docker image build,
seemingly due to a failure to download alpine package indices:
```
ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.3/main: temporary error (try again later)
...
ERROR 🐳 [testcontainers/cbwpthsp79aee52s] - The command '/bin/sh -c apk add --update nginx' returned a non-zero code: 1
```