### PR TITLE
Activate gradle build scans for CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,24 @@ services:
   - docker
 
 install:
-  - ./gradlew build -x check
+  - ./gradlew build -x check --scan
 
 jobs:
   include:
     - stage: test
       env: [ NAME=core ]
-      script: ./gradlew testcontainers:check javadoc
+      script: ./gradlew testcontainers:check javadoc --scan
 
     - stage: test
       env: [ NAME=core ]
       jdk: openjdk11
-      script: ./gradlew testcontainers:check
+      script: ./gradlew testcontainers:check --scan
 
     - env: [ NAME=selenium ]
-      script: ./gradlew selenium:check
+      script: ./gradlew selenium:check --scan
 
     - env: [ NAME=modules ]
-      script: ./gradlew check -x testcontainers:check -x selenium:check
+      script: ./gradlew check -x testcontainers:check -x selenium:check --scan
 
     # Run Docker-in-Docker tests inside Alpine
     - env: [ NAME="docker-in-alpine-docker" ]
@@ -36,7 +36,7 @@ jobs:
                 -v "$(pwd)":"$(pwd)" \
                 -w "$(pwd)" \
                 openjdk:8-jdk-alpine \
-                ./gradlew --no-daemon testcontainers:test --tests '*GenericContainerRuleTest'
+                ./gradlew --no-daemon testcontainers:test --tests '*GenericContainerRuleTest' --scan
 
     - stage: deploy
       sudo: false
@@ -45,7 +45,7 @@ jobs:
       script: skip
       deploy:
         provider: script
-        script: ./gradlew -Pversion=$TRAVIS_TAG release
+        script: ./gradlew -Pversion=$TRAVIS_TAG release --scan
         on:
           tags: true
           branch: master

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'com.gradle.build-scan' version '1.16'
     id 'io.franzbecker.gradle-lombok' version '1.14'
     id 'nebula.provided-base' version '3.0.3'
     id 'com.github.johnrengelman.shadow' version '2.0.2'
@@ -93,4 +94,9 @@ subprojects {
     dependencies {
         testCompile 'ch.qos.logback:logback-classic:1.2.3'
     }
+}
+
+buildScan {
+    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: ./gradlew testcontainers:check
+          command: ./gradlew testcontainers:check --scan
       - run:
           name: Save test results
           command: |
@@ -22,7 +22,7 @@ jobs:
       - run:
           command: |
             echo "transport.type=okhttp" >> core/src/test/resources/testcontainers.properties
-            ./gradlew testcontainers:check
+            ./gradlew testcontainers:check --scan
       - run:
           name: Save test results
           command: |
@@ -35,7 +35,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: ./gradlew check -x testcontainers:check -x selenium:check -x jdbc-test:check
+          command: ./gradlew check -x testcontainers:check -x selenium:check -x jdbc-test:check --scan
           environment:
             # Oracle JDBC drivers require a timezone to be set
             TZ: "/usr/share/zoneinfo/ETC/UTC"
@@ -53,7 +53,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: ./gradlew jdbc-test:check
+          command: ./gradlew jdbc-test:check --scan
           environment:
             # Oracle JDBC drivers require a timezone to be set
             TZ: "/usr/share/zoneinfo/ETC/UTC"
@@ -71,7 +71,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: ./gradlew selenium:check
+          command: ./gradlew selenium:check --scan
       - run:
           name: Save test results
           command: |


### PR DESCRIPTION
As discussed [via twitter](https://twitter.com/Kiview/status/1050713692541734913) this PR will activate build scans for CI builds. For an example see [this scan](https://scans.gradle.com/s/i4grzev4man3y) of a local build on my machine.

I had to add some configuration to `build.gralde` for this:
- The build scan plugin is applied first. Otherwise it will [not collect all data for Gradle < 4.3](https://docs.gradle.com/build-scan-plugin/#for_individual_builds).
- The terms of service are accepted via the corresponding configuration in `build.gradle`. Every build that is called with the `--scan` option will be published. @melix [suggested](https://twitter.com/CedricChampeau/status/1050717559006392320) to add a [more sophisticated configuration](https://github.com/apache/groovy/blob/master/gradle/build-scans.gradle), that will also publish all local builds if user accept it. For now I've only added the simple configuration.

Furthermore I've added the `--scan` option to all travis stages.