### PR TITLE
support to override default username and password in oracle-xe

### DIFF
--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -17,6 +17,9 @@ public class OracleContainer extends JdbcDatabaseContainer {
     private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
     private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 120;
 
+    private String username = "system";
+    private String password = "oracle";
+
     private static String resolveImageName() {
         String image = TestcontainersConfiguration.getInstance()
             .getProperties().getProperty("oracle.container.image");
@@ -67,12 +70,24 @@ public class OracleContainer extends JdbcDatabaseContainer {
 
     @Override
     public String getUsername() {
-        return "system";
+        return username;
     }
 
     @Override
     public String getPassword() {
-        return "oracle";
+        return password;
+    }
+
+    @Override
+    public OracleContainer withUsername(String username) {
+        this.username = username;
+        return this;
+    }
+
+    @Override
+    public OracleContainer withPassword(String password) {
+        this.password = password;
+        return this;
     }
 
     @SuppressWarnings("SameReturnValue")


### PR DESCRIPTION
our images have their own user with a schema for the application. So it is necessary to connect with the right username and password. 
With this patch the user of the OracleContainer could override the default username and password.