### PR TITLE
Redirect Docker-Compose stderr to INFO logger

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -638,7 +638,7 @@ class LocalDockerCompose implements DockerCompose {
         try {
             new ProcessExecutor().command(command)
                     .redirectOutput(Slf4jStream.of(logger()).asInfo())
-                    .redirectError(Slf4jStream.of(logger()).asError())
+                    .redirectError(Slf4jStream.of(logger()).asInfo()) // docker-compose will log pull information to stderr
                     .environment(environment)
                     .directory(pwd)
                     .exitValueNormal()


### PR DESCRIPTION
Fixes #1472 

Will be logged like this now:
```
12:32:57.136 INFO  🐳 [docker/compose:1.8.0] - Docker Compose container is running for command: pull
12:32:57.136 INFO  🐳 [docker/compose:1.8.0] - STDERR: Pulling db (orchardup/mysql:latest)...
12:32:57.137 INFO  🐳 [docker/compose:1.8.0] - STDOUT: latest: Pulling from orchardup/mysql
```