### PR TITLE
Remove invalid characters in ClassRule annotation

### DIFF
--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -124,7 +124,7 @@ public static GenericContainer elasticsearch =
 
 If the used image supports Docker's [Healthcheck](https://docs.docker.com/engine/reference/builder/#healthcheck) feature, you can directly leverage the `healthy` state of the container as your wait condition:
 ```java
-@ClassRule2.32.3
+@ClassRule
 public static GenericContainer container =
     new GenericContainer("image-with-healthcheck:4.2")
                .waitingFor(Wait.forHealthcheck());


### PR DESCRIPTION
The classRule annotation cannot contain characters at the end. It will give the user a compile error.