### PR TITLE
Changed Oracle thin URL for support Oracle 11 and 12 XE with SID

### DIFF
--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -62,7 +62,7 @@ public class OracleContainer extends JdbcDatabaseContainer {
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:oracle:thin:" + getUsername() + "/" + getPassword() + "@//" + getContainerIpAddress() + ":" + getOraclePort() + "/" + getSid();
+        return "jdbc:oracle:thin:" + getUsername() + "/" + getPassword() + "@" + getContainerIpAddress() + ":" + getOraclePort() + ":" + getSid();
     }
 
     @Override


### PR DESCRIPTION
Changed the thin URL format according to Oracle documentation to support 11 and 12XE versions using SID. Changed because the current format does not connect in Oracle 12 XE
Used the images below for tests:
wnameless/oracle-xe-11g:latest
pengbai/docker-oracle-12c-r1

https://docs.oracle.com/database/121/JJDBC/urls.htm#JJDBC28275