### PR TITLE
Allow extension of Neo4jContainer class

### DIFF
--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -19,7 +19,7 @@ import org.testcontainers.utility.LicenseAcceptance;
  * @param <S> "SELF" to be used in the <code>withXXX</code> methods.
  * @author Michael J. Simons
  */
-public final class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContainer<S> {
+public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContainer<S> {
 
     /**
      * The image defaults to the official Neo4j image: <a href="https://hub.docker.com/_/neo4j/">Neo4j</a>.


### PR DESCRIPTION
My team is trying to use Neo4jContainer in a Kotlin codebase but we have an issue with type inference.
Seems like Kotlin cannot infer the type when creating an instance of Neo4jContainer. The following code causes a type inference error:

```
val myNeo4jContainer = Neo4jContainer("imageName")
```

To fix it, a custom class that extends from Neo4jContainer needs
to be declared, for example:

```
class KNeo4jContainer(imageName: String) : Neo4jContainer<KNeo4jContainer>(imageName)

val myNeo4jContainer = KNeo4jContainer("imageName")
```

This change enables extending the Neo4jContainer class.