### PR TITLE
Simplify GitLab CI documentation

### DIFF
--- a/docs/ci/ci.md
+++ b/docs/ci/ci.md
@@ -2,40 +2,27 @@
 
 ## GitLab
 
+In order to use Testcontainers in a Gitlab CI pipeline, you need to run the job as a Docker container (see [Running inside Docker](../usage/inside_docker.md)).
+So edit your `.gitlab-ci.yml` to include the [Docker-In-Docker service](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker-executor) (`docker:dind`) and set the `DOCKER_HOST` variable to `tcp://docker:2375`.
 
-To be able to run your test container into the pipeline you need to run the job as a docker container (see [Running inside Docker](../usage/inside_docker.md)),
-so you need Docker-In-Docker (docker:dind) service and mount the docker's socket. Also if you have "Permission denied" you
-need to run your container as root user:
+Here is a sample `.gitlab-ci.yml` that executes test with gradle:
 
 ```yml
-# to improve performance
-variables:
-  DOCKER_DRIVER: overlay2
-
-# we need DinD service
+# DinD service is required for Testcontainers
 services:
   - docker:dind
 
+variables:
+  # Instruct Testcontainers to use the daemon of DinD.
+  DOCKER_HOST: "tcp://docker:2375"
+  # Improve performance with overlayfs.
+  DOCKER_DRIVER: overlay2
+
 test:
- image: docker:latest
+ image: gradle:5.0
  stage: test
- script:
-   - >
-      docker run -t --rm 
-      -v /var/run/docker.sock:/var/run/docker.sock
-      -v "$(pwd)":"$(pwd)"
-      -w "$(pwd)"
-      -u 0:0
-      gradle:3.4 ./gradlew test
- only:
-   - master
+ script: ./gradlew test
 ```
-
-In this job we run in a multiline command a docker container:
-* using the official gradle image
-* to be delete when finished
-* use the root user if you are running a Shared Runner
-
 
 ## CircleCI 2.0
 


### PR DESCRIPTION
Last week, I spend some time figuring out the best configuration for GitLab CI and DinD. At first, I used the [example in the docs](https://www.testcontainers.org/ci/ci.html#gitlab). Then I tried other ways.

As it turns out, the documented GitLab configuration is over-complicated. It uses three containers (`docker:latest`, `gradle:3.4`, `docker:dind`) and runs docker in a script, but that extra layer is unnecessary. By setting the `DOCKER_HOST` environment variable, you only need two containers.

This is a simpler alternative configuration:
```yml
# we need DinD service
services:
  - docker:dind

variables:
  # to improve performance
  DOCKER_DRIVER: overlay2
  # connect testcontainers to DinD service
  DOCKER_HOST: "tcp://docker:2375"

test:
 image: gradle:3.4
 stage: test
 script: ./gradlew test
```

This configuration is more readable, and has better performance. That's why I suggest to update the documentation for using Gitlab CI.

## How the previous configuration operates
*Disclaimer: I'm not a Docker expert.*

Let's take this configuration as an example:
```yaml
# complex configuration that I don't recommend
services:
  - docker:dind

gradle check:
  image: docker:latest
  script:
    - echo $DOCKER_HOST
    # returns tcp://docker:2375
    - >
      docker run -t --rm 
      -v /var/run/docker.sock:/var/run/docker.sock
      -v "$(pwd)":"$(pwd)"
      -w "$(pwd)"
      -u 0:0
      openjdk:11 ./gradlew check
```
The `docker run` command uses the daemon specified by the `DOCKER_HOST` [environment variable](https://docs.docker.com/engine/reference/commandline/cli/#environment-variables).

At Gitlab CI, `DOCKER_HOST` defaults to `tcp://docker:2375` if you define a `docker:dind` service ([proof](https://gitlab.com/TjeuKayim/testcontainers-gitlab-ci/-/jobs/137623462)).
If you don't define such service, [it will be empty](https://gitlab.com/TjeuKayim/testcontainers-gitlab-ci/-/jobs/137627947).

So in the example above, `docker run` will use the Docker daemon inside the `docker:dind` service (with default hostname `docker`).

The documentation explains it this way:
https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker-executor

> When using dind service we need to instruct docker, to talk with the
> daemon started inside of the service. The daemon is available with
> a network connection instead of the default /var/run/docker.sock socket.
> 
> The 'docker' hostname is the alias of the service container as described at
> https://docs.gitlab.com/ee/ci/docker/using_docker_images.html#accessing-the-services
> 
> Note that if you're using Kubernetes executor, the variable should be set to
> tcp://localhost:2375 because of how Kubernetes executor connects services
> to the job container

As I understand it, `docker run` will delegate the command to the `docker:dind` service. That service will spawn an `openjdk` container. In turn, Testcontainers will use the Docker daemon of `docker:dind` through the `/var/run/docker.sock` binding.

In conclusion, this configuration is over-complicated, because the `docker` container does nothing but delegating its work to `docker:dind`.
