### PR TITLE
[Docs] Change `withDockerfileFromBuilder` example to use expression Lamda

### DIFF
--- a/docs/usage/dockerfile.md
+++ b/docs/usage/dockerfile.md
@@ -39,12 +39,12 @@ programmatically), there is a DSL available to allow Dockerfiles to be defined i
 ```java
 new GenericContainer(
         new ImageFromDockerfile()
-                .withDockerfileFromBuilder(builder -> {
+                .withDockerfileFromBuilder(builder ->
                         builder
                                 .from("alpine:3.2")
                                 .run("apk add --update nginx")
                                 .cmd("nginx", "-g", "daemon off;")
-                                .build(); }))
+                                .build()))
                 .withExposedPorts(80);
 ```
 


### PR DESCRIPTION
Likely the preferable syntax. I've seen other examples in the user guide use this style e.g. under "Customizing the container".