### PR TITLE
Update commons-compress to 1.16.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     compile 'org.jetbrains:annotations:15.0'
     compile 'javax.annotation:javax.annotation-api:1.3.1'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
-    compile 'org.apache.commons:commons-compress:1.15'
+    compile 'org.apache.commons:commons-compress:1.16.1'
     // Added for JDK9 compatibility since it's missing this package
     compile 'javax.xml.bind:jaxb-api:2.3.0'
     compile ('org.rnorth.duct-tape:duct-tape:1.0.7') {


### PR DESCRIPTION
While it shouldn't affect any users of testcontainers, commons-compress has [CVE-2018-1324](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-1324). Bumping to the latest fixes the CVE (and all tests pass).