### PR TITLE
Add method to provide pre-configured MockServerClient from MockServerContainer

### DIFF
--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -2,6 +2,5 @@ description = "Testcontainers :: MockServer"
 
 dependencies {
     compile project(':testcontainers')
-
-    testCompile 'org.mock-server:mockserver-client-java:5.5.1'
+    compile 'org.mock-server:mockserver-client-java:5.5.1'
 }

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -1,5 +1,10 @@
 package org.testcontainers.containers;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mockserver.client.MockServerClient;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -8,6 +13,8 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
     public static final String VERSION = "5.5.1";
 
     public static final int PORT = 1080;
+
+    private final Map<String,MockServerClient> clients = new HashMap<>();
 
     public MockServerContainer() {
         this(VERSION);
@@ -25,5 +32,19 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
     public Integer getServerPort() {
         return getMappedPort(PORT);
+    }
+
+    public MockServerClient getClient() {
+        return getClient("");
+    }
+
+    public MockServerClient getClient(String path) {
+        return clients.computeIfAbsent(path, (p) -> new MockServerClient(getContainerIpAddress(), getServerPort(), p));
+    }
+
+    @Override
+    public void stop() {
+        super.stop();
+        clients.values().forEach(client -> client.close());
     }
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -46,7 +46,7 @@ public class MockServerContainerTest {
     }
 
     private static String responseFromMockserver(MockServerContainer mockServer, String expectedBody, String path) throws IOException {
-        new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort())
+        mockServer.getClient()
             .when(request(path))
             .respond(response(expectedBody));
 


### PR DESCRIPTION
The existing mockserver module does not provide much value over using a regular `GenericContainer`. If using a MockServerContainer in a test, we still need to add a `@BeforeClass` to construct a client instance after the server container has started like this:

```java
@Container
MockServerContainer mockServer;

static MockServerClient client;

@BeforeClass
public static void setup() {
  client = new MockServerClient(mockServer.getContainerIpAddress(), mockServer.getServerPort());
}

@Test
public void testSomething() {
  client.when(...)
           .respond(...);
}
```

After this PR, a MockServerClient can be obtained straight from the mockServer container like this:
```java
@Container
MockServerContainer mockServer;

@Test
public void testSomething() {
  mockServer.getClient()
           .when(...)
           .respond(...);
}
```