### PR TITLE
Adjust localstack services to 0.9.2 version

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  */
 public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
-    public static final String VERSION = "0.8.6";
+    public static final String VERSION = "0.9.2";
 
     private final List<Service> services = new ArrayList<>();
 
@@ -98,7 +98,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         }
 
         return new AwsClientBuilder.EndpointConfiguration(
-                "http://" +
+            "http://" +
                 ipAddress +
                 ":" +
                 getMappedPort(service.getPort()), "us-east-1");
@@ -123,23 +123,28 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     @Getter
     @FieldDefaults(makeFinal = true)
     public enum Service {
-        API_GATEWAY("apigateway",             4567),
-        KINESIS("kinesis",                 4568),
-        DYNAMODB("dynamodb",        4569),
-        DYNAMODB_STREAMS("dynamodbstreams",        4570),
-        // TODO: Clarify usage for ELASTICSEARCH and ELASTICSEARCH_SERVICE
-//        ELASTICSEARCH("es",           4571),
-        S3("s3",                    4572),
+        API_GATEWAY("apigateway",           4567),
+        KINESIS("kinesis",                  4568),
+        DYNAMODB("dynamodb",                4569),
+        DYNAMODB_STREAMS("dynamodbstreams", 4570),
+        ELASTICSEARCH("elasticsearch",      4571),
+        S3("s3",                            4572),
         FIREHOSE("firehose",                4573),
-        LAMBDA("lambda",                  4574),
-        SNS("sns",                     4575),
-        SQS("sqs",                     4576),
+        LAMBDA("lambda",                    4574),
+        SNS("sns",                          4575),
+        SQS("sqs",                          4576),
         REDSHIFT("redshift",                4577),
-//        ELASTICSEARCH_SERVICE("",   4578),
-        SES("ses",                     4579),
-        ROUTE53("route53",                 4580),
-        CLOUDFORMATION("cloudformation",          4581),
-        CLOUDWATCH("cloudwatch",              4582);
+        ELASTICSEARCH_SERVICE("es",         4578),
+        SES("ses",                          4579),
+        ROUTE53("route53",                  4580),
+        CLOUDFORMATION("cloudformation",    4581),
+        CLOUDWATCH("cloudwatch",            4582),
+        SSM("ssm",                          4583),
+        SECRETS_MANAGER("secretsmanager",   4584),
+        STEP_FUNCTIONS("stepfunctions",     4585),
+        CLOUDWATCH_LOGS("logs",             4586),
+        STS("sts",                          4592),
+        IAM("iam",                          4593);
 
         String localStackName;
 


### PR DESCRIPTION
Hello, since the 0.8.6 localstack supported few more services
https://github.com/localstack/localstack

I've added them to the list

Checked everything with a simple test 
```
 @Test
    public void services() {
        Set<LocalStackContainer.Service> failed = new HashSet<>();
        for (LocalStackContainer.Service srv : LocalStackContainer.Service.values()) {
            try (LocalStackContainer localstack = new LocalStackContainer().withServices(srv).withLogConsumer(new Slf4jLogConsumer(log))) {
                localstack.start();
            } catch (Exception e) {
                failed.add(srv);
            }
        }

        assertThat(failed.toString(), failed.size(), CoreMatchers.is(0));
    }
```

but it takes 7m on my mac, so I didn't commit that (feel free to tell if I need)