### PR TITLE
Allow to set Shared Memory size (shmSize) for GenericContainer

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -261,10 +261,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             logger().info("Creating container for image: {}", dockerImageName);
             profiler.start("Create container");
 
-            HostConfig hostConfig = buildHostConfig();
-
-            CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName)
-                .withHostConfig(hostConfig);
+            CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName);
 
             applyConfiguration(createCommand);
 
@@ -571,6 +568,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         combinedLabels.putAll(DockerClientFactory.DEFAULT_LABELS);
 
         createCommand.withLabels(combinedLabels);
+
+        HostConfig hostConfig = buildHostConfig();
+        createCommand.withHostConfig(hostConfig);
     }
 
     private Set<Link> findLinksFromThisContainer(String alias, LinkableContainer linkableContainer) {

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -49,14 +49,7 @@ import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
-import org.testcontainers.utility.Base58;
-import org.testcontainers.utility.DockerLoggerFactory;
-import org.testcontainers.utility.DockerMachineClient;
-import org.testcontainers.utility.MountableFile;
-import org.testcontainers.utility.PathUtils;
-import org.testcontainers.utility.ResourceReaper;
-import org.testcontainers.utility.TestcontainersConfiguration;
-import org.testcontainers.utility.ThrowingFunction;
+import org.testcontainers.utility.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -260,7 +260,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
             logger().info("Creating container for image: {}", dockerImageName);
             profiler.start("Create container");
-
             CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName);
             applyConfiguration(createCommand);
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -262,7 +262,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             profiler.start("Create container");
 
             CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName);
-
             applyConfiguration(createCommand);
 
             containerId = createCommand.exec().getId();

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1183,7 +1183,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     /**
      * Size of /dev/shm
-     * @param bytes The number of megabytes to assign the shared memory. If null, it will apply the Docker default which is 64 KB.
+     * @param bytes The number of megabytes to assign the shared memory. If null, it will apply the Docker default which is 64 MB.
      * @return this
      */
     public SELF withSharedMemorySize(Long bytes) {

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -455,7 +455,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     }
 
     private void applyConfiguration(CreateContainerCmd createCommand) {
-
+        HostConfig hostConfig = buildHostConfig();
+        createCommand.withHostConfig(hostConfig);
+        
         // Set up exposed ports (where there are no host port bindings defined)
         ExposedPort[] portArray = exposedPorts.stream()
                 .map(ExposedPort::new)
@@ -568,9 +570,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         combinedLabels.putAll(DockerClientFactory.DEFAULT_LABELS);
 
         createCommand.withLabels(combinedLabels);
-
-        HostConfig hostConfig = buildHostConfig();
-        createCommand.withHostConfig(hostConfig);
     }
 
     private Set<Link> findLinksFromThisContainer(String alias, LinkableContainer linkableContainer) {

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -157,10 +157,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     /**
      * The shared memory size to use when starting the container.
-     * This value is in megabytes.
+     * This value is in bytes.
      */
     @Nullable
-    private Integer shmSize;
+    private Long shmSize;
 
     private Map<MountableFile, String> copyToFileContainerPathMap = new HashMap<>();
 
@@ -264,7 +264,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
             HostConfig hostConfig = new HostConfig();
             if (shmSize != null) {
-                hostConfig.withShmSize(shmSize * FileUtils.ONE_MB);
+                hostConfig.withShmSize(shmSize);
             }
             CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName)
                 .withHostConfig(hostConfig);
@@ -1175,11 +1175,11 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     /**
      * Size of /dev/shm
-     * @param megabytes The number of megabytes to assign the shared memory. Null to not set any.
+     * @param bytes The number of megabybytestes to assign the shared memory. Null to not set any.
      * @return this
      */
