### PR TITLE
Simplify CassandraContainer type

### DIFF
--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  *
  * @author Eugeny Karpov
  */
-public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends GenericContainer<SELF> {
+public class CassandraContainer extends GenericContainer<CassandraContainer> {
 
     public static final String IMAGE = "cassandra";
     public static final Integer CQL_PORT = 9042;
@@ -101,7 +101,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      *
      * @param configLocation relative classpath with the directory that contains cassandra.yaml and other configuration files
      */
-    public SELF withConfigurationOverride(String configLocation) {
+    public CassandraContainer withConfigurationOverride(String configLocation) {
         this.configLocation = configLocation;
         return self();
     }
@@ -113,7 +113,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      *
      * @param initScriptPath relative classpath resource
      */
-    public SELF withInitScript(String initScriptPath) {
+    public CassandraContainer withInitScript(String initScriptPath) {
         this.initScriptPath = initScriptPath;
         return self();
     }
@@ -121,7 +121,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
     /**
      * Initialize Cassandra client with JMX reporting enabled or disabled
      */
-    public SELF withJmxReporting(boolean enableJmxReporting) {
+    public CassandraContainer withJmxReporting(boolean enableJmxReporting) {
         this.enableJmxReporting = enableJmxReporting;
         return self();
     }

--- a/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
+++ b/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
@@ -20,7 +20,7 @@ public class CassandraContainerTest {
 
     @Test
     public void testSimple() {
-        try (CassandraContainer cassandraContainer = new CassandraContainer<>()) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer()) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer, "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());
@@ -31,7 +31,7 @@ public class CassandraContainerTest {
     @Test
     public void testSpecificVersion() {
         String cassandraVersion = "3.0.15";
-        try (CassandraContainer cassandraContainer = new CassandraContainer<>("cassandra:" + cassandraVersion)) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer("cassandra:" + cassandraVersion)) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer, "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());
@@ -42,7 +42,7 @@ public class CassandraContainerTest {
     @Test
     public void testConfigurationOverride() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .withConfigurationOverride("cassandra-test-configuration-example")
         ) {
             cassandraContainer.start();
@@ -55,7 +55,7 @@ public class CassandraContainerTest {
     @Test(expected = ContainerLaunchException.class)
     public void testEmptyConfigurationOverride() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .withConfigurationOverride("cassandra-empty-configuration")
         ) {
             cassandraContainer.start();
@@ -65,7 +65,7 @@ public class CassandraContainerTest {
     @Test
     public void testInitScript() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .withInitScript("initial.cql")
         ) {
             cassandraContainer.start();
@@ -76,7 +76,7 @@ public class CassandraContainerTest {
     @Test
     public void testInitScriptWithLegacyCassandra() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>("cassandra:2.2.11")
+            CassandraContainer cassandraContainer = new CassandraContainer("cassandra:2.2.11")
                 .withInitScript("initial.cql")
         ) {
             cassandraContainer.start();
@@ -87,7 +87,7 @@ public class CassandraContainerTest {
     @Test
     public void testCassandraQueryWaitStrategy() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .waitingFor(new CassandraQueryWaitStrategy())
         ) {
             cassandraContainer.start();
@@ -98,7 +98,7 @@ public class CassandraContainerTest {
 
     @Test
     public void testCassandraGetCluster() {
-        try (CassandraContainer cassandraContainer = new CassandraContainer<>()) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer()) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer.getCluster(), "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());


### PR DESCRIPTION
Remove the SELF typing generic usage in `CassandraContainer` (change makes is consistent to other special containers, like `KafkaContainer`).

Was spawned by this discussion in Slack and simplifies the usage in other JVM languages such as Scala:
https://testcontainers.slack.com/archives/C1SUBPZK6/p1553198463052800

This would be an API breaking change, so it's open for discussion.