### PR TITLE
Change megabytes for bytes in withSharedMemorySize method documentation

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1144,7 +1144,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     /**
      * Size of /dev/shm
-     * @param bytes The number of megabytes to assign the shared memory. If null, it will apply the Docker default which is 64 MB.
+     * @param bytes The number of bytes to assign the shared memory. If null, it will apply the Docker default which is 64 MB.
      * @return this
      */
     public SELF withSharedMemorySize(Long bytes) {


### PR DESCRIPTION
This is just a simple fix for a method documentation. 

In GenericContainer class, withSharedMemorySize method was accepting MB as an argument. This was changed to accept Bytes instead, but the documentation of the method was not fully changed. This PR is just doing this small doc fix.