### PR TITLE
Reshade httphost

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ subprojects {
         relocate('META-INF/native/libnetty', 'META-INF/native/liborg-testcontainers-shaded-netty')
 
         [
+            "org.apache.http",
             "org.apache.commons.lang",
             "org.apache.commons.io",
             "org.apache.commons.codec",

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -19,7 +19,6 @@ shadowJar {
     mergeServiceFiles()
 
     exclude 'org/newsclub/**'
-    exclude 'org/apache/http/**'
 
     [
         'META-INF/io.netty.versions.properties',
@@ -41,6 +40,7 @@ shadowJar {
     ].each { exclude(it) }
 
     dependencies {
+        include(dependency('org.apache.httpcomponents:.*'))
         include(dependency('org.glassfish.*:.*'))
         include(dependency('org.aopalliance.*:.*'))
         include(dependency('javax.ws.rs:.*'))

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -1,6 +1,5 @@
 package org.testcontainers.elasticsearch;
 
-import org.apache.http.HttpHost;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.Base58;
@@ -56,7 +55,7 @@ public class ElasticsearchContainer extends GenericContainer {
             .withStartupTimeout(Duration.ofMinutes(2)));
     }
 
-    public HttpHost getHost() {
-        return new HttpHost(getContainerIpAddress(), getMappedPort(ELASTICSEARCH_DEFAULT_PORT));
+    public String getHttpHostAddress() {
+        return getContainerIpAddress() + ":" + getMappedPort(ELASTICSEARCH_DEFAULT_PORT);
     }
 }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -1,6 +1,7 @@
 package org.testcontainers.elasticsearch;
 
 
+import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
@@ -90,7 +91,7 @@ public class ElasticsearchContainerTest {
             credentialsProvider.setCredentials(AuthScope.ANY,
                     new UsernamePasswordCredentials(ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD));
 
-            client = RestClient.builder(container.getHost())
+            client = RestClient.builder(HttpHost.create(container.getHttpHostAddress()))
                     .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider))
                     .build();
         }


### PR DESCRIPTION
FYI @dadoonet, relating to #958 

As httpcore is a transitive dependency that we don't want to conflict with user's libs, we unfortunately need to:

* roll back #959, where we disabled the shading of this module. As is, we're at risk of internal breakage when transitive deps clash.
* in turn, stop exposing `HttpHost` in our public API. We should take a general stance of keeping our public APIs free of transitive deps (especially shaded ones)

The API method in ElasticsearchContainer will thus change, from:
```java
public HttpHost getHost()
```
to:
```java
public String getHttpHostAddress()
```

Usage in turn changes from:
```java
RestClient client = RestClient.builder(container.getHost()).build();
```
to the slightly more verbose but equivalent:
```java
RestClient client = RestClient.builder(HttpHost.create(container.getHttpHostAddress())).build();
```

@bsideup, @kiview and I have discussed at length and concluded that this is the only approach that we're comfortable with - despite the fact that this raises an unfortunate breaking change in the API of the Elasticsearch module, which we reluctantly have to do.

We are sorry that we did not catch this particular issue at PR stage - we're going to upgrade our static analysis to guard against inadvertent leakage of shaded dependencies. In the longer term we also, obviously, wish to reduce the weight of our dependency chain, both unshaded and shaded, so that this does not happen again.

We intend for this change to go out as 1.10.1.

I hope this is OK with you @dadoonet - our apologies again for not catching this before release.