### PR TITLE
Add support for Postgis to JDBC driver

### DIFF
--- a/docs/usage/database_containers.md
+++ b/docs/usage/database_containers.md
@@ -73,6 +73,9 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 `jdbc:tc:postgresql:9.6.8://hostname/databasename`
 
+### Using PostGIS
+
+`jdbc:tc:postgis:9.6://hostname/databasename`
 
 ## Using an init script
 

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -51,6 +51,8 @@ public class JDBCDriverTest {
                 {"jdbc:tc:mysql:5.5.43://hostname/databasename", EnumSet.noneOf(Options.class)},
                 {"jdbc:tc:mysql:5.5.43://hostname/databasename?useSSL=false", EnumSet.noneOf(Options.class)},
                 {"jdbc:tc:postgresql:9.6.8://hostname/databasename", EnumSet.noneOf(Options.class)},
+                {"jdbc:tc:postgis://hostname/databasename", EnumSet.noneOf(Options.class)},
+                {"jdbc:tc:postgis:9.6://hostname/databasename", EnumSet.noneOf(Options.class)},
                 {"jdbc:tc:mysql:5.6://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override", EnumSet.of(Options.CustomIniFile)},
                 {"jdbc:tc:mariadb://hostname/databasename", EnumSet.noneOf(Options.class)},
                 {"jdbc:tc:mariadb:10.2.14://hostname/databasename", EnumSet.noneOf(Options.class)},

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
@@ -1,0 +1,26 @@
+package org.testcontainers.containers;
+
+/**
+ * Factory for PostGIS containers, which are a special flavour os PostgreSQL.
+ */
+public class PostgisContainerProvider extends JdbcDatabaseContainerProvider {
+
+    private static final String NAME = "postgis";
+    private static final String DEFAULT_TAG = "10";
+    private static final String DEFAULT_IMAGE = "mdillon/postgis";
+
+    @Override
+    public boolean supports(String databaseType) {
+        return databaseType.equals(NAME);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance() {
+        return newInstance(DEFAULT_TAG);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(String tag) {
+        return new PostgreSQLContainer(DEFAULT_IMAGE + ":" + tag);
+    }
+}

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
@@ -1,7 +1,7 @@
 package org.testcontainers.containers;
 
 /**
- * Factory for PostGIS containers, which are a special flavour os PostgreSQL.
+ * Factory for PostGIS containers, which are a special flavour of PostgreSQL.
  */
 public class PostgisContainerProvider extends JdbcDatabaseContainerProvider {
 

--- a/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
+++ b/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
@@ -1,1 +1,2 @@
 org.testcontainers.containers.PostgreSQLContainerProvider
+org.testcontainers.containers.PostgisContainerProvider


### PR DESCRIPTION
This is an alternative implementation of #708, relying completely on the existing `PostgreSQLContainer` class.

