### PR TITLE
CouchbaseContainer fixes

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1081,33 +1081,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         }
     }
 
-    @Override
-    @SneakyThrows(IOException.class)
-    public void copyFileToContainer(Transferable transferable, String containerPath) {
-        if (!isCreated()) {
-            throw new IllegalStateException("copyFileToContainer can only be used with created / running container");
-        }
-
-        try (
-            ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            TarArchiveOutputStream tarArchive = new TarArchiveOutputStream(byteArrayOutputStream)
-        ) {
-            tarArchive.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-
-            File containerPathFile = new File(containerPath);
-            String remotePath = containerPathFile.getParent();
-            String destination = containerPathFile.getName();
-            transferable.transferTo(tarArchive, destination);
-            tarArchive.finish();
-
-            dockerClient
-                .copyArchiveToContainerCmd(containerId)
-                .withTarInputStream(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))
-                .withRemotePath(remotePath)
-                .exec();
-        }
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_1Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_1Test.java
@@ -4,7 +4,7 @@ import org.junit.ClassRule;
 
 public class Couchbase5_1Test extends BaseCouchbaseContainerTest {
     @ClassRule
-    public static CouchbaseContainer container = initCouchbaseContainer("couchbase/server:5.1.0");
+    public static CouchbaseContainer container = initCouchbaseContainer("couchbase/server:5.1.1");
 
     @Override
     public CouchbaseContainer getCouchbaseContainer() {

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/Couchbase5_5Test.java
@@ -4,7 +4,7 @@ import org.junit.ClassRule;
 
 public class Couchbase5_5Test extends BaseCouchbaseContainerTest {
     @ClassRule
-    public static CouchbaseContainer container = initCouchbaseContainer("couchbase/server:5.5.0");
+    public static CouchbaseContainer container = initCouchbaseContainer("couchbase/server:5.5.1");
 
     @Override
     public CouchbaseContainer getCouchbaseContainer() {

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
@@ -7,7 +7,7 @@ public class CouchbaseContainerTest {
 
     @Test
     public void shouldUseCorrectDockerImage() {
-        CouchbaseContainer couchbaseContainer = new CouchbaseContainer().withBeerSample(true);
+        CouchbaseContainer couchbaseContainer = new CouchbaseContainer().withClusterAdmin("admin", "foobar");
 
         Assert.assertEquals(CouchbaseContainer.DOCKER_IMAGE_NAME + CouchbaseContainer.VERSION,
             couchbaseContainer.getDockerImageName());


### PR DESCRIPTION
- removed example buckets
- added missing withClusterUsername method
- fixed capi port mapping:
  the environment patching was removed from the couchbase docker container.
  couchbase/docker@86e665b#diff-8941c93c7af57eff48058be15eb5ecff
- updated container from 5.1.0 to 5.1.1
