### PR TITLE
Improve the usability of GenericContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Added Kafka module ([\#546](https://github.com/testcontainers/testcontainers-java/pull/546))
+- Environment variables are now stored as Map instead of List ([\#550](https://github.com/testcontainers/testcontainers-java/pull/550))
+- Added `withEnv(String name, Function<Optional<String>, String> mapper)` with optional previous value ([\#550](https://github.com/testcontainers/testcontainers-java/pull/550))
+- Added `withFileSystemBind` overloaded method with `READ_WRITE` file mode by default ([\#550](https://github.com/testcontainers/testcontainers-java/pull/550))
 
 ## [1.5.1] - 2017-12-19
 

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -17,8 +17,10 @@ import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 public interface Container<SELF extends Container<SELF>> extends LinkableContainer {
 
@@ -181,6 +183,18 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @return this
      */
     SELF withEnv(String key, String value);
+
+    /**
+     * Add an environment variable to be passed to the container.
+     *
+     * @param key   environment variable key
+     * @param mapper environment variable value mapper, accepts old value as an argument
+     * @return this
+     */
+    default SELF withEnv(String key, Function<Optional<String>, String> mapper) {
+        Optional<String> oldValue = Optional.ofNullable(getEnvMap().get(key));
+        return withEnv(key, mapper.apply(oldValue));
+    }
 
     /**
      * Add environment variables to be passed to the container.

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -408,6 +408,10 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      */
     SELF withLogConsumer(Consumer<OutputFrame> consumer);
 
+    /**
+     *
+     * @deprecated please use {@code org.testcontainers.DockerClientFactory.instance().client().infoCmd().exec()}
+     */
     @Deprecated
     Info fetchDockerDaemonInfo() throws IOException;
 
@@ -485,6 +489,10 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     DockerClient getDockerClient();
 
+    /**
+     *
+     * @deprecated please use {@code org.testcontainers.DockerClientFactory.instance().client().infoCmd().exec()}
+     */
     @Deprecated
     Info getDockerDaemonInfo();
 
@@ -492,6 +500,10 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     String getContainerName();
 
+    /**
+     *
+     * @deprecated please use {@code org.testcontainers.DockerClientFactory.instance().client().inspectContainerCmd(container.getContainerId()).exec()}
+     */
     @Deprecated
     InspectContainerResponse getContainerInfo();
 

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -140,6 +140,17 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      *
      * @param hostPath the file system path on the host
      * @param containerPath the file system path inside the container
+     * @return this
+     */
+    default SELF withFileSystemBind(String hostPath, String containerPath) {
+        return withFileSystemBind(hostPath, containerPath, BindMode.READ_WRITE);
+    }
+
+    /**
+     * Adds a file system binding.
+     *
+     * @param hostPath the file system path on the host
+     * @param containerPath the file system path inside the container
      * @param mode the bind mode
      * @return this
      */
@@ -383,6 +394,7 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      */
     SELF withLogConsumer(Consumer<OutputFrame> consumer);
 
+    @Deprecated
     Info fetchDockerDaemonInfo() throws IOException;
 
     /**
@@ -438,7 +450,14 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     Future<String> getImage();
 
+    /**
+     *
+     * @deprecated use getEnvMap
+     */
+    @Deprecated
     List<String> getEnv();
+
+    Map<String, String> getEnvMap();
 
     String[] getCommandParts();
 
@@ -452,12 +471,14 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     DockerClient getDockerClient();
 
+    @Deprecated
     Info getDockerDaemonInfo();
 
     String getContainerId();
 
     String getContainerName();
 
+    @Deprecated
     InspectContainerResponse getContainerInfo();
 
     void setExposedPorts(List<Integer> exposedPorts);

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -912,6 +912,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         return self();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public synchronized Info fetchDockerDaemonInfo() throws IOException {
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -92,7 +92,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     private Future<String> image;
 
     @NonNull
-    private List<String> env = new ArrayList<>();
+    private Map<String, String> env = new HashMap<>();
 
     @NonNull
     private String[] commandParts = new String[0];
@@ -396,7 +396,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             createCommand.withCmd(commandParts);
         }
 
-        String[] envArray = env.stream()
+        String[] envArray = env.entrySet().stream()
+                .map(it -> it.getKey() + "=" + it.getValue())
                 .toArray(String[]::new);
         createCommand.withEnv(envArray);
 
@@ -533,12 +534,37 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         this.commandParts = commandParts;
     }
 
+    @Override
+    public Map<String, String> getEnvMap() {
+        return env;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<String> getEnv() {
+        return env.entrySet().stream()
+                .map(it -> it.getKey() + "=" + it.getValue())
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void setEnv(List<String> env) {
+        this.env = env.stream()
+                .map(it -> it.split("="))
+                .collect(Collectors.toMap(
+                        it -> it[0],
+                        it -> it[1]
+                ));
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public void addEnv(String key, String value) {
-        env.add(key + "=" + value);
+        env.put(key, value);
     }
 
     /**

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -81,9 +81,10 @@ public class GenericContainerRuleTest {
      * dirty way for testing.
      */
     @ClassRule
-    public static GenericContainer alpineEnvVar = new GenericContainer("alpine:3.2")
+    public static GenericContainer alpineEnvVar = new GenericContainer<>("alpine:3.2")
             .withExposedPorts(80)
-            .withEnv("MAGIC_NUMBER", "42")
+            .withEnv("MAGIC_NUMBER", "4")
+            .withEnv("MAGIC_NUMBER", oldValue -> oldValue.orElse("") + "2")
             .withCommand("/bin/sh", "-c", "while true; do echo \"$MAGIC_NUMBER\" | nc -l -p 80; done");
 
     /**


### PR DESCRIPTION
What was changed:
* store envs as Map, not List, so that one can get all envs as a map:
```
container.getEnvMap()
```

* add `withEnv` with mapper:
```
.withEnv("JAVA_OPTS", it -> it.orElse("") + " -javaagent:/foo.jar")
```

* use `READ_WRITE` bind mode if none was provided:
```
.withFileSystemBind("/foo", "/bar")
```

Also deprecated some methods from `Container` interface like `fetchDockerDaemonInfo` because we don't want to have them in our public API