### PR TITLE
Use HttpWaitStrategy for SimpleNginxTest

### DIFF
--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -5,6 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.NginxContainer;
+import org.testcontainers.containers.wait.HttpWaitStrategy;
 
 import java.io.*;
 import java.net.URLConnection;
@@ -20,8 +21,9 @@ public class SimpleNginxTest {
     private static File contentFolder = new File(System.getProperty("user.home") + "/.tmp-test-container");
 
     @Rule
-    public NginxContainer nginx = new NginxContainer()
-            .withCustomContent(contentFolder.toString());
+    public NginxContainer nginx = new NginxContainer<>()
+            .withCustomContent(contentFolder.toString())
+            .waitingFor(new HttpWaitStrategy());
 
     @BeforeClass
     public static void setupContent() throws FileNotFoundException {


### PR DESCRIPTION
To ensure proper waits and avoid race conditions (flaky test)

Since the Gradle migration we've been seeing a lot of the following stack trace. I have no idea why, but I suspect an improvement in test execution speed might have uncovered a previously hidden timing bug in our tests:
```
Gradle Test Executor 7 > org.testcontainers.junit.SimpleNginxTest > testSimple FAILED
   java.net.SocketException: Unexpected end of file from server
       at sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:851)
       at sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:678)
       at sun.net.www.http.HttpClient.parseHTTPHeader(HttpClient.java:848)
       at sun.net.www.http.HttpClient.parseHTTP(HttpClient.java:678)
       at sun.net.www.protocol.http.HttpURLConnection.getInputStream0(HttpURLConnection.java:1587)
       at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1492)
       at org.testcontainers.junit.SimpleNginxTest.testSimple(SimpleNginxTest.java:49)
```

This PR simply attaches an HttpWaitStrategy to the test. We could have added this to the `NginxContainer` itself, but I felt that would be counterproductive: users will typically need to customise the http wait strategy according to their nginx configuration, so we should leave it to them.