### PR TITLE
Socat sidecar proxy for Couchbase container to support random ports

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -556,7 +556,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * @see #waitingFor(org.testcontainers.containers.wait.strategy.WaitStrategy)
      */
     protected void waitUntilContainerStarted() {
-        getWaitStrategy().waitUntilReady(this);
+        org.testcontainers.containers.wait.strategy.WaitStrategy waitStrategy = getWaitStrategy();
+        if (waitStrategy != null) {
+            waitStrategy.waitUntilReady(this);
+        }
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -247,6 +247,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             containerId = createCommand.exec().getId();
             copyToFileContainerPathMap.forEach(this::copyFileToContainer);
 
+            containerIsCreated(containerId);
+
             logger().info("Starting container with ID: {}", containerId);
             profiler.start("Start container");
             dockerClient.startContainerCmd(containerId).exec();
@@ -354,6 +356,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     protected void configure() {
 
+    }
+
+    @SuppressWarnings({"EmptyMethod", "UnusedParameters"})
+    protected void containerIsCreated(String containerId) {
     }
 
     @SuppressWarnings({"EmptyMethod", "UnusedParameters"})
@@ -1031,8 +1037,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public void copyFileFromContainer(String containerPath, String destinationPath) throws IOException {
 
-        if (!isRunning()) {
-            throw new IllegalStateException("copyFileToContainer can only be used while the Container is running");
+        if (!isCreated()) {
+            throw new IllegalStateException("copyFileFromContainer can only be used when the Container is created.");
         }
 
         try (final TarArchiveInputStream tarInputStream = new TarArchiveInputStream(this.dockerClient

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -2,5 +2,5 @@ description = "Testcontainers :: Couchbase"
 
 dependencies {
     compile project(':testcontainers')
-    compile 'com.couchbase.client:java-client:2.5.7'
+    compile 'com.couchbase.client:java-client:2.6.0'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -2,5 +2,5 @@ description = "Testcontainers :: Couchbase"
 
 dependencies {
     compile project(':testcontainers')
-    compile 'com.couchbase.client:java-client:2.6.0'
+    compile 'com.couchbase.client:java-client:2.6.1'
 }

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -190,7 +190,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     }
 
     protected Integer getMappedPort(CouchbasePort port) {
-        return getMappedPort(port.originalPort);
+        return getMappedPort(port.getOriginalPort());
     }
 
     @Override

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -53,7 +53,11 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.*;
+import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.CAPI;
+import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.MEMCACHED;
+import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.MEMCACHED_SSL;
+import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.REST;
+import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.REST_SSL;
 
 /**
  * Based on Laurent Doguin version,
@@ -137,7 +141,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
             exposePortThroughProxy(networkAlias, port.getOriginalPort(), getMappedPort(port));
 
             // CAPI port has a special configuration file which is set via env
-            if (port == CouchbasePort.CAPI) {
+            if (port == CAPI) {
                 withEnv(port.getName(), getMappedPort(port) + "");
             }
         }
@@ -370,6 +374,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     private DefaultCouchbaseEnvironment createCouchbaseEnvironment() {
         initCluster();
         return DefaultCouchbaseEnvironment.builder()
+            .kvTimeout(10000)
             .bootstrapCarrierDirectPort(getMappedPort(MEMCACHED))
             .bootstrapCarrierSslPort(getMappedPort(MEMCACHED_SSL))
             .bootstrapHttpDirectPort(getMappedPort(REST))

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -27,25 +27,32 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
+import com.google.common.collect.Lists;
 import lombok.*;
 import lombok.experimental.Wither;
 import org.apache.commons.compress.utils.Sets;
+import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.Base58;
+import org.testcontainers.utility.MountableFile;
 
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.file.Files;
 import java.util.*;
 import java.util.stream.Stream;
 
 import static java.net.HttpURLConnection.HTTP_OK;
+import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.MEMCACHED;
+import static org.testcontainers.couchbase.CouchbaseContainer.CouchbasePort.REST;
 
 /**
  * Based on Laurent Doguin version,
@@ -57,6 +64,9 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     public static final String VERSION = "5.1.0";
     public static final ObjectMapper MAPPER = new ObjectMapper();
+    public static final String STATIC_CONFIG_NAME = "static_config";
+    public static final String STATIC_CONFIG_PATH = "/opt/couchbase/etc/couchbase/";
+    public static final String STATIC_CONFIG_LOCATION = STATIC_CONFIG_PATH + STATIC_CONFIG_NAME;
 
     @Wither
     private String memoryQuota = "300";
@@ -124,7 +134,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     @Override
     public Set<Integer> getLivenessCheckPortNumbers() {
-        return Sets.newHashSet(getMappedPort(8091));
+        return Sets.newHashSet(getMappedPort(REST));
     }
 
     @Override
@@ -133,29 +143,35 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
         String networkAlias = getNetworkAliases().get(0);
         proxy = new SocatContainer()
             .withNetwork(getNetwork())
-            .withTarget(8091, networkAlias);
+            // a (random and unused) target port is needed so that the container starts and stays active
+            .withTarget(4711, networkAlias);
 
-        for (Ports port : Ports.values()) {
+        for (CouchbasePort port : CouchbasePort.values()) {
             proxy.addExposedPort(port.getOriginalPort());
         }
 
         proxy.setWaitStrategy(null);
         proxy.start();
 
-        for (Ports port : Ports.values()) {
-            int originalPort = port.getOriginalPort();
-            int mappedPort = proxy.getMappedPort(originalPort);
+        for (CouchbasePort port : CouchbasePort.values()) {
+            exposePortThroughProxy(networkAlias, port.getOriginalPort(), getMappedPort(port));
 
-            ExecCreateCmdResponse createCmdResponse = dockerClient.execCreateCmd(proxy.getContainerId())
-                .withCmd("/usr/bin/socat", "TCP-LISTEN:" + originalPort + ",fork,reuseaddr", "TCP:" + networkAlias + ":" + mappedPort)
-                .exec();
-
-            dockerClient.execStartCmd(createCmdResponse.getId())
-                .exec(new ExecStartResultCallback());
-
-            withEnv(port.getEnvVarName(), mappedPort + "");
+            // CAPI port has a special configuration file which is set via env
+            if (port == CouchbasePort.CAPI) {
+                withEnv(port.getName(), getMappedPort(port) + "");
+            }
         }
         super.doStart();
+    }
+
+    private void exposePortThroughProxy(String networkAlias, int originalPort, int mappedPort) {
+        ExecCreateCmdResponse createCmdResponse = dockerClient
+            .execCreateCmd(proxy.getContainerId())
+            .withCmd("/usr/bin/socat", "TCP-LISTEN:" + originalPort + ",fork,reuseaddr", "TCP:" + networkAlias + ":" + mappedPort)
+            .exec();
+
+        dockerClient.execStartCmd(createCmdResponse.getId())
+            .exec(new ExecStartResultCallback());
     }
 
     @Override
@@ -171,6 +187,10 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     @Override
     public Integer getMappedPort(int originalPort) {
         return proxy.getMappedPort(originalPort);
+    }
+
+    protected Integer getMappedPort(CouchbasePort port) {
+        return getMappedPort(port.originalPort);
     }
 
     @Override
@@ -190,7 +210,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     @SneakyThrows
     public void initCluster() {
-        urlBase = String.format("http://%s:%s", getContainerIpAddress(), getMappedPort(8091));
+        urlBase = String.format("http://%s:%s", getContainerIpAddress(), getMappedPort(REST));
         String poolURL = "/pools/default";
         String poolPayload = "memoryQuota=" + URLEncoder.encode(memoryQuota, "UTF-8") + "&indexMemoryQuota=" + URLEncoder.encode(indexMemoryQuota, "UTF-8");
 
@@ -264,7 +284,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
         // Insert Bucket admin user
         UserSettings userSettings = UserSettings.build()
             .password(bucketSetting.password())
-            .roles(Collections.singletonList(new UserRole("bucket_admin", bucketSetting.name())));
+            .roles(getAdminRoles(bucketSetting.name()));
         try {
             clusterManager.upsertUser(AuthDomain.LOCAL, bucketSetting.name(), userSettings);
         } catch (Exception e) {
@@ -277,6 +297,18 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
                 bucket.query(Index.createPrimaryIndex().on(bucketSetting.name()));
             }
         }
+    }
+
+    private List<UserRole> getAdminRoles(String bucketName) {
+        return Lists.newArrayList(
+            new UserRole("bucket_admin", bucketName),
+            new UserRole("views_admin", bucketName),
+            new UserRole("query_manage_index", bucketName),
+            new UserRole("query_update", bucketName),
+            new UserRole("query_select", bucketName),
+            new UserRole("query_insert", bucketName),
+            new UserRole("query_delete", bucketName)
+        );
     }
 
     public void callCouchbaseRestAPI(String url, String payload) throws IOException {
@@ -297,6 +329,31 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     }
 
     @Override
+    @SneakyThrows
+    protected void containerIsCreated(String containerId) {
+        File tempFile = copyConfigFromContainer(containerId);
+        appendPortsToConfig(tempFile);
+        copyFileToContainer(MountableFile.forHostPath(tempFile.toPath()), STATIC_CONFIG_PATH);
+    }
+
+    private File copyConfigFromContainer(String containerId) throws IOException {
+        File tempDirectory = Files.createTempDirectory("testcontainer_" + containerId + "_").toFile();
+        tempDirectory.deleteOnExit();
+        File tempFile = new File(tempDirectory, STATIC_CONFIG_NAME);
+        tempFile.deleteOnExit();
+        logger().debug("Storing static_config in [{}].", tempFile.getAbsolutePath());
+        copyFileFromContainer(STATIC_CONFIG_LOCATION, tempFile.getPath());
+        return tempFile;
+    }
+
+    private void appendPortsToConfig(File tempFile) throws IOException {
+        for(CouchbasePort port: CouchbasePort.values()) {
+            String config = String.format("{%s, %d}.\n", port.name, getMappedPort(port));
+            FileUtils.writeStringToFile(tempFile, config, "UTF-8", true);
+        }
+    }
+
+    @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
         if (!newBuckets.isEmpty()) {
             for (BucketSettings bucketSetting : newBuckets) {
@@ -312,21 +369,30 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     private DefaultCouchbaseEnvironment createCouchbaseEnvironment() {
         initCluster();
         return DefaultCouchbaseEnvironment.builder()
-            .bootstrapCarrierDirectPort(getMappedPort(11210))
-            .bootstrapHttpDirectPort(getMappedPort(8091))
+            .bootstrapCarrierDirectPort(getMappedPort(MEMCACHED))
+            .bootstrapHttpDirectPort(getMappedPort(REST))
             .build();
     }
 
     @Getter
     @RequiredArgsConstructor
-    protected enum Ports {
-        CAPI("CAPI_PORT", 8092),
-        QUERY("QUERY_PORT", 8093),
-        FTS("FTS_HTTP_PORT", 8094),
-        MEMCACHED("MEMCACHED_PORT", 11210),
+    protected enum CouchbasePort {
+        REST("rest_port", 8091),
+        CAPI("capi_port", 8092),
+        QUERY("query_port", 8093),
+        FTS("fts_http_port", 8094),
+        CBAS("cbas_http_port", 8095),
+        EVENTING("eventing_http_port", 8096),
+        MEMCACHED("memcached_port", 11210),
+        REST_SSL("ssl_rest_port", 18091),
+        CAPI_SSL("ssl_capi_port", 18092),
+        QUERY_SSL("ssl_query_port", 18093),
+        FTS_SSL("fts_ssl_port", 18094),
+        CBAS_SSL("cbas_ssl_port", 18095),
+        EVENTING_SSL("eventing_ssl_port", 18096),
         ;
 
-        final String envVarName;
+        final String name;
 
         final int originalPort;
     }

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -152,7 +152,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
         proxy = new SocatContainer().withNetwork(getNetwork());
 
         for (CouchbasePort port : CouchbasePort.values()) {
-            if (port.isBootstrap()) {
+            if (port.isDynamic()) {
                 proxy.withTarget(port.getOriginalPort(), networkAlias);
             } else {
                 proxy.addExposedPort(port.getOriginalPort());
@@ -350,8 +350,8 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     }
 
     private void appendPortsToConfig(File tempFile) throws IOException {
-        for(CouchbasePort port: CouchbasePort.values()) {
-            if (! port.isBootstrap()) {
+        for (CouchbasePort port : CouchbasePort.values()) {
+            if (!port.isDynamic()) {
                 String config = String.format("{%s, %d}.\n", port.name, getMappedPort(port));
                 FileUtils.writeStringToFile(tempFile, config, "UTF-8", true);
             }
@@ -460,6 +460,6 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
         final int originalPort;
 
-        final boolean isBootstrap;
+        final boolean dynamic;
     }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/BaseCouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/BaseCouchbaseContainerTest.java
@@ -4,20 +4,22 @@ import com.couchbase.client.java.document.RawJsonDocument;
 import com.couchbase.client.java.query.N1qlQuery;
 import com.couchbase.client.java.query.N1qlQueryResult;
 import com.couchbase.client.java.query.N1qlQueryRow;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.List;
 
-/**
- * @author ctayeb
- *         created on 18/06/2017
- */
-public class CouchbaseContainerTest extends AbstractCouchbaseTest {
+public abstract class BaseCouchbaseContainerTest extends AbstractCouchbaseTest {
 
     private static final String ID = "toto";
 
     private static final String DOCUMENT = "{\"name\":\"toto\"}";
+
+    @AfterClass
+    public static void tearDown() {
+        tearDownContext();
+    }
 
     @Test
     public void shouldInsertDocument() {

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/BaseCouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/BaseCouchbaseContainerTest.java
@@ -4,7 +4,6 @@ import com.couchbase.client.java.document.RawJsonDocument;
 import com.couchbase.client.java.query.N1qlQuery;
 import com.couchbase.client.java.query.N1qlQueryResult;
 import com.couchbase.client.java.query.N1qlQueryRow;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -15,11 +14,6 @@ public abstract class BaseCouchbaseContainerTest extends AbstractCouchbaseTest {
     private static final String ID = "toto";
 
     private static final String DOCUMENT = "{\"name\":\"toto\"}";
-
-    @AfterClass
-    public static void tearDown() {
-        tearDownContext();
-    }
 
     @Test
     public void shouldInsertDocument() {

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/BaseCouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/BaseCouchbaseContainerTest.java
@@ -34,12 +34,4 @@ public abstract class BaseCouchbaseContainerTest extends AbstractCouchbaseTest {
         Assert.assertEquals(1, n1qlQueryRows.size());
         Assert.assertEquals(DOCUMENT, n1qlQueryRows.get(0).value().get(TEST_BUCKET).toString());
     }
-
-    @Test
-    public void shouldUseCorrectDockerImage() {
-        CouchbaseContainer couchbaseContainer = new CouchbaseContainer().withBeerSample(true);
-
-        Assert.assertEquals(CouchbaseContainer.DOCKER_IMAGE_NAME + CouchbaseContainer.VERSION,
-                            couchbaseContainer.getDockerImageName());
-    }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase4_6Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase4_6Test.java
@@ -1,0 +1,70 @@
+package org.testcontainers.couchbase;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.CouchbaseCluster;
+import com.couchbase.client.java.bucket.BucketType;
+import com.couchbase.client.java.cluster.DefaultBucketSettings;
+import com.couchbase.client.java.document.RawJsonDocument;
+import com.couchbase.client.java.query.N1qlParams;
+import com.couchbase.client.java.query.N1qlQuery;
+import com.couchbase.client.java.query.consistency.ScanConsistency;
+import lombok.Getter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Couchbase4_6Test {
+
+    public static final String TEST_BUCKET = "test";
+    public static final String DEFAULT_PASSWORD = "password";
+
+    private static final String ID = "toto";
+
+    private static final String DOCUMENT = "{\"name\":\"toto\"}";
+
+    @Getter(lazy = true)
+    private final static CouchbaseContainer couchbaseContainer = initCouchbaseContainer();
+
+    @Getter(lazy = true)
+    private final static Bucket bucket = openBucket(TEST_BUCKET, DEFAULT_PASSWORD);
+
+    @After
+    public void clear() {
+        if (getCouchbaseContainer().isIndex() && getCouchbaseContainer().isQuery() && getCouchbaseContainer().isPrimaryIndex()) {
+            getBucket().query(
+                N1qlQuery.simple(String.format("DELETE FROM `%s`", getBucket().name()),
+                    N1qlParams.build().consistency(ScanConsistency.STATEMENT_PLUS)));
+        } else {
+            getBucket().bucketManager().flush();
+        }
+    }
+
+    private static CouchbaseContainer initCouchbaseContainer() {
+        CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:4.6.5")
+            .withNewBucket(DefaultBucketSettings.builder()
+                .enableFlush(true)
+                .name(TEST_BUCKET)
+                .password(DEFAULT_PASSWORD)
+                .quota(100)
+                .replicas(0)
+                .type(BucketType.COUCHBASE)
+                .build());
+        couchbaseContainer.start();
+        return couchbaseContainer;
+    }
+
+    private static Bucket openBucket(String bucketName, String password) {
+        CouchbaseCluster cluster = getCouchbaseContainer().getCouchbaseCluster();
+        Bucket bucket = cluster.openBucket(bucketName, password);
+        Runtime.getRuntime().addShutdownHook(new Thread(bucket::close));
+        return bucket;
+    }
+
+    @Test
+    public void shouldInsertDocument() {
+        RawJsonDocument expected = RawJsonDocument.create(ID, DOCUMENT);
+        getBucket().upsert(expected);
+        RawJsonDocument result = getBucket().get(ID, RawJsonDocument.class);
+        Assert.assertEquals(expected.content(), result.content());
+    }
+}

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase4_6Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase4_6Test.java
@@ -1,7 +1,13 @@
 package org.testcontainers.couchbase;
 
+import org.junit.ClassRule;
+
 public class Couchbase4_6Test extends BaseCouchbaseContainerTest {
-    static {
-        imageName = "couchbase/server:4.6.5";
+    @ClassRule
+    public static CouchbaseContainer container = initCouchbaseContainer("couchbase/server:4.6.5");
+
+    @Override
+    public CouchbaseContainer getCouchbaseContainer() {
+        return container;
     }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase4_6Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase4_6Test.java
@@ -1,70 +1,7 @@
 package org.testcontainers.couchbase;
 
-import com.couchbase.client.java.Bucket;
-import com.couchbase.client.java.CouchbaseCluster;
-import com.couchbase.client.java.bucket.BucketType;
-import com.couchbase.client.java.cluster.DefaultBucketSettings;
-import com.couchbase.client.java.document.RawJsonDocument;
-import com.couchbase.client.java.query.N1qlParams;
-import com.couchbase.client.java.query.N1qlQuery;
-import com.couchbase.client.java.query.consistency.ScanConsistency;
-import lombok.Getter;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-
-public class Couchbase4_6Test {
-
-    public static final String TEST_BUCKET = "test";
-    public static final String DEFAULT_PASSWORD = "password";
-
-    private static final String ID = "toto";
-
-    private static final String DOCUMENT = "{\"name\":\"toto\"}";
-
-    @Getter(lazy = true)
-    private final static CouchbaseContainer couchbaseContainer = initCouchbaseContainer();
-
-    @Getter(lazy = true)
-    private final static Bucket bucket = openBucket(TEST_BUCKET, DEFAULT_PASSWORD);
-
-    @After
-    public void clear() {
-        if (getCouchbaseContainer().isIndex() && getCouchbaseContainer().isQuery() && getCouchbaseContainer().isPrimaryIndex()) {
-            getBucket().query(
-                N1qlQuery.simple(String.format("DELETE FROM `%s`", getBucket().name()),
-                    N1qlParams.build().consistency(ScanConsistency.STATEMENT_PLUS)));
-        } else {
-            getBucket().bucketManager().flush();
-        }
-    }
-
-    private static CouchbaseContainer initCouchbaseContainer() {
-        CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:4.6.5")
-            .withNewBucket(DefaultBucketSettings.builder()
-                .enableFlush(true)
-                .name(TEST_BUCKET)
-                .password(DEFAULT_PASSWORD)
-                .quota(100)
-                .replicas(0)
-                .type(BucketType.COUCHBASE)
-                .build());
-        couchbaseContainer.start();
-        return couchbaseContainer;
-    }
-
-    private static Bucket openBucket(String bucketName, String password) {
-        CouchbaseCluster cluster = getCouchbaseContainer().getCouchbaseCluster();
-        Bucket bucket = cluster.openBucket(bucketName, password);
-        Runtime.getRuntime().addShutdownHook(new Thread(bucket::close));
-        return bucket;
-    }
-
-    @Test
-    public void shouldInsertDocument() {
-        RawJsonDocument expected = RawJsonDocument.create(ID, DOCUMENT);
-        getBucket().upsert(expected);
-        RawJsonDocument result = getBucket().get(ID, RawJsonDocument.class);
-        Assert.assertEquals(expected.content(), result.content());
+public class Couchbase4_6Test extends BaseCouchbaseContainerTest {
+    static {
+        imageName = "couchbase/server:4.6.5";
     }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_1Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_1Test.java
@@ -1,0 +1,7 @@
+package org.testcontainers.couchbase;
+
+public class Couchbase5_1Test extends BaseCouchbaseContainerTest {
+    static {
+        imageName = "couchbase/server:5.1.0";
+    }
+}

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_1Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_1Test.java
@@ -1,7 +1,13 @@
 package org.testcontainers.couchbase;
 
+import org.junit.ClassRule;
+
 public class Couchbase5_1Test extends BaseCouchbaseContainerTest {
-    static {
-        imageName = "couchbase/server:5.1.0";
+    @ClassRule
+    public static CouchbaseContainer container = initCouchbaseContainer("couchbase/server:5.1.0");
+
+    @Override
+    public CouchbaseContainer getCouchbaseContainer() {
+        return container;
     }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
@@ -1,8 +1,13 @@
 package org.testcontainers.couchbase;
 
-public class Couchbase5_5Test extends BaseCouchbaseContainerTest {
-    static {
-        imageName = "couchbase/server:5.5.0";
-    }
+import org.junit.ClassRule;
 
+public class Couchbase5_5Test extends BaseCouchbaseContainerTest {
+    @ClassRule
+    public static CouchbaseContainer container = initCouchbaseContainer("couchbase/server:5.5.0");
+
+    @Override
+    public CouchbaseContainer getCouchbaseContainer() {
+        return container;
+    }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
@@ -1,0 +1,70 @@
+package org.testcontainers.couchbase;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.CouchbaseCluster;
+import com.couchbase.client.java.bucket.BucketType;
+import com.couchbase.client.java.cluster.DefaultBucketSettings;
+import com.couchbase.client.java.document.RawJsonDocument;
+import com.couchbase.client.java.query.N1qlParams;
+import com.couchbase.client.java.query.N1qlQuery;
+import com.couchbase.client.java.query.consistency.ScanConsistency;
+import lombok.Getter;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Couchbase5_5Test {
+
+    public static final String TEST_BUCKET = "test";
+    public static final String DEFAULT_PASSWORD = "password";
+
+    private static final String ID = "toto";
+
+    private static final String DOCUMENT = "{\"name\":\"toto\"}";
+
+    @Getter(lazy = true)
+    private final static CouchbaseContainer couchbaseContainer = initCouchbaseContainer();
+
+    @Getter(lazy = true)
+    private final static Bucket bucket = openBucket(TEST_BUCKET, DEFAULT_PASSWORD);
+
+    @After
+    public void clear() {
+        if (getCouchbaseContainer().isIndex() && getCouchbaseContainer().isQuery() && getCouchbaseContainer().isPrimaryIndex()) {
+            getBucket().query(
+                N1qlQuery.simple(String.format("DELETE FROM `%s`", getBucket().name()),
+                    N1qlParams.build().consistency(ScanConsistency.STATEMENT_PLUS)));
+        } else {
+            getBucket().bucketManager().flush();
+        }
+    }
+
+    private static CouchbaseContainer initCouchbaseContainer() {
+        CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:5.5.0")
+            .withNewBucket(DefaultBucketSettings.builder()
+                .enableFlush(true)
+                .name(TEST_BUCKET)
+                .password(DEFAULT_PASSWORD)
+                .quota(100)
+                .replicas(0)
+                .type(BucketType.COUCHBASE)
+                .build());
+        couchbaseContainer.start();
+        return couchbaseContainer;
+    }
+
+    private static Bucket openBucket(String bucketName, String password) {
+        CouchbaseCluster cluster = getCouchbaseContainer().getCouchbaseCluster();
+        Bucket bucket = cluster.openBucket(bucketName, password);
+        Runtime.getRuntime().addShutdownHook(new Thread(bucket::close));
+        return bucket;
+    }
+
+    @Test
+    public void shouldInsertDocument() {
+        RawJsonDocument expected = RawJsonDocument.create(ID, DOCUMENT);
+        getBucket().upsert(expected);
+        RawJsonDocument result = getBucket().get(ID, RawJsonDocument.class);
+        Assert.assertEquals(expected.content(), result.content());
+    }
+}

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
@@ -1,70 +1,8 @@
 package org.testcontainers.couchbase;
 
-import com.couchbase.client.java.Bucket;
-import com.couchbase.client.java.CouchbaseCluster;
-import com.couchbase.client.java.bucket.BucketType;
-import com.couchbase.client.java.cluster.DefaultBucketSettings;
-import com.couchbase.client.java.document.RawJsonDocument;
-import com.couchbase.client.java.query.N1qlParams;
-import com.couchbase.client.java.query.N1qlQuery;
-import com.couchbase.client.java.query.consistency.ScanConsistency;
-import lombok.Getter;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
-
-public class Couchbase5_5Test {
-
-    public static final String TEST_BUCKET = "test";
-    public static final String DEFAULT_PASSWORD = "password";
-
-    private static final String ID = "toto";
-
-    private static final String DOCUMENT = "{\"name\":\"toto\"}";
-
-    @Getter(lazy = true)
-    private final static CouchbaseContainer couchbaseContainer = initCouchbaseContainer();
-
-    @Getter(lazy = true)
-    private final static Bucket bucket = openBucket(TEST_BUCKET, DEFAULT_PASSWORD);
-
-    @After
-    public void clear() {
-        if (getCouchbaseContainer().isIndex() && getCouchbaseContainer().isQuery() && getCouchbaseContainer().isPrimaryIndex()) {
-            getBucket().query(
-                N1qlQuery.simple(String.format("DELETE FROM `%s`", getBucket().name()),
-                    N1qlParams.build().consistency(ScanConsistency.STATEMENT_PLUS)));
-        } else {
-            getBucket().bucketManager().flush();
-        }
+public class Couchbase5_5Test extends BaseCouchbaseContainerTest {
+    static {
+        imageName = "couchbase/server:5.5.0";
     }
 
-    private static CouchbaseContainer initCouchbaseContainer() {
-        CouchbaseContainer couchbaseContainer = new CouchbaseContainer("couchbase/server:5.5.0")
-            .withNewBucket(DefaultBucketSettings.builder()
-                .enableFlush(true)
-                .name(TEST_BUCKET)
-                .password(DEFAULT_PASSWORD)
-                .quota(100)
-                .replicas(0)
-                .type(BucketType.COUCHBASE)
-                .build());
-        couchbaseContainer.start();
-        return couchbaseContainer;
-    }
-
-    private static Bucket openBucket(String bucketName, String password) {
-        CouchbaseCluster cluster = getCouchbaseContainer().getCouchbaseCluster();
-        Bucket bucket = cluster.openBucket(bucketName, password);
-        Runtime.getRuntime().addShutdownHook(new Thread(bucket::close));
-        return bucket;
-    }
-
-    @Test
-    public void shouldInsertDocument() {
-        RawJsonDocument expected = RawJsonDocument.create(ID, DOCUMENT);
-        getBucket().upsert(expected);
-        RawJsonDocument result = getBucket().get(ID, RawJsonDocument.class);
-        Assert.assertEquals(expected.content(), result.content());
-    }
 }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
@@ -1,0 +1,15 @@
+package org.testcontainers.couchbase;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CouchbaseContainerTest {
+
+    @Test
+    public void shouldUseCorrectDockerImage() {
+        CouchbaseContainer couchbaseContainer = new CouchbaseContainer().withBeerSample(true);
+
+        Assert.assertEquals(CouchbaseContainer.DOCKER_IMAGE_NAME + CouchbaseContainer.VERSION,
+            couchbaseContainer.getDockerImageName());
+    }
+}


### PR DESCRIPTION
inspired by #785.

- containerIsCreated hook 
- added support for couchbase 5.5
- added [ALL couchbase client ports](https://developer.couchbase.com/documentation/server/current/install/install-ports.html#page-template-attributes)
- restructured integration tests for couchbase  4.6, 5.1 and 5.5