### PR TITLE
Add jdk9 build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk9
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - oraclejdk8
-  - oraclejdk9
 
 env:
   global:
@@ -31,6 +30,12 @@ jobs:
     - stage: test
       env: [ NAME=core ]
       script: ./mvnw -pl core test
+
+    - stage: test
+      env: [ NAME=core-jdk9 ]
+      script:
+        - jdk_switcher use oraclejdk9
+        - ./mvnw -pl core test
 
     - env: [ NAME=selenium ]
       script: ./mvnw -pl modules/selenium test

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,10 @@ jobs:
       script: ./mvnw -pl core test
 
     - stage: test
-      env: [ NAME=core-jdk9 ]
+      env: [ NAME=core ]
+      jdk:
+        - oraclejdk9
       script:
-        - jdk_switcher use oraclejdk9
         - ./mvnw -pl core test
 
     - env: [ NAME=selenium ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ jobs:
 
     - stage: test
       env: [ NAME=core ]
-      jdk:
-        - oraclejdk9
+      jdk: oraclejdk9
       script:
         - ./mvnw -pl core test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 ### Fixed
+- Fixed incompatibility of Docker-Compose container with JDK9. ([\#562](https://github.com/testcontainers/testcontainers-java/pull/562))
 - Fixed retrieval of Docker host IP when running inside Docker. ([\#479](https://github.com/testcontainers/testcontainers-java/issues/479))
 - Fixed overriding MySQL image command. ([\#534](https://github.com/testcontainers/testcontainers-java/issues/534))
 
 ### Changed
+- Added JDK9 build and tests to Travis-CI. ([\#562](https://github.com/testcontainers/testcontainers-java/pull/562))
 - Added Kafka module ([\#546](https://github.com/testcontainers/testcontainers-java/pull/546))
 - Added "Death Note" to track & kill spawned containers even if the JVM was "kill -9"ed ([\#545](https://github.com/testcontainers/testcontainers-java/pull/545))
 - Environment variables are now stored as Map instead of List ([\#550](https://github.com/testcontainers/testcontainers-java/pull/550))

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -48,6 +48,14 @@
             </exclusions>
         </dependency>
 
+
+        <!-- Added for JDK9 compatibility since it's missing this package -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+
         <dependency>
             <!-- docker-java uses SslConfigurator from jersey-common for TLS -->
             <groupId>org.glassfish.jersey.core</groupId>


### PR DESCRIPTION
I've added a jdk9 build (basically the first compiling step) to Travis. I also wonder if we should add openjdk8 and openjdk9 to the compiling step, or maybe switch to openjdk from oraclejdk, but it might be not really important for us,