### PR TITLE
implement MariaDBContainer#getDatabaseName

### DIFF
--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -52,6 +52,11 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
     }
 
     @Override
+    public String getDatabaseName() {
+    	return MARIADB_DATABASE;
+    }
+
+    @Override
     public String getUsername() {
         return MARIADB_USER;
     }


### PR DESCRIPTION
MariaDBContainer#getDatabaseName throws UnsupportedOperationException (
default from JdbcDatabaseContainer ). MySQL supports this method; thus
I do not see a reason why MariaDB should not.