### PR TITLE
Added an example using TestNG (#778)

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,6 +7,7 @@
     <version>NOVERSION</version>
     <modules>
         <module>redis-backed-cache</module>
+        <module>redis-backed-cache-testng</module>
         <module>disque-job-queue</module>
         <module>selenium-container</module>
         <module>spring-boot</module>

--- a/examples/redis-backed-cache-testng/pom.xml
+++ b/examples/redis-backed-cache-testng/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>testcontainers-java-examples</artifactId>
+        <groupId>org.testcontainers.examples</groupId>
+        <version>NOVERSION</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>redis-backed-cache-testng</artifactId>
+    <description>Redis Backend Cache testing example using TestNG</description>
+    <dependencies>
+        <dependency>
+            <groupId>redis.clients</groupId>
+            <artifactId>jedis</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.1.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>6.9.10</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+</project>

--- a/examples/redis-backed-cache-testng/src/main/java/com/mycompany/cache/Cache.java
+++ b/examples/redis-backed-cache-testng/src/main/java/com/mycompany/cache/Cache.java
@@ -1,0 +1,27 @@
+package com.mycompany.cache;
+
+import java.util.Optional;
+
+/**
+ * Cache, for storing data associated with keys.
+ */
+public interface Cache {
+
+    /**
+     * Store a value object in the cache with no specific expiry time. The object may be evicted by the cache any time,
+     * if necessary.
+     *
+     * @param key   key that may be used to retrieve the object in the future
+     * @param value the value object to be stored
+     */
+    void put(String key, Object value);
+
+    /**
+     * Retrieve a value object from the cache.
+     * @param key               the key that was used to insert the object initially
+     * @param expectedClass     for convenience, a class that the object should be cast to before being returned
+     * @param <T>               the class of the returned object
+     * @return                  the object if it was in the cache, or an empty Optional if not found.
+     */
+    <T> Optional<T> get(String key, Class<T> expectedClass);
+}

--- a/examples/redis-backed-cache-testng/src/main/java/com/mycompany/cache/RedisBackedCache.java
+++ b/examples/redis-backed-cache-testng/src/main/java/com/mycompany/cache/RedisBackedCache.java
@@ -1,0 +1,39 @@
+package com.mycompany.cache;
+
+import com.google.gson.Gson;
+import redis.clients.jedis.Jedis;
+
+import java.util.Optional;
+
+/**
+ * An implementation of {@link Cache} that stores data in Redis.
+ */
+public class RedisBackedCache implements Cache {
+
+    private final Jedis jedis;
+    private final String cacheName;
+    private final Gson gson;
+
+    public RedisBackedCache(Jedis jedis, String cacheName) {
+        this.jedis = jedis;
+        this.cacheName = cacheName;
+        this.gson = new Gson();
+    }
+
+    @Override
+    public void put(String key, Object value) {
+        String jsonValue = gson.toJson(value);
+        this.jedis.hset(this.cacheName, key, jsonValue);
+    }
+
+    @Override
+    public <T> Optional<T> get(String key, Class<T> expectedClass) {
+        String foundJson = this.jedis.hget(this.cacheName, key);
+
+        if (foundJson == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(gson.fromJson(foundJson, expectedClass));
+    }
+}

--- a/examples/redis-backed-cache-testng/src/test/java/RedisBackedCacheTest.java
+++ b/examples/redis-backed-cache-testng/src/test/java/RedisBackedCacheTest.java
@@ -1,0 +1,59 @@
+import com.mycompany.cache.Cache;
+import com.mycompany.cache.RedisBackedCache;
+import org.testcontainers.containers.GenericContainer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import redis.clients.jedis.Jedis;
+
+import java.util.Optional;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.*;
+
+/**
+ * Integration test for Redis-backed cache implementation.
+ */
+public class RedisBackedCacheTest {
+
+    private static GenericContainer redis = new GenericContainer("redis:3.0.6").withExposedPorts(6379);
+
+    private Cache cache;
+
+    @BeforeClass
+    public static void startContainer() {
+         redis.start();
+    }
+
+    @AfterClass
+    public static void stopContainer() {
+        redis.stop();
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        Jedis jedis = new Jedis(redis.getContainerIpAddress(), redis.getMappedPort(6379));
+
+        cache = new RedisBackedCache(jedis, "test");
+    }
+
+    @Test
+    public void testFindingAnInsertedValue() {
+        cache.put("foo", "FOO");
+        Optional<String> foundObject = cache.get("foo", String.class);
+
+        assertTrue("When an object in the cache is retrieved, it can be found",
+                        foundObject.isPresent());
+        assertEquals("When we put a String in to the cache and retrieve it, the value is the same",
+                        "FOO",
+                        foundObject.get());
+    }
+
+    @Test
+    public void testNotFindingAValueThatWasNotInserted() {
+        Optional<String> foundObject = cache.get("bar", String.class);
+
+        assertFalse("When an object that's not in the cache is retrieved, nothing is found",
+                foundObject.isPresent());
+    }
+}

--- a/examples/redis-backed-cache-testng/src/test/resources/logback-test.xml
+++ b/examples/redis-backed-cache-testng/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.apache.http" level="WARN"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="org.zeroturnaround.exec" level="WARN"/>
+</configuration>


### PR DESCRIPTION
The tests in this example are same as redis-backend-cache, but runs tests
using TestNG instead of JUnit.