### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+# See https://github.com/dependabot/feedback/issues/70 for current (beta) configurability
+version: 1
+update_configs:
+  - package_manager: "java:gradle"
+    directory: "/core"
+    update_schedule: "daily"


### PR DESCRIPTION
See https://github.com/dependabot/feedback/issues/70

This is a first attempt to configure dependabot to work with our multi-module repo structure.

The config file is a beta feature, and I'm not yet sure how well this will work. If it works OK for the `/core` directory, then I'd expect we may have to add an entry for each of the `/modules/*` directories as well.

Hopefully this would change if dependabot gained the ability to understand multi-module gradle builds natively, but for now I hope that this works.