### PR TITLE
Use Socat sidecar container in Couchbase to randomize the ports

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -556,7 +556,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * @see #waitingFor(org.testcontainers.containers.wait.strategy.WaitStrategy)
      */
     protected void waitUntilContainerStarted() {
-        getWaitStrategy().waitUntilReady(this);
+        org.testcontainers.containers.wait.strategy.WaitStrategy waitStrategy = getWaitStrategy();
+        if (waitStrategy != null) {
+            waitStrategy.waitUntilReady(this);
+        }
     }
 
     /**


### PR DESCRIPTION
After reviewing #783 I started thinking how we could utilize Socat sidecar container to pre-randomize the ports before starting the Couchbase and apparently it is possible 🎉 

/cc @kaidowei @tchlyah @ldoguin