### PR TITLE
Use ChromeOptions and FirefoxOptions instead of DesiredCapabilities

### DIFF
--- a/examples/selenium-container/pom.xml
+++ b/examples/selenium-container/pom.xml
@@ -15,7 +15,17 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
-            <version>2.45.0</version>
+            <version>3.141.59</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-firefox-driver</artifactId>
+            <version>3.141.59</version>
+        </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-chrome-driver</artifactId>
+            <version>3.141.59</version>
         </dependency>
         <dependency>
             <groupId>${testcontainers.group}</groupId>

--- a/examples/selenium-container/src/test/java/SeleniumContainerTest.java
+++ b/examples/selenium-container/src/test/java/SeleniumContainerTest.java
@@ -1,7 +1,6 @@
 import org.junit.Rule;
 import org.junit.Test;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
@@ -17,7 +16,7 @@ public class SeleniumContainerTest {
 
     @Rule
     public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
-                                                    .withDesiredCapabilities(DesiredCapabilities.chrome())
+                                                    .withCapabilities(new ChromeOptions)
                                                     .withRecordingMode(RECORD_ALL, new File("target"));
 
     @Test

--- a/examples/selenium-container/src/test/java/SeleniumContainerTest.java
+++ b/examples/selenium-container/src/test/java/SeleniumContainerTest.java
@@ -16,7 +16,7 @@ public class SeleniumContainerTest {
 
     @Rule
     public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
-                                                    .withCapabilities(new ChromeOptions)
+                                                    .withCapabilities(new ChromeOptions())
                                                     .withRecordingMode(RECORD_ALL, new File("target"));
 
     @Test

--- a/examples/selenium-container/src/test/java/SeleniumContainerTest.java
+++ b/examples/selenium-container/src/test/java/SeleniumContainerTest.java
@@ -2,6 +2,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
 import java.io.File;

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -3,7 +3,9 @@ description = "Testcontainers :: Selenium"
 dependencies {
     compile project(':testcontainers')
 
-    provided 'org.seleniumhq.selenium:selenium-remote-driver:2.52.0'
+    provided 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
+    provided 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
+    provided 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
 
     testCompile 'org.mortbay.jetty:jetty:6.1.25'
     testCompile project(':nginx')

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -4,8 +4,9 @@ dependencies {
     compile project(':testcontainers')
 
     provided 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
-    provided 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     provided 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
+    testCompile 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
+    testCompile 'org.seleniumhq.selenium:selenium-support:3.141.59'
 
     testCompile 'org.mortbay.jetty:jetty:6.1.25'
     testCompile project(':nginx')

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -122,9 +122,16 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     @Override
     protected void configure() {
 
+        String seleniumVersion = SeleniumUtils.determineClasspathSeleniumVersion();
+
         if (capabilities == null) {
-            logger().info("No capabilities provided, falling back to ChromeOptions");
-            capabilities = new ChromeOptions();
+            if (seleniumVersion.startsWith("2.")) {
+                logger().info("No capabilities provided, falling back to DesiredCapabilities.chrome()");
+                capabilities = DesiredCapabilities.chrome();
+            } else {
+                logger().info("No capabilities provided, falling back to ChromeOptions");
+                capabilities = new ChromeOptions();
+            }
         }
 
         if (recordingMode != VncRecordingMode.SKIP) {
@@ -138,7 +145,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         }
 
         if (!customImageNameIsSet) {
-            super.setDockerImageName(getImageForCapabilities(capabilities));
+            super.setDockerImageName(getImageForCapabilities(capabilities, seleniumVersion));
         }
 
         String timeZone = System.getProperty("user.timezone");
@@ -158,9 +165,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         setStartupAttempts(3);
     }
 
-    public static String getImageForCapabilities(Capabilities capabilities) {
-
-        String seleniumVersion = SeleniumUtils.determineClasspathSeleniumVersion();
+    public static String getImageForCapabilities(Capabilities capabilities, String seleniumVersion) {
 
         String browserName = capabilities.getBrowserName();
         switch (browserName) {
@@ -300,6 +305,4 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     public enum VncRecordingMode {
         SKIP, RECORD_ALL, RECORD_FAILING
     }
-
-
 }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -79,7 +79,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
     /**
      * Constructor taking a specific webdriver container name and tag
-     * @param dockerImageName
+     * @param dockerImageName Name of the docker image to pull
      */
     public BrowserWebDriverContainer(String dockerImageName) {
         this();
@@ -96,8 +96,11 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     }
 
     /**
-     * Deprecated. Use withCapabilities(Capabilities capabilities) instead:
+     * @deprecated Use withCapabilities(Capabilities capabilities) instead:
      * withCapabilities(new FirefoxOptions())
+     *
+     * @param capabilities DesiredCapabilities
+     * @return SELF
      * */
     @Deprecated
     public SELF withDesiredCapabilities(DesiredCapabilities capabilities) {

--- a/modules/selenium/src/main/java/org/testcontainers/containers/SeleniumUtils.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/SeleniumUtils.java
@@ -65,7 +65,7 @@ public final class SeleniumUtils {
 
     /**
      * Read Manifest to get Selenium Version.
-     * @param manifest
+     * @param manifest manifest
      * @return Selenium Version detected
      */
     public static String getSeleniumVersionFromManifest(Manifest manifest) {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -2,11 +2,13 @@ package org.testcontainers.junit;
 
 import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
 import java.util.concurrent.TimeUnit;
 
+import static java.lang.String.format;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
@@ -20,12 +22,19 @@ public class BaseWebDriverContainerTest {
         System.out.println("Selenium remote URL is: " + rule.getSeleniumAddress());
         System.out.println("VNC URL is: " + rule.getVncAddress());
 
-        //Runtime.getRuntime().exec("open " + rule.getVncUrl(driver)); // For debugging, on a Mac
-
         driver.get("http://www.google.com");
-        driver.findElement(By.name("q")).sendKeys("testcontainers");
-        driver.findElement(By.name("q")).submit();
-        assertEquals("the word 'testcontainers' appears in the search box", "testcontainers", driver.findElement(By.name("q")).getAttribute("value"));
+        WebElement search = driver.findElement(By.name("q"));
+        search.sendKeys("testcontainers");
+        search.submit();
+        assertEquals("the word 'testcontainers' appears in the search box", "testcontainers",
+            search.getAttribute("value"));
+    }
+
+    protected void assertBrowserNameIs(BrowserWebDriverContainer rule, String expectedName) {
+        RemoteWebDriver driver = setupDriverFromRule(rule);
+        String actual = driver.getCapabilities().getBrowserName();
+        assertTrue(format("actual browser name is %s", actual),
+            actual.equals(expectedName));
     }
 
     @NotNull

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -4,12 +4,14 @@ import org.jetbrains.annotations.NotNull;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 /**
@@ -26,8 +28,13 @@ public class BaseWebDriverContainerTest {
         WebElement search = driver.findElement(By.name("q"));
         search.sendKeys("testcontainers");
         search.submit();
-        assertEquals("the word 'testcontainers' appears in the search box", "testcontainers",
-            search.getAttribute("value"));
+
+        List<WebElement> results = new WebDriverWait(driver, 15)
+            .until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.cssSelector("#search h3")));
+
+        assertTrue("the word 'testcontainers' appears in search results",
+            results.stream()
+                .anyMatch(el -> el.getText().contains("testcontainers")));
     }
 
     protected void assertBrowserNameIs(BrowserWebDriverContainer rule, String expectedName) {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -4,7 +4,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.DefaultRecordingFileFactory;
 
@@ -19,7 +19,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
 
         @Rule
         public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
-                .withDesiredCapabilities(DesiredCapabilities.chrome())
+                .withCapabilities(new ChromeOptions())
                 .withRecordingMode(RECORD_ALL, new File("./build/"))
                 .withRecordingFileFactory(new DefaultRecordingFileFactory());
 
@@ -33,7 +33,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
 
         @Rule
         public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
-                .withDesiredCapabilities(DesiredCapabilities.chrome());
+                .withCapabilities(new ChromeOptions());
 
         @Test
         public void recordingTestThatShouldBeRecordedButDeleted() {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -17,7 +17,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedChrome() {
-        assertBrowserNameIs(chrome,"chrome");
+        assertBrowserNameIs(chrome, "chrome");
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -1,11 +1,10 @@
 package org.testcontainers.junit;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
-
-import java.io.IOException;
 
 /**
  *
@@ -14,15 +13,20 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Rule
     public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
-            .withDesiredCapabilities(DesiredCapabilities.chrome());
+        .withCapabilities(new ChromeOptions());
+
+    @Before
+    public void checkBrowserIsIndeedChrome() {
+        assertBrowserNameIs(chrome,"chrome");
+    }
 
     @Test
-    public void simpleTest() throws IOException {
+    public void simpleTest() {
         doSimpleWebdriverTest(chrome);
     }
 
     @Test
-    public void simpleExploreTest() throws IOException {
+    public void simpleExploreTest() {
         doSimpleExplore(chrome);
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
@@ -11,7 +11,7 @@ public class ContainerWithoutCapabilitiesTest extends BaseWebDriverContainerTest
 
     @Test
     public void chromeIsStartedIfNoCapabilitiesProvided() {
-        assertBrowserNameIs(chrome,"chrome");
+        assertBrowserNameIs(chrome, "chrome");
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
@@ -1,0 +1,21 @@
+package org.testcontainers.junit;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+
+public class ContainerWithoutCapabilitiesTest extends BaseWebDriverContainerTest{
+
+    @Rule
+    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer();
+
+    @Test
+    public void chromeIsStartedIfNoCapabilitiesProvided() {
+        assertBrowserNameIs(chrome,"chrome");
+    }
+
+    @Test
+    public void simpleExploreTestWhenNoCapabilitiesProvided(){
+        doSimpleExplore(chrome);
+    }
+}

--- a/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
@@ -2,10 +2,9 @@ package org.testcontainers.junit;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
-import java.io.IOException;
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -17,11 +16,11 @@ public class CustomWaitTimeoutWebDriverContainerTest extends BaseWebDriverContai
 
     @Rule
     public BrowserWebDriverContainer chromeWithCustomTimeout = new BrowserWebDriverContainer<>()
-            .withDesiredCapabilities(DesiredCapabilities.chrome())
+            .withCapabilities(new ChromeOptions())
             .withStartupTimeout(Duration.of(30, SECONDS));
 
     @Test
-    public void simpleTest() throws IOException {
+    public void simpleTest() {
         doSimpleWebdriverTest(chromeWithCustomTimeout);
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
@@ -1,8 +1,9 @@
 package org.testcontainers.junit;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
 /**
@@ -12,7 +13,12 @@ public class FirefoxWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Rule
     public BrowserWebDriverContainer firefox = new BrowserWebDriverContainer()
-            .withDesiredCapabilities(DesiredCapabilities.firefox());
+            .withCapabilities(new FirefoxOptions());
+
+    @Before
+    public void checkBrowserIsIndeedFirefox() {
+        assertBrowserNameIs(firefox,"firefox");
+    }
 
     @Test
     public void simpleTest() {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
@@ -17,7 +17,7 @@ public class FirefoxWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedFirefox() {
-        assertBrowserNameIs(firefox,"firefox");
+        assertBrowserNameIs(firefox, "firefox");
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/FlakyContainerCreationTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/FlakyContainerCreationTest.java
@@ -2,7 +2,7 @@ package org.testcontainers.junit;
 
 import org.junit.Ignore;
 import org.junit.Test;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
@@ -17,7 +17,7 @@ public class FlakyContainerCreationTest {
     public void testCreationOfManyContainers() {
         for (int i = 0; i < 50; i++) {
             BrowserWebDriverContainer container = new BrowserWebDriverContainer()
-                    .withDesiredCapabilities(DesiredCapabilities.chrome())
+                    .withCapabilities(new ChromeOptions())
                     .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.RECORD_FAILING, new File("build"));
 
             container.start();

--- a/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
@@ -5,7 +5,7 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.openqa.selenium.By;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.Network;
@@ -35,7 +35,7 @@ public class LinkedContainerTest {
     @Rule
     public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer<>()
             .withNetwork(network)
-            .withDesiredCapabilities(DesiredCapabilities.chrome());
+            .withCapabilities(new ChromeOptions());
 
     @BeforeClass
     public static void setupContent() throws FileNotFoundException {
@@ -55,7 +55,7 @@ public class LinkedContainerTest {
     }
 
     @Test
-    public void testWebDriverToNginxContainerAccessViaContainerLink() throws Exception {
+    public void testWebDriverToNginxContainerAccessViaContainerLink() {
         RemoteWebDriver driver = chrome.getWebDriver();
 
         driver.get("http://nginx/");

--- a/modules/selenium/src/test/java/org/testcontainers/junit/LocalServerWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/LocalServerWebDriverContainerTest.java
@@ -5,7 +5,7 @@ import org.mortbay.jetty.Server;
 import org.mortbay.jetty.bio.SocketConnector;
 import org.mortbay.jetty.handler.ResourceHandler;
 import org.openqa.selenium.By;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.utility.TestEnvironment;
@@ -20,7 +20,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 public class LocalServerWebDriverContainerTest {
 
     @Rule
-    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer().withDesiredCapabilities(DesiredCapabilities.chrome());
+    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer().withCapabilities(new ChromeOptions());
     private int localPort;
 
     /**
@@ -48,7 +48,7 @@ public class LocalServerWebDriverContainerTest {
     }
 
     @Test
-    public void testConnection() throws InterruptedException {
+    public void testConnection() {
         RemoteWebDriver driver = chrome.getWebDriver();
 
         // Construct a URL that the browser container can access

--- a/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
@@ -3,7 +3,7 @@ package org.testcontainers.junit;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
 /**
@@ -23,7 +23,7 @@ public class Selenium3xTest {
     @Test
     public void testAdditionalStartupString() {
         try (BrowserWebDriverContainer chrome = new BrowserWebDriverContainer("selenium/standalone-chrome-debug:" + tag)
-                .withDesiredCapabilities(DesiredCapabilities.chrome())) {
+                .withCapabilities(new ChromeOptions())) {
             chrome.start();
         }
     }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/SpecificImageNameWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/SpecificImageNameWebDriverContainerTest.java
@@ -2,10 +2,8 @@ package org.testcontainers.junit;
 
 import org.junit.Rule;
 import org.junit.Test;
-import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
-
-import java.io.IOException;
 
 /**
  *
@@ -14,15 +12,15 @@ public class SpecificImageNameWebDriverContainerTest extends BaseWebDriverContai
 
     @Rule
     public BrowserWebDriverContainer firefox = new BrowserWebDriverContainer("selenium/standalone-firefox:2.53.1-beryllium")
-            .withDesiredCapabilities(DesiredCapabilities.firefox());
+        .withCapabilities(new FirefoxOptions());
 
     @Test
-    public void simpleTest() throws IOException {
+    public void simpleTest() {
         doSimpleWebdriverTest(firefox);
     }
 
     @Test
-    public void simpleExploreTest() throws IOException {
+    public void simpleExploreTest() {
         doSimpleExplore(firefox);
     }
 }


### PR DESCRIPTION
The latest and recommended way to request a RemoteWebDriver is by passing ChromeOptions /  FirefoxOptions to the constructor instead of DesiredCapabilities. Both of these implement Capabilities interface so the change was quite straightforward, deprecating the old method and changing the field type to Capabilities.

Another improvement is that we will not throw IllegalException when capabilities are not provided, but fall back to starting a chrome container. So now you could just write:
```
@Rule
public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer();
```
omitting `withCapabilities(new ChromeOptions())` and it will work out of the box.