### PR TITLE
Issue-543 JdbcDatabaseContainer now accepts Future as image name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 - Abstracted and changed database init script functionality to support use of SQL-like scripts with non-JDBC connections. ([\#551](https://github.com/testcontainers/testcontainers-java/pull/551))
+- Added `JdbcDatabaseContainer(Future)` constructor. ([\#543](https://github.com/testcontainers/testcontainers-java/issues/543))
 
 ## [1.6.0] - 2018-01-28
 

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -33,12 +33,12 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
             .withConstantThroughput()
             .build();
 
-    public JdbcDatabaseContainer(@NonNull Future<String> image) {
-        super(image);
-    }
-
     public JdbcDatabaseContainer(@NonNull String dockerImageName) {
         super(dockerImageName);
+    }
+
+    public JdbcDatabaseContainer(@NonNull Future<String> image) {
+        super(image);
     }
 
     /**

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -1,5 +1,7 @@
 package org.testcontainers.containers;
 
+import java.util.concurrent.Future;
+import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.rnorth.ducttape.ratelimits.RateLimiter;
 import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
@@ -31,7 +33,11 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
             .withConstantThroughput()
             .build();
 
-    public JdbcDatabaseContainer(String dockerImageName) {
+    public JdbcDatabaseContainer(@NonNull Future<String> image) {
+        super(image);
+    }
+
+    public JdbcDatabaseContainer(@NonNull String dockerImageName) {
         super(dockerImageName);
     }
 


### PR DESCRIPTION
Fixes #543 

But now I have a question: may be a better approach would be to accept `Supplier` instead of `Future`? It seems to suit the desired functionality better.