### PR TITLE
Use latest available VNC recorder image 

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -35,7 +35,7 @@ public class TestcontainersConfiguration {
     }
 
     public String getVncRecordedContainerImage() {
-        return (String) properties.getOrDefault("vncrecorder.container.image", "richnorth/vnc-recorder:latest");
+        return (String) properties.getOrDefault("vncrecorder.container.image", "quay.io/testcontainers/vnc-recorder:1.1.0");
     }
 
     public String getDockerComposeContainerImage() {


### PR DESCRIPTION
This updates us to use `quay.io/testcontainers/vnc-recorder:1.1.0`, rather than the legacy `richnorth/vnc-recorder` image as the default VNC recorder.

This new base image is based upon testcontainers/vnc-recorder#1 and is intended to avoid an apparent segfault bug with the older version of debian that affects some users. 