### PR TITLE
Use hostname instead of hardcoded "name" string

### DIFF
--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -86,7 +86,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
                     throw new IllegalStateException("Maximum number of proxies exceeded");
                 }
 
-                final Proxy proxy = client.createProxy(hostname, "0.0.0.0:" + toxiPort, upstream);
+                final Proxy proxy = client.createProxy(upstream, "0.0.0.0:" + toxiPort, upstream);
                 return new ContainerProxy(proxy, getContainerIpAddress(), getMappedPort(toxiPort));
             } catch (IOException e) {
                 throw new RuntimeException("Proxy could not be created", e);

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -86,7 +86,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
                     throw new IllegalStateException("Maximum number of proxies exceeded");
                 }
 
-                final Proxy proxy = client.createProxy("name", "0.0.0.0:" + toxiPort, upstream);
+                final Proxy proxy = client.createProxy(hostname, "0.0.0.0:" + toxiPort, upstream);
                 return new ContainerProxy(proxy, getContainerIpAddress(), getMappedPort(toxiPort));
             } catch (IOException e) {
                 throw new RuntimeException("Proxy could not be created", e);


### PR DESCRIPTION
Proposal to use hostname instead of hardcoded string to allow for multiple proxies to be created.

In my use case I have multiple proxies: one for redis, another for a mock http server, etc.
With the current implementation, when I try to create the second proxy it fails with a "409 - proxy already exists".
This is because in the "getProxy" method we have the name of the proxy hardcoded to "name".

`final Proxy proxy = client.createProxy("name", "0.0.0.0:" + toxiPort, upstream);`

I am not sure if this requires a new test case with two proxies, and since it's the first time I'm contributing to this project I figured it would be better to get some feedback on the change before doing anything big.