### PR TITLE
Start shared containers in beforeAll callback (Jupiter)

### DIFF
--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersSharedContainerTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersSharedContainerTests.java
@@ -1,9 +1,11 @@
 package org.testcontainers.junit.jupiter;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Testcontainers
 class TestcontainersSharedContainerTests {
@@ -13,6 +15,11 @@ class TestcontainersSharedContainerTests {
         .withExposedPorts(80);
 
     private static String lastContainerId;
+
+    @BeforeAll
+    static void doSomethingWithAContainer() {
+        assertTrue(GENERIC_CONTAINER.isRunning());
+    }
 
     @Test
     void first_test() {


### PR DESCRIPTION
I've probably missed some edge cases, but all current tests are green.
We also explicitly don't support parallel test execution at this point.

Fixes #1019.