### PR TITLE
CredsStore validation for RegistryAuthLocator

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -183,6 +183,7 @@ public class RegistryAuthLocator {
         final JsonNode credsStoreNode = config.get("credsStore");
         if (credsStoreNode != null && !credsStoreNode.isMissingNode() && credsStoreNode.isTextual()) {
             final String credsStore = credsStoreNode.asText();
+            // todo: define behaviour on empty value
             return runCredentialProvider(reposName, credsStore);
         }
         return null;

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -183,7 +183,7 @@ public class RegistryAuthLocator {
         final JsonNode credsStoreNode = config.get("credsStore");
         if (credsStoreNode != null && !credsStoreNode.isMissingNode() && credsStoreNode.isTextual()) {
             final String credsStore = credsStoreNode.asText();
-            if (credsStore.isBlank()) {
+            if (isBlank(credsStore)) {
                 log.warn("CredStore field will be ignored, because value is blank");
                 return null;
             }

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -184,7 +184,7 @@ public class RegistryAuthLocator {
         if (credsStoreNode != null && !credsStoreNode.isMissingNode() && credsStoreNode.isTextual()) {
             final String credsStore = credsStoreNode.asText();
             if (isBlank(credsStore)) {
-                log.warn("CredStore field will be ignored, because value is blank");
+                log.warn("Docker auth config credsStore field will be ignored, because value is blank");
                 return null;
             }
             return runCredentialProvider(reposName, credsStore);

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -183,7 +183,10 @@ public class RegistryAuthLocator {
         final JsonNode credsStoreNode = config.get("credsStore");
         if (credsStoreNode != null && !credsStoreNode.isMissingNode() && credsStoreNode.isTextual()) {
             final String credsStore = credsStoreNode.asText();
-            // todo: define behaviour on empty value
+            if (credsStore.isBlank()) {
+                log.warn("CredStore field will be ignored, because value is blank");
+                return null;
+            }
             return runCredentialProvider(reposName, credsStore);
         }
         return null;

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -11,6 +11,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.junit.Assert.fail;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertNull;
 
@@ -99,6 +100,18 @@ public class RegistryAuthLocatorTest {
             "Not correct message discovered",
             "Fake credentials not found on credentials store 'https://not.a.real.registry/url'",
             discoveredMessage);
+    }
+
+    @Test
+    public void lookupAuthConfigWithCredStoreEmpty() throws URISyntaxException {
+        Map<String, String> emptyMap = new HashMap<>();
+        final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-store-empty.json", emptyMap);
+
+        DockerImageName dockerImageName = new DockerImageName("registry2.example.com/org/repo");
+        try {
+            authLocator.lookupAuthConfig(dockerImageName, new AuthConfig());
+            fail();
+        } catch (IllegalArgumentException e) { }
     }
 
     @NotNull

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -11,7 +11,6 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.fail;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertNull;
 

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -104,14 +104,12 @@ public class RegistryAuthLocatorTest {
 
     @Test
     public void lookupAuthConfigWithCredStoreEmpty() throws URISyntaxException {
-        Map<String, String> emptyMap = new HashMap<>();
-        final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-store-empty.json", emptyMap);
+        final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-store-empty.json");
 
         DockerImageName dockerImageName = new DockerImageName("registry2.example.com/org/repo");
-        try {
-            authLocator.lookupAuthConfig(dockerImageName, new AuthConfig());
-            fail();
-        } catch (IllegalArgumentException e) { }
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(dockerImageName, new AuthConfig());
+
+        assertNull("CredStore field will be ignored, because value is blank", authConfig.getAuth());
     }
 
     @NotNull

--- a/core/src/test/resources/auth-config/config-with-store-empty.json
+++ b/core/src/test/resources/auth-config/config-with-store-empty.json
@@ -1,0 +1,9 @@
+{
+    "auths": {
+        "registry.example.com": {}
+    },
+    "HttpHeaders": {
+        "User-Agent": "Docker-Client/18.03.0-ce (darwin)"
+    },
+    "credsStore": ""
+}


### PR DESCRIPTION
 ## Fixes
`RegistryAuthLocator` : Add additional validation for existing key `credsStore` but empty value

## Purpose
Define behaviour for RegistryAuthLocator on empty values in config

Offer: 
 - fail on empty value
 - ignore field with empty value & log -> return null;

## Background Context
Currently experienced problems using testcontainers, I found existing issue for my problem and decided to help. 
Potentially, put checks for all existing `keys` with empty strings

## References
ref: #921 