### PR TITLE
Fix typo in Postgresql gradle dependency

### DIFF
--- a/docs/modules/databases/postgres.md
+++ b/docs/modules/databases/postgres.md
@@ -7,7 +7,7 @@ See [Database containers](./index.md) for documentation and usage that is common
 Add the following dependency to your `pom.xml`/`build.gradle` file:
 
 ```groovy tab='Gradle'
-testCompile "org.testcontainers:postgres:{{latest_version}}"
+testCompile "org.testcontainers:postgresql:{{latest_version}}"
 ```
 
 ```xml tab='Maven'


### PR DESCRIPTION
The correct dependency is org.testcontainers:postgresql no org.testcontainers:postgres