### PR TITLE
Fix extraneous use of connection string `useSSL` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.1] - 2018-01-31
+
+### Fixed
+
+- Fixed extraneous insertion of `useSSL=false` in all JDBC URL strings, even for DBs that do not understand it. Usage is now restricted to MySQL by default and can be overridden by authors of `JdbcDatabaseContainer` subclasses ([\#568](https://github.com/testcontainers/testcontainers-java/issues/568))
+
 ## [1.6.0] - 2018-01-28
 
 ### Fixed

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -41,6 +41,7 @@ public class JDBCDriverTest {
                         {"jdbc:tc:mysql://hostname/databasename?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction", true, false, false},
                         {"jdbc:tc:mysql://hostname/databasename?useUnicode=yes&characterEncoding=utf8", false, true, false},
                         {"jdbc:tc:mysql://hostname/databasename", false, false, false},
+                        {"jdbc:tc:mysql://hostname/databasename?useSSL=false", false, false, false},
                         {"jdbc:tc:postgresql://hostname/databasename", false, false, false},
                         {"jdbc:tc:mysql:5.6://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override", false, false, true},
                 });

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -71,7 +71,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
         throw new UnsupportedOperationException();
     }
 
-    public SELF withPassword(String password){
+    public SELF withPassword(String password) {
         throw new UnsupportedOperationException();
     }
 
@@ -127,8 +127,9 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     /**
      * Creates a connection to the underlying containerized database instance.
      *
-     * @param queryString any special query string parameters that should be appended to the JDBC connection URL. The
-     *                    '?' character must be included
+     * @param queryString
+     *          query string parameters that should be appended to the JDBC connection URL.
+     *          The '?' character must be included
      * @return a Connection
      * @throws SQLException if there is a repeated failure to create the connection
      */
@@ -136,7 +137,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
         final Properties info = new Properties();
         info.put("user", this.getUsername());
         info.put("password", this.getPassword());
-        final String url = appendDisableSslConfig(this.getJdbcUrl() + queryString);
+        final String url = constructUrlForConnection(queryString);
 
         final Driver jdbcDriverInstance = getJdbcDriverInstance();
 
@@ -147,9 +148,18 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
         }
     }
 
-    private String appendDisableSslConfig(String connectionString){
-      String separator = connectionString.contains("?") ? "&" : "?";
-      return connectionString + separator + "useSSL=false";
+    /**
+     * Template method for constructing the JDBC URL to be used for creating {@link Connection}s.
+     * This should be overridden if the JDBC URL and query string concatenation or URL string
+     * construction needs to be different to normal.
+     *
+     * @param queryString
+     *          query string parameters that should be appended to the JDBC connection URL.
+     *          The '?' character must be included
+     * @return a full JDBC URL including queryString
+     */
+    protected String constructUrlForConnection(String queryString) {
+        return getJdbcUrl() + queryString;
     }
 
     protected void optionallyMapResourceParameterAsVolume(@NotNull String paramName, @NotNull String pathNameInContainer, @NotNull String defaultResource) {

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -55,6 +55,12 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     }
 
     @Override
+    protected String constructUrlForConnection(String queryString) {
+        String separator = queryString.contains("?") ? "&" : "?";
+        return getJdbcUrl() + separator + "useSSL=false";
+    }
+
+    @Override
     public String getDatabaseName() {
         return databaseName;
     }

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -56,8 +56,9 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
     @Override
     protected String constructUrlForConnection(String queryString) {
-        String separator = queryString.contains("?") ? "&" : "?";
-        return getJdbcUrl() + separator + "useSSL=false";
+        String url = super.constructUrlForConnection(queryString);
+        String separator = url.contains("?") ? "&" : "?";
+        return url + separator + "useSSL=false";
     }
 
     @Override

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -57,8 +57,13 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     @Override
     protected String constructUrlForConnection(String queryString) {
         String url = super.constructUrlForConnection(queryString);
-        String separator = url.contains("?") ? "&" : "?";
-        return url + separator + "useSSL=false";
+
+        if (! url.contains("useSSL=")) {
+            String separator = url.contains("?") ? "&" : "?";
+            return url + separator + "useSSL=false";
+        } else {
+            return url;
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a proposed fix for #568, hopefully to release quickly.