### PR TITLE
Allow testcontainers to have custom labels

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -80,6 +80,15 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     void addEnv(String key, String value);
 
     /**
+     * Add a label to the container. Consider using {@link #withLabel(String, String)}
+     * for build a container in a fluent style.
+     *
+     * @param key   label key
+     * @param value label value
+     */
+    void addLabel(String key, String value);
+
+    /**
      * Adds a file system binding. Consider using {@link #withFileSystemBind(String, String, BindMode)}
      * for building a container in a fluent style.
      *
@@ -203,6 +212,22 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @return this
      */
     SELF withEnv(Map<String, String> env);
+
+    /**
+     * Add a label to the container.
+     *
+     * @param key   label key
+     * @param value label value
+     * @return this
+     */
+    SELF withLabel(String key, String value);
+
+    /**
+     * Add labels to the container.
+     * @param labels map of labels
+     * @return this
+     */
+    SELF withLabels(Map<String, String> labels);
 
     /**
      * Set the command that should be run in the container

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -80,15 +80,6 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     void addEnv(String key, String value);
 
     /**
-     * Add a label to the container. Consider using {@link #withLabel(String, String)}
-     * for build a container in a fluent style.
-     *
-     * @param key   label key
-     * @param value label value
-     */
-    void addLabel(String key, String value);
-
-    /**
      * Adds a file system binding. Consider using {@link #withFileSystemBind(String, String, BindMode)}
      * for building a container in a fluent style.
      *

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -473,11 +473,15 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
         createContainerCmdModifiers.forEach(hook -> hook.accept(createCommand));
 
-        Map<String, String> labels = createCommand.getLabels();
-        labels = new HashMap<>(labels != null ? labels : Collections.emptyMap());
-        labels.putAll(DockerClientFactory.DEFAULT_LABELS);
-        labels.putAll(this.labels);
-        createCommand.withLabels(labels);
+        Map<String, String> createCommandLabels = createCommand.getLabels();
+        createCommandLabels = new HashMap<>(createCommandLabels != null ? createCommandLabels : Collections.emptyMap());
+
+        Map<String, String> combinedLabels = new HashMap<>();
+        combinedLabels.putAll(labels);
+        combinedLabels.putAll(DockerClientFactory.DEFAULT_LABELS);
+        combinedLabels.putAll(createCommandLabels);
+
+        createCommand.withLabels(combinedLabels);
     }
 
     private Set<Link> findLinksFromThisContainer(String alias, LinkableContainer linkableContainer) {

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -111,6 +111,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     private Map<String, String> env = new HashMap<>();
 
     @NonNull
+    private Map<String, String> labels = new HashMap<>();
+
+    @NonNull
     private String[] commandParts = new String[0];
 
     @NonNull
@@ -473,6 +476,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         Map<String, String> labels = createCommand.getLabels();
         labels = new HashMap<>(labels != null ? labels : Collections.emptyMap());
         labels.putAll(DockerClientFactory.DEFAULT_LABELS);
+        labels.putAll(this.labels);
         createCommand.withLabels(labels);
     }
 
@@ -578,6 +582,14 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public void addEnv(String key, String value) {
         env.put(key, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addLabel(String key, String value) {
+        labels.put(key, value);
     }
 
     /**
@@ -697,6 +709,24 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withEnv(Map<String, String> env) {
         env.forEach(this::addEnv);
+        return self();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SELF withLabel(String key, String value) {
+        this.addLabel(key, value);
+        return self();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SELF withLabels(Map<String, String> labels) {
+        labels.forEach(this::addLabel);
         return self();
     }
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -592,17 +592,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * {@inheritDoc}
      */
     @Override
