### PR TITLE
Add support for docker hub private registry credentials

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ subprojects {
             exceptionFormat = 'full'
             events "STARTED", "PASSED", "FAILED", "SKIPPED"
         }
+        failFast = true
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ subprojects {
             exceptionFormat = 'full'
             events "STARTED", "PASSED", "FAILED", "SKIPPED"
         }
-        failFast = true
     }
 
     repositories {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -35,6 +35,7 @@ shadowJar {
         'META-INF/services/org.glassfish.hk2.extension.*',
         'META-INF/services/org.jvnet.hk2.external.generator.*',
         'META-INF/services/org.glassfish.jersey.internal.spi.*',
+        'META-INF/services/java.security.Provider',
         'mozilla/public-suffix-list.txt',
     ].each { exclude(it) }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -95,7 +95,7 @@ dependencies {
         exclude(group: "net.java.dev.jna")
     }
 
-    shaded ('com.github.docker-java:docker-java:3.1.0-rc-3') {
+    shaded ('com.github.docker-java:docker-java:3.1.0-rc-4') {
         exclude(group: 'org.glassfish.jersey.core')
         exclude(group: 'org.glassfish.jersey.connectors')
         exclude(group: 'log4j')

--- a/core/src/jarFileTest/java/org/testcontainers/JarFileShadingTest.java
+++ b/core/src/jarFileTest/java/org/testcontainers/JarFileShadingTest.java
@@ -42,8 +42,8 @@ public class JarFileShadingTest extends AbstractJarFileTest {
         );
 
         assertThatFileList(root.resolve("META-INF").resolve("native")).containsOnly(
-                "liborg-testcontainers-shaded-netty-transport-native-epoll.so",
-                "liborg-testcontainers-shaded-netty-transport-native-kqueue.jnilib"
+                "liborg-testcontainers-shaded-netty_transport_native_epoll_x86_64.so",
+                "liborg-testcontainers-shaded-netty_transport_native_kqueue_x86_64.jnilib"
         );
     }
 

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -12,6 +12,7 @@ import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.dockerclient.auth.AuthDelegatingDockerClientConfig;
 import org.testcontainers.dockerclient.transport.TestcontainersDockerCmdExecFactory;
 import org.testcontainers.dockerclient.transport.okhttp.OkHttpDockerCmdExecFactory;
 import org.testcontainers.utility.TestcontainersConfiguration;
@@ -39,6 +40,8 @@ public abstract class DockerClientProviderStrategy {
 
     private static final AtomicBoolean FAIL_FAST_ALWAYS = new AtomicBoolean(false);
 
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DockerClientProviderStrategy.class);
+
     /**
      * @throws InvalidConfigurationException if this strategy fails
      */
@@ -63,8 +66,6 @@ public abstract class DockerClientProviderStrategy {
     protected int getPriority() {
         return 0;
     }
-
-    protected static final Logger LOGGER = LoggerFactory.getLogger(DockerClientProviderStrategy.class);
 
     /**
      * Determine the right DockerClientConfig to use for building clients by trial-and-error.
@@ -166,7 +167,7 @@ public abstract class DockerClientProviderStrategy {
 
     protected DockerClient getClientForConfig(DockerClientConfig config) {
         DockerClientBuilder clientBuilder = DockerClientBuilder
-            .getInstance(config);
+            .getInstance(new AuthDelegatingDockerClientConfig(config));
 
         String transportType = TestcontainersConfiguration.getInstance().getTransportType();
         if ("okhttp".equals(transportType)) {

--- a/core/src/main/java/org/testcontainers/dockerclient/auth/AuthDelegatingDockerClientConfig.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/auth/AuthDelegatingDockerClientConfig.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.RegistryAuthLocator;
 
-import static org.testcontainers.utility.LogUtils.logSafe;
+import static org.testcontainers.utility.AuthConfigUtil.toSafeString;
 
 /**
  * Facade implementation for {@link DockerClientConfig} which overrides how authentication
@@ -42,7 +42,7 @@ public class AuthDelegatingDockerClientConfig implements DockerClientConfig {
         final AuthConfig effectiveAuthConfig = RegistryAuthLocator.instance()
             .lookupAuthConfig(parsed, fallbackAuthConfig);
 
-        log.debug("Effective auth config [{}]", logSafe(effectiveAuthConfig));
+        log.debug("Effective auth config [{}]", toSafeString(effectiveAuthConfig));
         return effectiveAuthConfig;
     }
 

--- a/core/src/main/java/org/testcontainers/dockerclient/auth/AuthDelegatingDockerClientConfig.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/auth/AuthDelegatingDockerClientConfig.java
@@ -1,0 +1,52 @@
+package org.testcontainers.dockerclient.auth;
+
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.core.DockerClientConfig;
+import lombok.experimental.Delegate;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.RegistryAuthLocator;
+
+import static org.testcontainers.utility.LogUtils.logSafe;
+
+/**
+ * Facade implementation for {@link DockerClientConfig} which overrides how authentication
+ * configuration is obtained. A delegate {@link DockerClientConfig} will be called first
+ * to try and obtain auth credentials, but after that {@link RegistryAuthLocator} will be
+ * used to try and improve the auth resolution (e.g. using credential helpers).
+ */
+@Slf4j
+public class AuthDelegatingDockerClientConfig implements DockerClientConfig {
+
+    @Delegate(excludes = DelegateExclusions.class)
+    private DockerClientConfig delegate;
+
+    public AuthDelegatingDockerClientConfig(DockerClientConfig delegate) {
+        this.delegate = delegate;
+    }
+
+    public AuthConfig effectiveAuthConfig(String imageName) {
+        // allow docker-java auth config to be used as a fallback
+        AuthConfig fallbackAuthConfig;
+        try {
+            fallbackAuthConfig = delegate.effectiveAuthConfig(imageName);
+        } catch (Exception e) {
+            log.debug("Delegate call to effectiveAuthConfig failed with cause: '{}'. " +
+                "Resolution of auth config will continue using RegistryAuthLocator.",
+                e.getMessage());
+            fallbackAuthConfig = new AuthConfig();
+        }
+
+        // try and obtain more accurate auth config using our resolution
+        final DockerImageName parsed = new DockerImageName(imageName);
+        final AuthConfig effectiveAuthConfig = RegistryAuthLocator.instance()
+            .lookupAuthConfig(parsed, fallbackAuthConfig);
+
+        log.debug("Effective auth config [{}]", logSafe(effectiveAuthConfig));
+        return effectiveAuthConfig;
+    }
+
+    private interface DelegateExclusions {
+        AuthConfig effectiveAuthConfig(String imageName);
+    }
+}

--- a/core/src/main/java/org/testcontainers/dockerclient/transport/TestcontainersDockerCmdExecFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/TestcontainersDockerCmdExecFactory.java
@@ -80,16 +80,21 @@ public class TestcontainersDockerCmdExecFactory extends AbstractDockerCmdExecFac
         bootstrap = new Bootstrap();
 
         String scheme = dockerClientConfig.getDockerHost().getScheme();
+        String host = "";
 
         if ("unix".equals(scheme)) {
             nettyInitializer = new UnixDomainSocketInitializer();
+            host = "DUMMY";
         } else if ("tcp".equals(scheme)) {
             nettyInitializer = new InetSocketInitializer();
+            host = dockerClientConfig.getDockerHost().getHost() + ":"
+                + Integer.toString(dockerClientConfig.getDockerHost().getPort());
         }
 
         eventLoopGroup = nettyInitializer.init(bootstrap, dockerClientConfig);
 
-        baseResource = new NettyWebTarget(this::connect).path(dockerClientConfig.getApiVersion().asWebPathPart());
+        baseResource = new NettyWebTarget(this::connect, host)
+            .path(dockerClientConfig.getApiVersion().asWebPathPart());
     }
 
     private DuplexChannel connect() {

--- a/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/NamedPipeSocketFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/NamedPipeSocketFactory.java
@@ -1,20 +1,18 @@
 package org.testcontainers.dockerclient.transport.okhttp;
 
+import lombok.EqualsAndHashCode;
 import lombok.SneakyThrows;
 import lombok.Value;
 import org.scalasbt.ipcsocket.Win32NamedPipeSocket;
 
 import javax.net.SocketFactory;
-import java.io.FilterInputStream;
-import java.io.FilterOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
 
 @Value
+@EqualsAndHashCode(callSuper = false)
 public class NamedPipeSocketFactory extends SocketFactory {
 
     String socketPath;

--- a/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/UnixSocketFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/UnixSocketFactory.java
@@ -1,5 +1,6 @@
 package org.testcontainers.dockerclient.transport.okhttp;
 
+import lombok.EqualsAndHashCode;
 import lombok.SneakyThrows;
 import lombok.Value;
 import org.scalasbt.ipcsocket.UnixDomainSocket;
@@ -15,6 +16,7 @@ import java.net.Socket;
 import java.net.SocketAddress;
 
 @Value
+@EqualsAndHashCode(callSuper = false)
 public class UnixSocketFactory extends SocketFactory {
 
     String socketPath;

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -3,7 +3,6 @@ package org.testcontainers.images;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.ListImagesCmd;
 import com.github.dockerjava.api.exception.DockerClientException;
-import com.github.dockerjava.api.model.AuthConfig;
 import com.github.dockerjava.api.model.Image;
 import com.github.dockerjava.core.command.PullImageResultCallback;
 import lombok.NonNull;
@@ -15,7 +14,6 @@ import org.testcontainers.containers.ContainerFetchException;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.LazyFuture;
-import org.testcontainers.utility.RegistryAuthLocator;
 
 import java.util.HashSet;
 import java.util.List;
@@ -95,14 +93,10 @@ public class RemoteDockerImage extends LazyFuture<String> {
 
                 // The image is not available locally - pull it
                 try {
-                    final RegistryAuthLocator authLocator = new RegistryAuthLocator(dockerClient.authConfig());
-                    final AuthConfig effectiveAuthConfig = authLocator.lookupAuthConfig(imageName);
-
                     final PullImageResultCallback callback = new PullImageResultCallback();
                     dockerClient
                         .pullImageCmd(imageName.getUnversionedPart())
                         .withTag(imageName.getVersionPart())
-                        .withAuthConfig(effectiveAuthConfig)
                         .exec(callback);
                     callback.awaitCompletion();
                     AVAILABLE_IMAGE_NAME_CACHE.add(imageName);

--- a/core/src/main/java/org/testcontainers/utility/AuthConfigUtil.java
+++ b/core/src/main/java/org/testcontainers/utility/AuthConfigUtil.java
@@ -1,0 +1,34 @@
+package org.testcontainers.utility;
+
+import com.github.dockerjava.api.model.AuthConfig;
+import com.google.common.base.MoreObjects;
+import lombok.experimental.UtilityClass;
+import org.jetbrains.annotations.NotNull;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * TODO: Javadocs
+ */
+@UtilityClass
+public class AuthConfigUtil {
+    public static String toSafeString(AuthConfig authConfig) {
+        if (authConfig == null) {
+            return "null";
+        }
+
+        return MoreObjects.toStringHelper(authConfig)
+            .add("username", authConfig.getUsername())
+            .add("password", obfuscated(authConfig.getPassword()))
+            .add("auth", obfuscated(authConfig.getAuth()))
+            .add("email", authConfig.getEmail())
+            .add("registryAddress", authConfig.getRegistryAddress())
+            .add("registryToken", obfuscated(authConfig.getRegistrytoken()))
+            .toString();
+    }
+
+    @NotNull
+    private static String obfuscated(String value) {
+        return isNullOrEmpty(value) ? "blank" : "hidden non-blank value";
+    }
+}

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -7,7 +7,7 @@ import lombok.EqualsAndHashCode;
 
 import java.util.regex.Pattern;
 
-@EqualsAndHashCode
+@EqualsAndHashCode(exclude = "rawName")
 public final class DockerImageName {
 
     /* Regex patterns used for validation */

--- a/core/src/main/java/org/testcontainers/utility/LogUtils.java
+++ b/core/src/main/java/org/testcontainers/utility/LogUtils.java
@@ -2,12 +2,15 @@ package org.testcontainers.utility;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.LogContainerCmd;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.google.common.base.MoreObjects;
 import lombok.experimental.UtilityClass;
 import org.testcontainers.containers.output.FrameConsumerResultCallback;
 import org.testcontainers.containers.output.OutputFrame;
 
 import java.util.function.Consumer;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.testcontainers.containers.output.OutputFrame.OutputType.STDERR;
 import static org.testcontainers.containers.output.OutputFrame.OutputType.STDOUT;
 
@@ -38,5 +41,21 @@ public class LogUtils {
 
     public void followOutput(DockerClient dockerClient, String containerId, Consumer<OutputFrame> consumer) {
         followOutput(dockerClient, containerId, consumer, STDOUT, STDERR);
+    }
+
+    public static String logSafe(AuthConfig authConfig) {
+
+        if (authConfig == null) {
+            return "null";
+        }
+
+        return MoreObjects.toStringHelper(authConfig)
+            .add("username", authConfig.getUsername())
+            .add("password", isNullOrEmpty(authConfig.getPassword()) ? "blank" : "hidden non-blank value")
+            .add("auth", isNullOrEmpty(authConfig.getAuth()) ? "blank" : "hidden non-blank value")
+            .add("email", authConfig.getEmail())
+            .add("registryAddress", authConfig.getRegistryAddress())
+            .add("registryToken", isNullOrEmpty(authConfig.getRegistrytoken()) ? "blank" : "hidden non-blank value")
+            .toString();
     }
 }

--- a/core/src/main/java/org/testcontainers/utility/LogUtils.java
+++ b/core/src/main/java/org/testcontainers/utility/LogUtils.java
@@ -43,19 +43,4 @@ public class LogUtils {
         followOutput(dockerClient, containerId, consumer, STDOUT, STDERR);
     }
 
-    public static String logSafe(AuthConfig authConfig) {
-
-        if (authConfig == null) {
-            return "null";
-        }
-
-        return MoreObjects.toStringHelper(authConfig)
-            .add("username", authConfig.getUsername())
-            .add("password", isNullOrEmpty(authConfig.getPassword()) ? "blank" : "hidden non-blank value")
-            .add("auth", isNullOrEmpty(authConfig.getAuth()) ? "blank" : "hidden non-blank value")
-            .add("email", authConfig.getEmail())
-            .add("registryAddress", authConfig.getRegistryAddress())
-            .add("registryToken", isNullOrEmpty(authConfig.getRegistrytoken()) ? "blank" : "hidden non-blank value")
-            .toString();
-    }
 }

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -10,11 +10,15 @@ import org.zeroturnaround.exec.ProcessExecutor;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.testcontainers.utility.LogUtils.logSafe;
 
 /**
  * Utility to look up registry authentication information for an image.
@@ -22,47 +26,58 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class RegistryAuthLocator {
 
     private static final Logger log = getLogger(RegistryAuthLocator.class);
-
-    private final AuthConfig defaultAuthConfig;
-    private final File configFile;
-    private final String commandPathPrefix;
+    private static final String DEFAULT_REGISTRY_NAME = "index.docker.io";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static RegistryAuthLocator instance;
+    private final String commandPathPrefix;
+    private final File configFile;
 
     @VisibleForTesting
-    RegistryAuthLocator(AuthConfig defaultAuthConfig, File configFile, String commandPathPrefix) {
-        this.defaultAuthConfig = defaultAuthConfig;
+    RegistryAuthLocator(File configFile, String commandPathPrefix) {
         this.configFile = configFile;
         this.commandPathPrefix = commandPathPrefix;
     }
 
     /**
-     * @param defaultAuthConfig an AuthConfig object that should be returned if there is no overriding authentication
-     *                          available for images that are looked up
      */
-    public RegistryAuthLocator(AuthConfig defaultAuthConfig) {
-        this.defaultAuthConfig = defaultAuthConfig;
+    protected RegistryAuthLocator() {
         final String dockerConfigLocation = System.getenv().getOrDefault("DOCKER_CONFIG",
             System.getProperty("user.home") + "/.docker");
         this.configFile = new File(dockerConfigLocation + "/config.json");
         this.commandPathPrefix = "";
     }
 
+    public synchronized static RegistryAuthLocator instance() {
+        if (instance == null) {
+            instance = new RegistryAuthLocator();
+        }
+
+        return instance;
+    }
+
+    @VisibleForTesting
+    static void setInstance(RegistryAuthLocator overrideInstance) {
+        instance = overrideInstance;
+    }
+
     /**
      * Looks up an AuthConfig for a given image name.
      * <p>
-     * Lookup is performed in following order:
+     * Lookup is performed in following order, as per
+     * https://docs.docker.com/engine/reference/commandline/cli/:
      * <ol>
-     *     <li>{@code auths} is checked for existing credentials for the specified registry.</li>
-     *     <li>if no existing auth is found, {@code credHelpers} are checked for helper for the specified registry.</li>
-     *     <li>if no suitable {@code credHelpers} found, {@code credsStore} is used.</li>
-     *     <li>if no {@code credsStore} is found then the default configuration is returned.</li>
+     *     <li>{@code credHelpers}</li>
+     *     <li>{@code credsStore}</li>
+     *     <li>Hard-coded Base64 encoded auth in {@code auths}</li>
+     *     <li>otherwise, if no credentials have been found then behaviour falls back to docker-java's
+     *     implementation</li>
      * </ol>
      *
      * @param dockerImageName image name to be looked up (potentially including a registry URL part)
-     * @return an AuthConfig that is applicable to this specific image OR the defaultAuthConfig that has been set for
-     * this {@link RegistryAuthLocator}.
+     * @param defaultAuthConfig an AuthConfig object that should be returned if there is no overriding authentication available for images that are looked up
+     * @return an AuthConfig that is applicable to this specific image OR the defaultAuthConfig.
      */
-    public AuthConfig lookupAuthConfig(DockerImageName dockerImageName) {
+    public AuthConfig lookupAuthConfig(DockerImageName dockerImageName, AuthConfig defaultAuthConfig) {
 
         if (SystemUtils.IS_OS_WINDOWS) {
             log.debug("RegistryAuthLocator is not supported on Windows. Please help test or improve it and update " +
@@ -79,39 +94,62 @@ public class RegistryAuthLocator {
 
         try {
             final JsonNode config = OBJECT_MAPPER.readTree(configFile);
-            final String reposName = dockerImageName.getRegistry();
+            final String registryName = effectiveRegistryName(dockerImageName);
+            log.debug("registryName [{}] for dockerImageName [{}]", registryName, dockerImageName);
 
-            final AuthConfig existingAuthConfig = findExistingAuthConfig(config, reposName);
-            if (existingAuthConfig != null) {
-                return existingAuthConfig;
-            }
-            // auths is empty, using helper:
-            final AuthConfig helperAuthConfig = authConfigUsingHelper(config, reposName);
+            // use helper preferentially (per https://docs.docker.com/engine/reference/commandline/cli/)
+            final AuthConfig helperAuthConfig = authConfigUsingHelper(config, registryName);
             if (helperAuthConfig != null) {
+                log.debug("found helper auth config [{}]", logSafe(helperAuthConfig));
                 return helperAuthConfig;
             }
             // no credsHelper to use, using credsStore:
-            final AuthConfig storeAuthConfig = authConfigUsingStore(config, reposName);
+            final AuthConfig storeAuthConfig = authConfigUsingStore(config, registryName);
             if (storeAuthConfig != null) {
+                log.debug("found creds store auth config [{}]", logSafe(storeAuthConfig));
                 return storeAuthConfig;
             }
+            // fall back to base64 encoded auth hardcoded in config file
+            final AuthConfig existingAuthConfig = findExistingAuthConfig(config, registryName);
+            if (existingAuthConfig != null) {
+                log.debug("found existing auth config [{}]", logSafe(existingAuthConfig));
+                return existingAuthConfig;
+            }
+
+            log.debug("no matching Auth Configs - falling back to defaultAuthConfig [{}]", logSafe(defaultAuthConfig));
             // otherwise, defaultAuthConfig should already contain any credentials available
         } catch (Exception e) {
-            log.error("Failure when attempting to lookup auth config (dockerImageName: {}, configFile: {}. " +
-                "Falling back to docker-java default behaviour",
+            log.debug("Failure when attempting to lookup auth config (dockerImageName: {}, configFile: {}. Falling back to docker-java default behaviour. Exception message: {}",
                 dockerImageName,
                 configFile,
-                e);
+                e.getMessage());
         }
         return defaultAuthConfig;
     }
 
     private AuthConfig findExistingAuthConfig(final JsonNode config, final String reposName) throws Exception {
+
         final Map.Entry<String, JsonNode> entry = findAuthNode(config, reposName);
+
         if (entry != null && entry.getValue() != null && entry.getValue().size() > 0) {
-            return OBJECT_MAPPER
+            final AuthConfig deserializedAuth = OBJECT_MAPPER
                 .treeToValue(entry.getValue(), AuthConfig.class)
                 .withRegistryAddress(entry.getKey());
+
+            if (isBlank(deserializedAuth.getUsername()) &&
+                isBlank(deserializedAuth.getPassword()) &&
+                !isBlank(deserializedAuth.getAuth())) {
+
+                final String rawAuth = new String(Base64.getDecoder().decode(deserializedAuth.getAuth()));
+                final String[] splitRawAuth = rawAuth.split(":");
+
+                if (splitRawAuth.length == 2) {
+                    deserializedAuth.withUsername(splitRawAuth[0]);
+                    deserializedAuth.withPassword(splitRawAuth[1]);
+                }
+            }
+
+            return deserializedAuth;
         }
         return null;
     }
@@ -137,13 +175,13 @@ public class RegistryAuthLocator {
         return null;
     }
 
-    private Map.Entry<String, JsonNode> findAuthNode(final JsonNode config, final String reposName) throws Exception {
+    private Map.Entry<String, JsonNode> findAuthNode(final JsonNode config, final String reposName) {
         final JsonNode auths = config.get("auths");
         if (auths != null && auths.size() > 0) {
             final Iterator<Map.Entry<String, JsonNode>> fields = auths.fields();
             while (fields.hasNext()) {
                 final Map.Entry<String, JsonNode> entry = fields.next();
-                if (entry.getKey().endsWith("://" + reposName)) {
+                if (entry.getKey().contains("://" + reposName) || entry.getKey().equals(reposName)) {
                     return entry;
                 }
             }
@@ -169,7 +207,7 @@ public class RegistryAuthLocator {
                 .outputUTF8()
                 .trim();
         } catch (Exception e) {
-            log.error("Failure running docker credential helper ({})", credentialHelperName);
+            log.debug("Failure running docker credential helper ({})", credentialHelperName);
             throw e;
         }
 
@@ -180,5 +218,13 @@ public class RegistryAuthLocator {
             .withRegistryAddress(helperResponse.at("/ServerURL").asText())
             .withUsername(helperResponse.at("/Username").asText())
             .withPassword(helperResponse.at("/Secret").asText());
+    }
+
+    private String effectiveRegistryName(DockerImageName dockerImageName) {
+        if (isNullOrEmpty(dockerImageName.getRegistry())) {
+            return DEFAULT_REGISTRY_NAME;
+        } else {
+            return dockerImageName.getRegistry();
+        }
     }
 }

--- a/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
@@ -94,14 +94,15 @@ public class AuthenticatedImagePullTest {
     }
 
     private void putImageInRegistry() throws InterruptedException {
-        client.pullImageCmd("alpine:latest")
+        // It doesn't matter which image we use for this test, but use one that's likely to have been pulled already
+        final String dummySourceImage = TestcontainersConfiguration.getInstance().getRyukImage();
+
+        client.pullImageCmd(dummySourceImage)
             .exec(new PullImageResultCallback())
             .awaitCompletion(1, TimeUnit.MINUTES);
 
-        final String id = client.listImagesCmd()
-            .withImageNameFilter("alpine:latest")
+        final String id = client.inspectImageCmd(dummySourceImage)
             .exec()
-            .get(0)
             .getId();
 
         // push the image to the registry

--- a/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
@@ -1,0 +1,117 @@
+package org.testcontainers.utility;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.AuthConfig;
+import com.github.dockerjava.core.command.PullImageResultCallback;
+import com.github.dockerjava.core.command.PushImageResultCallback;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
+
+/**
+ * This test checks the integration between Testcontainers and an authenticated registry, but uses
+ * a mock instance of {@link RegistryAuthLocator} - the purpose of the test is solely to ensure that
+ * the auth locator is utilised, and that the credentials it provides flow through to the registry.
+ *
+ * {@link RegistryAuthLocatorTest} covers actual credential scenarios at a lower level, which are
+ * impractical to test end-to-end.
+ */
+public class AuthenticatedImagePullTest {
+
+    @ClassRule
+    public static GenericContainer authenticatedRegistry = new GenericContainer(new ImageFromDockerfile()
+        .withDockerfileFromBuilder(builder -> {
+            builder.from("registry:2")
+                .run("htpasswd -Bbn testuser notasecret > /htpasswd")
+                .env("REGISTRY_AUTH", "htpasswd")
+                .env("REGISTRY_AUTH_HTPASSWD_PATH", "/htpasswd")
+                .env("REGISTRY_AUTH_HTPASSWD_REALM", "Test");
+        }))
+        .withExposedPorts(5000)
+        .waitingFor(new HttpWaitStrategy());
+
+    private static RegistryAuthLocator originalAuthLocatorSingleton;
+    private static DockerClient client;
+
+    private static String testRegistryAddress;
+    private static String testImageName;
+    private static String testImageNameWithTag;
+
+    @BeforeClass
+    public static void setUp() {
+        originalAuthLocatorSingleton = RegistryAuthLocator.instance();
+        client = DockerClientFactory.instance().client();
+
+        testRegistryAddress = authenticatedRegistry.getContainerIpAddress() + ":" + authenticatedRegistry.getFirstMappedPort();
+        testImageName = testRegistryAddress + "/alpine";
+        testImageNameWithTag = testImageName + ":latest";
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        RegistryAuthLocator.setInstance(originalAuthLocatorSingleton);
+        client.removeImageCmd(testImageNameWithTag).withForce(true).exec();
+    }
+
+    @Test
+    public void testThatAuthLocatorIsUsed() throws Exception {
+
+        final DockerImageName expectedName = new DockerImageName(testImageNameWithTag);
+        final AuthConfig authConfig = new AuthConfig()
+            .withUsername("testuser")
+            .withPassword("notasecret")
+            .withRegistryAddress("http://" + testRegistryAddress);
+
+        // Replace the RegistryAuthLocator singleton with our mock, for the duration of this test
+        final RegistryAuthLocator mockAuthLocator = Mockito.mock(RegistryAuthLocator.class);
+        RegistryAuthLocator.setInstance(mockAuthLocator);
+        when(mockAuthLocator.lookupAuthConfig(eq(expectedName), any()))
+            .thenReturn(authConfig);
+
+        // a push will use the auth locator for authentication, although that isn't the goal of this test
+        putImageInRegistry();
+
+        // actually start a container, which will require an authenticated pull
+        try (final GenericContainer container = new GenericContainer<>(testImageNameWithTag)
+            .withCommand("/bin/sh", "-c", "sleep 10")) {
+            container.start();
+
+            assertTrue("container started following an authenticated pull", container.isRunning());
+        }
+    }
+
+    private void putImageInRegistry() throws InterruptedException {
+        client.pullImageCmd("alpine:latest")
+            .exec(new PullImageResultCallback())
+            .awaitCompletion(1, TimeUnit.MINUTES);
+
+        final String id = client.listImagesCmd()
+            .withImageNameFilter("alpine:latest")
+            .exec()
+            .get(0)
+            .getId();
+
+        // push the image to the registry
+        client.tagImageCmd(id, testImageName, "latest").exec();
+
+        client.pushImageCmd(testImageNameWithTag)
+            .exec(new PushImageResultCallback())
+            .awaitCompletion(1, TimeUnit.MINUTES);
+
+        // remove the image tag from local docker so that it must be pulled before use
+        client.removeImageCmd(testImageNameWithTag).withForce(true).exec();
+    }
+}

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -25,7 +25,7 @@ public class RegistryAuthLocatorTest {
     public void lookupAuthConfigWithoutCredentials() throws URISyntaxException {
         final RegistryAuthLocator authLocator = createTestAuthLocator("config-empty.json");
 
-        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("unauthenticated.registry.org/org/repo"));
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("unauthenticated.registry.org/org/repo"), new AuthConfig());
 
         assertEquals("Default docker registry URL is set on auth config", "https://index.docker.io/v1/", authConfig.getRegistryAddress());
         assertNull("No username is set", authConfig.getUsername());
@@ -33,10 +33,21 @@ public class RegistryAuthLocatorTest {
     }
 
     @Test
+    public void lookupAuthConfigWithBasicAuthCredentials() throws URISyntaxException {
+        final RegistryAuthLocator authLocator = createTestAuthLocator("config-basic-auth.json");
+
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"), new AuthConfig());
+
+        assertEquals("Default docker registry URL is set on auth config", "https://registry.example.com", authConfig.getRegistryAddress());
+        assertEquals("Username is set", "user", authConfig.getUsername());
+        assertEquals("Password is set", "pass", authConfig.getPassword());
+    }
+
+    @Test
     public void lookupAuthConfigUsingStore() throws URISyntaxException {
         final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-store.json");
 
-        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"));
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"), new AuthConfig());
 
         assertEquals("Correct server URL is obtained from a credential store", "url", authConfig.getRegistryAddress());
         assertEquals("Correct username is obtained from a credential store", "username", authConfig.getUsername());
@@ -47,7 +58,7 @@ public class RegistryAuthLocatorTest {
     public void lookupAuthConfigUsingHelper() throws URISyntaxException {
         final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-helper.json");
 
-        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"));
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"), new AuthConfig());
 
         assertEquals("Correct server URL is obtained from a credential store", "url", authConfig.getRegistryAddress());
         assertEquals("Correct username is obtained from a credential store", "username", authConfig.getUsername());
@@ -58,7 +69,7 @@ public class RegistryAuthLocatorTest {
     public void lookupUsingHelperEmptyAuth() throws URISyntaxException {
         final RegistryAuthLocator authLocator = createTestAuthLocator("config-empty-auth-with-helper.json");
 
-        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"));
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"), new AuthConfig());
 
         assertEquals("Correct server URL is obtained from a credential store", "url", authConfig.getRegistryAddress());
         assertEquals("Correct username is obtained from a credential store", "username", authConfig.getUsername());
@@ -69,18 +80,17 @@ public class RegistryAuthLocatorTest {
     public void lookupNonEmptyAuthWithHelper() throws URISyntaxException {
         final RegistryAuthLocator authLocator = createTestAuthLocator("config-existing-auth-with-helper.json");
 
-        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"));
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"), new AuthConfig());
 
-        assertEquals("Correct server URL is obtained from a credential store", "https://registry.example.com", authConfig.getRegistryAddress());
-        assertNull("No username is set", authConfig.getUsername());
-        assertEquals("Correct email is obtained from a credential store", "not@val.id", authConfig.getEmail());
-        assertEquals("Correct auth is obtained from a credential store", "encoded auth token", authConfig.getAuth());
+        assertEquals("Correct server URL is obtained from a credential helper", "url", authConfig.getRegistryAddress());
+        assertEquals("Correct username is obtained from a credential helper", "username", authConfig.getUsername());
+        assertEquals("Correct password is obtained from a credential helper", "secret", authConfig.getPassword());
     }
 
     @NotNull
     private RegistryAuthLocator createTestAuthLocator(String configName) throws URISyntaxException {
         final File configFile = new File(Resources.getResource("auth-config/" + configName).toURI());
-        return new RegistryAuthLocator(new AuthConfig(), configFile, configFile.getParentFile().getAbsolutePath() + "/");
+        return new RegistryAuthLocator(configFile, configFile.getParentFile().getAbsolutePath() + "/");
     }
 
 }

--- a/core/src/test/resources/auth-config/config-basic-auth.json
+++ b/core/src/test/resources/auth-config/config-basic-auth.json
@@ -1,0 +1,8 @@
+{
+    "auths": {
+        "https://registry.example.com": {
+            "email": "user@example.com",
+            "auth": "dXNlcjpwYXNz"
+        }
+    }
+}

--- a/core/src/test/resources/auth-config/config-existing-auth-with-helper.json
+++ b/core/src/test/resources/auth-config/config-existing-auth-with-helper.json
@@ -2,7 +2,7 @@
     "auths": {
         "https://registry.example.com": {
             "email": "not@val.id",
-            "auth": "encoded auth token"
+            "auth": "dXNlcjpwYXNz"
         }
     },
     "HttpHeaders": {


### PR DESCRIPTION
Closes #819 (I wanted to rebase onto master, so thought it best to start with a fresh branch and PR).

Fixes #820 

[This comment](https://github.com/testcontainers/testcontainers-java/issues/820#issuecomment-413708481) describes the approach:

> ~This is still WIP~, but tackles the two underlying issues that you and others have encountered:
> * basic auth credentials not being parsed out of the config.json file (for all private repos)
> * registry auth for index.docker.io being rejected. To resolve this I've overridden the effectiveAuthConfig method of DockerClientConfig for now, to try and come up with a solution that doesn't require changing docker-java (yet).
> 
> In the long term, this requires a fair amount of modification to docker-java to do it cleanly, but for now we can basically layer this on top and refactor later.
