### PR TITLE
Remove the need for explicit casting for MySQLContainer

### DIFF
--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/CustomizableMysqlTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/CustomizableMysqlTest.java
@@ -19,7 +19,7 @@ public class CustomizableMysqlTest {
 
     // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
     @Rule
-    public MySQLContainer mysql = (MySQLContainer) new MySQLContainer("mysql:5.5")
+    public MySQLContainer mysql = new MySQLContainer("mysql:5.5")
             .withDatabaseName(DB_NAME)
             .withUsername(USER)
             .withPassword(PWD)

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/EmptyPasswordMysqlTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/EmptyPasswordMysqlTest.java
@@ -18,7 +18,7 @@ public class EmptyPasswordMysqlTest {
 
     // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
     @Rule
-    public MySQLContainer mysql = (MySQLContainer) new MySQLContainer("mysql:5.5")
+    public MySQLContainer mysql = new MySQLContainer("mysql:5.5")
             .withDatabaseName(DB_NAME)
             .withUsername(USER)
             .withPassword("")

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
@@ -49,7 +49,7 @@ public class SimpleMySQLTest {
 
     @Test
     public void testSimple() throws SQLException {
-        MySQLContainer mysql = (MySQLContainer) new MySQLContainer()
+        MySQLContainer mysql = new MySQLContainer()
                 .withConfigurationOverride("somepath/mysql_conf_override")
                 .withLogConsumer(new Slf4jLogConsumer(logger));
         mysql.start();
@@ -66,7 +66,7 @@ public class SimpleMySQLTest {
 
     @Test
     public void testSpecificVersion() throws SQLException {
-        MySQLContainer mysqlOldVersion = (MySQLContainer) new MySQLContainer("mysql:5.5")
+        MySQLContainer mysqlOldVersion = new MySQLContainer("mysql:5.5")
                 .withConfigurationOverride("somepath/mysql_conf_override")
                 .withLogConsumer(new Slf4jLogConsumer(logger));
         mysqlOldVersion.start();
@@ -100,7 +100,7 @@ public class SimpleMySQLTest {
 
     @Test
     public void testCommandOverride() throws SQLException {
-        MySQLContainer mysqlCustomConfig = (MySQLContainer) new MySQLContainer().withCommand("mysqld --auto_increment_increment=42");
+        MySQLContainer mysqlCustomConfig = new MySQLContainer().withCommand("mysqld --auto_increment_increment=42");
         mysqlCustomConfig.start();
 
         try {
@@ -117,7 +117,7 @@ public class SimpleMySQLTest {
     @Test
     public void testMySQL8() throws SQLException {
         assumeFalse(SystemUtils.IS_OS_WINDOWS);
-        MySQLContainer container = new MySQLContainer<>("mysql:8.0.11")
+        MySQLContainer container = new MySQLContainer("mysql:8.0.11")
             .withCommand("mysqld --default-authentication-plugin=mysql_native_password");
         container.start();
 
@@ -135,7 +135,7 @@ public class SimpleMySQLTest {
     @Test
     public void testEmptyPasswordWithNonRootUser() {
 
-        MySQLContainer container = (MySQLContainer) new MySQLContainer("mysql:5.5").withDatabaseName("TEST")
+        MySQLContainer container = new MySQLContainer("mysql:5.5").withDatabaseName("TEST")
                 .withUsername("test").withPassword("").withEnv("MYSQL_ROOT_HOST", "%");
 
         try {

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -8,7 +8,7 @@ import java.util.Set;
 /**
  * @author richardnorth
  */
-public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MySQLContainer extends JdbcDatabaseContainer<MySQLContainer> {
 
     public static final String NAME = "mysql";
     public static final String IMAGE = "mysql";
@@ -96,25 +96,25 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         return "SELECT 1";
     }
 
-    public SELF withConfigurationOverride(String s) {
+    public MySQLContainer withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public MySQLContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public MySQLContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MySQLContainer withPassword(final String password) {
         this.password = password;
         return self();
     }


### PR DESCRIPTION
At $WORK we use TestContainer, and it's very annoying to do the `MySQLContainer mysql = (MySQLContainer) new MySQLContainer()` dance every time we want to create a MySQL container. Plus, the compiler complains about raw use of a parametrized class cast, so we have to add `@SupressWarning("rawtypes")`, which adds another level of verbosity. It would be nice if we could create
a MySQL container just by `MySQLContainer mysql = new MySQLContainer()`.