### PR TITLE
[WIP] Easier way to configure logging

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerLoggerFactory.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerLoggerFactory.java
@@ -1,26 +1,50 @@
 package org.testcontainers.utility;
 
+import java.lang.reflect.Proxy;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DockerLoggerFactory {
+    private static final ConcurrentMap<String, Logger> cache = new ConcurrentHashMap<>();
 
     public static Logger getLogger(String dockerImageName) {
+        return getLogger("org.testcontainers", dockerImageName);
+    }
 
-        final String abbreviatedName;
-        if (dockerImageName.contains("@sha256")) {
-            abbreviatedName = dockerImageName.substring(0, dockerImageName.indexOf("@sha256") + 14) + "...";
-        } else {
-            abbreviatedName = dockerImageName;
-        }
+    public static Logger getLogger(Class<?> source, String dockerImageName) {
+        return getLogger(source.getName(), dockerImageName);
+    }
 
-        if ("UTF-8".equals(System.getProperty("file.encoding"))) {
-            return LoggerFactory.getLogger("\uD83D\uDC33 [" + abbreviatedName + "]");
-        } else {
-            return LoggerFactory.getLogger("docker[" + abbreviatedName + "]");
-        }
+    public static Logger getLogger(String source, String dockerImageName) {
+        return cache.computeIfAbsent(source + "/" + dockerImageName, name -> {
+            final String abbreviatedName;
+            if (dockerImageName.contains("@sha256")) {
+                abbreviatedName = dockerImageName.substring(0, dockerImageName.indexOf("@sha256") + 14) + "...";
+            } else {
+                abbreviatedName = dockerImageName;
+            }
+
+            final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            final Logger logger = LoggerFactory.getLogger(source);
+
+            return (Logger) Proxy.newProxyInstance(
+                classLoader,
+                new Class[]{
+                    Logger.class
+                },
+                (proxy, method, args) -> {
+                    try (MDC.MDCCloseable c = MDC.putCloseable("image.name", abbreviatedName)) {
+                        return method.invoke(logger, args);
+                    }
+                }
+            );
+        });
     }
 }


### PR DESCRIPTION
This is small PR move the image name in a MDC context instead of using it as name of the logger. By default the name of the logger is `org.testcontainers` but if can be customized.

While looking at the generated logs, I see that the image name is often included in the log message, as example [here](https://github.com/testcontainers/testcontainers-java/blob/master/core/src/main/java/org/testcontainers/containers/GenericContainer.java#L231-L232) so I think that moving the image name to an MDC context is safe. 

Fixes #637
