### PR TITLE
Fix 'custom ini' used for MySQL tests to prevent startup failures

### DIFF
--- a/modules/jdbc-test/src/test/resources/somepath/mysql_conf_override/my.cnf
+++ b/modules/jdbc-test/src/test/resources/somepath/mysql_conf_override/my.cnf
@@ -1,4 +1,5 @@
 [mysqld]
+user = mysql
 port   		= 3306
 #socket 		= /tmp/mysql.sock
 skip-external-locking


### PR DESCRIPTION
This may not be strictly required, but it really ought to be present. I'm a little stumped as to how how this has been working without this setting.

Without this MySQL fails upon its second startup:
```
Finished mysql_install_db
180224 20:17:03 [Note] mysqld (mysqld 5.5.43) starting as process 1 ...
180224 20:17:03 [ERROR] Fatal error: Please read "Security" section of the manual to find out how to run mysqld as root!

180224 20:17:03 [ERROR] Aborting

180224 20:17:03 [Note] mysqld: Shutdown complete
```

This change *does not* affect run-time behaviour of MySQL for users, just the stability of our own internal tests.