### PR TITLE
getServicePort on DockerComposeContainer throws NullPointerException if service instance number in not used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Fixed extraneous insertion of `useSSL=false` in all JDBC URL strings, even for DBs that do not understand it. Usage is now restricted to MySQL by default and can be overridden by authors of `JdbcDatabaseContainer` subclasses ([\#568](https://github.com/testcontainers/testcontainers-java/issues/568))
+- Fixed `getServicePort` on `DockerComposeContainer` throws NullPointerException if service instance number in not used. ([\#619](https://github.com/testcontainers/testcontainers-java/issues/619))
 
 ### Changed
 - Abstracted and changed database init script functionality to support use of SQL-like scripts with non-JDBC connections. ([\#551](https://github.com/testcontainers/testcontainers-java/pull/551))

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -352,7 +352,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
      * @return a port that can be used for accessing the service container.
      */
     public Integer getServicePort(String serviceName, Integer servicePort) {
-        return ambassadorContainer.getMappedPort(ambassadorPortMappings.get(serviceName).get(servicePort));
+        return ambassadorContainer.getMappedPort(ambassadorPortMappings.get(getServiceInstanceName(serviceName)).get(servicePort));
     }
 
     public SELF withScaledService(String serviceBaseName, int numInstances) {

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeContainerTest.java
@@ -1,9 +1,13 @@
 package org.testcontainers.junit;
 
 import org.junit.Rule;
+import org.junit.Test;
 import org.testcontainers.containers.DockerComposeContainer;
 
 import java.io.File;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertNotNull;
 
 /**
  * Created by rnorth on 08/08/2015.
@@ -19,5 +23,14 @@ public class DockerComposeContainerTest extends BaseDockerComposeTest {
     @Override
     protected DockerComposeContainer getEnvironment() {
         return environment;
+    }
+
+    @Test
+    public void testGetServicePort() {
+        int serviceWithInstancePort = environment.getServicePort("redis_1", REDIS_PORT);
+        assertNotNull("Port is set for service with instance number", serviceWithInstancePort);
+        int serviceWithoutInstancePort = environment.getServicePort("redis", REDIS_PORT);
+        assertNotNull("Port is set for service with instance number", serviceWithoutInstancePort);
+        assertEquals("Service ports are the same", serviceWithInstancePort, serviceWithoutInstancePort);
     }
 }


### PR DESCRIPTION
This is quite a minor one, but maybe worth fixing for consistency.

It is possible to expose a service in `DockerComposeContainer` without specifying the instance number:

```java
new DockerComposeContainer(new File("src/test/resources/compose-test.yml"))
        .withExposedService("redis", 6379)
```

but when you then call `getServicePort("redis", 6379)`, a `NullPointerException` is thrown.

It works ok with `getServicePort("redis_1", 6379)`
