### PR TITLE
add dynamic couchbase port mappings:

### DIFF
--- a/modules/couchbase/AUTHORS
+++ b/modules/couchbase/AUTHORS
@@ -1,1 +1,2 @@
 ﻿Tayeb Chlyah <tayebchlyah@gmail.com>
+Dominik Weidemann <kaidowei@gmail.com>

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -126,15 +126,17 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     @Override
     protected void configure() {
         // Configurable ports
-        addExposedPorts(11210, 11207, 8091, 18091);
-
-        // Non configurable ports
-        addFixedExposedPort(8092, 8092);
-        addFixedExposedPort(8093, 8093);
-        addFixedExposedPort(8094, 8094);
-        addFixedExposedPort(8095, 8095);
-        addFixedExposedPort(18092, 18092);
-        addFixedExposedPort(18093, 18093);
+        addExposedPort(8091);
+        addExposedPort(8092);
+        addExposedPort(8093);
+        addExposedPort(8094);
+        addExposedPort(11207);
+        addExposedPort(11210);
+        addExposedPort(11214);
+        addExposedPort(18091);
+        addExposedPort(18092);
+        addExposedPort(18093);
+        addExposedPort(18094);
         setWaitStrategy(new HttpWaitStrategy().forPath("/ui/index.html#/"));
     }
 
