### PR TITLE
Fix wrong generics behaviour in ElasticsearchContainer

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -14,7 +14,7 @@ import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
  * Represents an elasticsearch docker instance which exposes by default port 9200 and 9300 (transport.tcp.port)
  * The docker image is by default fetched from docker.elastic.co/elasticsearch/elasticsearch
  */
-public class ElasticsearchContainer extends GenericContainer {
+public class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {
 
     /**
      * Elasticsearch Default HTTP port

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -45,7 +45,9 @@ public class ElasticsearchContainerTest {
 
     @Test
     public void elasticsearchDefaultTest() throws IOException {
-        try (ElasticsearchContainer container = new ElasticsearchContainer()){
+        try (ElasticsearchContainer container = new ElasticsearchContainer()
+            .withEnv("foo", "bar") // dummy env for compiler checking correct generics usage
+        ){
             container.start();
             Response response = getClient(container).performRequest(new Request("GET", "/"));
             assertThat(response.getStatusLine().getStatusCode(), is(200));


### PR DESCRIPTION
Fixes #962

Extending `GenericContainer` was missing the generic type.