### PR TITLE
Fix for @Wither in couchbase container (issues: #784)

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -29,7 +29,6 @@ import lombok.AllArgsConstructor;
 import lombok.Cleanup;
 import lombok.Getter;
 import lombok.SneakyThrows;
-import lombok.experimental.Wither;
 import org.apache.commons.compress.utils.Sets;
 import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.GenericContainer;
@@ -53,46 +52,35 @@ import static java.net.HttpURLConnection.HTTP_OK;
 public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     public static final String VERSION = "5.1.0";
+    public static final String DOCKER_IMAGE_NAME = "couchbase/server:";
     public static final ObjectMapper MAPPER = new ObjectMapper();
 
-    @Wither
     private String memoryQuota = "300";
 
-    @Wither
     private String indexMemoryQuota = "300";
 
-    @Wither
     private String clusterUsername = "Administrator";
 
-    @Wither
     private String clusterPassword = "password";
 
-    @Wither
     private boolean keyValue = true;
 
     @Getter
-    @Wither
     private boolean query = true;
 
     @Getter
-    @Wither
     private boolean index = true;
 
     @Getter
-    @Wither
     private boolean primaryIndex = true;
 
     @Getter
-    @Wither
     private boolean fts = false;
 
-    @Wither
     private boolean beerSample = false;
 
-    @Wither
     private boolean travelSample = false;
 
-    @Wither
     private boolean gamesIMSample = false;
 
     @Getter(lazy = true)
@@ -106,7 +94,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     private String urlBase;
 
     public CouchbaseContainer() {
-        super("couchbase/server:" + VERSION);
+        super(DOCKER_IMAGE_NAME + VERSION);
     }
 
     public CouchbaseContainer(String containerName) {
@@ -272,5 +260,60 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
             .bootstrapHttpDirectPort(getMappedPort(8091))
             .bootstrapHttpSslPort(getMappedPort(18091))
             .build();
+    }
+
+    public CouchbaseContainer withMemoryQuota(String memoryQuota) {
+        this.memoryQuota = memoryQuota;
+        return self();
+    }
+
+    public CouchbaseContainer withIndexMemoryQuota(String indexMemoryQuota) {
+        this.indexMemoryQuota = indexMemoryQuota;
+        return self();
+    }
+
+    public CouchbaseContainer withClusterPassword(String clusterPassword) {
+        this.clusterPassword = clusterPassword;
+        return self();
+    }
+
+    public CouchbaseContainer withKeyValue(boolean keyValue) {
+        this.keyValue = keyValue;
+        return self();
+    }
+
+    public CouchbaseContainer withQuery(boolean query) {
+        this.query = query;
+        return self();
+    }
+
+    public CouchbaseContainer withIndex(boolean index) {
+        this.index = index;
+        return self();
+    }
+
+    public CouchbaseContainer withPrimaryIndex(boolean primaryIndex) {
+        this.primaryIndex = primaryIndex;
+        return self();
+    }
+
+    public CouchbaseContainer withFts(boolean fts) {
+        this.fts = fts;
+        return self();
+    }
+
+    public CouchbaseContainer withBeerSample(boolean beerSample) {
+        this.beerSample = beerSample;
+        return self();
+    }
+
+    public CouchbaseContainer withTravelSample(boolean travelSample) {
+        this.travelSample = travelSample;
+        return self();
+    }
+
+    public CouchbaseContainer withGamesIMSample(boolean gamesIMSample) {
+        this.gamesIMSample = gamesIMSample;
+        return self();
     }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
@@ -38,4 +38,12 @@ public class CouchbaseContainerTest extends AbstractCouchbaseTest {
         Assert.assertEquals(1, n1qlQueryRows.size());
         Assert.assertEquals(DOCUMENT, n1qlQueryRows.get(0).value().get(TEST_BUCKET).toString());
     }
+
+    @Test
+    public void shouldUseCorrectDockerImage() {
+        CouchbaseContainer couchbaseContainer = new CouchbaseContainer().withBeerSample(true);
+
+        Assert.assertEquals(CouchbaseContainer.DOCKER_IMAGE_NAME + CouchbaseContainer.VERSION,
+                            couchbaseContainer.getDockerImageName());
+    }
 }


### PR DESCRIPTION
- Replaced Wither annotation with own with methods
  These methods do not clone the instance and therefore do not default to
  the standard alpine:3.5 image

- Added test to verify that the image name is not overridden by withXXX

- Made CouchbaseContainer conforming to other modules' containers
  Replaced the extends mechanism by the project standard

Thanks to @RobNE for the contribution