### PR TITLE
Feature/756

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.zeroturnaround.exec.ProcessExecutor;
 
@@ -187,6 +186,12 @@ public class RegistryAuthLocator {
     }
 
     private AuthConfig runCredentialProvider(String hostName, String credHelper) throws Exception {
+
+        if (StringUtils.isBlank(hostName)) {
+            log.debug("There is no point to locate AuthConfig for blank hostName, return null to allow fallback");
+            return null;
+        }
+
         final String credentialHelperName = getCredentialHelperName(credHelper);
         String data;
 

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -188,7 +188,7 @@ public class RegistryAuthLocator {
 
     private AuthConfig runCredentialProvider(String hostName, String credHelper) throws Exception {
 
-        if (StringUtils.isBlank(hostName)) {
+        if (isBlank(hostName)) {
             log.debug("There is no point to locate AuthConfig for blank hostName, return null to allow fallback");
             return null;
         }

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -116,7 +116,7 @@ public class RegistryAuthLocator {
             log.debug("no matching Auth Configs - falling back to defaultAuthConfig [{}]", toSafeString(defaultAuthConfig));
             // otherwise, defaultAuthConfig should already contain any credentials available
         } catch (Exception e) {
-            log.debug("Failure when attempting to lookup auth config (dockerImageName: {}, configFile: {}. Falling back to docker-java default behaviour. Exception message: {}",
+            log.warn("Failure when attempting to lookup auth config (dockerImageName: {}, configFile: {}. Falling back to docker-java default behaviour. Exception message: {}",
                 dockerImageName,
                 configFile,
                 e.getMessage());
@@ -189,7 +189,7 @@ public class RegistryAuthLocator {
     private AuthConfig runCredentialProvider(String hostName, String credHelper) throws Exception {
 
         if (isBlank(hostName)) {
-            log.debug("There is no point to locate AuthConfig for blank hostName, return null to allow fallback");
+            log.debug("There is no point to locate AuthConfig for blank hostName. Return NULL to allow fallback");
             return null;
         }
 
@@ -216,7 +216,10 @@ public class RegistryAuthLocator {
                 // We can handle it properly with fallback to other resources.
                 // https://github.com/docker/docker-credential-helpers/blob/19b711cc92fbaa47533646fa8adb457d199c99e1/credentials/error.go#L4-L6
                 if ("credentials not found in native keychain".equals(e.getResult().outputString().trim())) {
-                    log.debug("Credentials not found in native keychain, credential helper ({}), return null to allow fallback", credentialHelperName);
+                    log.info("Credentials not found in native keychain for host ({}), credential helper ({})",
+                        hostName,
+                        credentialHelperName);
+
                     return null;
                 }
                 log.debug("Failure running docker credential helper ({}) with output '{}'",

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -97,7 +97,7 @@ public class RegistryAuthLocatorTest {
 
         assertEquals(
             "Not correct message discovered",
-            "Fake credentials not found on credentials store 'https://adsfasdf.wrewerwer.com/asdfsdddd'",
+            "Fake credentials not found on credentials store 'https://not.a.real.registry/url'",
             discoveredMessage);
     }
 

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -4,8 +4,6 @@ import com.github.dockerjava.api.model.AuthConfig;
 import com.google.common.io.Resources;
 import org.apache.commons.lang.SystemUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Assume;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -15,12 +13,6 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertNull;
 
 public class RegistryAuthLocatorTest {
-
-    @BeforeClass
-    public static void nonWindowsTest() throws Exception {
-        Assume.assumeFalse(SystemUtils.IS_OS_WINDOWS);
-    }
-
     @Test
     public void lookupAuthConfigWithoutCredentials() throws URISyntaxException {
         final RegistryAuthLocator authLocator = createTestAuthLocator("config-empty.json");
@@ -90,7 +82,19 @@ public class RegistryAuthLocatorTest {
     @NotNull
     private RegistryAuthLocator createTestAuthLocator(String configName) throws URISyntaxException {
         final File configFile = new File(Resources.getResource("auth-config/" + configName).toURI());
-        return new RegistryAuthLocator(configFile, configFile.getParentFile().getAbsolutePath() + "/");
+
+        String commandPathPrefix = configFile.getParentFile().getAbsolutePath() + "/";
+        String commandExtension = "";
+
+        if (SystemUtils.IS_OS_WINDOWS) {
+            commandPathPrefix += "win/";
+
+            // need to provide executable extension otherwise won't run it
+            // with real docker wincredential exe there is no problem
+            commandExtension = ".bat";
+        }
+
+        return new RegistryAuthLocator(configFile, commandPathPrefix, commandExtension);
     }
 
 }

--- a/core/src/test/resources/auth-config/docker-credential-fake
+++ b/core/src/test/resources/auth-config/docker-credential-fake
@@ -4,7 +4,16 @@ if [[ $1 != "get" ]]; then
     exit 1
 fi
 
-read > /dev/null
+read inputLine
+
+if [[ $inputLine == "registry.example.com" ]]; then
+    echo Fake credentials not found on credentials store \'$inputLine\' 1>&2
+    exit 1
+fi
+if [[ $inputLine == "https://adsfasdf.wrewerwer.com/asdfsdddd" ]]; then
+    echo Fake credentials not found on credentials store \'$inputLine\' 1>&2
+    exit 1
+fi
 
 echo '{' \
      '  "ServerURL": "url",' \

--- a/core/src/test/resources/auth-config/docker-credential-fake
+++ b/core/src/test/resources/auth-config/docker-credential-fake
@@ -10,7 +10,7 @@ if [[ $inputLine == "registry2.example.com" ]]; then
     echo Fake credentials not found on credentials store \'$inputLine\' 1>&2
     exit 1
 fi
-if [[ $inputLine == "https://adsfasdf.wrewerwer.com/asdfsdddd" ]]; then
+if [[ $inputLine == "https://not.a.real.registry/url" ]]; then
     echo Fake credentials not found on credentials store \'$inputLine\' 1>&2
     exit 1
 fi

--- a/core/src/test/resources/auth-config/docker-credential-fake
+++ b/core/src/test/resources/auth-config/docker-credential-fake
@@ -6,7 +6,7 @@ fi
 
 read inputLine
 
-if [[ $inputLine == "registry.example.com" ]]; then
+if [[ $inputLine == "registry2.example.com" ]]; then
     echo Fake credentials not found on credentials store \'$inputLine\' 1>&2
     exit 1
 fi

--- a/core/src/test/resources/auth-config/win/docker-credential-fake.bat
+++ b/core/src/test/resources/auth-config/win/docker-credential-fake.bat
@@ -1,0 +1,10 @@
+@echo off
+if not "%1" == "get" (
+    exit 1
+)
+
+echo {
+echo   "ServerURL": "url",
+echo   "Username": "username",
+echo   "Secret": "secret"
+echo }

--- a/core/src/test/resources/auth-config/win/docker-credential-fake.bat
+++ b/core/src/test/resources/auth-config/win/docker-credential-fake.bat
@@ -9,7 +9,7 @@ if "%inputLine%" == "registry2.example.com" (
      echo Fake credentials not found on credentials store '%inputLine%' 1>&2
      exit 1
 )
-if "%inputLine%" == "https://adsfasdf.wrewerwer.com/asdfsdddd" (
+if "%inputLine%" == "https://not.a.real.registry/url" (
      echo Fake credentials not found on credentials store '%inputLine%' 1>&2
      exit 1
 )

--- a/core/src/test/resources/auth-config/win/docker-credential-fake.bat
+++ b/core/src/test/resources/auth-config/win/docker-credential-fake.bat
@@ -3,6 +3,17 @@ if not "%1" == "get" (
     exit 1
 )
 
+set /p inputLine=""
+
+if "%inputLine%" == "registry2.example.com" (
+     echo Fake credentials not found on credentials store '%inputLine%' 1>&2
+     exit 1
+)
+if "%inputLine%" == "https://adsfasdf.wrewerwer.com/asdfsdddd" (
+     echo Fake credentials not found on credentials store '%inputLine%' 1>&2
+     exit 1
+)
+
 echo {
 echo   "ServerURL": "url",
 echo   "Username": "username",


### PR DESCRIPTION
#756 tested on Windows. 
Fixed RegistryAuthLocatorTest on Windows and also allowed better fallbacks from running credential provider (to allow lookup alternative AuthConfigs), when:
1) there is no hostName, then there is no point to ask credentials
2) when credential helper response with "credentials not found in native keychain" to try other resources

Main reason for failing for me on Windows machine was #710 changes. When i used Netty or OkHttp together with npipe, then it worked fine. Yesterday evening i found out the reason and today morning i found also fix in master for that :-) - #865, breaking docker response by line breaks.