### PR TITLE
Enable line terminator matching for LogMessageWaitStrategy

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/LogMessageWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/LogMessageWaitStrategy.java
@@ -22,7 +22,8 @@ public class LogMessageWaitStrategy extends AbstractWaitStrategy {
         LogUtils.followOutput(DockerClientFactory.instance().client(), waitStrategyTarget.getContainerId(), waitingConsumer);
 
         Predicate<OutputFrame> waitPredicate = outputFrame ->
-            outputFrame.getUtf8String().matches(regEx);
+            // (?s) enables line terminator matching (equivalent to Pattern.DOTALL)
+            outputFrame.getUtf8String().matches("(?s)" + regEx);
 
         try {
             waitingConsumer.waitUntil(waitPredicate, startupTimeout.getSeconds(), TimeUnit.SECONDS, times);

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/LogMessageWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/LogMessageWaitStrategyTest.java
@@ -1,10 +1,10 @@
 package org.testcontainers.junit.wait.strategy;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
-
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Tests for {@link LogMessageWaitStrategy}.
@@ -38,6 +38,6 @@ public class LogMessageWaitStrategyTest extends AbstractWaitStrategyTest<LogMess
                 super.waitUntilReady();
                 ready.set(true);
             }
-        }.withRegEx(".*ready.*\\s").withTimes(2);
+        }.withRegEx(".*ready.*").withTimes(2);
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/LogMessageWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/LogMessageWaitStrategyTest.java
@@ -2,6 +2,8 @@ package org.testcontainers.junit.wait.strategy;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -9,7 +11,23 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * Tests for {@link LogMessageWaitStrategy}.
  */
+@RunWith(Parameterized.class)
 public class LogMessageWaitStrategyTest extends AbstractWaitStrategyTest<LogMessageWaitStrategy> {
+
+    private final String pattern;
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[] parameters() {
+        return new String[] {
+            ".*ready.*\\s",     // previous recommended style (explicit line ending)
+            ".*ready!\\s",      // explicit line ending without wildcard after expected text
+            ".*ready.*"         // new style (line ending matched by wildcard)
+        };
+    }
+
+    public LogMessageWaitStrategyTest(String pattern) {
+        this.pattern = pattern;
+    }
 
     private static final String READY_MESSAGE = "I'm ready!";
 
@@ -38,6 +56,6 @@ public class LogMessageWaitStrategyTest extends AbstractWaitStrategyTest<LogMess
                 super.waitUntilReady();
                 ready.set(true);
             }
-        }.withRegEx(".*ready.*").withTimes(2);
+        }.withRegEx(pattern).withTimes(2);
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/LogMessageWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/LogMessageWaitStrategyTest.java
@@ -1,10 +1,10 @@
 package org.testcontainers.junit.wait.strategy;
 
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Tests for {@link LogMessageWaitStrategy}.


### PR DESCRIPTION
Enable line terminator matching to make  expressions like ".*" matching even the end of a log line e.g. "waiting for connections on port 20017\n"