### PR TITLE
remove public modifier from JUnit5 example

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -144,8 +144,8 @@ public class SimpleMySQLTest {
 Example of starting a container in a `@BeforeEach` annotated method:
 
 ```java
-public class SimpleMySQLTest {
-    public MySQLContainer mysql = new MySQLContainer();
+class SimpleMySQLTest {
+    private MySQLContainer mysql = new MySQLContainer();
     
     @BeforeEach
     void before() {


### PR DESCRIPTION
This PR removes the public modifier for the JUnit5 example in the documentation.