### PR TITLE
Ensure that nginx test waits properly to reduce flakiness

### DIFF
--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -5,7 +5,7 @@ import org.testcontainers.containers.traits.LinkableContainer;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.Set;
 
 /**
@@ -22,7 +22,7 @@ public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericCo
     @NotNull
     @Override
     protected Set<Integer> getLivenessCheckPorts() {
-        return new HashSet<>(getMappedPort(80));
+        return Collections.singleton(getMappedPort(80));
     }
 
     @Override

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -5,12 +5,13 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.NginxContainer;
-import org.testcontainers.containers.wait.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
 import java.io.*;
 import java.net.URLConnection;
 
-import static org.rnorth.visibleassertions.VisibleAssertions.*;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
+import static org.rnorth.visibleassertions.VisibleAssertions.info;
 
 
 /**
@@ -22,9 +23,10 @@ public class SimpleNginxTest {
 
     @Rule
     public NginxContainer nginx = new NginxContainer<>()
-            .withCustomContent(contentFolder.toString())
-            .waitingFor(new HttpWaitStrategy());
+        .withCustomContent(contentFolder.toString())
+        .waitingFor(new HttpWaitStrategy());
 
+    @SuppressWarnings({"Duplicates", "ResultOfMethodCallIgnored"})
     @BeforeClass
     public static void setupContent() throws FileNotFoundException {
         contentFolder.mkdir();


### PR DESCRIPTION
Nginx container tests have been surprisingly flaky for a while, so I had a look into it.

It turns out that the `WaitStrategy` in the test has actually been skipping for some time with the warning `No exposed ports or mapped ports - cannot wait for status`.

I found that the `getLivenessCheckPorts` method in `NginxContainer` is implemented incorrectly - rather than producing a HashSet with the liveness check port number as a single member, it produces a HashSet _of capacity_ equal to the port number. This is obviously silly 😂 

This change fixes that behaviour, and also switches `SimpleNginxTest` to use the non-deprecated `HttpWaitStrategy` class.