@@ -267,10 +269,13 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     private DefaultCouchbaseEnvironment createCouchbaseEnvironment() {
         initCluster();
         return DefaultCouchbaseEnvironment.builder()
+            // must be disabled so that the CouchbaseInstrumentationHook can see all requests while bootstrapping
+            .bootstrapCarrierEnabled(false)
             .bootstrapCarrierDirectPort(getMappedPort(11210))
             .bootstrapCarrierSslPort(getMappedPort(11207))
             .bootstrapHttpDirectPort(getMappedPort(8091))
             .bootstrapHttpSslPort(getMappedPort(18091))
+            .couchbaseCoreSendHook(new CouchbaseInstrumentationHook(this))
             .build();
     }
 }

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseInstrumentationHook.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseInstrumentationHook.java
@@ -1,0 +1,146 @@
+package org.testcontainers.couchbase;
+
+import com.couchbase.client.core.hooks.CouchbaseCoreSendHook;
+import com.couchbase.client.core.lang.Tuple;
+import com.couchbase.client.core.lang.Tuple2;
+import com.couchbase.client.core.message.CouchbaseRequest;
+import com.couchbase.client.core.message.CouchbaseResponse;
+import com.couchbase.client.core.message.config.BucketConfigRequest;
+import com.couchbase.client.core.message.config.BucketConfigResponse;
+import com.couchbase.client.core.message.config.ClusterConfigRequest;
+import com.couchbase.client.core.message.config.ClusterConfigResponse;
+import com.couchbase.client.java.CouchbaseAsyncBucket;
+import com.couchbase.client.java.document.json.JsonArray;
+import com.couchbase.client.java.document.json.JsonObject;
+import com.couchbase.client.java.error.TranscodingException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import rx.Observable;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+public class CouchbaseInstrumentationHook implements CouchbaseCoreSendHook {
+    private final CouchbaseContainer couchbaseContainer;
+
+    @Override
+    public Tuple2<CouchbaseRequest, Observable<CouchbaseResponse>>
+    beforeSend(CouchbaseRequest originalRequest, Observable<CouchbaseResponse> originalResponse) {
+        if ((originalRequest instanceof ClusterConfigRequest)
+            || (originalRequest instanceof BucketConfigRequest)) {
+            return Tuple.create(originalRequest, originalResponse.map(this::instrumentResponse));
+        }
+        return Tuple.create(originalRequest, originalResponse);
+    }
+
+    private CouchbaseResponse instrumentResponse(CouchbaseResponse couchbaseResponse) {
+        if (couchbaseResponse.status().isSuccess()) {
+            if (couchbaseResponse instanceof ClusterConfigResponse) {
+                return instrumentClusterConfigResponse((ClusterConfigResponse) couchbaseResponse);
+            }
+            if (couchbaseResponse instanceof BucketConfigResponse) {
+                return instrumentBucketConfigResponse((BucketConfigResponse) couchbaseResponse);
+            }
+        }
+        return couchbaseResponse;
+    }
+
+
+    private CouchbaseResponse instrumentClusterConfigResponse(ClusterConfigResponse response) {
+        JsonObject json = extractJson(response);
+
+        arrayApply(json.getArray("nodes"), this::instrumentNode);
+
+        return new ClusterConfigResponse(json.toString(), response.status());
+    }
+
+    private CouchbaseResponse instrumentBucketConfigResponse(BucketConfigResponse response) {
+        JsonObject json = extractJson(response);
+
+        arrayApply(json.getArray("nodes"), this::instrumentNode);
+        arrayApply(json.getArray("nodesExt"), this::instrumentNodeExt);
+        instrumentServerList(json);
+
+        return new BucketConfigResponse(json.toString(), response.status());
+    }
+
+    private void instrumentNode(Object o) {
+        JsonObject json = (JsonObject) o;
+        JsonObject ports = json.getObject("ports");
+        if (ports != null) {
+            istrumentPortMap(ports);
+        }
+    }
+
+    private void instrumentServerList(JsonObject json) {
+        JsonObject vBucketServerMap = json.getObject("vBucketServerMap");
+        if (vBucketServerMap == null) {
+            return;
+        }
+
+        List<String> servers = vBucketServerMap.getArray("serverList")
+            .toList()
+            .stream()
+            .map(o -> (String) o)
+            .map(this::instrumentServerString)
+            .collect(Collectors.toList());
+
+        vBucketServerMap.put("serverList", servers);
+    }
+
+    private String instrumentServerString(String s) {
+        try {
+            int port = Integer.parseInt(s.replace("$HOST:", ""));
+            return "$HOST:" + couchbaseContainer.getMappedPort(port);
+        } catch (NumberFormatException e) {
+            log.warn("Could not extract port from String [{}]", s);
+            return s;
+        }
+    }
+
+    private void arrayApply(JsonArray array, Consumer<? super Object> function) {
+        if (array != null) {
+            array.forEach(function);
+        }
+    }
+
+    private void instrumentNodeExt(Object o) {
+        JsonObject json = (JsonObject) o;
+        JsonObject servicePorts = json.getObject("services");
+        if (servicePorts != null) {
+            istrumentPortMap(servicePorts);
+        }
+    }
+
+    private void istrumentPortMap(JsonObject ports) {
+        for (String portName : ports.getNames()) {
+            try {
+                ports.put(portName, couchbaseContainer.getMappedPort(ports.getInt(portName)));
+            } catch (IllegalArgumentException e) {
+                log.warn("Could not translate port ({}:{}). "
+                        + "This might indicate that the couchbase bootstrapping api changed. ",
+                    portName, ports.getInt(portName));
+            }
+        }
+    }
+
+
+    private JsonObject extractJson(ClusterConfigResponse response) {
+        return extractJson(response.config());
+    }
+
+    private JsonObject extractJson(BucketConfigResponse response) {
+        return extractJson(response.config());
+    }
+
+    private JsonObject extractJson(String config) {
+        try {
+            return CouchbaseAsyncBucket.JSON_OBJECT_TRANSCODER.stringToJsonObject(config);
+        } catch (Exception e) {
+            throw new TranscodingException("Could not decode cluster info.", e);
+        }
+    }
+}


### PR DESCRIPTION
- changed exposed ports according to https://developer.couchbase.com/documentation/server/current/install/install-ports.html#page-template-attributes
- added CouchbaseCoreSendHook which can modify all requests from and to
  the couchbase container
- intercepted cluster and bucket configuration to change hardcoded port
  values to the mappedPort of the container


There are many more candidates inside those two requests, that might be translated.
Would be really helpful to get some inside knowledge from a Couchbase dev maybe.

As a reference I add both default answers from the cluster so you can imagine where I replace the ports.

[pools_default_b_default.txt](https://github.com/testcontainers/testcontainers-java/files/2194979/pools_default_b_default.txt)
[pools_default.txt](https://github.com/testcontainers/testcontainers-java/files/2194980/pools_default.txt)

What I want to try out:
- using this container with spring (injecting the env into spring data)

additional notes:
- might be good to test the whole thing with the ssl ports


I'm looking forward for your feedback :)