### PR TITLE
Update Lombok to 1.16.20 for a better Java9 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.6</version>
+            <version>1.16.20</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
While working on elasticsearch module, I had issues when running `mvn clean install` under Java9:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.7.0:compile (default-compile) on project testcontainers-elasticsearch: Fatal error compiling: java.lang.NoSuchFieldError: pid -> [Help 1]
```

Upgrading Lombok to 1.16.20 fixes the problem.