### PR TITLE
Add db2 jdbc module

### DIFF
--- a/docs/usage/database_containers.md
+++ b/docs/usage/database_containers.md
@@ -44,6 +44,7 @@ Examples/Tests:
  * [PostgreSQL](https://github.com/testcontainers/testcontainers-java/blob/master/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java)
  * [Oracle-XE](https://github.com/testcontainers/testcontainers-java-module-oracle-xe/blob/master/src/test/java/org/testcontainers/junit/SimpleOracleTest.java)
  * [Virtuoso](https://github.com/testcontainers/testcontainers-java/blob/master/modules/virtuoso/src/test/java/org/testcontainers/junit/SimpleVirtuosoTest.java)
+ * [DB2](https://github.com/testcontainers/testcontainers-java/blob/master/modules/db2/src/test/java/org/testcontainers/junit/SimpleDb2Test.java)
 
 ### JDBC URL
 

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -1,0 +1,5 @@
+description = "Testcontainers :: JDBC :: DB2"
+
+dependencies {
+    compile project(':jdbc')
+}

--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -1,0 +1,94 @@
+package org.testcontainers.containers;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.output.WaitingConsumer;
+import org.testcontainers.utility.LogUtils;
+
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+
+public class Db2Container<SELF extends Db2Container<SELF>> extends JdbcDatabaseContainer<SELF> {
+
+    static final String NAME = "db2";
+    static final String DEFAULT_DB2_IMAGE_NAME = "ibmcom/db2express-c";
+    static final String DEFAULT_TAG = "10.5.0.5-3.10.0";
+    private static final int DB2_PORT = 50000;
+
+    private String username = "db2inst1";
+    private String password = "foobar1234";
+
+    private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
+    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 240;
+
+    public Db2Container() {
+        this(DEFAULT_DB2_IMAGE_NAME + ":" + DEFAULT_TAG);
+    }
+
+    public Db2Container(String imageName) {
+        super(imageName);
+        withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
+        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+    }
+
+    @Override
+    protected void configure() {
+        addExposedPort(DB2_PORT);
+
+        addEnv("LICENSE", "accept"); // TODO: explicit?
+        addEnv("DB2INST1_PASSWORD", password);
+
+        withCommand("db2start");
+
+    }
+
+    @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo) {
+        super.containerIsStarting(containerInfo);
+
+        WaitingConsumer waitingConsumer = new WaitingConsumer();
+        LogUtils.followOutput(DockerClientFactory.instance().client(), containerInfo.getId(), waitingConsumer);
+
+        Predicate<OutputFrame> waitPredicate = outputFrame ->
+            outputFrame.getUtf8String()
+                .matches("(?s).*DB2START processing was successful.*");
+
+
+        try {
+            waitingConsumer.waitUntil(waitPredicate);
+            execInContainer("/bin/sh", "-c", "runuser -l db2inst1 -c 'db2 create db tc'");
+        } catch (TimeoutException e) {
+            throw new ContainerLaunchException("Timeout while waiting for db started log message");
+        } catch (InterruptedException | IOException e) {
+            throw new ContainerLaunchException("Error while creating database");
+        }
+
+    }
+
+    @Override
+    public String getDriverClassName() {
+        return "com.ibm.db2.jcc.DB2Driver";
+    }
+
+    @Override
+    public String getJdbcUrl() {
+        return "jdbc:db2://" + getContainerIpAddress() + ":" + getMappedPort(DB2_PORT) + "/tc";
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    protected String getTestQueryString() {
+        return "SELECT 1 FROM SYSIBM.SYSDUMMY1";
+    }
+}

--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2ContainerProvider.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2ContainerProvider.java
@@ -1,0 +1,18 @@
+package org.testcontainers.containers;
+
+public class Db2ContainerProvider extends JdbcDatabaseContainerProvider {
+    @Override
+    public boolean supports(String databaseType) {
+        return databaseType.equals(Db2Container.NAME);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance() {
+        return newInstance(Db2Container.DEFAULT_TAG);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(String tag) {
+        return new Db2Container(Db2Container.DEFAULT_DB2_IMAGE_NAME + ":" + tag);
+    }
+}

--- a/modules/db2/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
+++ b/modules/db2/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.testcontainers.containers.Db2ContainerProvider

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,6 +2,11 @@ repositories {
     maven {
         url "https://maven.atlassian.com/3rdparty/"
     }
+
+    // for db2jcc4
+    maven {
+        url "https://artifacts.alfresco.com/nexus/content/repositories/public/"
+    }
 }
 
 dependencies {
@@ -11,6 +16,7 @@ dependencies {
     compile project(':oracle-xe')
     compile project(':mssqlserver')
     compile project(':clickhouse')
+    compile project(':db2')
 
     testCompile 'com.google.guava:guava:18.0'
     testCompile 'org.postgresql:postgresql:42.0.0'
@@ -19,6 +25,7 @@ dependencies {
     testCompile 'com.oracle:ojdbc6:12.1.0.1-atlassian-hosted'
     testCompile 'com.microsoft.sqlserver:mssql-jdbc:6.1.0.jre8'
     testCompile 'ru.yandex.clickhouse:clickhouse-jdbc:0.1.41'
+    testCompile 'com.ibm.db2.jcc:db2jcc4:10.1'
 
     testCompile 'com.zaxxer:HikariCP-java6:2.3.8'
     testCompile 'org.apache.tomcat:tomcat-jdbc:8.5.4'

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -59,6 +59,7 @@ public class JDBCDriverTest {
                 {"jdbc:tc:mariadb:10.2.14://hostname/databasename?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction", EnumSet.of(Options.ScriptedSchema)},
                 {"jdbc:tc:mariadb:10.2.14://hostname/databasename?TC_MY_CNF=somepath/mariadb_conf_override", EnumSet.of(Options.CustomIniFile)},
                 {"jdbc:tc:clickhouse://hostname/databasename", EnumSet.of(Options.PmdKnownBroken)},
+//                {"jdbc:tc:db2://hostname/databasename", EnumSet.noneOf(Options.class)}, // Test queries don't work
             });
     }
 

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleDb2Test.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleDb2Test.java
@@ -1,0 +1,38 @@
+package org.testcontainers.junit;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.Db2Container;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+
+
+public class SimpleDb2Test {
+
+    @Rule
+    public Db2Container db2 = new Db2Container();
+
+    @Test
+    public void testSimple() throws SQLException {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(db2.getJdbcUrl());
+        hikariConfig.setUsername(db2.getUsername());
+        hikariConfig.setPassword(db2.getPassword());
+
+        HikariDataSource ds = new HikariDataSource(hikariConfig);
+        Statement statement = ds.getConnection().createStatement();
+        statement.execute("SELECT 1 FROM SYSIBM.SYSDUMMY1");
+        ResultSet resultSet = statement.getResultSet();
+
+        resultSet.next();
+        int resultSetInt = resultSet.getInt(1);
+        assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+    }
+
+}

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -172,7 +172,7 @@ public class ConnectionUrl {
      * @author manikmagar
      */
     public interface Patterns {
-        Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^:]+))?://([^\\?]+)(\\?.*)?");
+        Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+2?)(:([^:]+))?://([^\\?]+)(\\?.*)?");
 
         Pattern ORACLE_URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:([a-z]+)(:([^(thin:)]+))?:thin:@([^\\?]+)(\\?.*)?");
 


### PR DESCRIPTION
Created during the Softwerkskammer Ruhr Hackergarten together with Felix Winkler.

I have some concerns regarding the license issues, similar to Oracle. On the one hand, we to provide an environment variable to accept the license when running the official IBM DB2 image.

The other problem is the JDBC driver. IBM doesn't provide the JAR on Maven Central. A search on Maven Central resulted in finding this Maven Repository: `https://artifacts.alfresco.com/nexus/content/repositories/public/`

Any good ideas how to proceed from here?

The general implementation works, as well as the JDBC-URL support, however the JDBC-URL support has some vendor specific SQL, so the test fails.

closes #432 