### PR TITLE
Use latest tag as default if no tag is specified

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -45,7 +45,7 @@ public final class DockerImageName {
             versioning = new TagVersioning(remoteName.split(":")[1]);
         } else {
             repo = remoteName;
-            versioning = null;
+            versioning = new TagVersioning("latest");
         }
     }
 

--- a/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
@@ -16,6 +16,7 @@ public class ImagePullTest {
         return new String[] {
             "alpine:latest",
             "alpine:3.6",
+            "alpine", // omitting the tag should work and default to latest
             "alpine@sha256:8fd4b76819e1e5baac82bd0a3d03abfe3906e034cc5ee32100d12aaaf3956dc7",
             "gliderlabs/alpine:latest",
             "gliderlabs/alpine:3.5",

--- a/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
@@ -24,7 +24,6 @@ public class DockerImageNameTest {
 
     @Test
     public void invalidNames() {
-        testInvalid("myname");
         testInvalid(":latest");
         testInvalid("/myname:latest");
         testInvalid("/myname@sha256:latest");


### PR DESCRIPTION
An alternative would be to throw an error since I don't see a case, where setting the versioning to `null` makes sense?

Fixes #676 