### PR TITLE
Add additional constructor to OracleContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - New module: Apache Pulsar ([\#713](https://github.com/testcontainers/testcontainers-java/pull/713))
 - Add support for defining container labels ([\#725](https://github.com/testcontainers/testcontainers-java/pull/725))
 - Use `quay.io/testcontainers/ryuk` instead of `bsideup/ryuk` ([\#721](https://github.com/testcontainers/testcontainers-java/pull/721))
+- Add support for 'bring your own' (build from Dockerfile) Oracle images in OracleContainer ([\#734](https://github.com/testcontainers/testcontainers-java/pull/734))
 
 ## [1.7.3] - 2018-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - Add support for defining container labels ([\#725](https://github.com/testcontainers/testcontainers-java/pull/725))
 - Use `quay.io/testcontainers/ryuk` instead of `bsideup/ryuk` ([\#721](https://github.com/testcontainers/testcontainers-java/pull/721))
 - Added Couchbase module ([\#688](https://github.com/testcontainers/testcontainers-java/pull/688))
-- Add support for 'bring your own' (build from Dockerfile) Oracle images in OracleContainer ([\#734](https://github.com/testcontainers/testcontainers-java/pull/734))
+- Add support for Dockerfile based images to OracleContainer ([\#734](https://github.com/testcontainers/testcontainers-java/pull/734))
 
 ## [1.7.3] - 2018-05-16
 

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -2,6 +2,8 @@ package org.testcontainers.containers;
 
 import org.testcontainers.utility.TestcontainersConfiguration;
 
+import java.util.concurrent.Future;
+
 /**
  * @author gusohal
  */
@@ -29,6 +31,10 @@ public class OracleContainer extends JdbcDatabaseContainer {
     }
 
     public OracleContainer(String dockerImageName) {
+        super(dockerImageName);
+    }
+
+    public OracleContainer(Future<String> dockerImageName) {
         super(dockerImageName);
     }
 


### PR DESCRIPTION
This makes it possible to use an container based on a Dockerfile instead of a published image