### PR TITLE
Enable automatic release version numbering

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,5 @@
+name-template: $NEXT_PATCH_VERSION
+tag-template: $NEXT_PATCH_VERSION
 template: |
     ## What's Changed
 


### PR DESCRIPTION
Using https://github.com/toolmantim/release-drafter/releases/tag/v4.0.0

If we need to manually specify a version (e.g. for a minor/major bump) we can still do that.