-    public SELF withSharedMemorySize(Integer megabytes) {
-        this.shmSize = megabytes;
+    public SELF withSharedMemorySize(Long bytes) {
+        this.shmSize = bytes;
         return self();
     }
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1183,7 +1183,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     /**
      * Size of /dev/shm
-     * @param bytes The number of megabytes to assign the shared memory. Null to not set any.
+     * @param bytes The number of megabytes to assign the shared memory. If null, it will apply the Docker default which is 64 KB.
      * @return this
      */
     public SELF withSharedMemorySize(Long bytes) {

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1183,7 +1183,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     /**
      * Size of /dev/shm
-     * @param bytes The number of megabybytestes to assign the shared memory. Null to not set any.
+     * @param bytes The number of megabytes to assign the shared memory. Null to not set any.
      * @return this
      */
     public SELF withSharedMemorySize(Long bytes) {

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -131,7 +131,7 @@ public class GenericContainerRuleTest {
      */
     @ClassRule
     public static GenericContainer redisWithSharedMemory = new GenericContainer("redis:3.0.2")
-        .withExposedPorts(REDIS_PORT).withSharedMemorySize(1024);
+        .withExposedPorts(REDIS_PORT).withSharedMemorySize(1024L);
 
 //    @Test
 //    public void simpleRedisTest() {
@@ -387,7 +387,7 @@ public class GenericContainerRuleTest {
 
     @Test
     public void sharedMemorySetTest() {
-        assertEquals("Shared memory is not set", redisWithSharedMemory.getShmSize(), 1024);
+        assertEquals("Shared memory is not set", redisWithSharedMemory.getShmSize(), 1024 * FileUtils.ONE_MB);
         HostConfig hostConfig =
             redisWithSharedMemory.getDockerClient().inspectContainerCmd(redisWithSharedMemory.getContainerId())
                 .exec().getHostConfig();

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -126,13 +126,6 @@ public class GenericContainerRuleTest {
             .withExtraHost("somehost", "192.168.1.10")
             .withCommand("/bin/sh", "-c", "while true; do cat /etc/hosts | nc -l -p 80; done");
 
-    /**
-     * Redis with shared memory
-     */
-    @ClassRule
-    public static GenericContainer redisWithSharedMemory = new GenericContainer("redis:3.0.2")
-        .withExposedPorts(REDIS_PORT).withSharedMemorySize(1024L * FileUtils.ONE_MB);
-
 //    @Test
 //    public void simpleRedisTest() {
 //        String ipAddress = redis.getContainerIpAddress();
@@ -387,10 +380,15 @@ public class GenericContainerRuleTest {
 
     @Test
     public void sharedMemorySetTest() {
-        assertEquals("Shared memory is not set", redisWithSharedMemory.getShmSize(), 1024 * FileUtils.ONE_MB);
-        HostConfig hostConfig =
-            redisWithSharedMemory.getDockerClient().inspectContainerCmd(redisWithSharedMemory.getContainerId())
-                .exec().getHostConfig();
-        assertEquals("Shared memory not set on container", hostConfig.getShmSize(), 1024 * FileUtils.ONE_MB);
+        try (GenericContainer containerWithSharedMemory = new GenericContainer("busybox:1.29")
+            .withSharedMemorySize(1024L * FileUtils.ONE_MB)) {
+
+            containerWithSharedMemory.start();
+
+            HostConfig hostConfig =
+                containerWithSharedMemory.getDockerClient().inspectContainerCmd(containerWithSharedMemory.getContainerId())
+                    .exec().getHostConfig();
+            assertEquals("Shared memory not set on container", hostConfig.getShmSize(), 1024 * FileUtils.ONE_MB);
+        }
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -7,6 +7,7 @@ import com.mongodb.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.rabbitmq.client.*;
+import org.apache.commons.io.FileUtils;
 import org.bson.Document;
 import org.junit.*;
 import org.rnorth.ducttape.RetryCountExceededException;
@@ -390,6 +391,6 @@ public class GenericContainerRuleTest {
         HostConfig hostConfig =
             redisWithSharedMemory.getDockerClient().inspectContainerCmd(redisWithSharedMemory.getContainerId())
                 .exec().getHostConfig();
-        assertEquals("Shared memory not set on container", hostConfig.getShmSize(), 1024);
+        assertEquals("Shared memory not set on container", hostConfig.getShmSize(), 1024 * FileUtils.ONE_MB);
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -131,7 +131,7 @@ public class GenericContainerRuleTest {
      */
     @ClassRule
     public static GenericContainer redisWithSharedMemory = new GenericContainer("redis:3.0.2")
-        .withExposedPorts(REDIS_PORT).withSharedMemorySize(1024L);
+        .withExposedPorts(REDIS_PORT).withSharedMemorySize(1024L * FileUtils.ONE_MB);
 
 //    @Test
 //    public void simpleRedisTest() {


### PR DESCRIPTION
Add the necessary code so that `shmSize` can be set on a GenericContainer.

This is especially useful for when starting Oracle docker images because they need at least 1GB of shared memory space.

> [docker run ... --shm-size=1g oracle/database:11.2.0.2-xe](https://github.com/oracle/docker-images/blob/master/OracleDatabase/SingleInstance/FAQ.md)

Fixes #952 