### PR TITLE
Add WARN log if provided Couchbase password offends default policy

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -67,6 +67,8 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     public static final String STATIC_CONFIG = "/opt/couchbase/etc/couchbase/static_config";
     public static final String CAPI_CONFIG = "/opt/couchbase/etc/couchdb/default.d/capi.ini";
 
+    private static final int REQUIRED_DEFAULT_PASSWORD_LENGTH = 6;
+
     private String memoryQuota = "300";
 
     private String indexMemoryQuota = "300";
@@ -116,6 +118,14 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     @Override
     public Set<Integer> getLivenessCheckPortNumbers() {
         return Sets.newHashSet(getMappedPort(REST));
+    }
+
+    @Override
+    protected void configure() {
+        if (clusterPassword.length() < REQUIRED_DEFAULT_PASSWORD_LENGTH) {
+            logger().warn("The provided cluster admin password length is less then the default password policy length. " +
+                "Cluster start will fail if configured password policy is offended.");
+        }
     }
 
     @Override

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -124,7 +124,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     protected void configure() {
         if (clusterPassword.length() < REQUIRED_DEFAULT_PASSWORD_LENGTH) {
             logger().warn("The provided cluster admin password length is less then the default password policy length. " +
-                "Cluster start will fail if configured password policy is offended.");
+                "Cluster start will fail if configured password requirements are not met.");
         }
     }
 


### PR DESCRIPTION
See #934 

TBH I was not sure how to proceed at this point. We have a similar password policy thing in #885. 
However, throwing an exception seems to harsh, since people might configure all kind of password policies in their image (I assume) and we should still support it if possible.