### PR TITLE
Fixed provided but shaded dependencies in modules by configuring a global shading rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 ### Fixed
 - Fix for setting `ryuk.container.timeout` causes a `ClassCastException` ([\#684](https://github.com/testcontainers/testcontainers-java/issues/684))
+- Fixed provided but shaded dependencies in modules ([\#693](https://github.com/testcontainers/testcontainers-java/issues/693))
 
 ### Changed
 

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'idea'
     apply plugin: 'io.franzbecker.gradle-lombok'
+    apply plugin: 'com.github.johnrengelman.shadow'
     apply from: "$rootDir/gradle/publishing.gradle"
     apply from: "$rootDir/gradle/bintray.gradle"
 
@@ -47,6 +48,42 @@ subprojects {
 
     repositories {
         jcenter()
+    }
+
+    shadowJar {
+        configurations = []
+        classifier = null
+
+        relocate('META-INF/native/libnetty', 'META-INF/native/liborg-testcontainers-shaded-netty')
+
+        [
+            "org.apache.http",
+            "org.apache.commons.lang",
+            "org.apache.commons.io",
+            "org.apache.commons.codec",
+            "org.glassfish",
+            "org.aopalliance",
+            "org.jvnet",
+            "javax.annotation",
+            "javax.inject",
+            "javax.ws.rs",
+            "com.fasterxml.jackson",
+            "jersey.repackaged",
+            "com.google",
+            "io.netty",
+            "org.bouncycastle",
+            "org.newsclub",
+            "org.zeroturnaround"
+        ].each { relocate(it, "org.testcontainers.shaded.$it") }
+    }
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) { publication ->
+                artifacts.removeAll { it.classifier == null }
+                artifact project.tasks.shadowJar
+            }
+        }
     }
 
     dependencies {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -2,15 +2,6 @@ apply plugin: 'com.github.johnrengelman.shadow'
 
 description = "Testcontainers Core"
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) { publication ->
-            artifacts.removeAll { it.classifier == null }
-            artifact project.tasks.shadowJar
-        }
-    }
-}
-
 sourceSets {
     jarFileTest
 }
@@ -24,7 +15,6 @@ configurations {
 
 shadowJar {
     configurations = [project.configurations.shaded]
-    classifier = null
 
     mergeServiceFiles()
 
@@ -45,28 +35,6 @@ shadowJar {
         'META-INF/services/org.glassfish.jersey.internal.spi.*',
         'mozilla/public-suffix-list.txt',
     ].each { exclude(it) }
-
-    relocate('META-INF/native/libnetty', 'META-INF/native/liborg-testcontainers-shaded-netty')
-
-    [
-        "org.apache.http",
-        "org.apache.commons.lang",
-        "org.apache.commons.io",
-        "org.apache.commons.codec",
-        "org.glassfish",
-        "org.aopalliance",
-        "org.jvnet",
-        "javax.annotation",
-        "javax.inject",
-        "javax.ws.rs",
-        "com.fasterxml.jackson",
-        "jersey.repackaged",
-        "com.google",
-        "io.netty",
-        "org.bouncycastle",
-        "org.newsclub",
-        "org.zeroturnaround"
-    ].each { relocate(it, "org.testcontainers.shaded.$it") }
 
     dependencies {
         include(dependency('org.apache.httpcomponents:.*'))


### PR DESCRIPTION
Fixes #656

Background:
Some modules were using shaded dependencies of `core` without doing the relocation.
This change will ensure that every module is using the same package as `core` to avoid it in future