### PR TITLE
Fix deadlock when ryuk does not acknowledge filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ### Fixed
+- Fixed deadlock when registering filters with ryuk container ([\#843](https://github.com/testcontainers/testcontainers-java/pull/843))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to this project will be documented in this file.
 ## UNRELEASED
 
 ### Fixed
-- Fixed deadlock when registering filters with ryuk container ([\#843](https://github.com/testcontainers/testcontainers-java/pull/843))
 
 ### Changed
 

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -373,7 +373,7 @@ public final class ResourceReaper {
          * @return true if the filters have been registered successfuly, false otherwise
          * @throws IOException if communication with Ryuk fails
          */
-        boolean register(List<Map.Entry<String, String>> filters) throws IOException {
+        protected boolean register(List<Map.Entry<String, String>> filters) throws IOException {
             String query = URLEncodedUtils.format(
                 filters.stream()
                     .map(it -> new BasicNameValuePair(it.getKey(), it.getValue()))

--- a/core/src/test/java/org/testcontainers/utility/FilterRegistryTest.java
+++ b/core/src/test/java/org/testcontainers/utility/FilterRegistryTest.java
@@ -1,0 +1,66 @@
+package org.testcontainers.utility;
+
+import org.junit.Test;
+import org.testcontainers.utility.ResourceReaper.FilterRegistry;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.AbstractMap.SimpleEntry;
+import java.util.List;
+import java.util.Map.Entry;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FilterRegistryTest {
+
+    private static final List<Entry<String, String>> FILTERS = asList(
+        new SimpleEntry<>("key1!", "value2?"), new SimpleEntry<>("key2#", "value2%")
+    );
+    private static final String URL_ENCODED_FILTERS = "key1%21=value2%3F&key2%23=value2%25";
+    private static final byte[] ACKNOWLEDGEMENT = FilterRegistry.ACKNOWLEDGMENT.getBytes();
+    private static final byte[] NO_ACKNOWLEDGEMENT = "".getBytes();
+    private static final String NEW_LINE = "\n";
+
+    @Test
+    public void registerReturnsTrueIfAcknowledgementIsReadFromInputStream() throws IOException {
+        FilterRegistry registry = new FilterRegistry(inputStream(ACKNOWLEDGEMENT), anyOutputStream());
+
+        assertTrue(registry.register(FILTERS));
+    }
+
+    @Test
+    public void registerReturnsFalseIfNoAcknowledgementIsReadFromInputStream() throws IOException {
+        FilterRegistry registry = new FilterRegistry(inputStream(NO_ACKNOWLEDGEMENT), anyOutputStream());
+
+        assertFalse(registry.register(FILTERS));
+    }
+
+    @Test
+    public void registerWritesUrlEncodedFiltersAndNewlineToOutputStream() throws IOException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        FilterRegistry registry = new FilterRegistry(anyInputStream(), outputStream);
+
+        registry.register(FILTERS);
+
+        assertEquals(URL_ENCODED_FILTERS + NEW_LINE, new String(outputStream.toByteArray()));
+    }
+
+    private static InputStream inputStream(byte[] bytes) {
+        return new ByteArrayInputStream(bytes);
+    }
+
+    private static InputStream anyInputStream() {
+        return inputStream(ACKNOWLEDGEMENT);
+    }
+
+    private static OutputStream anyOutputStream() {
+        return new ByteArrayOutputStream();
+    }
+
+}

--- a/core/src/test/java/org/testcontainers/utility/FilterRegistryTest.java
+++ b/core/src/test/java/org/testcontainers/utility/FilterRegistryTest.java
@@ -31,14 +31,18 @@ public class FilterRegistryTest {
     public void registerReturnsTrueIfAcknowledgementIsReadFromInputStream() throws IOException {
         FilterRegistry registry = new FilterRegistry(inputStream(ACKNOWLEDGEMENT), anyOutputStream());
 
-        assertTrue(registry.register(FILTERS));
+        boolean successful = registry.register(FILTERS);
+
+        assertTrue(successful);
     }
 
     @Test
     public void registerReturnsFalseIfNoAcknowledgementIsReadFromInputStream() throws IOException {
         FilterRegistry registry = new FilterRegistry(inputStream(NO_ACKNOWLEDGEMENT), anyOutputStream());
 
-        assertFalse(registry.register(FILTERS));
+        boolean successful = registry.register(FILTERS);
+
+        assertFalse(successful);
     }
 
     @Test


### PR DESCRIPTION
This PR should fix the issues #581 and #780.

In case ryuk cannot parse the request, no acknowledgement is sent resulting in a deadlock as `ResourceReaper` ignores the end of the stream and will continue waiting for one. This can happen under heavy load.

See [relevant code in ryuk](https://github.com/testcontainers/moby-ryuk/blob/master/main.go#L47). From the [documentation](https://golang.org/pkg/bufio/#Reader.ReadString) of `reader.readString`:

> If ReadString encounters an error before finding a delimiter, it returns the data read before the error and the error itself (often io.EOF)

The thread in `ResourceReaper` needs to check for the return value `null` when calling `BufferedReader#readLine` in order to check for the closed stream. From the [official documentation](https://docs.oracle.com/javase/8/docs/api/java/io/BufferedReader.html#readLine--) of that method:

> A String containing the contents of the line, not including any line-termination characters, or null if the end of the stream has been reached

I could reproduce the issue by building a patched version of testcontainers 1.8.3 release with extended logging resulting in the following log output (I truncated the file):

[ryuk_endless_loop.txt](https://github.com/testcontainers/testcontainers-java/files/2306659/ryuk_endless_loop.txt)

As you can see, the thread gets stuck trying to read from the ryuk socket waiting for an acknowledgement.

Can someone think of a way on how to implement an automated test for that?