### PR TITLE
make MYSQL_ROOT_PASSWORD and MYSQL_PASSWORD the same value

### DIFF
--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -42,7 +42,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         addEnv("MYSQL_DATABASE", databaseName);
         addEnv("MYSQL_USER", username);
         addEnv("MYSQL_PASSWORD", password);
-        addEnv("MYSQL_ROOT_PASSWORD", "test");
+        addEnv("MYSQL_ROOT_PASSWORD", password);
         setStartupAttempts(3);
     }
 


### PR DESCRIPTION
If I set the MSQL_PASSWORD, i think the MYSQL_ROOT_PASSWORD should be the same. 
