### PR TITLE
UnixDomainSocketInitializer uses configured docker host in connect()

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/transport/TestcontainersDockerCmdExecFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/TestcontainersDockerCmdExecFactory.java
@@ -159,7 +159,8 @@ public class TestcontainersDockerCmdExecFactory extends AbstractDockerCmdExecFac
 
         @Override
         public DuplexChannel connect(Bootstrap bootstrap) throws InterruptedException {
-            return (DuplexChannel) bootstrap.connect(new DomainSocketAddress("/var/run/docker.sock")).sync().channel();
+            String socketPath = getDockerClientConfig().getDockerHost().getPath();
+            return (DuplexChannel) bootstrap.connect(new DomainSocketAddress(socketPath)).sync().channel();
         }
     }
 


### PR DESCRIPTION
As described in [this comment](https://github.com/testcontainers/testcontainers-java/issues/854#issuecomment-418368406) UnixDomainSocketInitializer is using a default value for the socketPath instead of the one configured.