-    public void addLabel(String key, String value) throws IllegalArgumentException {
-        if (key.startsWith("org.testcontainers")) {
-            throw new IllegalArgumentException("The org.testcontainers namespace is reserved for interal use");
-        }
-        labels.put(key, value);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void addFileSystemBind(final String hostPath, final String containerPath, final BindMode mode, final SelinuxContext selinuxContext) {
 
         final MountableFile mountableFile = MountableFile.forHostPath(hostPath);
@@ -724,7 +713,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      */
     @Override
     public SELF withLabel(String key, String value) {
-        this.addLabel(key, value);
+        if (key.startsWith("org.testcontainers")) {
+            throw new IllegalArgumentException("The org.testcontainers namespace is reserved for interal use");
+        }
+        labels.put(key, value);
         return self();
     }
 
@@ -733,7 +725,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      */
     @Override
     public SELF withLabels(Map<String, String> labels) {
-        labels.forEach(this::addLabel);
+        labels.forEach(this::withLabel);
         return self();
     }
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -588,7 +588,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * {@inheritDoc}
      */
     @Override
-    public void addLabel(String key, String value) {
+    public void addLabel(String key, String value) throws IllegalArgumentException {
+        if (key.startsWith("org.testcontainers")) {
+            throw new IllegalArgumentException("The org.testcontainers namespace is reserved for interal use");
+        }
         labels.put(key, value);
     }
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -473,13 +473,12 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
         createContainerCmdModifiers.forEach(hook -> hook.accept(createCommand));
 
-        Map<String, String> createCommandLabels = createCommand.getLabels();
-        createCommandLabels = new HashMap<>(createCommandLabels != null ? createCommandLabels : Collections.emptyMap());
-
         Map<String, String> combinedLabels = new HashMap<>();
         combinedLabels.putAll(labels);
+        if (createCommand.getLabels() != null) {
+            combinedLabels.putAll(createCommand.getLabels());
+        }
         combinedLabels.putAll(DockerClientFactory.DEFAULT_LABELS);
-        combinedLabels.putAll(createCommandLabels);
 
         createCommand.withLabels(combinedLabels);
     }

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -238,7 +238,7 @@ public class GenericContainerRuleTest {
 
     @Test
     public void exceptionThrownWhenTryingToOverrideTestcontainersLabels() {
-        assertThrows("When trying to overwrite an 'org.testcontaienrs' label, withLabel() throws an exception",
+        assertThrows("When trying to overwrite an 'org.testcontainers' label, withLabel() throws an exception",
             IllegalArgumentException.class,
             () -> {
                 new GenericContainer("alpine:3.2")

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -128,15 +128,6 @@ public class GenericContainerRuleTest {
             .withExtraHost("somehost", "192.168.1.10")
             .withCommand("/bin/sh", "-c", "while true; do cat /etc/hosts | nc -l -p 80; done");
 
-    /**
-     * Create a container with a custom label for testing.
-     */
-    @ClassRule
-    public static GenericContainer alpineCustomLabel = new GenericContainer("alpine:3.2")
-            .withExposedPorts(80)
-            .withLabel("our.custom", "label")
-            .withCommand("/bin/sh", "-c", "while true; do cat /etc/hosts | nc -l -p 80; done");
-
 //    @Test
 //    public void simpleRedisTest() {
 //        String ipAddress = redis.getContainerIpAddress();
@@ -232,10 +223,28 @@ public class GenericContainerRuleTest {
 
     @Test
     public void customLabelTest() {
-        Map<String, String> labels = alpineCustomLabel.getCurrentContainerInfo().getConfig().getLabels();
-        assertTrue("org.testcontainers label is present", labels.containsKey("org.testcontainers"));
-        assertTrue("our.custom label is present", labels.containsKey("our.custom"));
-        assertEquals("our.custom label value is label", labels.get("our.custom"), "label");
+        try (final GenericContainer alpineCustomLabel = new GenericContainer("alpine:3.2")
+            .withLabel("our.custom", "label")
+            .withCommand("top")) {
+
+            alpineCustomLabel.start();
+
+            Map<String, String> labels = alpineCustomLabel.getCurrentContainerInfo().getConfig().getLabels();
+            assertTrue("org.testcontainers label is present", labels.containsKey("org.testcontainers"));
+            assertTrue("our.custom label is present", labels.containsKey("our.custom"));
+            assertEquals("our.custom label value is label", labels.get("our.custom"), "label");
+        }
+    }
+
+    @Test
+    public void exceptionThrownWhenTryingToOverrideTestcontainersLabels() {
+        assertThrows("When trying to overwrite an 'org.testcontaienrs' label, withLabel() throws an exception",
+            IllegalArgumentException.class,
+            () -> {
+                new GenericContainer("alpine:3.2")
+                    .withLabel("org.testcontainers.foo", "false");
+            }
+        );
     }
 
     @Test

--- a/docs/usage/generic_containers.md
+++ b/docs/usage/generic_containers.md
@@ -23,15 +23,12 @@ public static GenericContainer redis =
 
 // Set up a plain OS container and customize environment, 
 //   command and exposed ports. This just listens on port 80 
-//   and always returns '42'.
-//   The container will have a custom label named 'our.custom'
-//   with a value 'label'.
+//   and always returns '42'
 @ClassRule
 public static GenericContainer alpine =
 	new GenericContainer("alpine:3.2")
     		.withExposedPorts(80)
                .withEnv("MAGIC_NUMBER", "42")
-               .withLabel("our.custom", "label")
                .withCommand("/bin/sh", "-c", 
                "while true; do echo \"$MAGIC_NUMBER\" | nc -l -p 80; done");
 ```

--- a/docs/usage/generic_containers.md
+++ b/docs/usage/generic_containers.md
@@ -23,12 +23,15 @@ public static GenericContainer redis =
 
 // Set up a plain OS container and customize environment, 
 //   command and exposed ports. This just listens on port 80 
-//   and always returns '42'
+//   and always returns '42'.
+//   The container will have a custom label named 'our.custom'
+//   with a value 'label'.
 @ClassRule
 public static GenericContainer alpine =
 	new GenericContainer("alpine:3.2")
     		.withExposedPorts(80)
                .withEnv("MAGIC_NUMBER", "42")
+               .withLabel("our.custom", "label")
                .withCommand("/bin/sh", "-c", 
                "while true; do echo \"$MAGIC_NUMBER\" | nc -l -p 80; done");
 ```

--- a/docs/usage/options.md
+++ b/docs/usage/options.md
@@ -29,6 +29,14 @@ new GenericContainer(...)
 		.withEnv("API_TOKEN", "foo")
 ```
 
+### Labels
+
+To add a custom label to the container, use `withLabel`:
+```java
+new GenericContainer(...)
+        .withLabel("your.custom", "label")
+```
+
 ### Command
 
 By default the container will execute whatever command is specified in the image's Dockerfile. To override this, and specify a different command, use `withCommand`:


### PR DESCRIPTION
This may be useful for tools such as traefik which use docker labels for configuration