### PR TITLE
Support for WaitStrategy on DockerComposeContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Abstracted and changed database init script functionality to support use of SQL-like scripts with non-JDBC connections. ([\#551](https://github.com/testcontainers/testcontainers-java/pull/551))
 - Added `JdbcDatabaseContainer(Future)` constructor. ([\#543](https://github.com/testcontainers/testcontainers-java/issues/543))
 - Mark DockerMachineClientProviderStrategy as not persistable ([\#593](https://github.com/testcontainers/testcontainers-java/pull/593))
+- Added overloaded `withExposedService()` methods to `DockerComposeContainer` to allow user to define `WaitStrategy` for compose containers. ([\#174](https://github.com/testcontainers/testcontainers-java/issues/174) and [\#515](https://github.com/testcontainers/testcontainers-java/issues/515))
 
 ## [1.6.0] - 2018-01-28
 

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public interface Container<SELF extends Container<SELF>> extends LinkableContainer {
+public interface Container<SELF extends Container<SELF>> extends LinkableContainer, StartupTimeout {
 
     /**
      * @return a reference to this container instance, cast to the expected generic type.
@@ -280,15 +280,6 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @return this
      */
     SELF withClasspathResourceMapping(String resourcePath, String containerPath, BindMode mode, SelinuxContext selinuxContext);
-
-    /**
-     * Set the duration of waiting time until container treated as started.
-     * @see WaitStrategy#waitUntilReady(GenericContainer)
-     *
-     * @param startupTimeout timeout
-     * @return this
-     */
-    SELF withStartupTimeout(Duration startupTimeout);
 
     /**
      * Set the privilegedMode mode for the container

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -263,8 +263,9 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
 
     public SELF withExposedService(String serviceName, int servicePort, WaitStrategy waitStrategy) {
 
-        if (!serviceName.matches(".*_[0-9]+")) {
-            serviceName += "_1"; // implicit first instance of this service
+        String serviceInstanceName = serviceName;
+        if (!serviceInstanceName.matches(".*_[0-9]+")) {
+            serviceInstanceName += "_1"; // implicit first instance of this service
         }
 
         /*
@@ -283,15 +284,15 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
 
         // Ambassador container will be started together after docker compose has started
         int ambassadorPort = nextAmbassadorPort.getAndIncrement();
-        ambassadorPortMappings.computeIfAbsent(serviceName, __ -> new ConcurrentHashMap<>()).put(servicePort, ambassadorPort);
-        ambassadorContainer.withTarget(ambassadorPort, serviceName, servicePort);
-        ambassadorContainer.addLink(new FutureContainer(this.project + "_" + serviceName), serviceName);
+        ambassadorPortMappings.computeIfAbsent(serviceInstanceName, __ -> new ConcurrentHashMap<>()).put(servicePort, ambassadorPort);
+        ambassadorContainer.withTarget(ambassadorPort, serviceInstanceName, servicePort);
+        ambassadorContainer.addLink(new FutureContainer(this.project + "_" + serviceInstanceName), serviceInstanceName);
 
         /*
          * can have multiple wait strategies for a single container, e.g. if waiting on several ports
          * if no wait strategy is defined, the WaitAllStrategy will return immediately
          */
-        final WaitAllStrategy waitAllStrategy = waitStrategyMap.computeIfAbsent(serviceName, __ ->
+        final WaitAllStrategy waitAllStrategy = waitStrategyMap.computeIfAbsent(serviceInstanceName, __ ->
             (WaitAllStrategy) new WaitAllStrategy().withStartupTimeout(startupTimeout));
 
         if(waitStrategy != null) {

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainerInstance.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainerInstance.java
@@ -8,7 +8,13 @@ import org.testcontainers.containers.wait.WaitStrategy;
 import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 
 /**
  * Class to provide access to containers started through docker-compose

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainerInstance.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainerInstance.java
@@ -1,0 +1,132 @@
+package org.testcontainers.containers;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.*;
+import lombok.EqualsAndHashCode;
+import org.testcontainers.containers.wait.WaitStrategy;
+import org.testcontainers.images.RemoteDockerImage;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.*;
+
+/**
+ * Class to provide access to containers started through docker-compose
+ */
+@SuppressWarnings("ConstantConditions")
+@EqualsAndHashCode(callSuper = true)
+public class DockerComposeContainerInstance<SELF extends GenericContainer<SELF>> extends GenericContainer<SELF> {
+
+    private final Container container;
+    private final GenericContainer proxyContainer;
+    private Map<Integer, Integer> mappedPorts = new HashMap<>();
+
+    DockerComposeContainerInstance(Container container, GenericContainer proxyContainer,
+                                   Map<Integer, Integer> mappedPorts, WaitStrategy waitStrategy) {
+        this.container = container;
+        this.proxyContainer = proxyContainer;
+        if (mappedPorts != null) {
+            this.mappedPorts.putAll(mappedPorts);
+        }
+        if (waitStrategy != null) {
+            this.setWaitStrategy(waitStrategy);
+        }
+        this.setContainerProperties();
+    }
+
+    private void setContainerProperties() {
+        this.containerId = this.container.getId();
+        InspectContainerResponse containerInfo = dockerClient.inspectContainerCmd(this.containerId).exec();
+        this.setContainerInfo(containerInfo);
+        this.containerName = containerInfo.getName();
+        this.withExposedPorts(this.mappedPorts.keySet().toArray(new Integer[0]));
+        this.withCommand(this.container.getCommand());
+        this.withWorkingDirectory(containerInfo.getConfig().getWorkingDir());
+        this.withNetworkMode(containerInfo.getHostConfig().getNetworkMode());
+        this.setPrivilegedMode(containerInfo.getHostConfig().getPrivileged());
+        this.setImage();
+        this.setEnv();
+        this.setExtraHosts();
+        this.setNetworkProperties();
+        this.setPortBindings();
+        this.setBinds();
+        this.setVolumesFrom();
+    }
+
+    @Override
+    public void start() {
+        //container is started by docker compose, nothing to do
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Integer getMappedPort(int originalPort) {
+        return proxyContainer.getMappedPort(mappedPorts.get(originalPort));
+    }
+
+    private void setImage() {
+        String imageName = this.container.getImage();
+        try {
+            DockerImageName.validate(imageName);
+        } catch (IllegalArgumentException e) {
+            //if the image name does not have a label, used the latest label
+            imageName = String.format("%s:latest", imageName);
+        }
+
+        this.setImage(new RemoteDockerImage(imageName));
+    }
+
+    private void setEnv() {
+        final String[] env = this.getContainerInfo().getConfig().getEnv();
+        if (env != null) {
+            Arrays.stream(env)
+                .map(envVar -> envVar.split("="))
+                .forEach(pair -> this.addEnv(pair[0], pair[1]));
+        }
+    }
+
+    private void setExtraHosts() {
+        final String[] extraHosts = this.getContainerInfo().getHostConfig().getExtraHosts();
+        if (extraHosts != null) {
+            this.setExtraHosts(Arrays.asList(extraHosts));
+        }
+    }
+
+    private void setNetworkProperties() {
+        List<ContainerNetwork> networks = new ArrayList<>(this.getContainerInfo().getNetworkSettings().getNetworks().values());
+        final ContainerNetwork containerNetwork = networks.get(0);
+        if (containerNetwork.getAliases() != null) {
+            this.setNetworkAliases(containerNetwork.getAliases());
+        }
+
+        this.setNetwork(new Network.NetworkImpl(false, null, Collections.emptySet(), containerNetwork.getNetworkID()));
+    }
+
+    private void setPortBindings() {
+        List<String> portBindings = new ArrayList<>();
+        final Ports hostPortBindings = this.getContainerInfo().getHostConfig().getPortBindings();
+
+        for (Map.Entry<ExposedPort, Ports.Binding[]> binding : hostPortBindings.getBindings().entrySet()) {
+            for (Ports.Binding portBinding : binding.getValue()) {
+                portBindings.add(String.format("%s:%s", portBinding.toString(), binding.getKey()));
+            }
+        }
+        this.setPortBindings(portBindings);
+    }
+
+    private void setBinds() {
+        this.getContainerInfo().getMounts()
+            .forEach(mount -> this.withFileSystemBind(mount.getSource(), mount.getDestination().getPath(),
+                mount.getRW() ? BindMode.READ_WRITE : BindMode.READ_ONLY));
+    }
+
+    private void setVolumesFrom() {
+        final VolumesFrom[] volumesFrom = this.getContainerInfo().getHostConfig().getVolumesFrom();
+
+        if (volumesFrom != null) {
+            this.setVolumesFroms(Arrays.asList(volumesFrom));
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainerInstance.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainerInstance.java
@@ -2,7 +2,10 @@ package org.testcontainers.containers;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Container;
-import com.github.dockerjava.api.model.*;
+import com.github.dockerjava.api.model.ContainerNetwork;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.Ports;
+import com.github.dockerjava.api.model.VolumesFrom;
 import lombok.EqualsAndHashCode;
 import org.testcontainers.containers.wait.WaitStrategy;
 import org.testcontainers.images.RemoteDockerImage;

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -147,7 +147,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     protected WaitStrategy waitStrategy = Wait.defaultWaitStrategy();
 
     @Nullable
-    @Setter(AccessLevel.NONE)
+    @Setter(AccessLevel.PROTECTED)
     private InspectContainerResponse containerInfo;
 
     private List<Consumer<OutputFrame>> logConsumers = new ArrayList<>();

--- a/core/src/main/java/org/testcontainers/containers/StartupTimeout.java
+++ b/core/src/main/java/org/testcontainers/containers/StartupTimeout.java
@@ -1,0 +1,17 @@
+package org.testcontainers.containers;
+
+import org.testcontainers.containers.wait.WaitStrategy;
+
+import java.time.Duration;
+
+public interface StartupTimeout<SELF> {
+
+    /**
+     * Set the duration of waiting time until container treated as started.
+     * @see WaitStrategy#waitUntilReady(GenericContainer)
+     *
+     * @param startupTimeout timeout
+     * @return this
+     */
+    SELF withStartupTimeout(Duration startupTimeout);
+}

--- a/core/src/main/java/org/testcontainers/containers/wait/Wait.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/Wait.java
@@ -51,4 +51,15 @@ public class Wait {
         return forHttp(path)
                 .usingTls();
     }
+
+    /**
+     * Convenience method to return a WaitStrategy for log messages.
+     *
+     * @param regex the regex pattern to check for
+     * @param times the number of times the pattern is expected
+     * @return LogMessageWaitStrategy
+     */
+    public static LogMessageWaitStrategy forLogMessage(String regex, int times) {
+        return new LogMessageWaitStrategy().withRegEx(regex).withTimes(times);
+    }
 }

--- a/core/src/test/java/org/testcontainers/junit/BaseDockerComposeTest.java
+++ b/core/src/test/java/org/testcontainers/junit/BaseDockerComposeTest.java
@@ -1,9 +1,11 @@
 package org.testcontainers.junit;
 
 import com.github.dockerjava.api.model.Network;
-import org.jetbrains.annotations.NotNull;
-import org.junit.*;
-import org.rnorth.ducttape.unreliables.Unreliables;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.utility.TestEnvironment;
@@ -11,8 +13,6 @@ import redis.clients.jedis.Jedis;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.is;
@@ -75,14 +75,5 @@ public abstract class BaseDockerComposeTest {
         .map(Network::getName)
         .sorted()
         .collect(Collectors.toList());
-    }
-
-    @NotNull
-    private Callable<Boolean> getLivenessCheck(Jedis jedis) {
-        return () -> {
-            jedis.connect();
-            jedis.ping();
-            return true;
-        };
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/BaseDockerComposeTest.java
+++ b/core/src/test/java/org/testcontainers/junit/BaseDockerComposeTest.java
@@ -39,9 +39,6 @@ public abstract class BaseDockerComposeTest {
     public void simpleTest() {
         Jedis jedis = new Jedis(getEnvironment().getServiceHost("redis_1", REDIS_PORT), getEnvironment().getServicePort("redis_1", REDIS_PORT));
 
-        // TODO: remove following resolution of #160
-        Unreliables.retryUntilSuccess(10, TimeUnit.SECONDS, getLivenessCheck(jedis));
-
         jedis.incr("test");
         jedis.incr("test");
         jedis.incr("test");
@@ -53,9 +50,6 @@ public abstract class BaseDockerComposeTest {
     public void secondTest() {
         // used in manual checking for cleanup in between tests
         Jedis jedis = new Jedis(getEnvironment().getServiceHost("redis_1", REDIS_PORT), getEnvironment().getServicePort("redis_1", REDIS_PORT));
-
-        // TODO: remove following resolution of #160
-        Unreliables.retryUntilSuccess(10, TimeUnit.SECONDS, getLivenessCheck(jedis));
 
         jedis.incr("test");
         jedis.incr("test");

--- a/core/src/test/java/org/testcontainers/junit/DockerComposePassthroughTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposePassthroughTest.java
@@ -13,7 +13,7 @@ import java.io.File;
 
 import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.hasItem;
-import static org.rnorth.visibleassertions.VisibleAssertions.*;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertNotNull;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 
@@ -22,12 +22,12 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
  */
 public class DockerComposePassthroughTest {
 
+    private final TestWaitStrategy waitStrategy = new TestWaitStrategy();
+
     @BeforeClass
     public static void checkVersion() {
         Assume.assumeTrue(TestEnvironment.dockerApiAtLeast("1.22"));
     }
-
-    private final TestWaitStrategy waitStrategy = new TestWaitStrategy();
 
     @Rule
     public DockerComposeContainer compose =
@@ -63,10 +63,6 @@ public class DockerComposePassthroughTest {
      * Using a custom WaitStrategy to expose the reference for testability
      */
     class TestWaitStrategy extends HostPortWaitStrategy {
-
-        @Override
-        protected void waitUntilReady() {
-        }
 
         @SuppressWarnings("unchecked")
         public <SELF extends GenericContainer<SELF>> GenericContainer<SELF> getContainer() {

--- a/core/src/test/java/org/testcontainers/junit/DockerComposePassthroughTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposePassthroughTest.java
@@ -1,23 +1,21 @@
 package org.testcontainers.junit;
 
-import com.google.common.util.concurrent.Uninterruptibles;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.HostPortWaitStrategy;
 import org.testcontainers.utility.TestEnvironment;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.Socket;
-import java.util.concurrent.TimeUnit;
 
-import static org.rnorth.visibleassertions.VisibleAssertions.info;
-import static org.rnorth.visibleassertions.VisibleAssertions.pass;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.rnorth.visibleassertions.VisibleAssertions.*;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertNotNull;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 
 /**
  * Created by rnorth on 11/06/2016.
@@ -29,33 +27,50 @@ public class DockerComposePassthroughTest {
         Assume.assumeTrue(TestEnvironment.dockerApiAtLeast("1.22"));
     }
 
+    private final TestWaitStrategy waitStrategy = new TestWaitStrategy();
+
     @Rule
     public DockerComposeContainer compose =
-            new DockerComposeContainer(new File("src/test/resources/v2-compose-test-passthrough.yml"))
-                    .withEnv("foo", "bar")
-                    .withExposedService("alpine_1", 3000);
+        new DockerComposeContainer(new File("src/test/resources/v2-compose-test-passthrough.yml"))
+            .withEnv("foo", "bar")
+            .withExposedService("alpine_1", 3000, waitStrategy);
 
-    @Test(timeout = 30_000)
-    public void testEnvVar() throws IOException {
-        BufferedReader br = Unreliables.retryUntilSuccess(10, TimeUnit.SECONDS, () -> {
-            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
 
-            Socket socket = new Socket(compose.getServiceHost("alpine_1", 3000), compose.getServicePort("alpine_1", 3000));
-            return new BufferedReader(new InputStreamReader(socket.getInputStream()));
-        });
+    @Test
+    public <SELF extends GenericContainer<SELF>> void testContainerInstanceProperties() {
+        final GenericContainer<SELF> container = waitStrategy.getContainer();
 
-        Unreliables.retryUntilTrue(10, TimeUnit.SECONDS, () -> {
-            while (br.ready()) {
-                String line = br.readLine();
-                if (line.contains("bar=bar")) {
-                    pass("Mapped environment variable was found");
-                    return true;
-                }
-            }
-            info("Mapped environment variable was not found yet - process probably not ready");
-            Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
-            return false;
-        });
+        //check environment variable was set
+        assertEquals("Environment variable set correctly", "bar", container.getEnvMap().get("bar"));
 
+        //check other container properties
+        assertNotNull("Container id is not null", container.getContainerId());
+        assertThat("Container name", container.getContainerName(), endsWith("alpine_1"));
+        assertNotNull("Port mapped", container.getMappedPort(3000));
+        assertThat("Exposed Ports", container.getExposedPorts(), hasItem(3000));
+        assertEquals("Command is as expected", "/bin/sh -c /passthrough.sh", String.join(" ", container.getCommandParts()));
+        assertEquals("Working directory is as expected", "/", container.getWorkingDirectory());
+        assertNotNull("Network mode is set", container.getNetworkMode());
+        assertThat("Image name", container.getDockerImageName(), endsWith("alpine:latest"));
+        assertNotNull("Network is set", container.getNetwork().getId());
+        assertThat("Volume", container.getBinds().get(0).getVolume().getPath(), endsWith("/data"));
+        assertNotNull("Volumes From", container.getVolumesFroms().get(0).getContainer());
+
+    }
+
+    /*
+     * WaitStrategy is the only class that has access to the DockerComposeContainerInstance reference
+     * Using a custom WaitStrategy to expose the reference for testability
+     */
+    class TestWaitStrategy extends HostPortWaitStrategy {
+
+        @Override
+        protected void waitUntilReady() {
+        }
+
+        @SuppressWarnings("unchecked")
+        public <SELF extends GenericContainer<SELF>> GenericContainer<SELF> getContainer() {
+            return this.container;
+        }
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeWaitStrategyTest.java
@@ -1,0 +1,68 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.rnorth.ducttape.TimeoutException;
+import org.rnorth.visibleassertions.VisibleAssertions;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.wait.Wait;
+
+import java.io.File;
+import java.time.Duration;
+
+public class DockerComposeWaitStrategyTest {
+
+    private static final int REDIS_PORT = 6379;
+
+    @Test
+    public void testWaitOnListeningPort() {
+        final DockerComposeContainer environment = new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
+            .withExposedService("redis_1", REDIS_PORT, Wait.forListeningPort());
+
+        try {
+            environment.starting(Description.createTestDescription(Object.class, "name"));
+            VisibleAssertions.pass("Docker compose should start after waiting for listening port");
+        } catch (TimeoutException e) {
+            VisibleAssertions.fail("Docker compose should start after waiting for listening port with failed with: " + e);
+        }
+    }
+
+    @Test
+    public void testWaitOnMultipleStrategiesPassing() {
+        final DockerComposeContainer environment = new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
+            .withExposedService("redis_1", REDIS_PORT, Wait.forListeningPort())
+            .withExposedService("db_1", 3306, Wait.forLogMessage(".*ready for connections.*\\s", 1))
+            .withTailChildContainers(true);
+
+        try {
+            environment.starting(Description.createTestDescription(Object.class, "name"));
+            VisibleAssertions.pass("Docker compose should start after waiting for listening port");
+        } catch (TimeoutException e) {
+            VisibleAssertions.fail("Docker compose should start after waiting for listening port with failed with: " + e);
+        }
+    }
+
+    @Test
+    public void testWaitingFails() {
+        final DockerComposeContainer environment = new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
+            .withStartupTimeout(Duration.ofSeconds(10))
+            .withExposedService("redis_1", REDIS_PORT, Wait.forHttp("/test"));
+        VisibleAssertions.assertThrows("waiting on an invalid http path times out",
+            TimeoutException.class,
+            () -> environment.starting(Description.createTestDescription(Object.class, "name")));
+    }
+
+    @Test
+    public void testWaitOnOneOfMultipleStrategiesFailing() {
+        final DockerComposeContainer environment = new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
+            .withStartupTimeout(Duration.ofSeconds(10))
+            .withExposedService("redis_1", REDIS_PORT, Wait.forListeningPort())
+            .withExposedService("db_1", 3306, Wait.forLogMessage(".*test test test.*\\s", 1))
+            .withTailChildContainers(true);
+
+        VisibleAssertions.assertThrows("waiting on one failing strategy to time out",
+            TimeoutException.class,
+            () -> environment.starting(Description.createTestDescription(Object.class, "name")));
+    }
+
+}

--- a/core/src/test/resources/v2-compose-test-passthrough.yml
+++ b/core/src/test/resources/v2-compose-test-passthrough.yml
@@ -4,3 +4,15 @@ services:
     build: compose-dockerfile
     environment:
       bar: ${foo}
+    networks:
+      - test-net
+    working_dir: /
+    volumes_from:
+      - alpine2
+  alpine2:
+    build: compose-dockerfile
+    volumes:
+      - .:/data
+
+networks:
+  test-net:

--- a/docs/usage/docker_compose.md
+++ b/docs/usage/docker_compose.md
@@ -54,6 +54,54 @@ String redisUrl = environment.getServiceHost("redis_1", REDIS_PORT)
                   environment.getServicePort("redis_1", REDIS_PORT);
 ```
 
+## Startup timeout
+Ordinarily, Testcontainers waits for up to 60 seconds for all the exposed service ports to start listening.
+
+This simple measure provides a basic check whether a container is ready for use.
+
+If the default 60s timeout is not sufficient, it can be altered with the `withStartupTimeout()` method.
+The timeout specified by `withStartupTimeout()` applies to all docker-compose containers.
+
+There are overloaded `withExposedService` methods that take a `WaitStrategy` so you can specify a timeout strategy per container.
+
+
+### Waiting for startup examples
+
+Waiting for exposed port to start listening:
+```java
+@ClassRule
+public static DockerComposeContainer environment =
+    new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
+            .withStartupTimeout(Duration.ofSeconds(30))
+            .withExposedService("redis_1", REDIS_PORT, Wait.forListeningPort());
+```
+
+Wait for arbitrary status code on an HTTPS endpoint:
+```java
+@ClassRule
+public static DockerComposeContainer environment =
+    new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
+            .withStartupTimeout(Duration.ofSeconds(30))
+            .withExposedService("elasticsearch_1", ELASTICSEARCH_PORT, 
+                Wait.forHttp("/all")
+                    .forStatusCode(301)
+                    .usingTls());
+```
+
+Separate wait strategies for each container:
+```java
+@ClassRule
+public static DockerComposeContainer environment =
+    new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
+            .withStartupTimeout(Duration.ofSeconds(30))
+            .withExposedService("redis_1", REDIS_PORT, Wait.forListeningPort())
+            .withExposedService("elasticsearch_1", ELASTICSEARCH_PORT, 
+                Wait.forHttp("/all")
+                    .forStatusCode(301)
+                    .usingTls());
+```
+
+
 ## Using private repositories in Docker compose
 When Docker Compose is used in container mode (not local), it's needs to be made aware of Docker settings for private repositories. 
 By default, those setting are located in `$HOME/.docker/config.json`. 

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/ComposeContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/ComposeContainerIT.groovy
@@ -3,6 +3,7 @@ package org.testcontainers.spock
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClientBuilder
 import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.wait.Wait
 import spock.lang.Specification
 
 @Testcontainers
@@ -10,7 +11,7 @@ class ComposeContainerIT extends Specification {
 
     DockerComposeContainer composeContainer = new DockerComposeContainer(
             new File("src/test/resources/docker-compose.yml"))
-            .withExposedService("whoami_1", 80)
+            .withExposedService("whoami_1", 80, Wait.forHttp("/"))
 
     String host
 

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/SharedComposeContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/SharedComposeContainerIT.groovy
@@ -3,6 +3,7 @@ package org.testcontainers.spock
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClientBuilder
 import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.wait.Wait
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -12,7 +13,7 @@ class SharedComposeContainerIT extends Specification {
     @Shared
     DockerComposeContainer composeContainer = new DockerComposeContainer(
             new File("src/test/resources/docker-compose.yml"))
-            .withExposedService("whoami_1", 80)
+            .withExposedService("whoami_1", 80, Wait.forHttp("/"))
 
     String host
 


### PR DESCRIPTION
As discussed in #174 

@bsideup @kiview 
I think this probably requires a bit more work, but opening a PR to get your opinions on the approach, and see if you have any suggestions for improvement.

I've created a class `DockerComposeContainerInstance` which exposes containers created through Docker Compose and should behave consistently with regular `GenericContainers` after startup.

This should mean that any `WaitStrategy`, including customer user implementations. should work with `DockerComposeContainers`.

One concern I have is that with the current implementation, the `DockerComposeContainer` constructor returns as soon as the `SocatContainer` is available.
If users are waiting in their current tests through custom methods, it could now timeout instead of continuing if all exposed containers aren't available after 60 seconds.

The alternative is to keep the current implementation, but it is probably a better developer experience to apply a default `WaitStrategy` in most cases.

I'm also not sure about the same `DockerComposeContainerInstance`. Maybe `DockerComposeServiceContainer` would be better?