### PR TITLE
Fix problems with copying files and Docker-Compose on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## UNRELEASED
 ### Fixed
+- Problems with using container based docker-compose on Windows ([\#514](https://github.com/testcontainers/testcontainers-java/pull/514))
+- Problems with copying files on Windows ([\#514](https://github.com/testcontainers/testcontainers-java/pull/514))
 - Fixed regression in 1.4.3 when using Docker Compose on Windows ([\#439](https://github.com/testcontainers/testcontainers-java/issues/439))
 - Fixed local Docker Compose executable name resolution on Windows (#416)
 - Fixed TAR composition on Windows (#444)

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -398,6 +398,7 @@ interface DockerCompose {
 class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCompose> implements DockerCompose {
 
     private static final String DOCKER_SOCKET_PATH = "//var/run/docker.sock";
+    public static final char UNIX_PATH_SEPERATOR = ':';
 
     public ContainerisedDockerCompose(List<File> composeFiles, String identifier) {
 
@@ -416,7 +417,7 @@ class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCom
                         .map(MountableFile::forHostPath)
                         .map(MountableFile::getFilesystemPath)
                         .collect(toList());
-        final String composeFileEnvVariableValue = Joiner.on(File.pathSeparator).join(absoluteDockerComposeFiles);
+        final String composeFileEnvVariableValue = Joiner.on(UNIX_PATH_SEPERATOR).join(absoluteDockerComposeFiles); // we always need the UNIX path separator
         logger().debug("Set env COMPOSE_FILE={}", composeFileEnvVariableValue);
         addEnv(ENV_COMPOSE_FILE, composeFileEnvVariableValue);
         addFileSystemBind(pwd, containerPwd, READ_ONLY);

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -397,7 +397,7 @@ interface DockerCompose {
  */
 class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCompose> implements DockerCompose {
 
-    private static final String DOCKER_SOCKET_PATH = "//var/run/docker.sock";
+    private static final String DOCKER_SOCKET_PATH = "/var/run/docker.sock";
     public static final char UNIX_PATH_SEPERATOR = ':';
 
     public ContainerisedDockerCompose(List<File> composeFiles, String identifier) {

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -10,7 +10,6 @@ import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.SystemUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.runner.Description;
 import org.rnorth.ducttape.ratelimits.RateLimiter;
 import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
@@ -432,7 +431,6 @@ class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCom
         setWorkingDirectory(containerPwd);
     }
 
-    @NotNull
     private String getDockerSocketHostPath() {
         return SystemUtils.IS_OS_WINDOWS
                 ? "/" + DOCKER_SOCKET_PATH

--- a/core/src/main/java/org/testcontainers/images/builder/traits/ClasspathTrait.java
+++ b/core/src/main/java/org/testcontainers/images/builder/traits/ClasspathTrait.java
@@ -13,6 +13,6 @@ public interface ClasspathTrait<SELF extends ClasspathTrait<SELF> & BuildContext
     default SELF withFileFromClasspath(String path, String resourcePath) {
         final MountableFile mountableFile = MountableFile.forClasspathResource(resourcePath);
 
-        return ((SELF) this).withFileFromPath(path, Paths.get(mountableFile.getFilesystemPath()));
+        return ((SELF) this).withFileFromPath(path, Paths.get(mountableFile.getResolvedPath()));
     }
 }

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -10,7 +10,11 @@ import org.apache.commons.lang.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 import org.testcontainers.images.builder.Transferable;
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.file.Files;

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -182,7 +182,7 @@ public class MountableFile implements Transferable {
         String result = getResourcePath();
 
         if (SystemUtils.IS_OS_WINDOWS && result.startsWith("/")) {
-            result = PathUtils.createMinGWPath(result);
+            result = PathUtils.createMinGWPath(result).substring(1);
         }
 
         return result;

--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -8,9 +8,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertFalse;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
+import static org.rnorth.visibleassertions.VisibleAssertions.*;
 
 public class MountableFileTest {
 
@@ -108,7 +106,7 @@ public class MountableFileTest {
     }
 
     private void performChecks(final MountableFile mountableFile) {
-        final String mountablePath = mountableFile.getFilesystemPath();
+        final String mountablePath = mountableFile.getResolvedPath();
         assertTrue("The filesystem path '" + mountablePath + "' can be found", new File(mountablePath).exists());
         assertFalse("The filesystem path '" + mountablePath + "' does not contain any URL escaping", mountablePath.contains("%20"));
     }

--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static org.rnorth.visibleassertions.VisibleAssertions.*;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertFalse;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 public class MountableFileTest {
 


### PR DESCRIPTION
Copying files into the container did not work on Docker for Windows.
Also the docker socket needs to be mounted differently into the docker-compose container on Windows.

UNIX path separator needs to be used when building docker-compose env file path for containerized docker-compose.