### PR TITLE
Fix HttpWaitStrategy.forStatusCodeMatching used with HttpWaitStrategy.forStatusCode

### DIFF
--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
@@ -85,6 +85,21 @@ public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrat
     }
 
     /**
+     * Expects that the WaitStrategy throws a {@link RetryCountExceededException} after not receiving any of the
+     * error code defined with {@link HttpWaitStrategy#forStatusCode(int)}
+     * and {@link HttpWaitStrategy#forStatusCodeMatching(Predicate)}. Note that a 200 status code should not
+     * be considered as a successful return as not explicitly set.
+     * Test case for: https://github.com/testcontainers/testcontainers-java/issues/880
+     */
+    @Test
+    public void testWaitUntilReadyWithTimeoutAndWithLambdaShouldNotMatchOk() {
+        waitUntilReadyAndTimeout(startContainerWithCommand(createShellCommand("200 OK", GOOD_RESPONSE_BODY),
+            createHttpWaitStrategy(ready)
+                .forStatusCodeMatching(it -> it >= 300)
+        ));
+    }
+
+    /**
      * Expects that the WaitStrategy throws a {@link RetryCountExceededException} after not receiving an HTTP 200
      * response from the container within the timeout period.
      */


### PR DESCRIPTION
In #630 we introduced predicates but with a default one which is always present whatever is passed in the `forStatusCodeMatching()` method.

This commit adds a test that demonstrates the issue:

* We have a service returning `200 OK`
* The predicate expects anything which is a code >= to `300`
* The test should throw a Timeout as this condition is never reached but without the current fix, the test never throws the Timeout as 200 matches the default builtin predicate.

This commit fixes the problem by checking at startup time what is/are the predicates that needs to be applied.

Note that in most cases, an HTTP service is expected to throw a `200 OK` status so that fix might not fix actually any real problem and might be a theory only. But I'd prefer to have code that actually implements what is supposed to work.

Closes #880.