### PR TITLE
Update ryuk references to latest version - 0.2.3

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -51,7 +51,7 @@ public class TestcontainersConfiguration {
     }
 
     public String getRyukImage() {
-        return (String) properties.getOrDefault("ryuk.container.image", "quay.io/testcontainers/ryuk:0.2.2");
+        return (String) properties.getOrDefault("ryuk.container.image", "quay.io/testcontainers/ryuk:0.2.3");
     }
 
     public String getSSHdImage() {

--- a/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
@@ -22,8 +22,8 @@ public class ImagePullTest {
             "gliderlabs/alpine:3.5",
             "gliderlabs/alpine@sha256:a19aa4a17a525c97e5a90a0c53a9f3329d2dc61b0a14df5447757a865671c085",
             "quay.io/testcontainers/ryuk:latest",
-            "quay.io/testcontainers/ryuk:0.2.2",
-            "quay.io/testcontainers/ryuk@sha256:4b606e54c4bba1af4fd814019d342e4664d51e28d3ba2d18d24406edbefd66da",
+            "quay.io/testcontainers/ryuk:0.2.3",
+            "quay.io/testcontainers/ryuk@sha256:bb5a635cac4bd96c93cc476969ce11dc56436238ec7cd028d0524462f4739dd9",
         };
     }
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -44,7 +44,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 
 ## Customizing Ryuk resource reaper
 
-> **ryuk.container.image = quay.io/testcontainers/ryuk:0.2.2**
+> **ryuk.container.image = quay.io/testcontainers/ryuk:0.2.3**
 > The resource reaper is responsible for container removal and automatic cleanup of dead containers at JVM shutdown
 
 > **ryuk.container.privileged = false**


### PR DESCRIPTION
as version https://github.com/testcontainers/moby-ryuk/releases/tag/0.2.3 was released 

- test and docs probably doesnt need a change but I guess its nice to have as well