### PR TITLE
update mockserver to 5.5.1 and bind to port 1080 which is default

### DIFF
--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MockServer"
 dependencies {
     compile project(':testcontainers')
 
-    testCompile 'org.mock-server:mockserver-client-java:5.5.0'
+    testCompile 'org.mock-server:mockserver-client-java:5.5.1'
 }

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -5,9 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
-    public static final String VERSION = "5.5.0";
+    public static final String VERSION = "5.5.1";
 
-    public static final int PORT = 80;
+    public static final int PORT = 1080;
 
     public MockServerContainer() {
         this(VERSION);

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -1,7 +1,6 @@
 package org.testcontainers.containers;
 
 import lombok.Cleanup;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.client.MockServerClient;
 
@@ -20,27 +19,30 @@ public class MockServerContainerTest {
 
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {
-        @Cleanup MockServerContainer mockServer = new MockServerContainer(MockServerClient.class.getPackage().getImplementationVersion());
-        mockServer.start();
+        String actualVersion = MockServerClient.class.getPackage().getImplementationVersion();
+        try (MockServerContainer mockServer = new MockServerContainer(actualVersion)) {
+            mockServer.start();
 
-        String expectedBody = "Hello World!";
+            String expectedBody = "Hello World!";
 
-        assertThat("MockServer returns correct result",
-            responseFromMockserver(mockServer, expectedBody, "/hello"),
-            containsString(expectedBody)
-        );
+            assertThat("MockServer returns correct result",
+                responseFromMockserver(mockServer, expectedBody, "/hello"),
+                containsString(expectedBody)
+            );
+        }
     }
 
     @Test
     public void shouldCallDefaultMockserverVersion() throws Exception {
-        @Cleanup MockServerContainer mockServerDefault = new MockServerContainer();
-        mockServerDefault.start();
-        String expectedBody = "Hello Default World!";
+        try (MockServerContainer mockServerDefault = new MockServerContainer()) {
+            mockServerDefault.start();
+            String expectedBody = "Hello Default World!";
 
-        assertThat("MockServer returns correct result for default constructor",
-            responseFromMockserver(mockServerDefault, expectedBody, "/hellodefault"),
-            containsString(expectedBody)
-        );
+            assertThat("MockServer returns correct result for default constructor",
+                responseFromMockserver(mockServerDefault, expectedBody, "/hellodefault"),
+                containsString(expectedBody)
+            );
+        }
     }
 
     private static String responseFromMockserver(MockServerContainer mockServer, String expectedBody, String path) throws IOException {

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -1,39 +1,49 @@
 package org.testcontainers.containers;
 
 import lombok.Cleanup;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.client.MockServerClient;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 
-@Slf4j
 public class MockServerContainerTest {
 
     @ClassRule
-    public static MockServerContainer mockServer = new MockServerContainer(MockServerClient.class.getPackage().getImplementationVersion())
-        .withLogConsumer(new Slf4jLogConsumer(log));
+    public static MockServerContainer mockServer = new MockServerContainer(MockServerClient.class.getPackage().getImplementationVersion());
+
+    @ClassRule
+    public static MockServerContainer mockServerDefault = new MockServerContainer();
 
     @Test
-    public void testBasicScenario() throws Exception {
-        new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort())
-            .when(request("/hello"))
-            .respond(response("Hello World!"));
+    public void shouldCallActualMockserverVersion() throws Exception {
+        shouldCallMockserver(mockServer, "Hello World!", "/hello");
+    }
 
-        URLConnection urlConnection = new URL(mockServer.getEndpoint() + "/hello").openConnection();
+    @Test
+    public void shouldCallDefaultMockserverVersion() throws Exception {
+        shouldCallMockserver(mockServerDefault, "Hello Default World!", "/hellodefault");
+    }
+
+    private static void shouldCallMockserver(MockServerContainer mockServer, String expectedBody, String path) throws IOException {
+        new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort())
+            .when(request(path))
+            .respond(response(expectedBody));
+
+        URLConnection urlConnection = new URL(mockServer.getEndpoint() + path).openConnection();
         @Cleanup BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
         String line = reader.readLine();
         System.out.println(line);
 
-        assertTrue("MockServer returns correct result", line.contains("Hello World!"));
+        assertThat("MockServer returns correct result", line, containsString(expectedBody));
     }
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -29,7 +29,7 @@ public class MockServerContainerTest {
         String expectedBody = "Hello World!";
 
         assertThat("MockServer returns correct result",
-            responseFromMockserver(mockServerDefault, expectedBody, "/hello"),
+            responseFromMockserver(mockServer, expectedBody, "/hello"),
             containsString(expectedBody)
         );
     }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -26,15 +26,25 @@ public class MockServerContainerTest {
 
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {
-        shouldCallMockserver(mockServer, "Hello World!", "/hello");
+        String expectedBody = "Hello World!";
+
+        assertThat("MockServer returns correct result",
+            responseFromMockserver(mockServerDefault, expectedBody, "/hello"),
+            containsString(expectedBody)
+        );
     }
 
     @Test
     public void shouldCallDefaultMockserverVersion() throws Exception {
-        shouldCallMockserver(mockServerDefault, "Hello Default World!", "/hellodefault");
+        String expectedBody = "Hello Default World!";
+
+        assertThat("MockServer returns correct result for default constructor",
+            responseFromMockserver(mockServerDefault, expectedBody, "/hellodefault"),
+            containsString(expectedBody)
+        );
     }
 
-    private static void shouldCallMockserver(MockServerContainer mockServer, String expectedBody, String path) throws IOException {
+    private static String responseFromMockserver(MockServerContainer mockServer, String expectedBody, String path) throws IOException {
         new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort())
             .when(request(path))
             .respond(response(expectedBody));
@@ -43,7 +53,8 @@ public class MockServerContainerTest {
         @Cleanup BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
         String line = reader.readLine();
         System.out.println(line);
+        return line;
 
-        assertThat("MockServer returns correct result", line, containsString(expectedBody));
+
     }
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -18,14 +18,11 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 
 public class MockServerContainerTest {
 
-    @ClassRule
-    public static MockServerContainer mockServer = new MockServerContainer(MockServerClient.class.getPackage().getImplementationVersion());
-
-    @ClassRule
-    public static MockServerContainer mockServerDefault = new MockServerContainer();
-
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {
+        @Cleanup MockServerContainer mockServer = new MockServerContainer(MockServerClient.class.getPackage().getImplementationVersion());
+        mockServer.start();
+
         String expectedBody = "Hello World!";
 
         assertThat("MockServer returns correct result",
@@ -36,6 +33,8 @@ public class MockServerContainerTest {
 
     @Test
     public void shouldCallDefaultMockserverVersion() throws Exception {
+        @Cleanup MockServerContainer mockServerDefault = new MockServerContainer();
+        mockServerDefault.start();
         String expectedBody = "Hello Default World!";
 
         assertThat("MockServer returns correct result for default constructor",

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -1,9 +1,11 @@
 package org.testcontainers.containers;
 
 import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.client.MockServerClient;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -14,10 +16,12 @@ import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
+@Slf4j
 public class MockServerContainerTest {
 
     @ClassRule
-    public static MockServerContainer mockServer = new MockServerContainer();
+    public static MockServerContainer mockServer = new MockServerContainer(MockServerClient.class.getPackage().getImplementationVersion())
+        .withLogConsumer(new Slf4jLogConsumer(log));
 
     @Test
     public void testBasicScenario() throws Exception {

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -50,10 +50,6 @@ public class MockServerContainerTest {
 
         URLConnection urlConnection = new URL(mockServer.getEndpoint() + path).openConnection();
         @Cleanup BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
-        String line = reader.readLine();
-        System.out.println(line);
-        return line;
-
-
+        return reader.readLine();
     }
 }


### PR DESCRIPTION
in 5.5.1 they don't run container as root, so binding to 80 port
doesn't work anymore

https://github.com/jamesdbloom/mockserver/commit/6d33bd78d515fa1a26ff721c9d6bc6e40c77b4e9#diff-ebacf6f6ae4ee68078bb16454b23247d