### PR TITLE
Ryuk docker client api version extracted to configuration

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -54,6 +54,10 @@ public class TestcontainersConfiguration {
         return Integer.parseInt((String) properties.getOrDefault("ryuk.container.timeout", "30"));
     }
 
+    public String getRyukClientVersion() {
+        return (String) properties.get("ryuk.container.client.version");
+    }
+
     public String getKafkaImage() {
         return (String) properties.getOrDefault("kafka.container.image", "confluentinc/cp-kafka");
     }


### PR DESCRIPTION
Due to error in ryuk logs
Error response from daemon: client is newer than server (client API version: 1.29, server API version: 1.24)
allow to specify client version API manually