### PR TITLE
Add configuration for probot-stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 14
 exemptLabels:
   - pinned
   - security
+  - "resolution/acknowledged"
 # Label to use when marking an issue as stale
 staleLabel: stale
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 90
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 14
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. If you believe
+  this is a mistake, please reply to this comment to keep it open. If there isn't 
+  one already, a PR to fix or at least reproduce the problem in a test case will 
+  always help us get back on track to tackle this.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed due to inactivity. We apologise if
+  this is still an active problem for you, and would ask you to re-open the 
+  issue if this is the case.


### PR DESCRIPTION
Adding stale bot. It's already added to the project. Once this is merged, it will become active.

I've tweaked the example configuration to use some custom timings and comments:

* 90 days stale, with 14 days between the stale warning and the issue being closed
* I've tried to keep the comments actionable so that we get positive results out of doing this.

I think that over time we can reduce the time limits, but from our current starting position we should be quite generous.

WDYT?