### PR TITLE
Improve fluent builders

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/FixedHostPortGenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/FixedHostPortGenericContainer.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.NotNull;
  * <p>Callers are responsible for ensuring that this fixed port is actually available; failure will occur if it is
  * not available - which could manifest as flaky or unstable tests.</p>
  */
-public class FixedHostPortGenericContainer<SELF extends FixedHostPortGenericContainer<SELF>> extends GenericContainer<SELF> {
+public class FixedHostPortGenericContainer extends GenericContainer<FixedHostPortGenericContainer> {
     public FixedHostPortGenericContainer(@NotNull String dockerImageName) {
         super(dockerImageName);
     }
@@ -22,7 +22,7 @@ public class FixedHostPortGenericContainer<SELF extends FixedHostPortGenericCont
      * @param containerPort     a port in the container
      * @return                  this container
      */
-    public SELF withFixedExposedPort(int hostPort, int containerPort) {
+    public FixedHostPortGenericContainer withFixedExposedPort(int hostPort, int containerPort) {
 
         return withFixedExposedPort(hostPort, containerPort, InternetProtocol.TCP);
     }
@@ -34,7 +34,7 @@ public class FixedHostPortGenericContainer<SELF extends FixedHostPortGenericCont
      * @param protocol          an internet protocol (tcp or udp)
      * @return                  this container
      */
-    public SELF withFixedExposedPort(int hostPort, int containerPort, InternetProtocol protocol) {
+    public FixedHostPortGenericContainer withFixedExposedPort(int hostPort, int containerPort, InternetProtocol protocol) {
 
         super.addFixedExposedPort(hostPort, containerPort, protocol);
 

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/CustomizableMysqlTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/CustomizableMysqlTest.java
@@ -19,7 +19,7 @@ public class CustomizableMysqlTest {
 
     // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
     @Rule
-    public MySQLContainer mysql = (MySQLContainer) new MySQLContainer("mysql:5.5")
+    public MySQLContainer mysql = new MySQLContainer("mysql:5.5")
             .withDatabaseName(DB_NAME)
             .withUsername(USER)
             .withPassword(PWD)

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
@@ -45,7 +45,7 @@ public class SimpleMySQLTest {
 
     @Test
     public void testSimple() throws SQLException {
-        MySQLContainer mysql = (MySQLContainer) new MySQLContainer()
+        MySQLContainer mysql = new MySQLContainer()
                 .withConfigurationOverride("somepath/mysql_conf_override")
                 .withLogConsumer(new Slf4jLogConsumer(logger));
         mysql.start();
@@ -62,7 +62,7 @@ public class SimpleMySQLTest {
 
     @Test
     public void testSpecificVersion() throws SQLException {
-        MySQLContainer mysqlOldVersion = (MySQLContainer) new MySQLContainer("mysql:5.5")
+        MySQLContainer mysqlOldVersion = new MySQLContainer("mysql:5.5")
                 .withConfigurationOverride("somepath/mysql_conf_override")
                 .withLogConsumer(new Slf4jLogConsumer(logger));
         mysqlOldVersion.start();
@@ -96,7 +96,7 @@ public class SimpleMySQLTest {
 
     @Test
     public void testCommandOverride() throws SQLException {
-        MySQLContainer mysqlCustomConfig = (MySQLContainer) new MySQLContainer().withCommand("mysqld --auto_increment_increment=42");
+        MySQLContainer mysqlCustomConfig = new MySQLContainer().withCommand("mysqld --auto_increment_increment=42");
         mysqlCustomConfig.start();
 
         try {

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -5,7 +5,7 @@ package org.testcontainers.containers;
  *
  * @author Miguel Gonzalez Sanchez
  */
-public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MariaDBContainer extends  JdbcDatabaseContainer<MariaDBContainer> {
 
     public static final String NAME = "mariadb";
     public static final String IMAGE = "mariadb";
@@ -55,7 +55,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
 
     @Override
     public String getDatabaseName() {
-    	return MARIADB_DATABASE;
+        return MARIADB_DATABASE;
     }
 
     @Override
@@ -73,7 +73,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         return "SELECT 1";
     }
 
-    public SELF withConfigurationOverride(String s) {
+    public MariaDBContainer withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -8,7 +8,7 @@ import java.util.Set;
 /**
  * @author richardnorth
  */
-public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MySQLContainer extends JdbcDatabaseContainer<MySQLContainer> {
 
     public static final String NAME = "mysql";
     public static final String IMAGE = "mysql";
@@ -88,25 +88,25 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         return "SELECT 1";
     }
 
-    public SELF withConfigurationOverride(String s) {
+    public MySQLContainer withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public MySQLContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public MySQLContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MySQLContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -11,7 +11,7 @@ import java.util.Set;
 /**
  * @author richardnorth
  */
-public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer {
+public class NginxContainer extends GenericContainer<NginxContainer> implements LinkableContainer {
 
     private static final int NGINX_DEFAULT_PORT = 80;
 
@@ -39,7 +39,7 @@ public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericCo
         addFileSystemBind(htmlContentPath, "/usr/share/nginx/html", BindMode.READ_ONLY);
     }
 
-    public SELF withCustomContent(String htmlContentPath) {
+    public NginxContainer withCustomContent(String htmlContentPath) {
         this.setCustomContent(htmlContentPath);
         return self();
     }

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -21,7 +21,7 @@ public class SimpleNginxTest {
     private static File contentFolder = new File(System.getProperty("user.home") + "/.tmp-test-container");
 
     @Rule
-    public NginxContainer nginx = new NginxContainer<>()
+    public NginxContainer nginx = new NginxContainer()
             .withCustomContent(contentFolder.toString())
             .waitingFor(new HttpWaitStrategy());
 

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -5,7 +5,7 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 /**
  * @author gusohal
  */
-public class OracleContainer extends JdbcDatabaseContainer {
+public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     public static final String NAME = "oracle";
 

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -12,7 +12,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 /**
  * @author richardnorth
  */
-public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class PostgreSQLContainer extends JdbcDatabaseContainer<PostgreSQLContainer> {
     public static final String NAME = "postgresql";
     public static final String IMAGE = "postgres";
     public static final String DEFAULT_TAG = "9.6.8";
@@ -81,19 +81,19 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public PostgreSQLContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public PostgreSQLContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public PostgreSQLContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -33,7 +33,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  * <p>
  * The container should expose Selenium remote control protocol and VNC.
  */
-public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SELF>> extends GenericContainer<SELF> implements VncService, LinkableContainer {
+public class BrowserWebDriverContainer extends GenericContainer<BrowserWebDriverContainer> implements VncService, LinkableContainer {
 
     private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:%s";
     private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:%s";
@@ -84,7 +84,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     }
 
 
-    public SELF withDesiredCapabilities(DesiredCapabilities desiredCapabilities) {
+    public BrowserWebDriverContainer withDesiredCapabilities(DesiredCapabilities desiredCapabilities) {
         this.desiredCapabilities = desiredCapabilities;
         return self();
     }
@@ -266,18 +266,18 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
      */
     @Deprecated
-    public SELF withLinkToContainer(LinkableContainer otherContainer, String alias) {
+    public BrowserWebDriverContainer withLinkToContainer(LinkableContainer otherContainer, String alias) {
         addLink(otherContainer, alias);
         return self();
     }
 
-    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory) {
+    public BrowserWebDriverContainer withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory) {
         this.recordingMode = recordingMode;
         this.vncRecordingDirectory = vncRecordingDirectory;
         return self();
     }
 
-    public SELF withRecordingFileFactory(RecordingFileFactory recordingFileFactory) {
+    public BrowserWebDriverContainer withRecordingFileFactory(RecordingFileFactory recordingFileFactory) {
         this.recordingFileFactory = recordingFileFactory;
         return self();
     }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
@@ -16,7 +16,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 public class CustomWaitTimeoutWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Rule
-    public BrowserWebDriverContainer chromeWithCustomTimeout = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer chromeWithCustomTimeout = new BrowserWebDriverContainer()
             .withDesiredCapabilities(DesiredCapabilities.chrome())
             .withStartupTimeout(Duration.of(30, SECONDS));
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
@@ -27,13 +27,13 @@ public class LinkedContainerTest {
     public Network network = Network.newNetwork();
 
     @Rule
-    public NginxContainer nginx = new NginxContainer<>()
+    public NginxContainer nginx = new NginxContainer()
             .withNetwork(network)
             .withNetworkAliases("nginx")
             .withCustomContent(contentFolder.toString());
 
     @Rule
-    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
             .withNetwork(network)
             .withDesiredCapabilities(DesiredCapabilities.chrome());
 

--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -21,7 +21,7 @@ import static com.github.dockerjava.api.model.Capability.IPC_LOCK;
  *
  * Other helpful features include the withVaultPort, and withVaultToken methods for convenience.
  */
-public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericContainer<SELF>
+public class VaultContainer extends GenericContainer<VaultContainer>
         implements LinkableContainer {
 
     private static final String VAULT_PORT = "8200";
@@ -78,7 +78,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param token the root token value to set for Vault.
      * @return this
      */
-    public SELF withVaultToken(String token) {
+    public VaultContainer withVaultToken(String token) {
         withEnv("VAULT_DEV_ROOT_TOKEN_ID", token);
         withEnv("VAULT_TOKEN", token);
         return self();
@@ -90,7 +90,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param port the port number you want to have the Vault container listen on for tests.
      * @return this
      */
-    public SELF withVaultPort(int port){
+    public VaultContainer withVaultPort(int port){
         setVaultPortRequested(true);
         String vaultPort = String.valueOf(port);
         withEnv("VAULT_ADDR", "http://0.0.0.0:" + VAULT_PORT);
@@ -110,7 +110,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param remainingSecrets var args list of secrets to add to specified path
      * @return this
      */
-    public SELF withSecretInVault(String path, String firstSecret, String... remainingSecrets) {
+    public VaultContainer withSecretInVault(String path, String firstSecret, String... remainingSecrets) {
         List<String> list = new ArrayList<>();
         list.add(firstSecret);
         for(String secret : remainingSecrets) {

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
@@ -23,7 +23,7 @@ public class VaultContainerTest {
     private static final String VAULT_TOKEN = "my-root-token";
 
     @ClassRule
-    public static VaultContainer vaultContainer = new VaultContainer<>()
+    public static VaultContainer vaultContainer = new VaultContainer()
             .withVaultToken(VAULT_TOKEN)
             .withVaultPort(VAULT_PORT)
             .withSecretInVault("secret/testing1", "top_secret=password123")


### PR DESCRIPTION
Currently many containers (JDBC based, Nginx, Vault) are not very great as fluent builders. They are all parametrized, that means the user has to instance them with the sqare brackets to denote the type.
That's not intuitive, and the Testcontainers docs don't mention it anywhere. Moreover, the compiler still complains about raw types, because we can't declare a container variable parametrized by itself.

If we don't parametrize the container, than we can't invoke the methods of `GenericContainer` without losing the call chain. The compiler doesn't know about the concrete type of the builder. For example,
for `MySQLContainer` this causes a compiler error:

```java
public MySQLContainer mySQLContainer = new MySQLContainer("mysql:5.7")
        .withClasspathResourceMapping("/mysql-initdb", "/docker-entrypoint-initdb.d", BindMode.READ_ONLY)
        .withDatabaseName("test-warehouse");
```

A solution is not to parametrize concrete containers and let the type propagate to `GenericContainer`.