### PR TITLE
Update commons-compress to 1.18

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     compile 'org.jetbrains:annotations:15.0'
     compile 'javax.annotation:javax.annotation-api:1.3.1'
     compile 'com.google.code.findbugs:jsr305:3.0.2'
-    compile 'org.apache.commons:commons-compress:1.16.1'
+    compile 'org.apache.commons:commons-compress:1.18'
     // Added for JDK9 compatibility since it's missing this package
     compile 'javax.xml.bind:jaxb-api:2.3.0'
     compile ('org.rnorth.duct-tape:duct-tape:1.0.7') {


### PR DESCRIPTION
While it shouldn't affect any users of testcontainers, commons-compress has [CVE-2018-11771](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-11771). Bumping to the latest fixes the CVE.

Feels a bit like [deja vu](https://github.com/testcontainers/testcontainers-java/pull/677) 😉 