### PR TITLE
CouchbaseContainer: Fix java.net.SocketException exception in stop()

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -180,7 +180,8 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     @Override
     public void stop() {
-        Stream.<Runnable>of(super::stop, proxy::stop, this::stopCluster).parallel().forEach(Runnable::run);
+        stopCluster();
+        Stream.<Runnable>of(super::stop, proxy::stop).parallel().forEach(Runnable::run);
     }
 
     private void stopCluster() {

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
@@ -12,4 +12,11 @@ public class CouchbaseContainerTest {
         Assert.assertEquals(CouchbaseContainer.DOCKER_IMAGE_NAME + CouchbaseContainer.VERSION,
             couchbaseContainer.getDockerImageName());
     }
+
+    @Test
+    public void shouldStopWithoutThrowingException() {
+        CouchbaseContainer couchbaseContainer = new CouchbaseContainer();
+        couchbaseContainer.start();
+        couchbaseContainer.stop();
+    }
 }


### PR DESCRIPTION
Motivation
==========
When `stop()` was called without a prior call to `createCouchbaseEnvironment()`, it would throw a `SocketException` because `stopCluster()` would end up trying to initialize the cluster at the same time the container is being shut down.

Modifications
=============
Call `stopCluster()` before stopping the container, instead of in parallel.

Result
======
`stopCluster()` might still call `createCouchbaseEnvironment()`, but the call succeeds and the environment is immediately cleaned up.