### PR TITLE
Added withLogConsumer() method to DockerComposeContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Deprecated `WaitStrategy` and implementations in favour of classes with same names in `org.testcontainers.containers.strategy` ([\#600](https://github.com/testcontainers/testcontainers-java/pull/600))
 - Added `ContainerState` interface representing the state of a started container ([\#600](https://github.com/testcontainers/testcontainers-java/pull/600))
 - Added `WaitStrategyTarget` interface which is the target of the new `WaitStrategy` ([\#600](https://github.com/testcontainers/testcontainers-java/pull/600))
+- Added `withLogConsumer(String serviceName, Consumer<OutputFrame> consumer)` method to `DockerComposeContainer` ([\#605](https://github.com/testcontainers/testcontainers-java/issues/605))
 
 ## [1.6.0] - 2018-01-28
 

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeLogConsumerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeLogConsumerTest.java
@@ -20,7 +20,11 @@ public class DockerComposeLogConsumerTest {
             .withExposedService("redis_1", 6379)
             .withLogConsumer("redis_1", logConsumer);
 
-        environment.starting(Description.createTestDescription(Object.class, "name"));
-        logConsumer.waitUntil(frame -> frame.getType() == STDOUT && frame.getUtf8String().contains("Ready to accept connections"), 5, TimeUnit.SECONDS);
+        try {
+            environment.starting(Description.EMPTY);
+            logConsumer.waitUntil(frame -> frame.getType() == STDOUT && frame.getUtf8String().contains("Ready to accept connections"), 5, TimeUnit.SECONDS);
+        } finally {
+            environment.finished(Description.EMPTY);
+        }
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeLogConsumerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeLogConsumerTest.java
@@ -1,0 +1,26 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.output.WaitingConsumer;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.testcontainers.containers.output.OutputFrame.OutputType.STDOUT;
+
+public class DockerComposeLogConsumerTest {
+
+    @Test
+    public void testLogConsumer() throws TimeoutException {
+        WaitingConsumer logConsumer = new WaitingConsumer();
+        DockerComposeContainer environment = new DockerComposeContainer(new File("src/test/resources/v2-compose-test.yml"))
+            .withExposedService("redis_1", 6379)
+            .withLogConsumer("redis_1", logConsumer);
+
+        environment.starting(Description.createTestDescription(Object.class, "name"));
+        logConsumer.waitUntil(frame -> frame.getType() == STDOUT && frame.getUtf8String().contains("Ready to accept connections"), 5, TimeUnit.SECONDS);
+    }
+}


### PR DESCRIPTION
Added `withLogConsumer(String serviceName, Consumer<OutputFrame> consumer)` method to `DockerComposeContainer`

Fixes #605