### PR TITLE
Improve compatibility by disabling Cassandra JMX reporting

### DIFF
--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -151,6 +151,11 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
 
     public static Cluster getCluster(ContainerState containerState) {
         return Cluster.builder()
+            // Disable jmx reporting because it is dependant on the version of dropwizard-metrics that the
+            // consuming application uses.
+            // See https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/#metrics-4-compatibility
+            // for instructions on how to enable jmx metrics
+            .withoutJMXReporting()
             .addContactPoint(containerState.getContainerIpAddress())
             .withPort(containerState.getMappedPort(CQL_PORT))
             .build();


### PR DESCRIPTION
Disable JMX because it relies on an old version of dropwizard-metrics that
causes this client creation to fail at runtime if the newer metrics library is used.

See https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/#metrics-4-compatibility
for more information and instructions to enable jmx metrics on newer libraries.

This is technically a breaking change as anyone who expects the returned `Cluster` to have jmx metrics enabled.

Also, in the unreleased 4.0 Cassandra java client they update to dropwizard-metrics 4.0 and this change will no longer be necessary.