### PR TITLE
 Make JdbcDatabaseContainer#getDriverClassName public

### DIFF
--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
@@ -110,9 +110,28 @@ public class SimpleMySQLTest {
 
     }
 
+    @Test
+    public void testMySQL8() throws SQLException {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+        MySQLContainer container = new MySQLContainer<>("mysql:8.0.11")
+            .withCommand("mysqld --default-authentication-plugin=mysql_native_password");
+        container.start();
+
+        try {
+            ResultSet resultSet = performQuery(container, "SELECT VERSION()");
+            String resultSetString = resultSet.getString(1);
+
+            assertTrue("The database version can be set using a container rule parameter", "8.0.11".equals(resultSetString));
+        }
+        finally {
+            container.stop();
+        }
+    }
+
     @NonNull
     protected ResultSet performQuery(MySQLContainer containerRule, String sql) throws SQLException {
         HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setDriverClassName(containerRule.getDriverClassName());
         hikariConfig.setJdbcUrl(containerRule.getJdbcUrl());
         hikariConfig.setUsername(containerRule.getUsername());
         hikariConfig.setPassword(containerRule.getPassword());

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -47,7 +47,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     /**
      * @return the name of the actual JDBC driver to use
      */
-    protected abstract String getDriverClassName();
+    public abstract String getDriverClassName();
 
     /**
      * @return a JDBC URL that may be used to connect to the dockerized DB


### PR DESCRIPTION
There are use cases which require configuring the actual JDBC `driverClassName` on `DataSource` pool implementation. One such example that I ran into recently is using a HikariCP pool with MySQL 8 Testcontainer (related #736).

This PR changes the visibility of `JdbcDatabaseContainer#getDriverClassName` method to `public`. With this change, the `driverClassName` of the container can be reused when configuring the `DataSource`, rather than having to manually specify it.

There's an additional commit that adds a test to demonstrate the described problem - without setting `driverClassName` on `HikariConfig` this test fails (due to wrong driver being used implicitly) with the following stacktrace:

```
com.zaxxer.hikari.pool.PoolInitializationException: Exception during pool initialization

	at com.zaxxer.hikari.pool.BaseHikariPool.initializeConnections(BaseHikariPool.java:544)
	at com.zaxxer.hikari.pool.BaseHikariPool.<init>(BaseHikariPool.java:171)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:60)
	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:48)
	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:80)
	at org.testcontainers.junit.SimpleMySQLTest.performQuery(SimpleMySQLTest.java:139)
	at org.testcontainers.junit.SimpleMySQLTest.testMySQL8(SimpleMySQLTest.java:121)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:68)
	at com.intellij.rt.execution.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:47)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:242)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:70)
Caused by: java.sql.SQLException: Unknown system variable 'tx_isolation'
Query is : SELECT @@tx_isolation
	at org.mariadb.jdbc.internal.util.ExceptionMapper.get(ExceptionMapper.java:136)
	at org.mariadb.jdbc.internal.util.ExceptionMapper.throwException(ExceptionMapper.java:69)
	at org.mariadb.jdbc.MariaDbStatement.executeQueryEpilog(MariaDbStatement.java:242)
	at org.mariadb.jdbc.MariaDbStatement.executeInternal(MariaDbStatement.java:270)
	at org.mariadb.jdbc.MariaDbStatement.executeQuery(MariaDbStatement.java:383)
	at org.mariadb.jdbc.MariaDbConnection.getTransactionIsolation(MariaDbConnection.java:767)
	at com.zaxxer.hikari.pool.BaseHikariPool.addConnection(BaseHikariPool.java:446)
	at com.zaxxer.hikari.pool.BaseHikariPool.initializeConnections(BaseHikariPool.java:542)
	... 28 more
Caused by: org.mariadb.jdbc.internal.util.dao.QueryException: Unknown system variable 'tx_isolation'
Query is : SELECT @@tx_isolation
	at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.getResult(AbstractQueryProtocol.java:939)
	at org.mariadb.jdbc.internal.protocol.AbstractQueryProtocol.executeQuery(AbstractQueryProtocol.java:604)
	at org.mariadb.jdbc.MariaDbStatement.executeInternal(MariaDbStatement.java:261)
	... 32 more
```