### PR TITLE
MockServerContainer: remove dependency to java api

### DIFF
--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,6 +3,5 @@ description = "Testcontainers :: MockServer"
 dependencies {
     compile project(':testcontainers')
 
-    compileOnly 'org.mock-server:mockserver-client-java:5.4.1'
     testCompile 'org.mock-server:mockserver-client-java:5.4.1'
 }

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -1,9 +1,6 @@
 package org.testcontainers.containers;
 
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.mockserver.client.MockServerClient;
 
 @Slf4j
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
@@ -11,9 +8,6 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
     public static final String VERSION = "5.4.1";
 
     public static final int PORT = 80;
-
-    @Getter
-    private MockServerClient client;
 
     public MockServerContainer() {
         this(VERSION);
@@ -23,13 +17,6 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
         super("jamesdbloom/mockserver:mockserver-" + version);
         withCommand("/opt/mockserver/run_mockserver.sh -logLevel INFO -serverPort " + PORT);
         addExposedPorts(PORT);
-    }
-
-    @Override
-    protected void containerIsStarted(InspectContainerResponse containerInfo) {
-        super.containerIsStarted(containerInfo);
-
-        client = new MockServerClient(getContainerIpAddress(), getMappedPort(PORT));
     }
 
     public String getEndpoint() {

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -22,4 +22,8 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
     public String getEndpoint() {
         return String.format("http://%s:%d", getContainerIpAddress(), getMappedPort(PORT));
     }
+
+    public Integer getServerPort() {
+        return getMappedPort(PORT);
+    }
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -3,6 +3,7 @@ package org.testcontainers.containers;
 import lombok.Cleanup;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.mockserver.client.MockServerClient;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -20,7 +21,7 @@ public class MockServerContainerTest {
 
     @Test
     public void testBasicScenario() throws Exception {
-        mockServer.getClient()
+        new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getMappedPort(MockServerContainer.PORT))
             .when(request("/hello"))
             .respond(response("Hello World!"));
 

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -21,7 +21,7 @@ public class MockServerContainerTest {
 
     @Test
     public void testBasicScenario() throws Exception {
-        new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getMappedPort(MockServerContainer.PORT))
+        new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort())
             .when(request("/hello"))
             .respond(response("Hello World!"));
 


### PR DESCRIPTION
originally that was not good idea to depend on something which
can brake binary compatibility :)

this change will allow to start any mockserver container version,
doesn't matter which version of the client in the classpath