### PR TITLE
Add TcpHost to ElasticsearchContainer

### DIFF
--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,4 +3,5 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     compile project(':testcontainers')
     testCompile "org.elasticsearch.client:elasticsearch-rest-client:6.4.1"
+    testCompile "org.elasticsearch.client:transport:6.4.1"
 }

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -4,6 +4,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.Base58;
 
+import java.net.InetSocketAddress;
 import java.time.Duration;
 
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -57,5 +58,9 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
     public String getHttpHostAddress() {
         return getContainerIpAddress() + ":" + getMappedPort(ELASTICSEARCH_DEFAULT_PORT);
+    }
+
+    public InetSocketAddress getTcpHost() {
+        return new InetSocketAddress(getContainerIpAddress(), getMappedPort(ELASTICSEARCH_DEFAULT_TCP_PORT));
     }
 }


### PR DESCRIPTION
Applications have 2 ways to communicate with ElasticSearch:
- via REST client
- via transport client

ElasticsearchContainer currently only allows the usage of the REST client.

This allows the application to connect to the container via transport client.