### PR TITLE
Fix #534 for the MariaDB container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Linux/Mac: Added support for docker credential helpers so that images may be pulled from private registries. See [\#729](https://github.com/testcontainers/testcontainers-java/issues/729), [\#647](https://github.com/testcontainers/testcontainers-java/issues/647) and [\#567](https://github.com/testcontainers/testcontainers-java/issues/567).
 - Ensure that the `COMPOSE_FILE` environment variable is populated with all relevant compose file names when running docker-compose in local mode [\#755](https://github.com/testcontainers/testcontainers-java/issues/755).
+- Fixed issue whereby specified command in MariaDB image was not being applied. ([\#534](https://github.com/testcontainers/testcontainers-java/issues/534))
 
 ### Changed
 - Update Apache Pulsar module to 2.0.1 [\#760](https://github.com/testcontainers/testcontainers-java/issues/760).

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMariaDBTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMariaDBTest.java
@@ -56,7 +56,7 @@ public class SimpleMariaDBTest {
     public void testMariaDBWithCustomIniFile() throws SQLException {
         assumeFalse(SystemUtils.IS_OS_WINDOWS);
         MariaDBContainer mariadbCustomConfig = new MariaDBContainer("mariadb:10.1.16")
-                                                .withConfigurationOverride("somepath/mariadb_conf_override");
+            .withConfigurationOverride("somepath/mariadb_conf_override");
         mariadbCustomConfig.start();
 
         try {
@@ -64,6 +64,23 @@ public class SimpleMariaDBTest {
             String result = resultSet.getString(1);
 
             assertEquals("The InnoDB file format has been set by the ini file content", "Barracuda", result);
+        } finally {
+            mariadbCustomConfig.stop();
+        }
+    }
+
+    @Test
+    public void testMariaDBWithCommandOverride() throws SQLException {
+
+        MariaDBContainer mariadbCustomConfig = (MariaDBContainer) new MariaDBContainer("mariadb:10.1.16")
+            .withCommand("mysqld --auto_increment_increment=10");
+        mariadbCustomConfig.start();
+
+        try {
+            ResultSet resultSet = performQuery(mariadbCustomConfig, "show variables like 'auto_increment_increment'");
+            String result = resultSet.getString("Value");
+
+            assertEquals("Auto increment increment should be overriden by command line", "10", result);
         } finally {
             mariadbCustomConfig.stop();
         }

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -39,7 +39,6 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         addEnv("MYSQL_USER", MARIADB_USER);
         addEnv("MYSQL_PASSWORD", MARIADB_PASSWORD);
         addEnv("MYSQL_ROOT_PASSWORD", MARIADB_PASSWORD);
-        setCommand("mysqld");
         setStartupAttempts(3);
     }
 


### PR DESCRIPTION
This fixes #534 for the MariaDB container, which was also affected.