### PR TITLE
Shade commons io

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -51,6 +51,7 @@ shadowJar {
     [
         "org.apache.http",
         "org.apache.commons.lang",
+        "org.apache.commons.io",
         "org.glassfish",
         "org.aopalliance",
         "org.jvnet",
@@ -79,6 +80,7 @@ shadowJar {
         include(dependency('org.newsclub.*:.*'))
         include(dependency('org.zeroturnaround:zt-exec'))
         include(dependency('commons-lang:commons-lang'))
+        include(dependency('commons-io:commons-io'))
     }
 }
 
@@ -115,6 +117,7 @@ dependencies {
     shaded 'org.rnorth:tcp-unix-socket-proxy:1.0.1'
     shaded 'org.zeroturnaround:zt-exec:1.8'
     shaded 'commons-lang:commons-lang:2.6'
+    shaded 'commons-io:commons-io:2.5'
     // docker-java uses SslConfigurator from jersey-common for TLS
     shaded ('org.glassfish.jersey.core:jersey-common:2.23.1') {
         // SslConfigurator doesn't use classes from dependencies


### PR DESCRIPTION
Master fails with (as reported by @barrycommins):
```
java.lang.NoClassDefFoundError: org/apache/commons/io/output/TeeOutputStream

    at org.testcontainers.containers.LocalDockerCompose.invoke(DockerComposeContainer.java:515)
    at org.testcontainers.containers.DockerComposeContainer.runWithCompose(DockerComposeContainer.java:153)
    at org.testcontainers.containers.DockerComposeContainer.finished(DockerComposeContainer.java:205)
    at org.testcontainers.containers.FailureDetectingExternalResource$1.evaluate(FailureDetectingExternalResource.java:36)
    at org.testcontainers.containers.FailureDetectingExternalResource$1.evaluate(FailureDetectingExternalResource.java:30)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
    at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
    at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
    at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
    at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
    at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.io.output.TeeOutputStream
    at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
    ... 12 more
```

It seems that we shade `zt-exec` but not `commons-io` (transitive dependency)