### PR TITLE
Make it possible to turn off Ryuk with an environment variable

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -120,7 +120,7 @@ public class DockerClientFactory {
                     "  Total Memory: " + dockerInfo.getMemTotal() / (1024 * 1024) + " MB");
 
             String ryukContainerId = null;
-            boolean useRyuk = !"false".equals(System.getenv("TESTCONTAINERS_RYUK_ENABLED"));
+            boolean useRyuk = !Boolean.parseBoolean(System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
             if (useRyuk) {
                 ryukContainerId = ResourceReaper.start(hostIpAddress, client);
                 log.info("Ryuk started - will monitor and terminate Testcontainers containers on JVM exit");

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -42,11 +42,20 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **kafka.container.image = confluentinc/cp-kafka**  
 > Used by KafkaContainer 
 
-## Customizing ryuk resource reaper
+## Customizing Ryuk resource reaper
 
 > **ryuk.container.image = quay.io/testcontainers/ryuk:0.2.2**
 > The resource reaper is responsible for container removal and automatic cleanup of dead containers at JVM shutdown
 
 > **ryuk.container.privileged = false**
 > In some environments ryuk must be started in privileged mode to work properly (--privileged flag)
+
+### Disabling Ryuk
+Ryuk must be started as a privileged container.  
+If your environment already implements automatic cleanup of containers after the execution,
+but does not allow starting privileged containers, you can turn off the Ryuk container by setting
+`TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
+
+!!!tip
+    Note that Testcontainers will continue doing the cleanup at JVM's shutdown, unless you `kill -9` your JVM process.
 


### PR DESCRIPTION
Set `TESTCONTAINERS_RYUK_DISABLED` environment variable to `true`.

Closes #1023 #700.