### PR TITLE
Fix ScriptUtils splitting with Windows EOF (#1467, #1465)

### DIFF
--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -206,7 +206,7 @@ public abstract class ScriptUtils {
 							blockCommentEndDelimiter), resource);
 					}
 				}
-				else if (c == ' ' || c == '\n' || c == '\t') {
+				else if (c == ' ' || c == '\n' || c == '\t' || c == '\r') {
 					// avoid multiple adjacent whitespace characters
 					if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ' ') {
 						c = ' ';

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
@@ -28,4 +28,21 @@ public class ScriptUtilsTest {
         assertEquals("SELECT * from `bar`", statements.get(4));
         assertEquals("INSERT INTO bar (foo) VALUES ('hello world')", statements.get(6));
     }
+
+    /*
+     * Test ScriptUtils script splitting with some ugly/hard-to-split cases and linux line endings
+     */
+    @Test
+    public void testSplitWithWidnwosLineEnding() throws IOException {
+        final String script = Resources.toString(Resources.getResource("splittable.sql"), Charsets.UTF_8);
+        final String scriptWithWindowsLineEndings = script.replaceAll("\n", "\r\n");
+        final List<String> statements = new ArrayList<>();
+        ScriptUtils.splitSqlScript("resourcename", scriptWithWindowsLineEndings, ";", "--", "/*", "*/", statements);
+
+        assertEquals(7, statements.size());
+        assertEquals("SELECT \"a /* string literal containing comment characters like -- here\"", statements.get(2));
+        assertEquals("SELECT \"a 'quoting' \\\"scenario ` involving BEGIN keyword\\\" here\"", statements.get(3));
+        assertEquals("SELECT * from `bar`", statements.get(4));
+        assertEquals("INSERT INTO bar (foo) VALUES ('hello world')", statements.get(6));
+    }
 }


### PR DESCRIPTION
This fixes the following issue: https://github.com/testcontainers/testcontainers-java/issues/1465