### PR TITLE
Change capitalisation of the project name to the commonly used form

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# TestContainers
+# Testcontainers
 
-> TestContainers is a Java 8 library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
+> Testcontainers is a Java 8 library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 
 [![Build Status](https://travis-ci.org/testcontainers/testcontainers-java.svg?branch=master)](https://travis-ci.org/testcontainers/testcontainers-java)
 

--- a/book.js
+++ b/book.js
@@ -1,7 +1,7 @@
 module.exports = {
     root: "./docs",
 
-    title: "TestContainers",
+    title: "Testcontainers",
 
     structure: {
         readme: "index.md"

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>testcontainers</artifactId>
 
-    <name>TestContainers Core</name>
+    <name>Testcontainers Core</name>
 
     <dependencies>
         <dependency>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
-# TestContainers
+# Testcontainers
 
-> TestContainers is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
+> Testcontainers is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 
 [![Build Status](https://travis-ci.org/testcontainers/testcontainers-java.svg?branch=master)](https://travis-ci.org/testcontainers/testcontainers-java)
 [View on Github](https://github.com/testcontainers/testcontainers-java)
@@ -9,14 +9,14 @@
 
 ## Use Cases
 
-TestContainers makes it easy to launch useful Docker containers for the duration of JUnit tests.
+Testcontainers makes it easy to launch useful Docker containers for the duration of JUnit tests.
 
  * **Data access layer integration tests**: use a containerized instance of a MySQL, PostgreSQL or Oracle database to test your data access layer code for complete compatibility, but without requiring complex setup on developers' machines and safe in the knowledge that your tests will always start with a known DB state. Any other database type that can be containerized can also be used.
  * **Application integration tests**: for running your application in a short-lived test mode with dependencies, such as databases, message queues or web servers.
  * **UI/Acceptance tests**: use containerized web browsers, compatible with Selenium, for conducting automated UI tests. Each test can get a fresh instance of the browser, with no browser state, plugin variations or automated browser upgrades to worry about. And you get a video recording of each test session, or just each session where tests failed.
  * **Much more!** Check out the various [contributed modules](https://github.com/testcontainers) or create your own custom container classes using [`GenericContainer`](usage/generic_containers.md) as a base.
 
-## Who is using TestContainers?
+## Who is using Testcontainers?
 
  * [ZeroTurnaround](https://zeroturnaround.com) - Testing of the Java Agents, micro-services, Selenium browser automation
  * [Zipkin](http://zipkin.io) - MySQL and Cassandra testing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,9 +2,9 @@
 
 ### Prerequisites
 
-Docker or docker-machine (for OS X) must be installed on the machine you are running tests on. TestContainers currently requires JDK 1.8 and is compatible with JUnit.
+Docker or docker-machine (for OS X) must be installed on the machine you are running tests on. Testcontainers currently requires JDK 1.8 and is compatible with JUnit.
 
-If you want to use TestContainers on Windows you can try the [alpha release](usage/windows_support.md).
+If you want to use Testcontainers on Windows you can try the [alpha release](usage/windows_support.md).
 
 ### Docker environment discovery
 
@@ -31,7 +31,7 @@ Testcontainers will try to connect to a Docker daemon using the following strate
 
 ## Maven dependencies
 
-TestContainers is distributed in a handful of Maven modules:
+Testcontainers is distributed in a handful of Maven modules:
 
 * **testcontainers** for just core functionality, generic containers and docker-compose support
 * **mysql**, **postgresql** or **oracle-xe** for database container support

--- a/docs/usage/database_containers.md
+++ b/docs/usage/database_containers.md
@@ -2,19 +2,19 @@
 
 ## Benefits
 
-You might want to use TestContainers' database support:
+You might want to use Testcontainers' database support:
 
- * **Instead of H2 database for DAO unit tests that depend on database features that H2 doesn't emulate.** TestContainers is not as performant as H2, but does give you the benefit of 100% database compatibility (since it runs a real DB inside of a container).
- * **Instead of a database running on the local machine or in a VM** for DAO unit tests or end-to-end integration tests that need a database to be present. In this context, the benefit of TestContainers is that the database always starts in a known state, without any contamination between test runs or on developers' local machines.
+ * **Instead of H2 database for DAO unit tests that depend on database features that H2 doesn't emulate.** Testcontainers is not as performant as H2, but does give you the benefit of 100% database compatibility (since it runs a real DB inside of a container).
+ * **Instead of a database running on the local machine or in a VM** for DAO unit tests or end-to-end integration tests that need a database to be present. In this context, the benefit of Testcontainers is that the database always starts in a known state, without any contamination between test runs or on developers' local machines.
 
 > Note: Of course, it's still important to have as few tests that hit the database as possible, and make good use of mocks for components higher up the stack.
 
 You can obtain a temporary database in one of two ways:
 
  * **JUnit @Rule/@ClassRule**: this mode starts a database inside a container before your tests and tears it down afterwards.
- * **Using a specially modified JDBC URL**: after making a very simple modification to your system's JDBC URL string, TestContainers will provide a disposable stand-in database that can be used without requiring modification to your application code.
+ * **Using a specially modified JDBC URL**: after making a very simple modification to your system's JDBC URL string, Testcontainers will provide a disposable stand-in database that can be used without requiring modification to your application code.
 
-TestContainers currently supports MySQL, PostgreSQL, Oracle XE and Virtuoso.
+Testcontainers currently supports MySQL, PostgreSQL, Oracle XE and Virtuoso.
 
 > Note: Oracle XE support does not bundle the proprietary Oracle JDBC drivers - you must provide these yourself.
 
@@ -47,7 +47,7 @@ Examples/Tests:
 
 ### JDBC URL
 
-As long as you have TestContainers and the appropriate JDBC driver on your classpath, you can simply modify regular JDBC connection URLs to get a fresh containerized instance of the database each time your application starts up.
+As long as you have Testcontainers and the appropriate JDBC driver on your classpath, you can simply modify regular JDBC connection URLs to get a fresh containerized instance of the database each time your application starts up.
 
 _N.B:_
 * _TC needs to be on your application's classpath at runtime for this to work_
@@ -59,13 +59,13 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 ### JDBC URL examples
 
-#### Simple TestContainers JDBC driver usage
+#### Simple Testcontainers JDBC driver usage
 
 `jdbc:tc:mysql://somehostname:someport/databasename`
 
 *(Note: this will use the latest version of MySQL)*
 
-#### Using TestContainers with a fixed version
+#### Using Testcontainers with a fixed version
 
 `jdbc:tc:mysql:5.6.23://somehostname:someport/databasename`
 
@@ -76,7 +76,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 ## Using an init script
 
-TestContainers can run an initscript after the database container is started, but before your code is given a connection to it. The script must be on the classpath, and is referenced as follows:
+Testcontainers can run an initscript after the database container is started, but before your code is given a connection to it. The script must be on the classpath, and is referenced as follows:
 
 `jdbc:tc:mysql://hostname/databasename?TC_INITSCRIPT=somepath/init_mysql.sql`
 

--- a/docs/usage/docker_compose.md
+++ b/docs/usage/docker_compose.md
@@ -93,4 +93,4 @@ To work around this problem, create `config.json` in separate location with real
   "credsStore" : "osxkeychain"
 }
 ```
-and specify the location to TestContainers using any of the two first methods from above. 
+and specify the location to Testcontainers using any of the two first methods from above. 

--- a/docs/usage/inside_docker.md
+++ b/docs/usage/inside_docker.md
@@ -5,7 +5,7 @@
 Testcontainers itself can be used from inside a container.
 This is very useful for different CI scenarios like running everything in containers on Jenkins, or Docker-based CI tools such as Drone.
 
-TestContainers will automatically detect if it's inside a container and instead of "localhost" will use the default gateway's IP.
+Testcontainers will automatically detect if it's inside a container and instead of "localhost" will use the default gateway's IP.
 
 However, additional configuration is required if you use [volume mapping](options.md#volume-mapping). The following points need to be considered:
 
@@ -21,7 +21,7 @@ $ tree .
 └── src
     └── test
         └── java
-            └── MyTestWithTestContainers.java
+            └── MyTestWithTestcontainers.java
 
 $ docker run -it --rm -v $PWD:$PWD -w $PWD -v /var/run/docker.sock:/var/run/docker.sock maven:3 mvn test
 ```

--- a/modules/database-commons/pom.xml
+++ b/modules/database-commons/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>database-commons</artifactId>
-    <name>TestContainers :: Database-Commons</name>
+    <name>Testcontainers :: Database-Commons</name>
 
     <dependencies>
         <dependency>

--- a/modules/jdbc-test/pom.xml
+++ b/modules/jdbc-test/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>jdbc-test</artifactId>
-    <name>TestContainers :: JDBC :: Tests</name>
+    <name>Testcontainers :: JDBC :: Tests</name>
 
     <dependencies>
         <dependency>

--- a/modules/jdbc/pom.xml
+++ b/modules/jdbc/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>jdbc</artifactId>
-    <name>TestContainers :: JDBC</name>
+    <name>Testcontainers :: JDBC</name>
 
     <dependencies>
         <dependency>

--- a/modules/kafka/pom.xml
+++ b/modules/kafka/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>kafka</artifactId>
-    <name>TestContainers :: Apache Kafka</name>
+    <name>Testcontainers :: Apache Kafka</name>
 
     <dependencies>
         <dependency>

--- a/modules/mysql/pom.xml
+++ b/modules/mysql/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>mysql</artifactId>
-    <name>TestContainers :: JDBC :: MySQL</name>
+    <name>Testcontainers :: JDBC :: MySQL</name>
 
     <dependencies>
         <dependency>

--- a/modules/nginx/pom.xml
+++ b/modules/nginx/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>nginx</artifactId>
-    <name>TestContainers :: nginx</name>
+    <name>Testcontainers :: nginx</name>
 
     <dependencies>
         <dependency>

--- a/modules/postgresql/pom.xml
+++ b/modules/postgresql/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>postgresql</artifactId>
-    <name>TestContainers :: JDBC :: PostgreSQL</name>
+    <name>Testcontainers :: JDBC :: PostgreSQL</name>
 
     <dependencies>
         <dependency>

--- a/modules/selenium/pom.xml
+++ b/modules/selenium/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>selenium</artifactId>
-    <name>TestContainers :: Selenium</name>
+    <name>Testcontainers :: Selenium</name>
 
     <dependencies>
         <dependency>

--- a/modules/virtuoso/pom.xml
+++ b/modules/virtuoso/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	
 	<artifactId>virtuoso</artifactId>
-	<name>TestContainers :: JDBC :: Virtuoso</name>
+	<name>Testcontainers :: JDBC :: Virtuoso</name>
 	
 	<repositories>
 		<repository>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <packaging>pom</packaging>
 
-    <name>TestContainers Parent POM</name>
+    <name>Testcontainers Parent POM</name>
     <description>
         Isolated container management for Java code testing
     </description>


### PR DESCRIPTION
…Testcontainers

Because 2 years after the project release is a fine time to finally settle whether it's `TestContainers` or `Testcontainers`

🙃