### PR TITLE
Allow to escape sql delimiter

### DIFF
--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 
+import java.sql.CallableStatement;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -67,6 +68,7 @@ public class JDBCDriverTest {
 
         if (performTestForScriptedSchema) {
             performTestForScriptedSchema(jdbcUrl);
+            performTestForScriptedSchemaWithProcedure(jdbcUrl);
         }
 
         if (performTestForCharacterSet) {
@@ -99,11 +101,20 @@ public class JDBCDriverTest {
                 assertEquals("A basic SELECT query succeeds where the schema has been applied from a script", "hello world", resultSetString);
                 return true;
             });
-
-            assertTrue("The database returned a record as expected", result);
-
         }
     }
+    
+    private void performTestForScriptedSchemaWithProcedure(String jdbcUrl) throws SQLException {
+      try (HikariDataSource dataSource = getDataSource(jdbcUrl, 1)) {
+          CallableStatement proc = dataSource.getConnection().prepareCall("{call count_foo()}");
+          boolean result = proc.execute();
+          ResultSet rs = proc.getResultSet();
+          rs.first();
+          String foo = rs.getString(1);
+          assertEquals("A stored procedure call succeesfully returned the first record from database", "hello world", foo);
+          assertTrue("Calling stored procedure returns data as expected", result);
+      }
+  }
 
     private void performSimpleTestWithCharacterSet(String jdbcUrl) throws SQLException {
         try (HikariDataSource dataSource = getDataSource(jdbcUrl, 1)) {

--- a/modules/jdbc-test/src/test/resources/somepath/init_mysql.sql
+++ b/modules/jdbc-test/src/test/resources/somepath/init_mysql.sql
@@ -3,3 +3,13 @@ CREATE TABLE bar (
 );
 
 INSERT INTO bar (foo) VALUES ('hello world');
+
+DROP PROCEDURE IF EXISTS count_foo;
+
+CREATE PROCEDURE count_foo()
+BEGIN
+
+select * from bar\;
+select 1 from dual\;
+
+END;

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ext/ScriptUtils.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ext/ScriptUtils.java
@@ -267,6 +267,7 @@ public abstract class ScriptUtils {
 				for (String statement : statements) {
 					lineNumber++;
 					try {
+					    	statement = statement.replace("\\;", ";");
 						stmt.execute(statement);
 						int rowsAffected = stmt.getUpdateCount();
 						if (LOGGER.isDebugEnabled()) {


### PR DESCRIPTION
This PR allows a feature that will replace an escaped SQL delimiter `\;` with `;`. See #570 For issue details. 

Any SQL Delimiter inside stored procedure or functions can be escaped for ScriptUtil to correctly parse and create objects. 