### PR TITLE
Add DockerHealthcheckWaitStrategy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Deprecated `WaitStrategy` and implementations in favour of classes with same names in `org.testcontainers.containers.strategy` ([\#600](https://github.com/testcontainers/testcontainers-java/pull/600))
 - Added `ContainerState` interface representing the state of a started container ([\#600](https://github.com/testcontainers/testcontainers-java/pull/600))
 - Added `WaitStrategyTarget` interface which is the target of the new `WaitStrategy` ([\#600](https://github.com/testcontainers/testcontainers-java/pull/600))
+- Added `DockerHealthcheckWaitStrategy` that is based on Docker's built-in [healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck).
 
 ## [1.6.0] - 2018-01-28
 

--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -15,6 +15,8 @@ import java.util.stream.Collectors;
 
 public interface ContainerState {
 
+    String STATE_HEALTHY = "healthy";
+
     /**
      * Get the IP address that this container may be reached on (may not be the local machine).
      *
@@ -30,6 +32,17 @@ public interface ContainerState {
     default Boolean isRunning() {
         try {
             return getContainerId() != null && DockerClientFactory.instance().client().inspectContainerCmd(getContainerId()).exec().getState().getRunning();
+        } catch (DockerException e) {
+            return false;
+        }
+    }
+
+    /**
+     * @return has the container health state 'healthy'?
+     */
+    default Boolean isHealthy() {
+        try {
+            return getContainerId() != null && DockerClientFactory.instance().client().inspectContainerCmd(getContainerId()).exec().getState().getHealth().getStatus().equals(STATE_HEALTHY);
         } catch (DockerException e) {
             return false;
         }

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/DockerHealthcheckWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/DockerHealthcheckWaitStrategy.java
@@ -1,0 +1,25 @@
+package org.testcontainers.containers.wait.strategy;
+
+import org.rnorth.ducttape.TimeoutException;
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.containers.ContainerLaunchException;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wait strategy leveraging Docker's built-in healthcheck mechanism.
+ *
+ * @see <a href="https://docs.docker.com/engine/reference/builder/#healthcheck">https://docs.docker.com/engine/reference/builder/#healthcheck</a>
+ */
+public class DockerHealthcheckWaitStrategy extends AbstractWaitStrategy {
+
+    @Override
+    protected void waitUntilReady() {
+
+        try {
+            Unreliables.retryUntilTrue((int) startupTimeout.getSeconds(), TimeUnit.SECONDS, () -> waitStrategyTarget.isHealthy());
+        } catch (TimeoutException e) {
+            throw new ContainerLaunchException("Timed out waiting for container to become healthy");
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/Wait.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/Wait.java
@@ -61,4 +61,13 @@ public class Wait {
     public static LogMessageWaitStrategy forLogMessage(String regex, int times) {
         return new LogMessageWaitStrategy().withRegEx(regex).withTimes(times);
     }
+
+    /**
+     * Convenience method to return a WaitStrategy leveraging Docker's built-in healthcheck.
+     *
+     * @return DockerHealthcheckWaitStrategy
+     */
+    public static DockerHealthcheckWaitStrategy forHealthcheck() {
+        return new DockerHealthcheckWaitStrategy();
+    }
 }

--- a/core/src/test/java/org/testcontainers/containers/wait/strategy/DockerHealthcheckWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/strategy/DockerHealthcheckWaitStrategyTest.java
@@ -1,0 +1,36 @@
+package org.testcontainers.containers.wait.strategy;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.time.Duration;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertThrows;
+
+public class DockerHealthcheckWaitStrategyTest {
+
+    private GenericContainer container;
+
+    @Before
+    public void setUp() {
+        // Using a Dockerfile here, since Dockerfile builder DSL doesn't support HEALTHCHECK
+        container = new GenericContainer(new ImageFromDockerfile()
+            .withFileFromClasspath("write_file_and_loop.sh", "health-wait-strategy-dockerfile/write_file_and_loop.sh")
+            .withFileFromClasspath("Dockerfile", "health-wait-strategy-dockerfile/Dockerfile"))
+            .waitingFor(new DockerHealthcheckWaitStrategy().withStartupTimeout(Duration.ofSeconds(3)));
+    }
+
+    @Test
+    public void startsOnceHealthy() {
+        container.start();
+    }
+
+    @Test
+    public void containerStartFailsIfContainerIsUnhealthy() {
+        container.withCommand("ash");
+        assertThrows("Container launch fails when unhealthy", ContainerLaunchException.class, container::start);
+    }
+}

--- a/core/src/test/resources/health-wait-strategy-dockerfile/Dockerfile
+++ b/core/src/test/resources/health-wait-strategy-dockerfile/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+HEALTHCHECK --interval=1s CMD test -e /testfile
+
+ADD write_file_and_loop.sh write_file_and_loop.sh
+RUN chmod +x write_file_and_loop.sh
+
+CMD ["/write_file_and_loop.sh"]

--- a/core/src/test/resources/health-wait-strategy-dockerfile/write_file_and_loop.sh
+++ b/core/src/test/resources/health-wait-strategy-dockerfile/write_file_and_loop.sh
@@ -1,0 +1,8 @@
+#!/bin/ash
+
+echo sleeping
+sleep 2
+echo writing file
+touch /testfile
+
+while true; do sleep 1; done


### PR DESCRIPTION
Adds a DockerHealthcheckWaitStrategy that relies on the built-in Docker [healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck).

TBH I was not sure what's our current _template_ for creating `WaitStrategy` tests, so I tried to keep it as simple as possible. The `write_file_and_loop.sh` could surely be included into the Dockerfile `CMD`, but his way it seemed to be a bit easier for debugging purposes.

This PR also implicitly adds a `isHealthy()` method to the `ContainerState` interface.

Regarding backwards compatibility, I'm not sure how docker-java behaves if the health state is missing. docker-java itself documents to support it since Docker version 1.12.  