### PR TITLE
Remove unnecessary start() call in initCouchbaseContainer() method

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/AbstractCouchbaseTest.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/AbstractCouchbaseTest.java
@@ -37,7 +37,6 @@ public abstract class AbstractCouchbaseTest {
     protected static CouchbaseContainer initCouchbaseContainer(String imageName) {
         CouchbaseContainer couchbaseContainer = (imageName == null) ? new CouchbaseContainer() : new CouchbaseContainer(imageName);
         couchbaseContainer.withNewBucket(getDefaultBucketSettings());
-        couchbaseContainer.start();
         return couchbaseContainer;
     }
 


### PR DESCRIPTION
Seems the wrong place, since the containers themselves are annotated with `@ClassRule` in the tests.