### PR TITLE
Added builder for timeouts in JdbcDatabaseContainer (#715)

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -213,14 +213,18 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
 
     /**
      * @return startup time to allow, including image pull time, in seconds
+     * @deprecated should not be overridden anymore, use {@link #withStartupTimeoutSeconds(int)} in constructor instead
      */
+    @Deprecated
     protected int getStartupTimeoutSeconds() {
         return startupTimeoutSeconds;
     }
 
     /**
      * @return time to allow for the database to start and establish an initial connection, in seconds
+     * @deprecated should not be overridden anymore, use {@link #withConnectTimeoutSeconds(int)} in constructor instead
      */
+    @Deprecated
     protected int getConnectTimeoutSeconds() {
         return connectTimeoutSeconds;
     }

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -33,6 +33,9 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
         .withConstantThroughput()
         .build();
 
+    private int startupTimeoutSeconds = 120;
+    private int connectTimeoutSeconds = 120;
+
     public JdbcDatabaseContainer(@NonNull final String dockerImageName) {
         super(dockerImageName);
     }
@@ -84,6 +87,28 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     public SELF withDatabaseName(String dbName) {
         throw new UnsupportedOperationException();
 
+    }
+
+    /**
+     * Set startup time to allow, including image pull time, in seconds.
+     *
+     * @param startupTimeoutSeconds startup time to allow, including image pull time, in seconds
+     * @return self
+     */
+    public SELF withStartupTimeoutSeconds(int startupTimeoutSeconds) {
+        this.startupTimeoutSeconds = startupTimeoutSeconds;
+        return self();
+    }
+
+    /**
+     * Set time to allow for the database to start and establish an initial connection, in seconds.
+     *
+     * @param connectTimeoutSeconds time to allow for the database to start and establish an initial connection in seconds
+     * @return self
+     */
+    public SELF withConnectTimeoutSeconds(int connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+        return self();
     }
 
     @Override
@@ -190,13 +215,13 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
      * @return startup time to allow, including image pull time, in seconds
      */
     protected int getStartupTimeoutSeconds() {
-        return 120;
+        return startupTimeoutSeconds;
     }
 
     /**
      * @return time to allow for the database to start and establish an initial connection, in seconds
      */
     protected int getConnectTimeoutSeconds() {
-        return 120;
+        return connectTimeoutSeconds;
     }
 }

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -14,12 +14,17 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     private String username = "SA";
     private String password = "A_Str0ng_Required_Password";
 
+    private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
+    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 240;
+
     public MSSQLServerContainer() {
         this(IMAGE + ":" + DEFAULT_TAG);
     }
 
     public MSSQLServerContainer(final String dockerImageName) {
         super(dockerImageName);
+        withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
+        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
     }
 
     @Override

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -14,6 +14,9 @@ public class OracleContainer extends JdbcDatabaseContainer {
     private static final int ORACLE_PORT = 1521;
     private static final int APEX_HTTP_PORT = 8080;
 
+    private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
+    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 120;
+
     private static String resolveImageName() {
         String image = TestcontainersConfiguration.getInstance()
             .getProperties().getProperty("oracle.container.image");
@@ -27,15 +30,19 @@ public class OracleContainer extends JdbcDatabaseContainer {
     }
 
     public OracleContainer() {
-        super(resolveImageName());
+        this(resolveImageName());
     }
 
     public OracleContainer(String dockerImageName) {
         super(dockerImageName);
+        withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
+        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
     }
 
     public OracleContainer(Future<String> dockerImageName) {
         super(dockerImageName);
+        withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
+        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
     }
 
     @Override
@@ -45,7 +52,6 @@ public class OracleContainer extends JdbcDatabaseContainer {
 
     @Override
     protected void configure() {
-
         addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
     }
 
@@ -86,10 +92,5 @@ public class OracleContainer extends JdbcDatabaseContainer {
     @Override
     public String getTestQueryString() {
         return "SELECT 1 FROM DUAL";
-    }
-
-    @Override
-    protected int getStartupTimeoutSeconds() {
-        return 240;
     }
 }


### PR DESCRIPTION
Added builder functionality for timeouts in JdbcDatabaseContainer to improve usability for e.g. MS SQL Server image which needs much more time to start up. 

I have seen the workaround with override from @vpavic at #715 and made it configurable by builder pattern to increase usability.

@kiview or @rnorth may take a look at it?