### PR TITLE
Fix local docker-compose support on Windows10

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -622,13 +623,12 @@ class LocalDockerCompose implements DockerCompose {
         environment.put(ENV_PROJECT_NAME, identifier);
 
 
-        final List<String> absoluteDockerComposeFiles = composeFiles.stream()
+        final Stream<String> absoluteDockerComposeFilePaths = composeFiles.stream()
             .map(File::getAbsolutePath)
-            .map(Objects::toString)
-            .collect(toList());
+            .map(Objects::toString);
 
-        final String composeFileEnvVariableValue = absoluteDockerComposeFiles.stream()
-            .collect(joining(File.pathSeparator + ""));
+        final String composeFileEnvVariableValue = absoluteDockerComposeFilePaths.collect(
+            joining(File.pathSeparator + ""));
         logger().debug("Set env COMPOSE_FILE={}", composeFileEnvVariableValue);
 
         final File pwd = composeFiles.get(0).getAbsoluteFile().getParentFile().getAbsoluteFile();

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -33,14 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -52,7 +45,6 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static org.testcontainers.containers.BindMode.READ_ONLY;
 import static org.testcontainers.containers.BindMode.READ_WRITE;
-import static org.testcontainers.containers.ContainerisedDockerCompose.UNIX_PATH_SEPERATOR;
 
 /**
  * Container which launches Docker Compose, for the purposes of launching a defined set of containers.
@@ -632,11 +624,13 @@ class LocalDockerCompose implements DockerCompose {
 
         final List<String> absoluteDockerComposeFiles = composeFiles.stream()
             .map(File::getAbsolutePath)
-            .map(MountableFile::forHostPath)
-            .map(MountableFile::getFilesystemPath)
+            .map(Objects::toString)
             .collect(toList());
-        final String composeFileEnvVariableValue = absoluteDockerComposeFiles.stream().collect(joining(UNIX_PATH_SEPERATOR + "")); // we always need the UNIX path separator
+
+        final String composeFileEnvVariableValue = absoluteDockerComposeFiles.stream()
+            .collect(joining(File.pathSeparator + ""));
         logger().debug("Set env COMPOSE_FILE={}", composeFileEnvVariableValue);
+
         final File pwd = composeFiles.get(0).getAbsoluteFile().getParentFile().getAbsoluteFile();
         environment.put(ENV_COMPOSE_FILE, composeFileEnvVariableValue);
 


### PR DESCRIPTION
Local Docker-Compose was failing on Windows10 because of different, path related, problems.

Also note that the `COMPOSE_FILE` environment variable uses system specific path separators:
> The COMPOSE_FILE environment variable can now contain multiple files, separated by the host system's standard path separator :slightly_smiling_face: on Mac/Linux, ; on Windows).