### PR TITLE
Add RecordingFileFactory with default implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Use Visible Assertions 2.1.0 for pre-flight test output (eliminating Jansi/JNR-POSIX dependencies for lower likelihood of conflict. JNA is now used internally by Visible Assertions instead).
 - Mark all links functionality as deprecated. This is pending removal in a later release. Please see [\#465](https://github.com/testcontainers/testcontainers-java/issues/465). {@link Network} features should be used instead.
 - Added support for copying files to/from running containers ([\#378](https://github.com/testcontainers/testcontainers-java/issues/378))
+- Added support for customising the recording file name ([\#500](https://github.com/testcontainers/testcontainers-java/issues/500))
 
 ## [1.4.3] - 2017-10-14
 ### Fixed

--- a/docs/usage/webdriver_containers.md
+++ b/docs/usage/webdriver_containers.md
@@ -87,7 +87,7 @@ new BrowserWebDriverContainer()
                 .withRecordingFileFactory(new CustomRecordingFileFactory())
 ```
 
-Note the factory must implement org.testcontainers.containers.RecordingFileFactory.
+Note the factory must implement `org.testcontainers.containers.RecordingFileFactory`.
 
 ## More examples
 

--- a/docs/usage/webdriver_containers.md
+++ b/docs/usage/webdriver_containers.md
@@ -80,6 +80,15 @@ new BrowserWebDriverContainer()
 ```
 Note that the seconds parameter to `withRecordingMode` should be a directory where recordings can be saved.
 
+If you would like to customise the file name of the recording, or provide a different directory at runtime based on the description of the test and/or its success or failure, you may provide a custom recording file factory as follows:
+```java
+new BrowserWebDriverContainer()
+                //...
+                .withRecordingFileFactory(new CustomRecordingFileFactory())
+```
+
+Note the factory must implement org.testcontainers.containers.RecordingFileFactory.
+
 ## More examples
 
 A few different examples are shown in [ChromeWebDriverContainerTest.java](https://github.com/testcontainers/testcontainers-java/blob/master/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java).

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -182,11 +182,10 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
     @Override
     protected void failed(Throwable e, Description description) {
-
         switch (recordingMode) {
             case RECORD_FAILING:
             case RECORD_ALL:
-                stopAndRetainRecording(description, false);
+                stopAndRetainRecordingForDescriptionAndSuccessState(description, false);
                 break;
         }
         currentVncRecordings.clear();
@@ -194,10 +193,9 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
     @Override
     protected void succeeded(Description description) {
-
         switch (recordingMode) {
             case RECORD_ALL:
-                stopAndRetainRecording(description, true);
+                stopAndRetainRecordingForDescriptionAndSuccessState(description, true);
                 break;
         }
         currentVncRecordings.clear();
@@ -211,7 +209,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         this.stop();
     }
 
-    private void stopAndRetainRecording(Description description, boolean succeeded) {
+    private void stopAndRetainRecordingForDescriptionAndSuccessState(Description description, boolean succeeded) {
         File recordingFile = recordingFileFactory.recordingFileForTest(vncRecordingDirectory, description, succeeded);
         LOGGER.info("Screen recordings for test {} will be stored at: {}", description.getDisplayName(), recordingFile);
 

--- a/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
@@ -1,0 +1,24 @@
+package org.testcontainers.containers;
+
+import org.junit.runner.Description;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class DefaultRecordingFileFactory implements RecordingFileFactory {
+
+    private static final SimpleDateFormat filenameDateFormat = new SimpleDateFormat("YYYYMMdd-HHmmss");
+
+    @Override
+    public File recordingFileForTest(File vncRecordingDirectory, Description description, boolean succeeded) {
+        final String prefix = succeeded ? "PASSED" : "FAILED";
+        final String fileName = String.format("%s-%s-%s-%s.flv",
+                prefix,
+                description.getTestClass().getSimpleName(),
+                description.getMethodName(),
+                filenameDateFormat.format(new Date())
+        );
+        return new File(vncRecordingDirectory, fileName);
+    }
+}

--- a/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
@@ -9,11 +9,14 @@ import java.util.Date;
 public class DefaultRecordingFileFactory implements RecordingFileFactory {
 
     private static final SimpleDateFormat filenameDateFormat = new SimpleDateFormat("YYYYMMdd-HHmmss");
+    private static final String PASSED = "PASSED";
+    private static final String FAILED = "FAILED";
+    private static final String FILENAME_FORMAT = "%s-%s-%s-%s.flv";
 
     @Override
     public File recordingFileForTest(File vncRecordingDirectory, Description description, boolean succeeded) {
-        final String prefix = succeeded ? "PASSED" : "FAILED";
-        final String fileName = String.format("%s-%s-%s-%s.flv",
+        final String prefix = succeeded ? PASSED : FAILED;
+        final String fileName = String.format(FILENAME_FORMAT,
                 prefix,
                 description.getTestClass().getSimpleName(),
                 description.getMethodName(),

--- a/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
@@ -1,0 +1,9 @@
+package org.testcontainers.containers;
+
+import org.junit.runner.Description;
+
+import java.io.File;
+
+public interface RecordingFileFactory {
+    File recordingFileForTest(File vncRecordingDirectory, Description description, boolean succeeded);
+}

--- a/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
@@ -1,0 +1,57 @@
+package org.testcontainers.containers;
+
+import lombok.Value;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.runner.Description.createTestDescription;
+
+@RunWith(Parameterized.class)
+@Value
+public class DefaultRecordingFileFactoryTest {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("YYYYMMdd-HHmmss");
+
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Random random = new Random();
+        return new ArrayList<Object[]>() {{
+            add(new Object[]{format("testMethodName%d", random.nextInt()), "FAILED", FALSE});
+            add(new Object[]{format("testMethodName%d", random.nextInt()), "PASSED", TRUE});
+        }};
+    }
+
+    private final DefaultRecordingFileFactory factory = new DefaultRecordingFileFactory();
+    private final String methodName;
+    private final String prefix;
+    private final boolean success;
+
+    @Test
+    public void recordingFileThatShouldDescribeTheTestResultAtThePresentTime() throws Exception {
+        File vncRecordingDirectory = Files.createTempDirectory("recording").toFile();
+        Description description = createTestDescription(getClass().getCanonicalName(), methodName, Test.class);
+
+        File recordingFile = factory.recordingFileForTest(vncRecordingDirectory, description, success);
+
+        File expectedFile = new File(vncRecordingDirectory, format("%s-%s-%s-%s.flv",
+                prefix,
+                getClass().getSimpleName(),
+                methodName,
+                DATE_FORMAT.format(new Date()))
+        );
+        assertEquals(expectedFile, recordingFile);
+    }
+}

--- a/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
@@ -12,7 +12,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Random;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -33,10 +32,9 @@ public class DefaultRecordingFileFactoryTest {
 
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
-        Random random = new Random();
         Collection<Object[]> args = new ArrayList<>();
-        args.add(new Object[]{format("testMethodName%d", random.nextInt()), "FAILED", FALSE});
-        args.add(new Object[]{format("testMethodName%d", random.nextInt()), "PASSED", TRUE});
+        args.add(new Object[]{"testMethod1", "FAILED", FALSE});
+        args.add(new Object[]{"testMethod2", "PASSED", TRUE});
         return args;
     }
 

--- a/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
@@ -7,10 +7,12 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Random;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
@@ -24,20 +26,19 @@ public class DefaultRecordingFileFactoryTest {
 
     private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("YYYYMMdd-HHmmss");
 
-
-    @Parameterized.Parameters
-    public static Collection<Object[]> data() {
-        Random random = new Random();
-        return new ArrayList<Object[]>() {{
-            add(new Object[]{format("testMethodName%d", random.nextInt()), "FAILED", FALSE});
-            add(new Object[]{format("testMethodName%d", random.nextInt()), "PASSED", TRUE});
-        }};
-    }
-
     private final DefaultRecordingFileFactory factory = new DefaultRecordingFileFactory();
     private final String methodName;
     private final String prefix;
     private final boolean success;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        Random random = new Random();
+        Collection<Object[]> args = new ArrayList<>();
+        args.add(new Object[]{format("testMethodName%d", random.nextInt()), "FAILED", FALSE});
+        args.add(new Object[]{format("testMethodName%d", random.nextInt()), "PASSED", TRUE});
+        return args;
+    }
 
     @Test
     public void recordingFileThatShouldDescribeTheTestResultAtThePresentTime() throws Exception {

--- a/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
@@ -8,22 +8,25 @@ import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
+import java.util.List;
 
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
+import static java.time.LocalDateTime.now;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.assertThat;
 import static org.junit.runner.Description.createTestDescription;
 
 @RunWith(Parameterized.class)
 @Value
 public class DefaultRecordingFileFactoryTest {
 
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("YYYYMMdd-HHmmss");
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("YYYYMMdd-HHmmss");
 
     private final DefaultRecordingFileFactory factory = new DefaultRecordingFileFactory();
     private final String methodName;
@@ -45,12 +48,13 @@ public class DefaultRecordingFileFactoryTest {
 
         File recordingFile = factory.recordingFileForTest(vncRecordingDirectory, description, success);
 
-        File expectedFile = new File(vncRecordingDirectory, format("%s-%s-%s-%s.flv",
-                prefix,
-                getClass().getSimpleName(),
-                methodName,
-                DATE_FORMAT.format(new Date()))
+        String expectedFilePrefix = format("%s-%s-%s", prefix, getClass().getSimpleName(), methodName);
+
+        List<File> expectedPossibleFileNames = Arrays.asList(
+                new File(vncRecordingDirectory, format("%s-%s.flv", expectedFilePrefix, now().format(DATETIME_FORMATTER))),
+                new File(vncRecordingDirectory, format("%s-%s.flv", expectedFilePrefix, now().minusSeconds(1L).format(DATETIME_FORMATTER)))
         );
-        assertEquals(expectedFile, recordingFile);
+
+        assertThat(expectedPossibleFileNames, hasItem(recordingFile));
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -4,6 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.testcontainers.containers.BrowserWebDriverContainer;
+import org.testcontainers.containers.DefaultRecordingFileFactory;
 
 import java.io.File;
 
@@ -17,7 +18,8 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
     @Rule
     public BrowserWebDriverContainer chromeThatRecordsAllTests = new BrowserWebDriverContainer()
             .withDesiredCapabilities(DesiredCapabilities.chrome())
-            .withRecordingMode(RECORD_ALL, new File("./target/"));
+            .withRecordingMode(RECORD_ALL, new File("./target/"))
+            .withRecordingFileFactory(new DefaultRecordingFileFactory());
 
     @Rule
     public BrowserWebDriverContainer chromeThatRecordsFailingTests = new BrowserWebDriverContainer()


### PR DESCRIPTION
By default this returns a file in the given vlc recording directory named `<RESULT>-<TestClassName>-<testMethodName>-<YYYYMMdd-HHmmss>.flv`, where RESULT is either `PASSED` or `FAILED`.

A custom factory can be provided to BrowserWebDriverContainer#withRecordingFileFactory.

The factory is only applicable if the BrowserWebDriverContainer#recordingMode enables the retention of recordings.

Fixes #500.