### PR TITLE
Support MySQL 8

### DIFF
--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testCompile 'com.google.guava:guava:18.0'
     testCompile 'org.postgresql:postgresql:42.0.0'
-    testCompile 'mysql:mysql-connector-java:5.1.45'
+    testCompile 'mysql:mysql-connector-java:8.0.14'
     testCompile 'org.mariadb.jdbc:mariadb-java-client:1.4.6'
     testCompile 'com.oracle:ojdbc6:12.1.0.1-atlassian-hosted'
     testCompile 'com.microsoft.sqlserver:mssql-jdbc:6.1.0.jre8'

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -1,5 +1,6 @@
 package org.testcontainers.jdbc;
 
+import com.googlecode.junittoolbox.ParallelParameterized;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.commons.dbutils.QueryRunner;
@@ -21,7 +22,7 @@ import static org.junit.Assume.assumeFalse;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
-@RunWith(Parameterized.class)
+@RunWith(ParallelParameterized.class)
 public class JDBCDriverTest {
 
     private enum Options {

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -1,6 +1,5 @@
 package org.testcontainers.jdbc;
 
-import com.googlecode.junittoolbox.ParallelParameterized;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.commons.dbutils.QueryRunner;
@@ -22,7 +21,7 @@ import static org.junit.Assume.assumeFalse;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
-@RunWith(ParallelParameterized.class)
+@RunWith(Parameterized.class)
 public class JDBCDriverTest {
 
     private enum Options {
@@ -199,7 +198,7 @@ public class JDBCDriverTest {
         boolean result = new QueryRunner(dataSource).query("SHOW VARIABLES LIKE 'character\\_set\\_connection'", rs -> {
             rs.next();
             String resultSetInt = rs.getString(2);
-            assertEquals("Passing query parameters to set DB connection encoding is successful", "utf8", resultSetInt);
+            assertEquals("Passing query parameters to set DB connection encoding is successful", "utf8mb4", resultSetInt);
             return true;
         });
 

--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -198,8 +198,8 @@ public class JDBCDriverTest {
         HikariDataSource dataSource = getDataSource(jdbcUrl, 1);
         boolean result = new QueryRunner(dataSource).query("SHOW VARIABLES LIKE 'character\\_set\\_connection'", rs -> {
             rs.next();
-            String resultSetInt = rs.getString(2);
-            assertEquals("Passing query parameters to set DB connection encoding is successful", "utf8mb4", resultSetInt);
+            String resultSetString = rs.getString(2);
+            assertTrue("Passing query parameters to set DB connection encoding is successful", resultSetString.startsWith("utf8"));
             return true;
         });
 

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/AbstractContainerDatabaseTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/AbstractContainerDatabaseTest.java
@@ -9,9 +9,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-/**
- * TODO: Javadocs
- */
 abstract class AbstractContainerDatabaseTest {
 
     ResultSet performQuery(JdbcDatabaseContainer container, String sql) throws SQLException {

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/AbstractContainerDatabaseTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/AbstractContainerDatabaseTest.java
@@ -1,0 +1,35 @@
+package org.testcontainers.junit;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+
+import javax.sql.DataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * TODO: Javadocs
+ */
+abstract class AbstractContainerDatabaseTest {
+
+    ResultSet performQuery(JdbcDatabaseContainer container, String sql) throws SQLException {
+        DataSource ds = getDataSource(container);
+        Statement statement = ds.getConnection().createStatement();
+        statement.execute(sql);
+        ResultSet resultSet = statement.getResultSet();
+
+        resultSet.next();
+        return resultSet;
+    }
+
+    DataSource getDataSource(JdbcDatabaseContainer container) {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(container.getJdbcUrl());
+        hikariConfig.setUsername(container.getUsername());
+        hikariConfig.setPassword(container.getPassword());
+
+        return new HikariDataSource(hikariConfig);
+    }
+}

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/MultiVersionMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/MultiVersionMySQLTest.java
@@ -1,0 +1,37 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.testcontainers.containers.MySQLContainer;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+
+@RunWith(Parameterized.class)
+public class MultiVersionMySQLTest extends AbstractContainerDatabaseTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static String[] params() {
+        return new String[]{"5.5.62", "5.6.42", "5.7.26", "8.0.16"};
+    }
+
+    private final String version;
+
+    public MultiVersionMySQLTest(String version) {
+        this.version = version;
+    }
+
+    @Test
+    public void versionCheckTest() throws SQLException {
+        try (final MySQLContainer container = new MySQLContainer<>("mysql:" + version)) {
+            container.start();
+            final ResultSet resultSet = performQuery(container, "SELECT VERSION()");
+            final String resultSetString = resultSet.getString(1);
+
+            assertEquals("The database version can be set using a container rule parameter", version, resultSetString);
+        }
+    }
+}

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleClickhouseTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleClickhouseTest.java
@@ -1,33 +1,22 @@
 package org.testcontainers.junit;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.ClickHouseContainer;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
-public class SimpleClickhouseTest {
+public class SimpleClickhouseTest extends AbstractContainerDatabaseTest {
 
     @Rule
     public ClickHouseContainer clickhouse = new ClickHouseContainer();
 
     @Test
     public void testSimple() throws SQLException {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setJdbcUrl(clickhouse.getJdbcUrl());
-        hikariConfig.setUsername(clickhouse.getUsername());
-        hikariConfig.setPassword(clickhouse.getPassword());
-
-        HikariDataSource ds = new HikariDataSource(hikariConfig);
-        Statement statement = ds.getConnection().createStatement();
-        statement.execute("SELECT 1");
-        ResultSet resultSet = statement.getResultSet();
+        ResultSet resultSet = performQuery(clickhouse, "SELECT 1");
 
         resultSet.next();
         int resultSetInt = resultSet.getInt(1);

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
@@ -1,11 +1,10 @@
 package org.testcontainers.junit;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.MSSQLServerContainer;
 
+import javax.sql.DataSource;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -15,22 +14,14 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 /**
  * @author Stefan Hufschmidt
  */
-public class SimpleMSSQLServerTest {
+public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
 
     @Rule
     public MSSQLServerContainer mssqlServer = new MSSQLServerContainer();
 
     @Test
     public void testSimple() throws SQLException {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setJdbcUrl(mssqlServer.getJdbcUrl());
-        hikariConfig.setUsername(mssqlServer.getUsername());
-        hikariConfig.setPassword(mssqlServer.getPassword());
-
-        HikariDataSource ds = new HikariDataSource(hikariConfig);
-        Statement statement = ds.getConnection().createStatement();
-        statement.execute("SELECT 1");
-        ResultSet resultSet = statement.getResultSet();
+        ResultSet resultSet = performQuery(mssqlServer, "SELECT 1");
 
         resultSet.next();
         int resultSetInt = resultSet.getInt(1);
@@ -39,12 +30,7 @@ public class SimpleMSSQLServerTest {
 
     @Test
     public void testSetupDatabase() throws SQLException {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setJdbcUrl(mssqlServer.getJdbcUrl());
-        hikariConfig.setUsername(mssqlServer.getUsername());
-        hikariConfig.setPassword(mssqlServer.getPassword());
-
-        HikariDataSource ds = new HikariDataSource(hikariConfig);
+        DataSource ds = getDataSource(mssqlServer);
         Statement statement = ds.getConnection().createStatement();
         statement.executeUpdate("CREATE DATABASE [test];");
         statement = ds.getConnection().createStatement();

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
@@ -23,7 +23,6 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
     public void testSimple() throws SQLException {
         ResultSet resultSet = performQuery(mssqlServer, "SELECT 1");
 
-        resultSet.next();
         int resultSetInt = resultSet.getInt(1);
         assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
     }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMariaDBTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMariaDBTest.java
@@ -1,26 +1,21 @@
 package org.testcontainers.junit;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-import lombok.NonNull;
-
 import org.apache.commons.lang.SystemUtils;
 import org.junit.Test;
 import org.testcontainers.containers.MariaDBContainer;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 
+import static org.junit.Assume.assumeFalse;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
-import static org.junit.Assume.assumeFalse;
 
 
 /**
  * @author Miguel Gonzalez Sanchez
  */
-public class SimpleMariaDBTest {
+public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
@@ -84,21 +79,5 @@ public class SimpleMariaDBTest {
         } finally {
             mariadbCustomConfig.stop();
         }
-    }
-
-    @NonNull
-    protected ResultSet performQuery(MariaDBContainer containerRule, String sql) throws SQLException {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setJdbcUrl(containerRule.getJdbcUrl());
-        hikariConfig.setUsername(containerRule.getUsername());
-        hikariConfig.setPassword(containerRule.getPassword());
-
-        HikariDataSource ds = new HikariDataSource(hikariConfig);
-        Statement statement = ds.getConnection().createStatement();
-        statement.execute(sql);
-        ResultSet resultSet = statement.getResultSet();
-
-        resultSet.next();
-        return resultSet;
     }
 }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
@@ -1,17 +1,5 @@
 package org.testcontainers.junit;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
-
 import org.apache.commons.lang.SystemUtils;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -20,13 +8,19 @@ import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
-import lombok.NonNull;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 
 /**
  * @author richardnorth
  */
-public class SimpleMySQLTest {
+public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleMySQLTest.class);
 
@@ -115,24 +109,6 @@ public class SimpleMySQLTest {
     }
 
     @Test
-    public void testMySQL8() throws SQLException {
-        assumeFalse(SystemUtils.IS_OS_WINDOWS);
-        MySQLContainer container = new MySQLContainer<>("mysql:8.0.11")
-            .withCommand("mysqld --default-authentication-plugin=mysql_native_password");
-        container.start();
-
-        try {
-            ResultSet resultSet = performQuery(container, "SELECT VERSION()");
-            String resultSetString = resultSet.getString(1);
-
-            assertTrue("The database version can be set using a container rule parameter", "8.0.11".equals(resultSetString));
-        }
-        finally {
-            container.stop();
-        }
-    }
-
-    @Test
     public void testExplicitInitScript() throws SQLException {
         try (MySQLContainer container = (MySQLContainer) new MySQLContainer()
             .withInitScript("somepath/init_mysql.sql")
@@ -159,22 +135,5 @@ public class SimpleMySQLTest {
         } finally {
             container.stop();
         }
-    }
-
-    @NonNull
-    protected ResultSet performQuery(MySQLContainer containerRule, String sql) throws SQLException {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setDriverClassName(containerRule.getDriverClassName());
-        hikariConfig.setJdbcUrl(containerRule.getJdbcUrl());
-        hikariConfig.setUsername(containerRule.getUsername());
-        hikariConfig.setPassword(containerRule.getPassword());
-
-        HikariDataSource ds = new HikariDataSource(hikariConfig);
-        Statement statement = ds.getConnection().createStatement();
-        statement.execute(sql);
-        ResultSet resultSet = statement.getResultSet();
-
-        resultSet.next();
-        return resultSet;
     }
 }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleOracleTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleOracleTest.java
@@ -1,7 +1,5 @@
 package org.testcontainers.junit;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -9,7 +7,6 @@ import org.testcontainers.containers.OracleContainer;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
@@ -17,25 +14,18 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
  * @author gusohal
  */
 @Ignore
-public class SimpleOracleTest {
+public class SimpleOracleTest extends AbstractContainerDatabaseTest {
 
     @Rule
     public OracleContainer oracle = new OracleContainer();
 
     @Test
     public void testSimple() throws SQLException {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setJdbcUrl(oracle.getJdbcUrl());
-        hikariConfig.setUsername(oracle.getUsername());
-        hikariConfig.setPassword(oracle.getPassword());
-
-        HikariDataSource ds = new HikariDataSource(hikariConfig);
-        Statement statement = ds.getConnection().createStatement();
-        statement.execute("SELECT 1 FROM dual");
-        ResultSet resultSet = statement.getResultSet();
+        ResultSet resultSet = performQuery(oracle, "SELECT 1 FROM dual");
 
         resultSet.next();
         int resultSetInt = resultSet.getInt(1);
+
         assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
     }
 }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java
@@ -1,21 +1,17 @@
 package org.testcontainers.junit;
 
-import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import org.junit.Test;
-import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
 /**
  * @author richardnorth
  */
-public class SimplePostgreSQLTest {
+public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
@@ -40,19 +36,5 @@ public class SimplePostgreSQLTest {
             String firstColumnValue = resultSet.getString(1);
             assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
         }
-    }
-
-    private ResultSet performQuery(JdbcDatabaseContainer container, String sql) throws SQLException {
-        HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setJdbcUrl(container.getJdbcUrl());
-        hikariConfig.setUsername(container.getUsername());
-        hikariConfig.setPassword(container.getPassword());
-
-        HikariDataSource ds = new HikariDataSource(hikariConfig);
-        Statement statement = ds.getConnection().createStatement();
-        statement.execute(sql);
-        ResultSet resultSet = statement.getResultSet();
-        resultSet.next();
-        return resultSet;
     }
 }

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -70,10 +70,14 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
         if (! url.contains("useSSL=")) {
             String separator = url.contains("?") ? "&" : "?";
-            return url + separator + "useSSL=false";
-        } else {
-            return url;
+            url = url + separator + "useSSL=false";
         }
+
+        if (! url.contains("allowPublicKeyRetrieval=")) {
+            url = url + "&allowPublicKeyRetrieval=true";
+        }
+
+        return url;
     }
 
     @Override


### PR DESCRIPTION
Fixes #736
Replaces #1168

Note that this PR includes some long overdue refactoring of the database container tests - it made sense to do this as I was adding another test class, and doing so without refactoring would have worsened duplication.

The actual substance of the change is quite small, and visible in the [MySQLContainer](https://github.com/testcontainers/testcontainers-java/pull/1470/files#diff-ba526635017ac9645a3ab3a7e367a822) class.

Quoting the [rationale](https://github.com/testcontainers/testcontainers-java/pull/1168#issuecomment-490244330):
> Testcontainers has the driver as a runtime dependency, not transitive, so it's completely up to the user to choose which driver they need.

> I've just tried this out, modifying our jdbc tests to use the newer driver, and found a few things:

>The v8 driver seems to be backwards compatible (as you'd hope!) with 5.5, 5.6, 5.7.
With the v8 driver, MySqlContainer still chokes when connecting to mysql:8, throwing SQLNonTransientConnectionException: Public Key Retrieval is not allowed

>However, this can be fixed by adding allowPublicKeyRetrieval=true to the query string params, as we already do with useSSL=false.

>The allowPublicKeyRetrieval option goes back as far as MySql 5.1, (which predates Docker Hub) and seems to be compatible with any pre-8 image that we'd want to test.

>Thus, I now have the following test code working without problems:

```
for (String tag : asList("5.5", "5.6", "5.7", "8")) {
    try (final MySQLContainer container = new MySQLContainer<>("mysql:" + tag)) {
         container.start();
    }
}
```