### PR TITLE
Add support for transparently using local images with docker-compose

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -154,7 +154,11 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
         synchronized (MUTEX) {
             registerContainersForShutdown();
             if (pull) {
-                pullImages();
+                try {
+                    pullImages();
+                } catch (ContainerLaunchException e) {
+                    logger().warn("Exception while pulling images, using local images if available", e);
+                }
             }
             applyScaling(); // scale before up, so that all scaled instances are available first for linking
             createServices();

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeLocalImageTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeLocalImageTest.java
@@ -1,0 +1,27 @@
+package org.testcontainers.junit;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.command.PullImageResultCallback;
+import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.DockerComposeContainer;
+
+import java.io.File;
+
+public class DockerComposeLocalImageTest {
+
+    @Test
+    public void usesLocalImageEvenWhenPullFails() throws InterruptedException {
+        tagImage("redis:4.0.10", "redis-local", "latest");
+
+        DockerComposeContainer composeContainer = new DockerComposeContainer(new File("src/test/resources/local-compose-test.yml"))
+            .withExposedService("redis", 6379);
+        composeContainer.start();
+    }
+
+    private void tagImage(String sourceImage, String targetImage, String targetTag) throws InterruptedException {
+        DockerClient client = DockerClientFactory.instance().client();
+        client.pullImageCmd(sourceImage).exec(new PullImageResultCallback()).awaitCompletion();
+        client.tagImageCmd(sourceImage, targetImage, targetTag).exec();
+    }
+}

--- a/core/src/test/resources/local-compose-test.yml
+++ b/core/src/test/resources/local-compose-test.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  redis:
+    image: redis-local:latest
+    ports:
+      - 6379


### PR DESCRIPTION
`DockerComposeContainer` will WARN if `pullImages()` fails, but will now try to continue using local images implicitly.
A lower layer will already log an `ERROR` when the pulling fails, so this is unfortunate from an UX perspective.

Fixes #674 