### PR TITLE
Add Travis job for examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,9 @@ jobs:
                 openjdk:8-jdk-alpine \
                 ./gradlew --no-daemon testcontainers:test --tests '*GenericContainerRuleTest'
 
+    - env: [ NAME="examples"]
+      script: mvn -f examples/pom.xml test
+
     - stage: deploy
       sudo: false
       services: []

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,9 +38,6 @@ jobs:
                 openjdk:8-jdk-alpine \
                 ./gradlew --no-daemon testcontainers:test --tests '*GenericContainerRuleTest'
 
-    - env: [ NAME="examples"]
-      script: mvn -f examples/pom.xml test
-
     - stage: deploy
       sudo: false
       services: []

--- a/circle.yml
+++ b/circle.yml
@@ -91,7 +91,7 @@ jobs:
           name: Save test results
           command: |
             mkdir -p ~/junit/
-            find . -type f -regex "examples/*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+            find examples -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
           when: always
       - store_test_results:
             path: ~/junit

--- a/circle.yml
+++ b/circle.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: mvn -f examples/pom.xml test
+          command: mvn -B -f examples/pom.xml test
       - run:
           name: Save test results
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -82,6 +82,21 @@ jobs:
           path: ~/junit
       - store_artifacts:
           path: ~/junit
+  examples:
+    steps:
+      - checkout
+      - run:
+          command: mvn -f examples/pom.xml test
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex "examples/*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+            path: ~/junit
+      - store_artifacts:
+            path: ~/junit
 
 workflows:
   version: 2
@@ -92,3 +107,4 @@ workflows:
       - modules-no-jdbc-test-no-selenium
       - modules-jdbc-test
       - selenium
+      - examples

--- a/examples/selenium-container/src/test/java/SeleniumContainerTest.java
+++ b/examples/selenium-container/src/test/java/SeleniumContainerTest.java
@@ -30,7 +30,7 @@ public class SeleniumContainerTest {
         searchInput.sendKeys("Rick Astley");
         searchInput.submit();
 
-        WebElement otherPage = driver.findElementByLinkText("Rickrolling");
+        WebElement otherPage = driver.findElementByPartialLinkText("Rickrolling");
         otherPage.click();
 
         boolean expectedTextFound = driver.findElementsByCssSelector("p")


### PR DESCRIPTION
I just realized (while reviewing #893), that our examples are not part of the CI. I'm not sure if this was a conscious decision, but I suppose not.

For now, I just added an additional job to Travis using maven, but I think it makes sense to migrate them to Gradle in a next step.

