### PR TITLE
Disable Gradle daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,24 +7,24 @@ services:
   - docker
 
 install:
-  - ./gradlew build -x check --scan
+  - ./gradlew build -x check --scan --no-daemon
 
 jobs:
   include:
     - stage: test
       env: [ NAME=core ]
-      script: ./gradlew testcontainers:check javadoc --scan
+      script: ./gradlew testcontainers:check javadoc --scan --no-daemon
 
     - stage: test
       env: [ NAME=core ]
       jdk: openjdk11
-      script: ./gradlew testcontainers:check --scan
+      script: ./gradlew testcontainers:check --scan --no-daemon
 
     - env: [ NAME=selenium ]
-      script: ./gradlew selenium:check --scan
+      script: ./gradlew selenium:check --scan --no-daemon
 
     - env: [ NAME=modules ]
-      script: ./gradlew check -x testcontainers:check -x selenium:check --scan
+      script: ./gradlew check -x testcontainers:check -x selenium:check --scan --no-daemon
 
     # Run Docker-in-Docker tests inside Alpine
     - env: [ NAME="docker-in-alpine-docker" ]
@@ -45,7 +45,7 @@ jobs:
       script: skip
       deploy:
         provider: script
-        script: ./gradlew -Pversion=$TRAVIS_TAG release --scan
+        script: ./gradlew -Pversion=$TRAVIS_TAG release --scan --no-daemon
         on:
           tags: true
           branch: master


### PR DESCRIPTION
All branches on Travis CI have been failing in the Docker-in-Docker part of the build, with error logs similar to those shown in https://github.com/gradle/gradle/issues/3318. It's hard to tell what's happening, but I'd like to try disabling the Gradle daemon: I suspect that the problem is due to the Gradle caches being accessed concurrently by the daemon from the install phase and the docker-in-docker phase.

As it's hard to really tell exactly what's going on, I'd like to try merging this and see if it stabilises things - I think it's pretty harmless and so far seems to work better.