### PR TITLE
Allow setting database name and user when using JDBC URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ node_modules/
 
 .gradle/
 build/
+
+# Eclipse IDE files
+**/.project
+**/.classpath
+**/.settings
+**/bin/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,13 @@ sudo: required
 services:
   - docker
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - '$HOME/.gradle'
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
 
 install:
   - ./gradlew build -x check
@@ -40,7 +44,7 @@ jobs:
                 -v "$(pwd)":"$(pwd)" \
                 -w "$(pwd)" \
                 openjdk:8-jdk-alpine \
-                ./gradlew testcontainers:test --tests '*GenericContainerRuleTest'
+                ./gradlew --no-daemon testcontainers:test --tests '*GenericContainerRuleTest'
 
     - stage: deploy
       sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ All notable changes to this project will be documented in this file.
 - Abstracted and changed database init script functionality to support use of SQL-like scripts with non-JDBC connections. ([\#551](https://github.com/testcontainers/testcontainers-java/pull/551))
 - Added `JdbcDatabaseContainer(Future)` constructor. ([\#543](https://github.com/testcontainers/testcontainers-java/issues/543))
 - Mark DockerMachineClientProviderStrategy as not persistable ([\#593](https://github.com/testcontainers/testcontainers-java/pull/593))
+- Enhancements and Fixes for JDBC URL usage to create Containers ([\#594](https://github.com/testcontainers/testcontainers-java/pull/594))
+    - Extracted JDBC URL manipulations to a separate class - `ConnectionUrl`. 
+    - Added an overloaded method `JdbcDatabaseContainerProvider.newInstance(ConnectionUrl)`, with default implementation delegating to the existing `newInstance(tag)` method. (Relates to [\#566](https://github.com/testcontainers/testcontainers-java/issues/566))
+    - Added an implementation of `MySQLContainerProvider.newInstance(ConnectionUrl)` that uses Database Name, User, and Password from JDBC URL while creating new MySQL Container. (Fixes [\#566](https://github.com/testcontainers/testcontainers-java/issues/566) for MySQL Container)
+    - Fixed JDBC URL Regex Pattern to ensure all supported Database URL's are accepted (Fixes [\#596](https://github.com/testcontainers/testcontainers-java/issues/596))
+    - Filtered out TestContainer parameters (TC_*) from query string before passing to database (Fixes [\#345](https://github.com/testcontainers/testcontainers-java/issues/345))
 
 ## [1.6.0] - 2018-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Abstracted and changed database init script functionality to support use of SQL-like scripts with non-JDBC connections. ([\#551](https://github.com/testcontainers/testcontainers-java/pull/551))
 - Added `JdbcDatabaseContainer(Future)` constructor. ([\#543](https://github.com/testcontainers/testcontainers-java/issues/543))
+- Mark DockerMachineClientProviderStrategy as not persistable ([\#593](https://github.com/testcontainers/testcontainers-java/pull/593))
 
 ## [1.6.0] - 2018-01-28
 

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerMachineClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerMachineClientProviderStrategy.java
@@ -25,6 +25,11 @@ public class DockerMachineClientProviderStrategy extends DockerClientProviderStr
     }
 
     @Override
+    protected boolean isPersistable() {
+        return false;
+    }
+
+    @Override
     protected int getPriority() {
         return ProxiedUnixSocketClientProviderStrategy.PRIORITY - 10;
     }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -37,8 +37,8 @@ public class JDBCDriverTest {
         return asList(
                 new Object[][]{
                         {"jdbc:tc:mysql:5.5.43://hostname/databasename", false, false, false},
-                        {"jdbc:tc:mysql://hostname/databasename?TC_INITSCRIPT=somepath/init_mysql.sql", true, false, false},
-                        {"jdbc:tc:mysql://hostname/databasename?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction", true, false, false},
+                        {"jdbc:tc:mysql://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mysql.sql", true, false, false},
+                        {"jdbc:tc:mysql://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction", true, false, false},
                         {"jdbc:tc:mysql://hostname/databasename?useUnicode=yes&characterEncoding=utf8", false, true, false},
                         {"jdbc:tc:mysql://hostname/databasename", false, false, false},
                         {"jdbc:tc:mysql://hostname/databasename?useSSL=false", false, false, false},
@@ -100,7 +100,21 @@ public class JDBCDriverTest {
                 assertEquals("A basic SELECT query succeeds where the schema has been applied from a script", "hello world", resultSetString);
                 return true;
             });
-
+            
+            result = new QueryRunner(dataSource).query("select CURRENT_USER()", rs -> {
+              rs.next();
+              String resultUser = rs.getString(1);
+              assertEquals("User from query param is created.", "someuser@%", resultUser);
+              return true;
+          });
+            
+            result = new QueryRunner(dataSource).query("SELECT DATABASE()", rs -> {
+              rs.next();
+              String resultDB = rs.getString(1);
+              assertEquals("Database name from URL String is used.", "databasename", resultDB);
+              return true;
+          });
+           
             assertTrue("The database returned a record as expected", result);
 
         }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -35,26 +35,26 @@ public class JDBCDriverTest {
     @Parameterized.Parameters(name = "{index} - {0}")
     public static Iterable<Object[]> data() {
         return asList(
-                new Object[][]{
-                        {"jdbc:tc:mysql:5.5.43://hostname/databasename", false, false, false},
-                        {"jdbc:tc:mysql://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mysql.sql", true, false, false},
-                        {"jdbc:tc:mysql://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction", true, false, false},
-                        {"jdbc:tc:mysql://hostname/databasename?useUnicode=yes&characterEncoding=utf8", false, true, false},
-                        {"jdbc:tc:mysql://hostname/databasename", false, false, false},
-                        {"jdbc:tc:mysql://hostname/databasename?useSSL=false", false, false, false},
-                        {"jdbc:tc:postgresql://hostname/databasename", false, false, false},
-                        {"jdbc:tc:mysql:5.6://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override", false, false, true},
-                });
+            new Object[][]{
+                {"jdbc:tc:mysql:5.5.43://hostname/databasename", false, false, false},
+                {"jdbc:tc:mysql://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mysql.sql", true, false, false},
+                {"jdbc:tc:mysql://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction", true, false, false},
+                {"jdbc:tc:mysql://hostname/databasename?useUnicode=yes&characterEncoding=utf8", false, true, false},
+                {"jdbc:tc:mysql://hostname/databasename", false, false, false},
+                {"jdbc:tc:mysql://hostname/databasename?useSSL=false", false, false, false},
+                {"jdbc:tc:postgresql://hostname/databasename", false, false, false},
+                {"jdbc:tc:mysql:5.6://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override", false, false, true},
+            });
     }
 
     public static void sampleInitFunction(Connection connection) throws SQLException {
         connection.createStatement().execute("CREATE TABLE bar (\n" +
-                "  foo VARCHAR(255)\n" +
-                ");");
+            "  foo VARCHAR(255)\n" +
+            ");");
         connection.createStatement().execute("INSERT INTO bar (foo) VALUES ('hello world');");
         connection.createStatement().execute("CREATE TABLE my_counter (\n" +
-                "  n INT\n" +
-                ");");
+            "  n INT\n" +
+            ");");
     }
 
     @AfterClass
@@ -100,21 +100,21 @@ public class JDBCDriverTest {
                 assertEquals("A basic SELECT query succeeds where the schema has been applied from a script", "hello world", resultSetString);
                 return true;
             });
-            
+
             result = new QueryRunner(dataSource).query("select CURRENT_USER()", rs -> {
-              rs.next();
-              String resultUser = rs.getString(1);
-              assertEquals("User from query param is created.", "someuser@%", resultUser);
-              return true;
-          });
-            
+                rs.next();
+                String resultUser = rs.getString(1);
+                assertEquals("User from query param is created.", "someuser@%", resultUser);
+                return true;
+            });
+
             result = new QueryRunner(dataSource).query("SELECT DATABASE()", rs -> {
-              rs.next();
-              String resultDB = rs.getString(1);
-              assertEquals("Database name from URL String is used.", "databasename", resultDB);
-              return true;
-          });
-           
+                rs.next();
+                String resultDB = rs.getString(1);
+                assertEquals("Database name from URL String is used.", "databasename", resultDB);
+                return true;
+            });
+
             assertTrue("The database returned a record as expected", result);
 
         }

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
 import java.util.concurrent.Future;
+
 import lombok.NonNull;
 import org.jetbrains.annotations.NotNull;
 import org.rnorth.ducttape.ratelimits.RateLimiter;
@@ -29,9 +30,9 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     protected Map<String, String> parameters = new HashMap<>();
 
     private static final RateLimiter DB_CONNECT_RATE_LIMIT = RateLimiterBuilder.newBuilder()
-            .withRate(10, TimeUnit.SECONDS)
-            .withConstantThroughput()
-            .build();
+        .withRate(10, TimeUnit.SECONDS)
+        .withConstantThroughput()
+        .build();
 
     public JdbcDatabaseContainer(@NonNull final String dockerImageName) {
         super(dockerImageName);
@@ -133,9 +134,8 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     /**
      * Creates a connection to the underlying containerized database instance.
      *
-     * @param queryString
-     *          query string parameters that should be appended to the JDBC connection URL.
-     *          The '?' character must be included
+     * @param queryString query string parameters that should be appended to the JDBC connection URL.
+     *                    The '?' character must be included
      * @return a Connection
      * @throws SQLException if there is a repeated failure to create the connection
      */
@@ -159,9 +159,8 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
      * This should be overridden if the JDBC URL and query string concatenation or URL string
      * construction needs to be different to normal.
      *
-     * @param queryString
-     *          query string parameters that should be appended to the JDBC connection URL.
-     *          The '?' character must be included
+     * @param queryString query string parameters that should be appended to the JDBC connection URL.
+     *                    The '?' character must be included
      * @return a full JDBC URL including queryString
      */
     protected String constructUrlForConnection(String queryString) {

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainerProvider.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainerProvider.java
@@ -1,5 +1,7 @@
 package org.testcontainers.containers;
 
+import org.testcontainers.jdbc.ConnectionUrl;
+
 /**
  * Base class for classes that can provide a JDBC container.
  */
@@ -8,4 +10,14 @@ public abstract class JdbcDatabaseContainerProvider {
     public abstract boolean supports(String databaseType);
 
     public abstract JdbcDatabaseContainer newInstance(String tag);
+    
+    /**
+     * Get the new Instance with Tag and Url. Default Implementation delegates call to {@link #newInstance(tag)} method.
+     * @param tag
+     * @param url
+     * @return
+     */
+    public JdbcDatabaseContainer newInstance(ConnectionUrl url) {
+      return newInstance(url.getImageTag());
+    }
 }

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainerProvider.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainerProvider.java
@@ -7,17 +7,26 @@ import org.testcontainers.jdbc.ConnectionUrl;
  */
 public abstract class JdbcDatabaseContainerProvider {
 
+    /**
+     * Tests if the specified database type is supported by this Container Provider. It should match to the base image name.
+     * @param databaseType {@link String}
+     * @return <code>true</code> when provider can handle this database type, else <code>false</code>.
+     */
     public abstract boolean supports(String databaseType);
 
-    public abstract JdbcDatabaseContainer newInstance(String tag);
-    
     /**
-     * Get the new Instance with Tag and Url. Default Implementation delegates call to {@link #newInstance(tag)} method.
+     * Instantiate a new {@link JdbcDatabaseContainer} with specified image tag.
      * @param tag
-     * @param url
-     * @return
+     * @return Instance of {@link JdbcDatabaseContainer}
+     */
+    public abstract JdbcDatabaseContainer newInstance(String tag);
+
+    /**
+     * Instantiate a new {@link JdbcDatabaseContainer} using information provided with {@link ConnectionUrl}.
+     * @param url {@link ConnectionUrl}
+     * @return Instance of {@link JdbcDatabaseContainer}
      */
     public JdbcDatabaseContainer newInstance(ConnectionUrl url) {
-      return newInstance(url.getImageTag());
+        return newInstance(url.getImageTag());
     }
 }

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -13,196 +13,197 @@ import lombok.Getter;
 
 /**
  * This is an Immutable class holding JDBC Connection Url and its parsed components, used by {@link ContainerDatabaseDriver}.
- * 
+ * <p>
  * {@link ConnectionUrl#parseUrl()} method must be called after instantiating this class.
- * 
+ *
  * @author manikmagar
- * 
  */
 public class ConnectionUrl {
-  
-  @Getter
-  private String url;
-  
-  private String databaseType;
-  
-  @Getter
-  private String imageTag = "latest";
-  
-  private String dbHostString;
-  
-  @Getter
-  private boolean inDaemonMode = false;
-  
-  @Getter
-  private Optional<String> databaseHost = Optional.empty();
-  
-  @Getter
-  private Optional<Integer> databasePort = Optional.empty();
-  
-  @Getter
-  private Optional<String> databaseName = Optional.empty();
-  
-  @Getter
-  private Optional<String> initScriptPath = Optional.empty();
-  
-  @Getter
-  private Optional<InitFunctionDef> initFunction = Optional.empty();
-  
-  @Getter
-  private Optional<String> queryString;
-  
-  private ConnectionUrl() {
-    //Not Allowed here
-  }
 
-  public ConnectionUrl(final String url) {
-    this.url = Objects.requireNonNull(url, "Connection URL cannot be null");
-  }
-  
-  public String getDatabaseType() {
-    return Objects.requireNonNull(this.databaseType, "Database Type cannot be null. Have you called parseUrl() method?");
-  }
+    @Getter
+    private String url;
 
-  
-  /**
-   * This is a part of the connection string that may specify host:port/databasename. 
-   * It may vary for different clients and so clients can parse it as needed. 
-   * @return
-   */
-  public String getDbHostString() {
-    return Objects.requireNonNull(this.dbHostString, "Database Host String cannot be null. Have you called parseUrl() method?");
-  }
+    private String databaseType;
 
-  public static boolean accepts(final String url) {
-    return url.startsWith("jdbc:tc:");
-  }
-  
-  public void parseUrl() {
-    /*
-    Extract from the JDBC connection URL:
-     * The database type (e.g. mysql, postgresql, ...)
-     * The docker tag, if provided.
-     * The URL query string, if provided
-   */
-    Matcher urlMatcher = Patterns.URL_MATCHING_PATTERN.matcher(this.getUrl());
-    if (!urlMatcher.matches()) {
-      //Try for Oracle pattern
-      urlMatcher = Patterns.ORACLE_URL_MATCHING_PATTERN.matcher(this.getUrl());
-      if(!urlMatcher.matches()) {
-        throw new IllegalArgumentException("JDBC URL matches jdbc:tc: prefix but the database or tag name could not be identified");
-      }
-    }
-    databaseType = urlMatcher.group(1);
-    
-    imageTag = Optional.ofNullable(urlMatcher.group(3)).orElse("latest");
-    
-    //String like hostname:port/database name, which may vary based on target database.
-    //Clients can further parse it as needed.
-    dbHostString = urlMatcher.group(4);
-    
-    //In case it matches to the default pattern
-    Matcher dbInstanceMatcher = Patterns.DB_INSTANCE_MATCHING_PATTERN.matcher(dbHostString);
-    if(dbInstanceMatcher.matches()) {
-      databaseHost = Optional.of(dbInstanceMatcher.group(1));
-      databasePort = Optional.ofNullable(dbInstanceMatcher.group(3)).map(value -> Integer.valueOf(value));
-      databaseName = Optional.of(dbInstanceMatcher.group(4));
-    }
-  
-    queryString = Optional.ofNullable(urlMatcher.group(5));
-    getQueryParameters();
-    
-    Matcher matcher = Patterns.INITSCRIPT_MATCHING_PATTERN.matcher(this.getUrl());
-    if(matcher.matches()) {
-      initScriptPath = Optional.ofNullable(matcher.group(2));  
-    }
-    
-    Matcher funcMatcher = Patterns.INITFUNCTION_MATCHING_PATTERN.matcher(this.getUrl());
-    if(funcMatcher.matches()) {
-      initFunction = Optional.of(new InitFunctionDef(funcMatcher.group(2), funcMatcher.group(4)));
-    }
-    
-    Matcher daemonMatcher = Patterns.DAEMON_MATCHING_PATTERN.matcher(this.getUrl());
-    inDaemonMode =  daemonMatcher.matches() ? Boolean.parseBoolean(daemonMatcher.group(2)) : false;
-    
-  }
-  
-  /**
-   * Get the TestContainers Parameters such as Init Function, Init Script path etc.
-   * @return {@link Map}
-   */
-  public Map<String, String> getContainerParameters() {
+    @Getter
+    private String imageTag = "latest";
 
-    Map<String, String> results = new HashMap<>();
+    private String dbHostString;
 
-    Matcher matcher = Patterns.TC_PARAM_MATCHING_PATTERN.matcher(this.getUrl());
-    while (matcher.find()) {
-        String key = matcher.group(1);
-        String value = matcher.group(2);
-        results.put(key, value);
+    @Getter
+    private boolean inDaemonMode = false;
+
+    @Getter
+    private Optional<String> databaseHost = Optional.empty();
+
+    @Getter
+    private Optional<Integer> databasePort = Optional.empty();
+
+    @Getter
+    private Optional<String> databaseName = Optional.empty();
+
+    @Getter
+    private Optional<String> initScriptPath = Optional.empty();
+
+    @Getter
+    private Optional<InitFunctionDef> initFunction = Optional.empty();
+
+    @Getter
+    private Optional<String> queryString;
+
+    private ConnectionUrl() {
+        //Not Allowed here
     }
 
-    return results;
-  }
-  
-  /**
-   * Get all Query paramters specified in the Connection URL after ?. This also includes TestContainers parameters.
-   * @return {@link Map}
-   */
-  public Map<String, String> getQueryParameters() {
-
-    Map<String, String> results = new HashMap<>();
-    StringJoiner query = new StringJoiner("&");
-    Matcher matcher = Patterns.QUERY_PARAM_MATCHING_PATTERN.matcher(this.getQueryString().orElse(""));
-    while (matcher.find()) {
-        String key = matcher.group(1);
-        String value = matcher.group(2);
-        if(!key.startsWith("TC_")) query.add(key + "=" + value);
-        results.put(key, value);
+    public ConnectionUrl(final String url) {
+        this.url = Objects.requireNonNull(url, "Connection URL cannot be null");
     }
-    
-    queryString = Optional.of("?" + query.toString());
-    return results;
-  }
-  
-  @Override
-  public boolean equals(Object obj) {
-    if(Objects.isNull(obj) || !(obj instanceof ConnectionUrl)) return false;
-    return this.getUrl().equals(((ConnectionUrl)obj).getUrl());
-  }
 
-  /**
-   * This interface defines the Regex Patterns used by {@link ConnectionUrl}.
-   * 
-   * @author manikmagar
-   *
-   */
-  public interface Patterns {
-    final Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^:]+))?://([^\\?]+)(\\?.*)?");
-    
-    final Pattern ORACLE_URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^(thin:)]+))?:thin:@([^\\?]+)(\\?.*)?");
+    public String getDatabaseType() {
+        return Objects.requireNonNull(this.databaseType, "Database Type cannot be null. Have you called parseUrl() method?");
+    }
 
-    //Matches to part of string - hostname:port/databasename
-    final Pattern DB_INSTANCE_MATCHING_PATTERN = Pattern.compile("([^:]+)(:([0-9]+))?/([^\\\\?]+)");
-    
-    final Pattern DAEMON_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_DAEMON=([^\\?&]+).*");
-    final Pattern INITSCRIPT_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITSCRIPT=([^\\?&]+).*");
-    final Pattern INITFUNCTION_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITFUNCTION=" +
+
+    /**
+     * This is a part of the connection string that may specify host:port/databasename.
+     * It may vary for different clients and so clients can parse it as needed.
+     *
+     * @return
+     */
+    public String getDbHostString() {
+        return Objects.requireNonNull(this.dbHostString, "Database Host String cannot be null. Have you called parseUrl() method?");
+    }
+
+    public static boolean accepts(final String url) {
+        return url.startsWith("jdbc:tc:");
+    }
+
+    public void parseUrl() {
+        /*
+        Extract from the JDBC connection URL:
+         * The database type (e.g. mysql, postgresql, ...)
+         * The docker tag, if provided.
+         * The URL query string, if provided
+       */
+        Matcher urlMatcher = Patterns.URL_MATCHING_PATTERN.matcher(this.getUrl());
+        if (!urlMatcher.matches()) {
+            //Try for Oracle pattern
+            urlMatcher = Patterns.ORACLE_URL_MATCHING_PATTERN.matcher(this.getUrl());
+            if (!urlMatcher.matches()) {
+                throw new IllegalArgumentException("JDBC URL matches jdbc:tc: prefix but the database or tag name could not be identified");
+            }
+        }
+        databaseType = urlMatcher.group(1);
+
+        imageTag = Optional.ofNullable(urlMatcher.group(3)).orElse("latest");
+
+        //String like hostname:port/database name, which may vary based on target database.
+        //Clients can further parse it as needed.
+        dbHostString = urlMatcher.group(4);
+
+        //In case it matches to the default pattern
+        Matcher dbInstanceMatcher = Patterns.DB_INSTANCE_MATCHING_PATTERN.matcher(dbHostString);
+        if (dbInstanceMatcher.matches()) {
+            databaseHost = Optional.of(dbInstanceMatcher.group(1));
+            databasePort = Optional.ofNullable(dbInstanceMatcher.group(3)).map(value -> Integer.valueOf(value));
+            databaseName = Optional.of(dbInstanceMatcher.group(4));
+        }
+
+        queryString = Optional.ofNullable(urlMatcher.group(5));
+        getQueryParameters();
+
+        Matcher matcher = Patterns.INITSCRIPT_MATCHING_PATTERN.matcher(this.getUrl());
+        if (matcher.matches()) {
+            initScriptPath = Optional.ofNullable(matcher.group(2));
+        }
+
+        Matcher funcMatcher = Patterns.INITFUNCTION_MATCHING_PATTERN.matcher(this.getUrl());
+        if (funcMatcher.matches()) {
+            initFunction = Optional.of(new InitFunctionDef(funcMatcher.group(2), funcMatcher.group(4)));
+        }
+
+        Matcher daemonMatcher = Patterns.DAEMON_MATCHING_PATTERN.matcher(this.getUrl());
+        inDaemonMode = daemonMatcher.matches() ? Boolean.parseBoolean(daemonMatcher.group(2)) : false;
+
+    }
+
+    /**
+     * Get the TestContainers Parameters such as Init Function, Init Script path etc.
+     *
+     * @return {@link Map}
+     */
+    public Map<String, String> getContainerParameters() {
+
+        Map<String, String> results = new HashMap<>();
+
+        Matcher matcher = Patterns.TC_PARAM_MATCHING_PATTERN.matcher(this.getUrl());
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String value = matcher.group(2);
+            results.put(key, value);
+        }
+
+        return results;
+    }
+
+    /**
+     * Get all Query paramters specified in the Connection URL after ?. This also includes TestContainers parameters.
+     *
+     * @return {@link Map}
+     */
+    public Map<String, String> getQueryParameters() {
+
+        Map<String, String> results = new HashMap<>();
+        StringJoiner query = new StringJoiner("&");
+        Matcher matcher = Patterns.QUERY_PARAM_MATCHING_PATTERN.matcher(this.getQueryString().orElse(""));
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            String value = matcher.group(2);
+            if (!key.startsWith("TC_")) query.add(key + "=" + value);
+            results.put(key, value);
+        }
+
+        queryString = Optional.of("?" + query.toString());
+        return results;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (Objects.isNull(obj) || !(obj instanceof ConnectionUrl)) return false;
+        return this.getUrl().equals(((ConnectionUrl) obj).getUrl());
+    }
+
+    /**
+     * This interface defines the Regex Patterns used by {@link ConnectionUrl}.
+     *
+     * @author manikmagar
+     */
+    public interface Patterns {
+        final Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^:]+))?://([^\\?]+)(\\?.*)?");
+
+        final Pattern ORACLE_URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^(thin:)]+))?:thin:@([^\\?]+)(\\?.*)?");
+
+        //Matches to part of string - hostname:port/databasename
+        final Pattern DB_INSTANCE_MATCHING_PATTERN = Pattern.compile("([^:]+)(:([0-9]+))?/([^\\\\?]+)");
+
+        final Pattern DAEMON_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_DAEMON=([^\\?&]+).*");
+        final Pattern INITSCRIPT_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITSCRIPT=([^\\?&]+).*");
+        final Pattern INITFUNCTION_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITFUNCTION=" +
             "((\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)*\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +
             "::" +
             "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +
             ".*");
 
-    final Pattern TC_PARAM_MATCHING_PATTERN = Pattern.compile("(TC_[A-Z_]+)=([^\\?&]+)");
-   
-    final Pattern QUERY_PARAM_MATCHING_PATTERN = Pattern.compile("([^\\?&=]+)=([^\\?&]+)");
-    
-  }
-  
-  @Getter
-  @AllArgsConstructor
-  public class InitFunctionDef {
-    private String className;
-    private String methodName;
-  }
+        final Pattern TC_PARAM_MATCHING_PATTERN = Pattern.compile("(TC_[A-Z_]+)=([^\\?&]+)");
+
+        final Pattern QUERY_PARAM_MATCHING_PATTERN = Pattern.compile("([^\\?&=]+)=([^\\?&]+)");
+
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public class InitFunctionDef {
+        private String className;
+        private String methodName;
+    }
 }

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -85,12 +85,11 @@ public class ConnectionUrl {
      * The docker tag, if provided.
      * The URL query string, if provided
    */
-    boolean isOracle = false;
     Matcher urlMatcher = Patterns.URL_MATCHING_PATTERN.matcher(this.getUrl());
     if (!urlMatcher.matches()) {
       //Try for Oracle pattern
       urlMatcher = Patterns.ORACLE_URL_MATCHING_PATTERN.matcher(this.getUrl());
-      if(!(isOracle = urlMatcher.matches())) {
+      if(!urlMatcher.matches()) {
         throw new IllegalArgumentException("JDBC URL matches jdbc:tc: prefix but the database or tag name could not be identified");
       }
     }

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -1,12 +1,13 @@
 package org.testcontainers.jdbc;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import lombok.*;
 
 /**
  * This is an Immutable class holding JDBC Connection Url and its parsed components, used by {@link ContainerDatabaseDriver}.

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -1,0 +1,198 @@
+package org.testcontainers.jdbc;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * This is an Immutable class holding JDBC Connection Url and its parsed components, used by {@link ContainerDatabaseDriver}.
+ * 
+ * {@link ConnectionUrl#parseUrl()} method must be called after instantiating this class.
+ * 
+ * @author manikmagar
+ * 
+ */
+public class ConnectionUrl {
+  
+  @Getter
+  private String url;
+  
+  private String databaseType;
+  
+  @Getter
+  private String imageTag = "latest";
+  
+  private String dbHostString;
+  
+  @Getter
+  private boolean inDaemonMode = false;
+  
+  @Getter
+  private Optional<String> databaseHost = Optional.empty();
+  
+  @Getter
+  private Optional<Integer> databasePort = Optional.empty();
+  
+  @Getter
+  private Optional<String> databaseName = Optional.empty();
+  
+  @Getter
+  private Optional<String> initScriptPath = Optional.empty();
+  
+  @Getter
+  private Optional<InitFunctionDef> initFunction = Optional.empty();
+  
+  @Getter
+  private Optional<String> queryString;
+  
+  private ConnectionUrl() {
+    //Not Allowed here
+  }
+
+  public ConnectionUrl(final String url) {
+    this.url = Objects.requireNonNull(url, "Connection URL cannot be null");
+  }
+  
+  public String getDatabaseType() {
+    return Objects.requireNonNull(this.databaseType, "Database Type cannot be null. Have you called parseUrl() method?");
+  }
+
+  
+  /**
+   * This is a part of the connection string that may specify host:port/databasename. 
+   * It may vary for different clients and so clients can parse it as needed. 
+   * @return
+   */
+  public String getDbHostString() {
+    return Objects.requireNonNull(this.dbHostString, "Database Host String cannot be null. Have you called parseUrl() method?");
+  }
+
+  public static boolean accepts(final String url) {
+    return url.startsWith("jdbc:tc:");
+  }
+  
+  public void parseUrl() {
+    /*
+    Extract from the JDBC connection URL:
+     * The database type (e.g. mysql, postgresql, ...)
+     * The docker tag, if provided.
+     * The URL query string, if provided
+   */
+    Matcher urlMatcher = Patterns.URL_MATCHING_PATTERN.matcher(this.getUrl());
+    if (!urlMatcher.matches()) {
+        throw new IllegalArgumentException("JDBC URL matches jdbc:tc: prefix but the database or tag name could not be identified");
+    }
+    databaseType = urlMatcher.group(1);
+    
+    imageTag = Optional.ofNullable(urlMatcher.group(3)).orElse("latest");
+    
+    //String like hostname:port/database name, which may vary based on target database.
+    //Clients can further parse it as needed.
+    dbHostString = urlMatcher.group(4);
+    
+    //In case it matches to the default pattern
+    Matcher dbInstanceMatcher = Patterns.DB_INSTANCE_MATCHING_PATTERN.matcher(dbHostString);
+    if(dbInstanceMatcher.matches()) {
+      databaseHost = Optional.of(dbInstanceMatcher.group(1));
+      databasePort = Optional.ofNullable(dbInstanceMatcher.group(3)).map(value -> Integer.valueOf(value));
+      databaseName = Optional.of(dbInstanceMatcher.group(4));
+    }
+  
+    queryString = Optional.ofNullable(urlMatcher.group(5));
+    
+    Matcher matcher = Patterns.INITSCRIPT_MATCHING_PATTERN.matcher(this.getUrl());
+    if(matcher.matches()) {
+      initScriptPath = Optional.ofNullable(matcher.group(2));  
+    }
+    
+    Matcher funcMatcher = Patterns.INITFUNCTION_MATCHING_PATTERN.matcher(this.getUrl());
+    if(funcMatcher.matches()) {
+      initFunction = Optional.of(new InitFunctionDef(funcMatcher.group(2), funcMatcher.group(4)));
+    }
+    
+    Matcher daemonMatcher = Patterns.DAEMON_MATCHING_PATTERN.matcher(this.getUrl());
+    inDaemonMode =  daemonMatcher.matches() ? Boolean.parseBoolean(daemonMatcher.group(2)) : false;
+    
+  }
+  
+  /**
+   * Get the TestContainers Parameters such as Init Function, Init Script path etc.
+   * @return {@link Map}
+   */
+  public Map<String, String> getContainerParameters() {
+
+    Map<String, String> results = new HashMap<>();
+
+    Matcher matcher = Patterns.TC_PARAM_MATCHING_PATTERN.matcher(this.getUrl());
+    while (matcher.find()) {
+        String key = matcher.group(1);
+        String value = matcher.group(2);
+        results.put(key, value);
+    }
+
+    return results;
+  }
+  
+  /**
+   * Get all Query paramters specified in the Connection URL after ?. This also includes TestContainers parameters.
+   * @return {@link Map}
+   */
+  public Map<String, String> getQueryParameters() {
+
+    Map<String, String> results = new HashMap<>();
+
+    Matcher matcher = Patterns.QUERY_PARAM_MATCHING_PATTERN.matcher(this.getQueryString().orElse(""));
+    while (matcher.find()) {
+        String key = matcher.group(1);
+        String value = matcher.group(2);
+        results.put(key, value);
+    }
+
+    return results;
+  }
+  
+  @Override
+  public boolean equals(Object obj) {
+    if(Objects.isNull(obj) || !(obj instanceof ConnectionUrl)) return false;
+    return this.getUrl().equals(((ConnectionUrl)obj).getUrl());
+  }
+
+  /**
+   * This interface defines the Regex Patterns used by {@link ConnectionUrl}.
+   * 
+   * @author manikmagar
+   *
+   */
+  public interface Patterns {
+    final Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^:]+))?://([^\\?]+)(\\?.*)?");
+    
+    //Matches to part of string - hostname:port/databasename
+    final Pattern DB_INSTANCE_MATCHING_PATTERN = Pattern.compile("([^:]+)(:([0-9]+))?/([^\\\\?]+)");
+    
+    final Pattern DAEMON_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_DAEMON=([^\\?&]+).*");
+    final Pattern INITSCRIPT_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITSCRIPT=([^\\?&]+).*");
+    final Pattern INITFUNCTION_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITFUNCTION=" +
+            "((\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)*\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +
+            "::" +
+            "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +
+            ".*");
+
+    final Pattern TC_PARAM_MATCHING_PATTERN = Pattern.compile("([A-Z_]+)=([^\\?&]+)");
+    
+    final Pattern QUERY_PARAM_MATCHING_PATTERN = Pattern.compile("([^\\?&=]+)=([^\\?&]+)");
+    
+  }
+  
+  @Getter
+  @AllArgsConstructor
+  public class InitFunctionDef {
+    private String className;
+    private String methodName;
+  }
+}

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -48,8 +48,7 @@ public class ConnectionUrlDriversTests {
 
     @Test
     public void test() throws SQLException {
-        ConnectionUrl url = new ConnectionUrl(jdbcUrl);
-        url.parseUrl();
+        ConnectionUrl url = ConnectionUrl.newInstance(jdbcUrl);
         assertEquals("Database Type is as expected", databaseType, url.getDatabaseType());
         assertEquals("Image tag is as expected", tag, url.getImageTag());
         assertEquals("Database Host String is as expected", dbHostString, url.getDbHostString());

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -1,0 +1,58 @@
+package org.testcontainers.jdbc;
+
+import static java.util.Arrays.asList;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+
+import java.sql.SQLException;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+
+/**
+ * This Test class validates that all supported JDBC URL's can be parsed by ConnectionUrl class.
+ * @author ManikMagar
+ *
+ */
+@RunWith(Parameterized.class)
+public class ConnectionUrlDriversTests {
+
+  @Parameter
+  public String jdbcUrl;
+  @Parameter(1)
+  public String databaseType;
+  @Parameter(2)
+  public String tag;
+  @Parameter(3)
+  public String dbHostString;
+  @Parameter(4)
+  public String databaseName;
+
+  @Parameterized.Parameters(name = "{index} - {0}")
+  public static Iterable<Object[]> data() {
+    return asList(
+                  new Object[][] {
+                      {"jdbc:tc:mysql:5.5.43://hostname/test", "mysql", "5.5.43","hostname/test","test"},
+                      {"jdbc:tc:mysql://hostname/test", "mysql", "latest","hostname/test","test"},
+                      {"jdbc:tc:postgresql:1.2.3://hostname/test", "postgresql", "1.2.3","hostname/test","test"},
+                      {"jdbc:tc:postgresql://hostname/test", "postgresql", "latest","hostname/test","test"},
+                      {"jdbc:tc:sqlserver:1.2.3://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", "1.2.3","localhost;instance=SQLEXPRESS:1433;databaseName=test",""},
+                      {"jdbc:tc:sqlserver://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", "latest","localhost;instance=SQLEXPRESS:1433;databaseName=test",""},
+                      {"jdbc:tc:mariadb:1.2.3://localhost:3306/test", "mariadb", "1.2.3","localhost:3306/test","test"},
+                      {"jdbc:tc:mariadb://localhost:3306/test", "mariadb", "latest","localhost:3306/test","test"},
+                      {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521/test", "oracle", "1.2.3","localhost:1521/test","test"},
+                      {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", "latest","localhost:1521/test","test"}
+                  });
+  }
+  
+  @Test
+  public void test() throws SQLException {
+     ConnectionUrl url = new ConnectionUrl(jdbcUrl);
+     url.parseUrl();
+     assertEquals("Database Type is as expected", databaseType, url.getDatabaseType());
+     assertEquals("Image tag is as expected", tag, url.getImageTag());
+     assertEquals("Database Host String is as expected", dbHostString, url.getDbHostString());
+     assertEquals("Database Name is as expected", databaseName, url.getDatabaseName().orElse(""));
+  }
+}

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -12,47 +12,47 @@ import org.junit.runners.Parameterized.Parameter;
 
 /**
  * This Test class validates that all supported JDBC URL's can be parsed by ConnectionUrl class.
- * @author ManikMagar
  *
+ * @author ManikMagar
  */
 @RunWith(Parameterized.class)
 public class ConnectionUrlDriversTests {
 
-  @Parameter
-  public String jdbcUrl;
-  @Parameter(1)
-  public String databaseType;
-  @Parameter(2)
-  public String tag;
-  @Parameter(3)
-  public String dbHostString;
-  @Parameter(4)
-  public String databaseName;
+    @Parameter
+    public String jdbcUrl;
+    @Parameter(1)
+    public String databaseType;
+    @Parameter(2)
+    public String tag;
+    @Parameter(3)
+    public String dbHostString;
+    @Parameter(4)
+    public String databaseName;
 
-  @Parameterized.Parameters(name = "{index} - {0}")
-  public static Iterable<Object[]> data() {
-    return asList(
-                  new Object[][] {
-                      {"jdbc:tc:mysql:5.5.43://hostname/test", "mysql", "5.5.43","hostname/test","test"},
-                      {"jdbc:tc:mysql://hostname/test", "mysql", "latest","hostname/test","test"},
-                      {"jdbc:tc:postgresql:1.2.3://hostname/test", "postgresql", "1.2.3","hostname/test","test"},
-                      {"jdbc:tc:postgresql://hostname/test", "postgresql", "latest","hostname/test","test"},
-                      {"jdbc:tc:sqlserver:1.2.3://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", "1.2.3","localhost;instance=SQLEXPRESS:1433;databaseName=test",""},
-                      {"jdbc:tc:sqlserver://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", "latest","localhost;instance=SQLEXPRESS:1433;databaseName=test",""},
-                      {"jdbc:tc:mariadb:1.2.3://localhost:3306/test", "mariadb", "1.2.3","localhost:3306/test","test"},
-                      {"jdbc:tc:mariadb://localhost:3306/test", "mariadb", "latest","localhost:3306/test","test"},
-                      {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521/test", "oracle", "1.2.3","localhost:1521/test","test"},
-                      {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", "latest","localhost:1521/test","test"}
-                  });
-  }
-  
-  @Test
-  public void test() throws SQLException {
-     ConnectionUrl url = new ConnectionUrl(jdbcUrl);
-     url.parseUrl();
-     assertEquals("Database Type is as expected", databaseType, url.getDatabaseType());
-     assertEquals("Image tag is as expected", tag, url.getImageTag());
-     assertEquals("Database Host String is as expected", dbHostString, url.getDbHostString());
-     assertEquals("Database Name is as expected", databaseName, url.getDatabaseName().orElse(""));
-  }
+    @Parameterized.Parameters(name = "{index} - {0}")
+    public static Iterable<Object[]> data() {
+        return asList(
+            new Object[][]{
+                {"jdbc:tc:mysql:5.5.43://hostname/test", "mysql", "5.5.43", "hostname/test", "test"},
+                {"jdbc:tc:mysql://hostname/test", "mysql", "latest", "hostname/test", "test"},
+                {"jdbc:tc:postgresql:1.2.3://hostname/test", "postgresql", "1.2.3", "hostname/test", "test"},
+                {"jdbc:tc:postgresql://hostname/test", "postgresql", "latest", "hostname/test", "test"},
+                {"jdbc:tc:sqlserver:1.2.3://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", "1.2.3", "localhost;instance=SQLEXPRESS:1433;databaseName=test", ""},
+                {"jdbc:tc:sqlserver://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", "latest", "localhost;instance=SQLEXPRESS:1433;databaseName=test", ""},
+                {"jdbc:tc:mariadb:1.2.3://localhost:3306/test", "mariadb", "1.2.3", "localhost:3306/test", "test"},
+                {"jdbc:tc:mariadb://localhost:3306/test", "mariadb", "latest", "localhost:3306/test", "test"},
+                {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521/test", "oracle", "1.2.3", "localhost:1521/test", "test"},
+                {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", "latest", "localhost:1521/test", "test"}
+            });
+    }
+
+    @Test
+    public void test() throws SQLException {
+        ConnectionUrl url = new ConnectionUrl(jdbcUrl);
+        url.parseUrl();
+        assertEquals("Database Type is as expected", databaseType, url.getDatabaseType());
+        assertEquals("Image tag is as expected", tag, url.getImageTag());
+        assertEquals("Database Host String is as expected", dbHostString, url.getDbHostString());
+        assertEquals("Database Name is as expected", databaseName, url.getDatabaseName().orElse(""));
+    }
 }

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
@@ -3,77 +3,78 @@ package org.testcontainers.jdbc;
 import static org.rnorth.visibleassertions.VisibleAssertions.*;
 
 import org.junit.Test;
+
 public class ConnectionUrlTest {
 
-  @Test
-  public void testConnectionUrl1() {
-    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d";
-    ConnectionUrl url = new ConnectionUrl(urlString);
-    url.parseUrl();
-  
-    assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
-    assertEquals("Database Image tag value is as expected", "5.6.23", url.getImageTag());
-    assertEquals("Database Host String is as expected", "somehostname:3306/databasename", url.getDbHostString());
-    assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
-    assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
-    assertEquals("Database Port value is as expected", 3306, url.getDatabasePort().get());
-    assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
-    
-    assertEquals("Parameter a is captured", "b", url.getQueryParameters().get("a"));
-    assertEquals("Parameter c is captured", "d", url.getQueryParameters().get("c"));
-  }
-  
+    @Test
+    public void testConnectionUrl1() {
+        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d";
+        ConnectionUrl url = new ConnectionUrl(urlString);
+        url.parseUrl();
 
-  @Test
-  public void testConnectionUrl2() {
-    String urlString = "jdbc:tc:mysql://somehostname/databasename";
-    ConnectionUrl url = new ConnectionUrl(urlString);
-    url.parseUrl();
-    
-    assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
-    assertEquals("Database Image tag value is as expected", "latest", url.getImageTag());
-    assertEquals("Database Host String is as expected", "somehostname/databasename", url.getDbHostString());
-    assertEquals("Query String value is as expected", "?", url.getQueryString().get());
-    assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
-    assertFalse("Database Port is null as expected", url.getDatabasePort().isPresent());
-    assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
-    
-    assertTrue("Connection Parameters set is empty", url.getQueryParameters().isEmpty());
+        assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
+        assertEquals("Database Image tag value is as expected", "5.6.23", url.getImageTag());
+        assertEquals("Database Host String is as expected", "somehostname:3306/databasename", url.getDbHostString());
+        assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
+        assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
+        assertEquals("Database Port value is as expected", 3306, url.getDatabasePort().get());
+        assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
 
-  }
-  
-  @Test
-  public void testInitScriptPathCapture() {
-    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
-    ConnectionUrl url = new ConnectionUrl(urlString);
-    url.parseUrl();
+        assertEquals("Parameter a is captured", "b", url.getQueryParameters().get("a"));
+        assertEquals("Parameter c is captured", "d", url.getQueryParameters().get("c"));
+    }
 
-    assertEquals("Database Type value is as expected", "somepath/init_mysql.sql", url.getInitScriptPath().get());
-    assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
-    assertEquals("INIT SCRIPT Path exists in Container Parameters", "somepath/init_mysql.sql", url.getContainerParameters().get("TC_INITSCRIPT"));
 
-  }
-  
-  @Test
-  public void testInitFunctionCapture() {
-    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
-    ConnectionUrl url = new ConnectionUrl(urlString);
-    url.parseUrl();
-    
-    assertTrue("Init Function parameter exists", url.getInitFunction().isPresent());
-    
-    assertEquals("Init function class is as expected", "org.testcontainers.jdbc.JDBCDriverTest", url.getInitFunction().get().getClassName());
-    assertEquals("Init function class is as expected", "sampleInitFunction", url.getInitFunction().get().getMethodName());
-    
-  }
-  
-  @Test
-  public void testDaemonCapture() {
-    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
-    ConnectionUrl url = new ConnectionUrl(urlString);
-    url.parseUrl();
+    @Test
+    public void testConnectionUrl2() {
+        String urlString = "jdbc:tc:mysql://somehostname/databasename";
+        ConnectionUrl url = new ConnectionUrl(urlString);
+        url.parseUrl();
 
-    assertTrue("Daemon flag is set to true.",url.isInDaemonMode());
-    
-  }
+        assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
+        assertEquals("Database Image tag value is as expected", "latest", url.getImageTag());
+        assertEquals("Database Host String is as expected", "somehostname/databasename", url.getDbHostString());
+        assertEquals("Query String value is as expected", "?", url.getQueryString().get());
+        assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
+        assertFalse("Database Port is null as expected", url.getDatabasePort().isPresent());
+        assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
+
+        assertTrue("Connection Parameters set is empty", url.getQueryParameters().isEmpty());
+
+    }
+
+    @Test
+    public void testInitScriptPathCapture() {
+        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
+        ConnectionUrl url = new ConnectionUrl(urlString);
+        url.parseUrl();
+
+        assertEquals("Database Type value is as expected", "somepath/init_mysql.sql", url.getInitScriptPath().get());
+        assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
+        assertEquals("INIT SCRIPT Path exists in Container Parameters", "somepath/init_mysql.sql", url.getContainerParameters().get("TC_INITSCRIPT"));
+
+    }
+
+    @Test
+    public void testInitFunctionCapture() {
+        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
+        ConnectionUrl url = new ConnectionUrl(urlString);
+        url.parseUrl();
+
+        assertTrue("Init Function parameter exists", url.getInitFunction().isPresent());
+
+        assertEquals("Init function class is as expected", "org.testcontainers.jdbc.JDBCDriverTest", url.getInitFunction().get().getClassName());
+        assertEquals("Init function class is as expected", "sampleInitFunction", url.getInitFunction().get().getMethodName());
+
+    }
+
+    @Test
+    public void testDaemonCapture() {
+        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
+        ConnectionUrl url = new ConnectionUrl(urlString);
+        url.parseUrl();
+
+        assertTrue("Daemon flag is set to true.", url.isInDaemonMode());
+
+    }
 }

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
@@ -1,8 +1,9 @@
 package org.testcontainers.jdbc;
 
 
+import static org.rnorth.visibleassertions.VisibleAssertions.*;
+
 import org.junit.Test;
-import org.rnorth.visibleassertions.VisibleAssertions;
 
 public class ConnectionUrlTest {
 
@@ -12,16 +13,16 @@ public class ConnectionUrlTest {
     ConnectionUrl url = new ConnectionUrl(urlString);
     url.parseUrl();
     
-    VisibleAssertions.assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
-    VisibleAssertions.assertEquals("Database Image tag value is as expected", "5.6.23", url.getImageTag());
-    VisibleAssertions.assertEquals("Database Host String is as expected", "somehostname:3306/databasename", url.getDbHostString());
-    VisibleAssertions.assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
-    VisibleAssertions.assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
-    VisibleAssertions.assertEquals("Database Port value is as expected", 3306, url.getDatabasePort().get());
-    VisibleAssertions.assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
+    assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
+    assertEquals("Database Image tag value is as expected", "5.6.23", url.getImageTag());
+    assertEquals("Database Host String is as expected", "somehostname:3306/databasename", url.getDbHostString());
+    assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
+    assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
+    assertEquals("Database Port value is as expected", 3306, url.getDatabasePort().get());
+    assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
     
-    VisibleAssertions.assertEquals("Parameter a is captured", "b", url.getQueryParameters().get("a"));
-    VisibleAssertions.assertEquals("Parameter c is captured", "d", url.getQueryParameters().get("c"));
+    assertEquals("Parameter a is captured", "b", url.getQueryParameters().get("a"));
+    assertEquals("Parameter c is captured", "d", url.getQueryParameters().get("c"));
     
   }
   
@@ -32,15 +33,15 @@ public class ConnectionUrlTest {
     ConnectionUrl url = new ConnectionUrl(urlString);
     url.parseUrl();
     
-    VisibleAssertions.assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
-    VisibleAssertions.assertEquals("Database Image tag value is as expected", "latest", url.getImageTag());
-    VisibleAssertions.assertEquals("Database Host String is as expected", "somehostname/databasename", url.getDbHostString());
-    VisibleAssertions.assertFalse("Query String is null as expected", url.getQueryString().isPresent());
-    VisibleAssertions.assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
-    VisibleAssertions.assertFalse("Database Port is null as expected", url.getDatabasePort().isPresent());
-    VisibleAssertions.assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
+    assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
+    assertEquals("Database Image tag value is as expected", "latest", url.getImageTag());
+    assertEquals("Database Host String is as expected", "somehostname/databasename", url.getDbHostString());
+    assertEquals("Query String value is as expected", "?", url.getQueryString().get());
+    assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
+    assertFalse("Database Port is null as expected", url.getDatabasePort().isPresent());
+    assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
     
-    VisibleAssertions.assertTrue("Connection Parameters set is empty", url.getQueryParameters().isEmpty());
+    assertTrue("Connection Parameters set is empty", url.getQueryParameters().isEmpty());
   }
   
   @Test
@@ -49,9 +50,9 @@ public class ConnectionUrlTest {
     ConnectionUrl url = new ConnectionUrl(urlString);
     url.parseUrl();
     
-    VisibleAssertions.assertEquals("Database Type value is as expected", "somepath/init_mysql.sql", url.getInitScriptPath().get());
-    
-    VisibleAssertions.assertEquals("INIT SCRIPT Path exists in Container Parameters", "somepath/init_mysql.sql", url.getContainerParameters().get("TC_INITSCRIPT"));
+    assertEquals("Database Type value is as expected", "somepath/init_mysql.sql", url.getInitScriptPath().get());
+    assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
+    assertEquals("INIT SCRIPT Path exists in Container Parameters", "somepath/init_mysql.sql", url.getContainerParameters().get("TC_INITSCRIPT"));
     
   }
   
@@ -61,10 +62,10 @@ public class ConnectionUrlTest {
     ConnectionUrl url = new ConnectionUrl(urlString);
     url.parseUrl();
     
-    VisibleAssertions.assertTrue("Init Function parameter exists", url.getInitFunction().isPresent());
+    assertTrue("Init Function parameter exists", url.getInitFunction().isPresent());
     
-    VisibleAssertions.assertEquals("Init function class is as expected", "org.testcontainers.jdbc.JDBCDriverTest", url.getInitFunction().get().getClassName());
-    VisibleAssertions.assertEquals("Init function class is as expected", "sampleInitFunction", url.getInitFunction().get().getMethodName());
+    assertEquals("Init function class is as expected", "org.testcontainers.jdbc.JDBCDriverTest", url.getInitFunction().get().getClassName());
+    assertEquals("Init function class is as expected", "sampleInitFunction", url.getInitFunction().get().getMethodName());
     
   }
   
@@ -74,7 +75,9 @@ public class ConnectionUrlTest {
     ConnectionUrl url = new ConnectionUrl(urlString);
     url.parseUrl();
     
-    VisibleAssertions.assertTrue("Daemon flag is set to true.",url.isInDaemonMode());
+    assertTrue("Daemon flag is set to true.",url.isInDaemonMode());
     
   }
+  
+  
 }

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
@@ -1,0 +1,80 @@
+package org.testcontainers.jdbc;
+
+
+import org.junit.Test;
+import org.rnorth.visibleassertions.VisibleAssertions;
+
+public class ConnectionUrlTest {
+
+  @Test
+  public void testConnectionUrl1() {
+    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d";
+    ConnectionUrl url = new ConnectionUrl(urlString);
+    url.parseUrl();
+    
+    VisibleAssertions.assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
+    VisibleAssertions.assertEquals("Database Image tag value is as expected", "5.6.23", url.getImageTag());
+    VisibleAssertions.assertEquals("Database Host String is as expected", "somehostname:3306/databasename", url.getDbHostString());
+    VisibleAssertions.assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
+    VisibleAssertions.assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
+    VisibleAssertions.assertEquals("Database Port value is as expected", 3306, url.getDatabasePort().get());
+    VisibleAssertions.assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
+    
+    VisibleAssertions.assertEquals("Parameter a is captured", "b", url.getQueryParameters().get("a"));
+    VisibleAssertions.assertEquals("Parameter c is captured", "d", url.getQueryParameters().get("c"));
+    
+  }
+  
+
+  @Test
+  public void testConnectionUrl2() {
+    String urlString = "jdbc:tc:mysql://somehostname/databasename";
+    ConnectionUrl url = new ConnectionUrl(urlString);
+    url.parseUrl();
+    
+    VisibleAssertions.assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
+    VisibleAssertions.assertEquals("Database Image tag value is as expected", "latest", url.getImageTag());
+    VisibleAssertions.assertEquals("Database Host String is as expected", "somehostname/databasename", url.getDbHostString());
+    VisibleAssertions.assertFalse("Query String is null as expected", url.getQueryString().isPresent());
+    VisibleAssertions.assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
+    VisibleAssertions.assertFalse("Database Port is null as expected", url.getDatabasePort().isPresent());
+    VisibleAssertions.assertEquals("Database Name value is as expected", "databasename", url.getDatabaseName().get());
+    
+    VisibleAssertions.assertTrue("Connection Parameters set is empty", url.getQueryParameters().isEmpty());
+  }
+  
+  @Test
+  public void testInitScriptPathCapture() {
+    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
+    ConnectionUrl url = new ConnectionUrl(urlString);
+    url.parseUrl();
+    
+    VisibleAssertions.assertEquals("Database Type value is as expected", "somepath/init_mysql.sql", url.getInitScriptPath().get());
+    
+    VisibleAssertions.assertEquals("INIT SCRIPT Path exists in Container Parameters", "somepath/init_mysql.sql", url.getContainerParameters().get("TC_INITSCRIPT"));
+    
+  }
+  
+  @Test
+  public void testInitFunctionCapture() {
+    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
+    ConnectionUrl url = new ConnectionUrl(urlString);
+    url.parseUrl();
+    
+    VisibleAssertions.assertTrue("Init Function parameter exists", url.getInitFunction().isPresent());
+    
+    VisibleAssertions.assertEquals("Init function class is as expected", "org.testcontainers.jdbc.JDBCDriverTest", url.getInitFunction().get().getClassName());
+    VisibleAssertions.assertEquals("Init function class is as expected", "sampleInitFunction", url.getInitFunction().get().getMethodName());
+    
+  }
+  
+  @Test
+  public void testDaemonCapture() {
+    String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
+    ConnectionUrl url = new ConnectionUrl(urlString);
+    url.parseUrl();
+    
+    VisibleAssertions.assertTrue("Daemon flag is set to true.",url.isInDaemonMode());
+    
+  }
+}

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
@@ -2,15 +2,20 @@ package org.testcontainers.jdbc;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.*;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class ConnectionUrlTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
 
     @Test
     public void testConnectionUrl1() {
         String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d";
-        ConnectionUrl url = new ConnectionUrl(urlString);
-        url.parseUrl();
+        ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
         assertEquals("Database Image tag value is as expected", "5.6.23", url.getImageTag());
@@ -28,8 +33,7 @@ public class ConnectionUrlTest {
     @Test
     public void testConnectionUrl2() {
         String urlString = "jdbc:tc:mysql://somehostname/databasename";
-        ConnectionUrl url = new ConnectionUrl(urlString);
-        url.parseUrl();
+        ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
         assertEquals("Database Image tag value is as expected", "latest", url.getImageTag());
@@ -46,20 +50,23 @@ public class ConnectionUrlTest {
     @Test
     public void testInitScriptPathCapture() {
         String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
-        ConnectionUrl url = new ConnectionUrl(urlString);
-        url.parseUrl();
+        ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertEquals("Database Type value is as expected", "somepath/init_mysql.sql", url.getInitScriptPath().get());
         assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
         assertEquals("INIT SCRIPT Path exists in Container Parameters", "somepath/init_mysql.sql", url.getContainerParameters().get("TC_INITSCRIPT"));
+
+        //Parameter sets are unmodifiable
+        thrown.expect(UnsupportedOperationException.class);
+        url.getContainerParameters().remove("TC_INITSCRIPT");
+        url.getQueryParameters().remove("a");
 
     }
 
     @Test
     public void testInitFunctionCapture() {
         String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
-        ConnectionUrl url = new ConnectionUrl(urlString);
-        url.parseUrl();
+        ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertTrue("Init Function parameter exists", url.getInitFunction().isPresent());
 
@@ -71,8 +78,7 @@ public class ConnectionUrlTest {
     @Test
     public void testDaemonCapture() {
         String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
-        ConnectionUrl url = new ConnectionUrl(urlString);
-        url.parseUrl();
+        ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertTrue("Daemon flag is set to true.", url.isInDaemonMode());
 

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ContainerDatabaseDriverTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ContainerDatabaseDriverTest.java
@@ -13,23 +13,23 @@ import java.util.Properties;
 
 public class ContainerDatabaseDriverTest {
 
-	private static final String PLAIN_POSTGRESQL_JDBC_URL = "jdbc:postgresql://localhost:5432/test";
+    private static final String PLAIN_POSTGRESQL_JDBC_URL = "jdbc:postgresql://localhost:5432/test";
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-	@Test
-	public void shouldNotTryToConnectToNonMatchingJdbcUrlDirectly() throws SQLException {
-		ContainerDatabaseDriver driver = new ContainerDatabaseDriver();
-		Connection connection = driver.connect(PLAIN_POSTGRESQL_JDBC_URL, new Properties());
-		Assert.assertNull(connection);
-	}
+    @Test
+    public void shouldNotTryToConnectToNonMatchingJdbcUrlDirectly() throws SQLException {
+        ContainerDatabaseDriver driver = new ContainerDatabaseDriver();
+        Connection connection = driver.connect(PLAIN_POSTGRESQL_JDBC_URL, new Properties());
+        Assert.assertNull(connection);
+    }
 
-	@Test
-	public void shouldNotTryToConnectToNonMatchingJdbcUrlViaDriverManager() throws SQLException {
-		thrown.expect(SQLException.class);
-		thrown.expectMessage(CoreMatchers.startsWith("No suitable driver found for "));
-		DriverManager.getConnection(PLAIN_POSTGRESQL_JDBC_URL);
-	}
+    @Test
+    public void shouldNotTryToConnectToNonMatchingJdbcUrlViaDriverManager() throws SQLException {
+        thrown.expect(SQLException.class);
+        thrown.expectMessage(CoreMatchers.startsWith("No suitable driver found for "));
+        DriverManager.getConnection(PLAIN_POSTGRESQL_JDBC_URL);
+    }
 
 }

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
@@ -1,7 +1,6 @@
 package org.testcontainers.containers;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
@@ -1,8 +1,6 @@
 package org.testcontainers.containers;
 
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import org.testcontainers.jdbc.ConnectionUrl;
 

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
@@ -1,9 +1,27 @@
 package org.testcontainers.containers;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.testcontainers.jdbc.ConnectionUrl;
+
 /**
  * Factory for MySQL containers.
  */
 public class MySQLContainerProvider extends JdbcDatabaseContainerProvider {
+  
+    /**
+     * Groups URL of format "jdbc:tc:(databaseType):(optinal_image_tag)//(hostanme)(optional :(numeric_port))/(databasename)(?parameters)"
+     */
+    private static final Pattern MYSQL_URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^:]+))?://([^:]+)(:([0-9]+))?/([^\\\\?]+)(\\\\?.*)?");
+   
+    private static final String USER_PARAM = "user";
+    
+    private static final String PASSWORD_PARAM = "password";
+    
+  
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(MySQLContainer.NAME);
@@ -13,4 +31,26 @@ public class MySQLContainerProvider extends JdbcDatabaseContainerProvider {
     public JdbcDatabaseContainer newInstance(String tag) {
         return new MySQLContainer(MySQLContainer.IMAGE + ":" + tag);
     }
+    
+    @Override
+    public JdbcDatabaseContainer newInstance(ConnectionUrl url) {
+      Objects.requireNonNull(url, "Connection URL cannot be null");
+      
+      Matcher urlMatcher = MYSQL_URL_MATCHING_PATTERN.matcher(url.getUrl());
+      
+      if(!urlMatcher.matches()) {
+        //TODO: Is this necessary?
+        throw new IllegalArgumentException("JDBC URL matches jdbc:tc: prefix but does not match the Expected MySQL URL Format");
+      }
+
+      final String databaseName = url.getDatabaseName().orElse("test");
+      final String user = url.getQueryParameters().getOrDefault(USER_PARAM, "test");
+      final String password = url.getQueryParameters().getOrDefault(PASSWORD_PARAM, "test");
+      
+      return newInstance(url.getImageTag())
+               .withDatabaseName(databaseName)
+               .withUsername(user)
+               .withPassword(password);
+    }
+
 }

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
@@ -10,17 +10,12 @@ import org.testcontainers.jdbc.ConnectionUrl;
  * Factory for MySQL containers.
  */
 public class MySQLContainerProvider extends JdbcDatabaseContainerProvider {
-  
-    /**
-     * Groups URL of format "jdbc:tc:(databaseType):(optinal_image_tag)//(hostanme)(optional :(numeric_port))/(databasename)(?parameters)"
-     */
-    private static final Pattern MYSQL_URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^:]+))?://([^:]+)(:([0-9]+))?/([^\\\\?]+)(\\\\?.*)?");
-   
+
     private static final String USER_PARAM = "user";
-    
+
     private static final String PASSWORD_PARAM = "password";
-    
-  
+
+
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(MySQLContainer.NAME);
@@ -30,23 +25,16 @@ public class MySQLContainerProvider extends JdbcDatabaseContainerProvider {
     public JdbcDatabaseContainer newInstance(String tag) {
         return new MySQLContainer(MySQLContainer.IMAGE + ":" + tag);
     }
-    
-    @Override
-    public JdbcDatabaseContainer newInstance(ConnectionUrl url) {
-      Objects.requireNonNull(url, "Connection URL cannot be null");
-      
-      Matcher urlMatcher = MYSQL_URL_MATCHING_PATTERN.matcher(url.getUrl());
-      
-      if(!urlMatcher.matches()) {
-        //TODO: Is this necessary?
-        throw new IllegalArgumentException("JDBC URL matches jdbc:tc: prefix but does not match the Expected MySQL URL Format");
-      }
 
-      final String databaseName = url.getDatabaseName().orElse("test");
-      final String user = url.getQueryParameters().getOrDefault(USER_PARAM, "test");
-      final String password = url.getQueryParameters().getOrDefault(PASSWORD_PARAM, "test");
-      
-      return newInstance(url.getImageTag())
+    @Override
+    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+      Objects.requireNonNull(connectionUrl, "Connection URL cannot be null");
+
+      final String databaseName = connectionUrl.getDatabaseName().orElse("test");
+      final String user = connectionUrl.getQueryParameters().getOrDefault(USER_PARAM, "test");
+      final String password = connectionUrl.getQueryParameters().getOrDefault(PASSWORD_PARAM, "test");
+
+      return newInstance(connectionUrl.getImageTag())
                .withDatabaseName(databaseName)
                .withUsername(user)
                .withPassword(password);

--- a/modules/spock/README.md
+++ b/modules/spock/README.md
@@ -1,0 +1,65 @@
+# TestContainers-Spock
+[Spock](https://github.com/spockframework/spock) extension for [TestContainers](https://github.com/testcontainers/testcontainers-java) library, which allows to use Docker containers inside of Spock tests.
+
+# Usage
+
+## @Testcontainers class-annotation
+
+Specifying the `@Testcontainers` annotation will instruct Spock to start and stop all testcontainers accordingly. This annotation 
+can be mixed with Spock's `@Shared` annotation to indicate, that containers shouldn't be restarted between tests.
+
+```groovy
+@Testcontainers
+class DatabaseTest extends Specification {
+
+    @Shared
+    PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer()
+            .withDatabaseName("foo")
+            .withUsername("foo")
+            .withPassword("secret")
+
+    def "database is accessible"() {
+
+        given: "a jdbc connection"
+        HikariConfig hikariConfig = new HikariConfig()
+        hikariConfig.setJdbcUrl(postgreSQLContainer.jdbcUrl)
+        hikariConfig.setUsername("foo")
+        hikariConfig.setPassword("secret")
+        HikariDataSource ds = new HikariDataSource(hikariConfig)
+
+        when: "querying the database"
+        Statement statement = ds.getConnection().createStatement()
+        statement.execute("SELECT 1")
+        ResultSet resultSet = statement.getResultSet()
+        resultSet.next()
+
+        then: "result is returned"
+        int resultSetInt = resultSet.getInt(1)
+        resultSetInt == 1
+    }
+}
+```
+
+## General TestContainers usage
+
+See the [TestContainers documentation](https://www.testcontainers.org/) for more information about the underlying library.
+
+# Attributions
+The initial version of this project was heavily inspired by the excellent [JUnit5 docker extension](https://github.com/FaustXVI/junit5-docker) by [FaustXVI](https://github.com/FaustXVI).
+
+# License
+Copyright 2016 Kevin Wittek
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this project except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+See [LICENSE](LICENSE).

--- a/modules/spock/README.md
+++ b/modules/spock/README.md
@@ -46,20 +46,3 @@ See the [TestContainers documentation](https://www.testcontainers.org/) for more
 
 # Attributions
 The initial version of this project was heavily inspired by the excellent [JUnit5 docker extension](https://github.com/FaustXVI/junit5-docker) by [FaustXVI](https://github.com/FaustXVI).
-
-# License
-Copyright 2016 Kevin Wittek
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this project except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-See [LICENSE](LICENSE).

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'groovy'
+}
+
+description = "Testcontainers :: Spock-Extension"
+
+dependencies {
+    compile project(':testcontainers')
+    compile 'org.spockframework:spock-core:1.0-groovy-2.4'
+
+    testCompile project(':mysql')
+    testCompile project(':postgresql')
+    testCompile 'com.zaxxer:HikariCP:2.6.1'
+
+    testRuntime 'org.postgresql:postgresql:42.0.0'
+    testRuntime 'mysql:mysql-connector-java:6.0.6'
+}

--- a/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
@@ -1,0 +1,15 @@
+package org.testcontainers.spock
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.METHOD])
+@ExtensionAnnotation(TestcontainersExtension)
+@interface Testcontainers {
+
+}

--- a/modules/spock/src/main/groovy/org/testcontainers/spock/TestcontainersExtension.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/TestcontainersExtension.groovy
@@ -1,0 +1,17 @@
+package org.testcontainers.spock
+
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.model.SpecInfo
+
+class TestcontainersExtension extends AbstractAnnotationDrivenExtension<Testcontainers> {
+
+    @Override
+    void visitSpecAnnotation(Testcontainers annotation, SpecInfo spec) {
+        def interceptor = new TestcontainersMethodInterceptor(spec)
+        spec.addSetupSpecInterceptor(interceptor)
+        spec.addCleanupSpecInterceptor(interceptor)
+        spec.addSetupInterceptor(interceptor)
+        spec.addCleanupInterceptor(interceptor)
+    }
+
+}

--- a/modules/spock/src/main/groovy/org/testcontainers/spock/TestcontainersMethodInterceptor.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/TestcontainersMethodInterceptor.groovy
@@ -1,0 +1,108 @@
+package org.testcontainers.spock
+
+import org.spockframework.runtime.extension.AbstractMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FieldInfo
+import org.spockframework.runtime.model.SpecInfo
+import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.GenericContainer
+
+class TestcontainersMethodInterceptor extends AbstractMethodInterceptor {
+
+    private final SpecInfo spec
+
+    TestcontainersMethodInterceptor(SpecInfo spec) {
+        this.spec = spec
+    }
+
+    @Override
+    void interceptSetupSpecMethod(IMethodInvocation invocation) throws Throwable {
+        def containers = findAllContainers(true)
+        startContainers(containers, invocation)
+
+        def compose = findAllComposeContainers(true)
+        startComposeContainers(compose, invocation)
+
+        invocation.proceed()
+    }
+
+    void interceptCleanupSpecMethod(IMethodInvocation invocation) throws Throwable {
+        def containers = findAllContainers(true)
+        stopContainers(containers, invocation)
+
+        def compose = findAllComposeContainers(true)
+        stopComposeContainers(compose, invocation)
+
+        invocation.proceed()
+    }
+
+    @Override
+    void interceptSetupMethod(IMethodInvocation invocation) throws Throwable {
+        def containers = findAllContainers(false)
+        startContainers(containers, invocation)
+
+        def compose = findAllComposeContainers(false)
+        startComposeContainers(compose, invocation)
+
+        invocation.proceed()
+    }
+
+
+    @Override
+    void interceptCleanupMethod(IMethodInvocation invocation) throws Throwable {
+        def containers = findAllContainers(false)
+        stopContainers(containers, invocation)
+
+        def compose = findAllComposeContainers(false)
+        stopComposeContainers(compose, invocation)
+
+        invocation.proceed()
+    }
+
+    private List<FieldInfo> findAllContainers(boolean shared) {
+        spec.allFields.findAll { FieldInfo f ->
+            GenericContainer.isAssignableFrom(f.type) && f.shared == shared
+        }
+    }
+
+    private List<FieldInfo> findAllComposeContainers(boolean shared) {
+        spec.allFields.findAll { FieldInfo f ->
+            DockerComposeContainer.isAssignableFrom(f.type) && f.shared == shared
+        }
+    }
+
+    private static void startContainers(List<FieldInfo> containers, IMethodInvocation invocation) {
+        containers.each { FieldInfo f ->
+            GenericContainer container = readContainerFromField(f, invocation)
+            if(!container.isRunning()){
+                container.start()
+            }
+        }
+    }
+
+    private static void stopContainers(List<FieldInfo> containers, IMethodInvocation invocation) {
+        containers.each { FieldInfo f ->
+            GenericContainer container = readContainerFromField(f, invocation)
+            container.stop()
+        }
+    }
+
+    private static void startComposeContainers(List<FieldInfo> compose, IMethodInvocation invocation) {
+        compose.each { FieldInfo f ->
+            DockerComposeContainer c = f.readValue(invocation.instance) as DockerComposeContainer
+            c.starting(null)
+        }
+    }
+
+    private static void stopComposeContainers(List<FieldInfo> compose, IMethodInvocation invocation) {
+        compose.each { FieldInfo f ->
+            DockerComposeContainer c = f.readValue(invocation.instance) as DockerComposeContainer
+            c.finished(null)
+        }
+    }
+
+
+    private static GenericContainer readContainerFromField(FieldInfo f, IMethodInvocation invocation) {
+        f.readValue(invocation.instance) as GenericContainer
+    }
+}

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/ComposeContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/ComposeContainerIT.groovy
@@ -1,0 +1,34 @@
+package org.testcontainers.spock
+
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClientBuilder
+import org.testcontainers.containers.DockerComposeContainer
+import spock.lang.Specification
+
+@Testcontainers
+class ComposeContainerIT extends Specification {
+
+    DockerComposeContainer composeContainer = new DockerComposeContainer(
+            new File("src/test/resources/docker-compose.yml"))
+            .withExposedService("whoami_1", 80)
+
+    String host
+
+    int port
+
+    def setup() {
+        host = composeContainer.getServiceHost("whoami_1", 80)
+        port = composeContainer.getServicePort("whoami_1", 80)
+    }
+
+    def "running compose defined container is accessible on configured port"() {
+        given: "a http client"
+        def client = HttpClientBuilder.create().build()
+
+        when: "accessing web server"
+        def response = client.execute(new HttpGet("http://$host:$port"))
+
+        then: "docker container is running and returns http status code 200"
+        response.statusLine.statusCode == 200
+    }
+}

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/MySqlContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/MySqlContainerIT.groovy
@@ -1,0 +1,26 @@
+package org.testcontainers.spock
+
+import org.testcontainers.containers.MySQLContainer
+import spock.lang.Shared
+import spock.lang.Specification
+
+/**
+ * This test verifies, that setup and cleanup of containers works correctly.
+ * It's easily achieved using the <code>MySQLContainer</code>, since it will fail
+ * if the same image is running.
+ *
+ * @see <a href="https://github.com/testcontainers/testcontainers-spock/issues/19">Second container is started when stopping old container</a>
+ */
+@Testcontainers
+class MySqlContainerIT extends Specification {
+
+    @Shared
+    MySQLContainer mySQLContainer = new MySQLContainer()
+
+    def "dummy test"() {
+        expect:
+        mySQLContainer.isRunning()
+    }
+
+
+}

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/PostgresContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/PostgresContainerIT.groovy
@@ -1,0 +1,44 @@
+package org.testcontainers.spock
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.testcontainers.containers.PostgreSQLContainer
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.sql.ResultSet
+import java.sql.Statement
+
+@Testcontainers
+class PostgresContainerIT extends Specification {
+
+    @Shared
+    PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer()
+            .withDatabaseName("foo")
+            .withUsername("foo")
+            .withPassword("secret")
+
+    def "waits until postgres accepts jdbc connections"() {
+
+        given: "a jdbc connection"
+        HikariConfig hikariConfig = new HikariConfig()
+        hikariConfig.setJdbcUrl(postgreSQLContainer.jdbcUrl)
+        hikariConfig.setUsername("foo")
+        hikariConfig.setPassword("secret")
+        HikariDataSource ds = new HikariDataSource(hikariConfig)
+
+        when: "querying the database"
+        Statement statement = ds.getConnection().createStatement()
+        statement.execute("SELECT 1")
+        ResultSet resultSet = statement.getResultSet()
+        resultSet.next()
+
+        then: "result is returned"
+        int resultSetInt = resultSet.getInt(1)
+        resultSetInt == 1
+
+        cleanup:
+        ds.close()
+    }
+
+}

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/SharedComposeContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/SharedComposeContainerIT.groovy
@@ -1,0 +1,36 @@
+package org.testcontainers.spock
+
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.HttpClientBuilder
+import org.testcontainers.containers.DockerComposeContainer
+import spock.lang.Shared
+import spock.lang.Specification
+
+@Testcontainers
+class SharedComposeContainerIT extends Specification {
+
+    @Shared
+    DockerComposeContainer composeContainer = new DockerComposeContainer(
+            new File("src/test/resources/docker-compose.yml"))
+            .withExposedService("whoami_1", 80)
+
+    String host
+
+    int port
+
+    def setup() {
+        host = composeContainer.getServiceHost("whoami_1", 80)
+        port = composeContainer.getServicePort("whoami_1", 80)
+    }
+
+    def "running compose defined container is accessible on configured port"() {
+        given: "a http client"
+        def client = HttpClientBuilder.create().build()
+
+        when: "accessing web server"
+        def response = client.execute(new HttpGet("http://$host:$port"))
+
+        then: "docker container is running and returns http status code 200"
+        response.statusLine.statusCode == 200
+    }
+}

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/TestHierarchyIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/TestHierarchyIT.groovy
@@ -1,0 +1,25 @@
+package org.testcontainers.spock
+
+import org.testcontainers.containers.PostgreSQLContainer
+import spock.lang.Shared
+
+/**
+ * This test verifies that integration tests can subclass each other
+ */
+@Testcontainers
+class TestHierarchyIT extends MySqlContainerIT {
+
+    @Shared
+    PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer()
+            .withDatabaseName("foo")
+            .withUsername("foo")
+            .withPassword("secret")
+
+    def "both containers are running"() {
+        expect:
+        postgreSQLContainer.isRunning()
+        mySQLContainer.isRunning()
+
+    }
+
+}

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/TestcontainersRestartBetweenTestsIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/TestcontainersRestartBetweenTestsIT.groovy
@@ -1,0 +1,31 @@
+package org.testcontainers.spock
+
+import org.testcontainers.containers.GenericContainer
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@Stepwise
+@Testcontainers
+class TestcontainersRestartBetweenTestsIT extends Specification {
+
+    GenericContainer genericContainer = new GenericContainer("httpd:2.4-alpine")
+            .withExposedPorts(80)
+
+    @Shared
+    String lastContainerId
+
+    def "retrieving first id"() {
+        when:
+        lastContainerId = genericContainer.containerId
+
+        then:
+        true
+    }
+
+    def "containers is recreated between tests"() {
+        expect:
+        genericContainer.containerId != lastContainerId
+    }
+
+}

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/TestcontainersSharedContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/TestcontainersSharedContainerIT.groovy
@@ -1,0 +1,47 @@
+package org.testcontainers.spock
+
+import org.apache.http.client.methods.CloseableHttpResponse
+import org.apache.http.client.methods.HttpGet
+import org.apache.http.impl.client.CloseableHttpClient
+import org.apache.http.impl.client.HttpClientBuilder
+import org.testcontainers.containers.GenericContainer
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+
+@Stepwise
+@Testcontainers
+class TestcontainersSharedContainerIT extends Specification {
+
+    @Shared
+    GenericContainer genericContainer = new GenericContainer("httpd:2.4-alpine")
+            .withExposedPorts(80)
+
+    @Shared
+    String lastContainerId
+
+    def "starts accessible docker container"() {
+        given: "a http client"
+        def client = HttpClientBuilder.create().build()
+        lastContainerId = genericContainer.containerId
+
+        when: "accessing web server"
+        CloseableHttpResponse response = performHttpRequest(client)
+
+        then: "docker container is running and returns http status code 200"
+        response.statusLine.statusCode == 200
+    }
+
+    def "containers keeps on running between features"() {
+        expect:
+        genericContainer.containerId == lastContainerId
+    }
+
+    private CloseableHttpResponse performHttpRequest(CloseableHttpClient client) {
+        String ip = genericContainer.containerIpAddress
+        String port = genericContainer.getMappedPort(80)
+        def response = client.execute(new HttpGet("http://$ip:$port"))
+        response
+    }
+
+}

--- a/modules/spock/src/test/resources/docker-compose.yml
+++ b/modules/spock/src/test/resources/docker-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  whoami:
+    image: emilevauge/whoami

--- a/modules/spock/src/test/resources/logback-test.xml
+++ b/modules/spock/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
This PR implements #566.

1. Extracts out JDBC Url manipulations to a separate class - ConnectionUrl.
2. Adds an overloaded method JdbcDatabaseContainerProvider.newInstance(ConnectionUrl), with default implementation delegating to the existing newInstance(tag) method. 
3. Adds an implementation of newInstance(ConnectionUrl) in MySQLContainerProvider to use Database Name, user, and password from JDBC URL while creating new Container.
4. Added/Updated Test cases for new functionality.
5. Bug Fix: Query Parameters are not used when a connection is created from a cached container. (see [this](https://github.com/testcontainers/testcontainers-java/pull/594#issuecomment-372830327) comment) Fixes #610  

**Note:** Other Containers Providers such as PostgreSQL will remain unaffected and continue to use earlier implementation of newInstance(tag) due to default delegation, until another implementation is provided.
