### PR TITLE
implement database delegate abstraction for ScriptUtils

### DIFF
--- a/modules/database-commons/pom.xml
+++ b/modules/database-commons/pom.xml
@@ -9,19 +9,13 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>jdbc</artifactId>
-    <name>TestContainers :: JDBC</name>
+    <artifactId>database-commons</artifactId>
+    <name>TestContainers :: Database-Commons</name>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>database-commons</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>

--- a/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
@@ -19,6 +19,8 @@ public abstract class AbstractDatabaseDelegate<CONTAINER, CONNECTION> implements
      */
     private CONNECTION connection;
 
+    private boolean isConnectionStarted = false;
+
     public AbstractDatabaseDelegate(CONTAINER container) {
         this.container = container;
     }
@@ -27,8 +29,9 @@ public abstract class AbstractDatabaseDelegate<CONTAINER, CONNECTION> implements
      * Get or create new connection to the database
      */
     protected CONNECTION getConnection() {
-        if (connection == null) {
+        if (!isConnectionStarted) {
             connection = createNewConnection();
+            isConnectionStarted = true;
         }
         return connection;
     }
@@ -44,8 +47,9 @@ public abstract class AbstractDatabaseDelegate<CONTAINER, CONNECTION> implements
 
     @Override
     public void close() {
-        if (connection != null) {
+        if (isConnectionStarted) {
             closeConnectionQuietly(connection);
+            isConnectionStarted = false;
         }
     }
 

--- a/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
@@ -1,0 +1,61 @@
+package org.testcontainers.delegate;
+
+import java.util.Collection;
+
+/**
+ * @param <CONTAINER>  testcontainers container
+ * @param <CONNECTION> connection to the database
+ * @author Eugeny Karpov
+ */
+public abstract class AbstractDatabaseDelegate<CONTAINER, CONNECTION> implements DatabaseDelegate {
+
+    /**
+     * Testcontainers container
+     */
+    protected CONTAINER container;
+
+    /**
+     * Database connection
+     */
+    private CONNECTION connection;
+
+    public AbstractDatabaseDelegate(CONTAINER container) {
+        this.container = container;
+    }
+
+    /**
+     * Get or create new connection to the database
+     */
+    protected CONNECTION getConnection() {
+        if (connection == null) {
+            connection = createNewConnection();
+        }
+        return connection;
+    }
+
+    @Override
+    public void execute(Collection<String> statements, String scriptPath, boolean continueOnError, boolean ignoreFailedDrops) {
+        int lineNumber = 0;
+        for (String statement : statements) {
+            lineNumber++;
+            execute(statement, scriptPath, lineNumber, continueOnError, ignoreFailedDrops);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (connection != null) {
+            closeConnectionQuietly(connection);
+        }
+    }
+
+    /**
+     * Quietly close the connection
+     */
+    protected abstract void closeConnectionQuietly(CONNECTION connection);
+
+    /**
+     * Template method for creating new connections to the database
+     */
+    protected abstract CONNECTION createNewConnection();
+}

--- a/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
@@ -3,16 +3,10 @@ package org.testcontainers.delegate;
 import java.util.Collection;
 
 /**
- * @param <CONTAINER>  testcontainers container
  * @param <CONNECTION> connection to the database
  * @author Eugeny Karpov
  */
-public abstract class AbstractDatabaseDelegate<CONTAINER, CONNECTION> implements DatabaseDelegate {
-
-    /**
-     * Testcontainers container
-     */
-    protected CONTAINER container;
+public abstract class AbstractDatabaseDelegate<CONNECTION> implements DatabaseDelegate {
 
     /**
      * Database connection
@@ -20,10 +14,6 @@ public abstract class AbstractDatabaseDelegate<CONTAINER, CONNECTION> implements
     private CONNECTION connection;
 
     private boolean isConnectionStarted = false;
-
-    public AbstractDatabaseDelegate(CONTAINER container) {
-        this.container = container;
-    }
 
     /**
      * Get or create new connection to the database

--- a/modules/database-commons/src/main/java/org/testcontainers/delegate/DatabaseDelegate.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/delegate/DatabaseDelegate.java
@@ -1,0 +1,31 @@
+package org.testcontainers.delegate;
+
+import java.util.Collection;
+
+/**
+ * Database delegate
+ *
+ * Gives an abstraction from concrete database
+ *
+ * @author Eugeny Karpov
+ */
+public interface DatabaseDelegate extends AutoCloseable {
+
+    /**
+     * Execute statement by the implementation of the delegate
+     */
+    void execute(String statement, String scriptPath, int lineNumber, boolean continueOnError, boolean ignoreFailedDrops);
+
+    /**
+     * Execute collection of statements
+     */
+    void execute(Collection<String> statements, String scriptPath, boolean continueOnError, boolean ignoreFailedDrops);
+
+    /**
+     * Close connection to the database
+     *
+     * Overridden to suppress throwing Exception
+     */
+    @Override
+    void close();
+}

--- a/modules/database-commons/src/main/java/org/testcontainers/exception/ConnectionCreationException.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/exception/ConnectionCreationException.java
@@ -1,0 +1,13 @@
+package org.testcontainers.exception;
+
+/**
+ * Inability to create connection to the database
+ *
+ * @author Eugeny Karpov
+ */
+public class ConnectionCreationException extends RuntimeException {
+
+    public ConnectionCreationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -4,7 +4,8 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.JdbcDatabaseContainerProvider;
-import org.testcontainers.jdbc.ext.ScriptUtils;
+import org.testcontainers.delegate.DatabaseDelegate;
+import org.testcontainers.ext.ScriptUtils;
 
 import javax.script.ScriptException;
 import java.io.IOException;
@@ -153,7 +154,8 @@ public class ContainerDatabaseDriver implements Driver {
               an init script or function has been specified, use it
              */
             if (!initializedContainers.contains(container.getContainerId())) {
-                runInitScriptIfRequired(url, connection);
+                DatabaseDelegate databaseDelegate = new JdbcDatabaseDelegate(container);
+                runInitScriptIfRequired(url, databaseDelegate);
                 runInitFunctionIfRequired(url, connection);
                 initializedContainers.add(container.getContainerId());
             }
@@ -214,10 +216,10 @@ public class ContainerDatabaseDriver implements Driver {
      * Run an init script from the classpath.
      *
      * @param url        the JDBC URL to check for init script declarations.
-     * @param connection JDBC connection to apply init scripts to.
+     * @param databaseDelegate database delegate to apply init scripts to the database
      * @throws SQLException on script or DB error
      */
-    private void runInitScriptIfRequired(String url, Connection connection) throws SQLException {
+    private void runInitScriptIfRequired(String url, DatabaseDelegate databaseDelegate) throws SQLException {
         Matcher matcher = INITSCRIPT_MATCHING_PATTERN.matcher(url);
         if (matcher.matches()) {
             String initScriptPath = matcher.group(2);
@@ -230,7 +232,7 @@ public class ContainerDatabaseDriver implements Driver {
                 }
 
                 String sql = IOUtils.toString(resource, StandardCharsets.UTF_8);
-                ScriptUtils.executeSqlScript(connection, initScriptPath, sql);
+                ScriptUtils.executeDatabaseScript(databaseDelegate, initScriptPath, sql);
             } catch (IOException e) {
                 LOGGER.warn("Could not load classpath init script: {}", initScriptPath);
                 throw new SQLException("Could not load classpath init script: " + initScriptPath, e);

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerLessJdbcDelegate.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerLessJdbcDelegate.java
@@ -1,0 +1,36 @@
+package org.testcontainers.jdbc;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.exception.ConnectionCreationException;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Containerless jdbc database delegate
+ *
+ * Is used only with deprecated ScriptUtils
+ *
+ * @see org.testcontainers.ext.ScriptUtils
+ */
+@Slf4j
+public class ContainerLessJdbcDelegate extends JdbcDatabaseDelegate {
+
+    private Connection connection;
+
+    public ContainerLessJdbcDelegate(Connection connection) {
+        super(null);
+        this.connection = connection;
+    }
+
+    @Override
+    protected Statement createNewConnection() {
+        try {
+            return connection.createStatement();
+        } catch (SQLException e) {
+            log.error("Could create JDBC statement");
+            throw new ConnectionCreationException("Could create JDBC statement", e);
+        }
+    }
+}

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
@@ -1,0 +1,58 @@
+package org.testcontainers.jdbc;
+
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.delegate.AbstractDatabaseDelegate;
+import org.testcontainers.exception.ConnectionCreationException;
+import org.testcontainers.ext.ScriptUtils;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * JDBC database delegate
+ *
+ * @author Eugeny Karpov
+ */
+@Slf4j
+public class JdbcDatabaseDelegate extends AbstractDatabaseDelegate<JdbcDatabaseContainer, Statement> {
+
+    public JdbcDatabaseDelegate(JdbcDatabaseContainer jdbcDatabaseContainer) {
+        super(jdbcDatabaseContainer);
+    }
+
+    @Override
+    protected Statement createNewConnection() {
+        try {
+            return container.createConnection("").createStatement();
+        } catch (SQLException e) {
+            log.error("Could not obtain JDBC connection");
+            throw new ConnectionCreationException("Could not obtain JDBC connection", e);
+        }
+    }
+
+
+    @Override
+    public void execute(String statement, String scriptPath, int lineNumber, boolean continueOnError, boolean ignoreFailedDrops) {
+        try {
+            boolean rowsAffected = getConnection().execute(statement);
+            log.debug("{} returned as updateCount for SQL: {}", rowsAffected, statement);
+        } catch (SQLException ex) {
+            boolean dropStatement = statement.trim().toLowerCase().startsWith("drop");
+            if (continueOnError || (dropStatement && ignoreFailedDrops)) {
+                log.debug("Failed to execute SQL script statement at line {} of resource {}: {}", lineNumber, scriptPath, statement, ex);
+            } else {
+                throw new ScriptUtils.ScriptStatementFailedException(statement, lineNumber, scriptPath, ex);
+            }
+        }
+    }
+
+    @Override
+    protected void closeConnectionQuietly(Statement statement) {
+        try {
+            statement.close();
+        } catch (Exception e) {
+            log.error("Could not close JDBC connection", e);
+        }
+    }
+}

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
@@ -15,10 +15,12 @@ import java.sql.Statement;
  * @author Eugeny Karpov
  */
 @Slf4j
-public class JdbcDatabaseDelegate extends AbstractDatabaseDelegate<JdbcDatabaseContainer, Statement> {
+public class JdbcDatabaseDelegate extends AbstractDatabaseDelegate<Statement> {
 
-    public JdbcDatabaseDelegate(JdbcDatabaseContainer jdbcDatabaseContainer) {
-        super(jdbcDatabaseContainer);
+    private JdbcDatabaseContainer container;
+
+    public JdbcDatabaseDelegate(JdbcDatabaseContainer container) {
+        this.container = container;
     }
 
     @Override

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ext/ScriptUtils.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ext/ScriptUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2002-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.testcontainers.jdbc.ext;
+
+import org.testcontainers.jdbc.ContainerLessJdbcDelegate;
+
+import javax.script.ScriptException;
+import java.sql.Connection;
+import java.util.List;
+
+/**
+ * Wrapper for database-agnostic ScriptUtils
+ *
+ * @see org.testcontainers.ext.ScriptUtils
+ * @deprecated Needed only to keep binary compatibility for this internal API. Consider using database-agnostic ScriptUtils
+ */
+public abstract class ScriptUtils {
+
+    /**
+     * Default statement separator within SQL scripts.
+     */
+    public static final String DEFAULT_STATEMENT_SEPARATOR = ";";
+
+    /**
+     * Fallback statement separator within SQL scripts.
+     * <p>Used if neither a custom defined separator nor the
+     * {@link #DEFAULT_STATEMENT_SEPARATOR} is present in a given script.
+     */
+    public static final String FALLBACK_STATEMENT_SEPARATOR = "\n";
+
+    /**
+     * Default prefix for line comments within SQL scripts.
+     */
+    public static final String DEFAULT_COMMENT_PREFIX = "--";
+
+    /**
+     * Default start delimiter for block comments within SQL scripts.
+     */
+    public static final String DEFAULT_BLOCK_COMMENT_START_DELIMITER = "/*";
+
+    /**
+     * Default end delimiter for block comments within SQL scripts.
+     */
+    public static final String DEFAULT_BLOCK_COMMENT_END_DELIMITER = "*/";
+
+    /**
+     * Prevent instantiation of this utility class.
+     */
+    private ScriptUtils() {
+        /* no-op */
+    }
+
+    /**
+     * @see org.testcontainers.ext.ScriptUtils
+     * @deprecated Needed only to keep binary compatibility for this internal API. Consider using database-agnostic ScriptUtils
+     */
+    public static void splitSqlScript(String resource, String script, String separator, String commentPrefix,
+                                      String blockCommentStartDelimiter, String blockCommentEndDelimiter, List<String> statements) {
+        org.testcontainers.ext.ScriptUtils.splitSqlScript(resource, script, separator, commentPrefix, blockCommentStartDelimiter, blockCommentEndDelimiter, statements);
+    }
+
+    /**
+     * @see org.testcontainers.ext.ScriptUtils
+     * @deprecated Needed only to keep binary compatibility for this internal API. Consider using database-agnostic ScriptUtils
+     */
+    public static boolean containsSqlScriptDelimiters(String script, String delim) {
+        return org.testcontainers.ext.ScriptUtils.containsSqlScriptDelimiters(script, delim);
+    }
+
+    /**
+     * @see org.testcontainers.ext.ScriptUtils
+     * @deprecated Needed only to keep binary compatibility for this internal API. Consider using database-agnostic ScriptUtils
+     */
+    public static void executeSqlScript(Connection connection, String scriptPath, String script) throws ScriptException {
+        org.testcontainers.ext.ScriptUtils.executeDatabaseScript(new ContainerLessJdbcDelegate(connection), scriptPath, script);
+    }
+
+    /**
+     * @see org.testcontainers.ext.ScriptUtils
+     * @deprecated Needed only to keep binary compatibility for this internal API. Consider using database-agnostic ScriptUtils
+     */
+    public static void executeSqlScript(Connection connection, String scriptPath, String script, boolean continueOnError,
+                                        boolean ignoreFailedDrops, String commentPrefix, String separator, String blockCommentStartDelimiter,
+                                        String blockCommentEndDelimiter) throws ScriptException {
+        org.testcontainers.ext.ScriptUtils.executeDatabaseScript(new ContainerLessJdbcDelegate(connection), scriptPath,
+                script, continueOnError, ignoreFailedDrops, commentPrefix, separator, blockCommentStartDelimiter, blockCommentEndDelimiter);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,7 @@
         <module>modules/selenium</module>
         <module>modules/nginx</module>
         <module>modules/jdbc-test</module>
+        <module>modules/database-commons</module>
     </modules>
 
     <profiles>


### PR DESCRIPTION
Currently ScriptUtils class is tied up with relational databases. This PR introduces database delegate concept allowing for ScriptUtils to work with any database (Cassandra with CQL as an example). It allows Cassandra container (different PR) to use ScriptUtils without any code duplication. 

Blocker for PR https://github.com/testcontainers/testcontainers-java/pull/525