### PR TITLE
Fix docker registry auth parsing of GCR json key format credentials

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -154,7 +154,7 @@ public class RegistryAuthLocator {
                 !isBlank(deserializedAuth.getAuth())) {
 
                 final String rawAuth = new String(Base64.getDecoder().decode(deserializedAuth.getAuth()));
-                final String[] splitRawAuth = rawAuth.split(":");
+                final String[] splitRawAuth = rawAuth.split(":", 2);
 
                 if (splitRawAuth.length == 2) {
                     deserializedAuth.withUsername(splitRawAuth[0]);

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -11,8 +11,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertNull;
+import static org.rnorth.visibleassertions.VisibleAssertions.*;
 
 public class RegistryAuthLocatorTest {
     @Test
@@ -35,6 +34,17 @@ public class RegistryAuthLocatorTest {
         assertEquals("Default docker registry URL is set on auth config", "https://registry.example.com", authConfig.getRegistryAddress());
         assertEquals("Username is set", "user", authConfig.getUsername());
         assertEquals("Password is set", "pass", authConfig.getPassword());
+    }
+
+    @Test
+    public void lookupAuthConfigWithJsonKeyCredentials() throws URISyntaxException {
+        final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-json-key.json");
+
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(new DockerImageName("registry.example.com/org/repo"), new AuthConfig());
+
+        assertEquals("Default docker registry URL is set on auth config", "https://registry.example.com", authConfig.getRegistryAddress());
+        assertEquals("Username is set", "_json_key", authConfig.getUsername());
+        assertNotNull("Password is set", authConfig.getPassword());
     }
 
     @Test

--- a/core/src/test/resources/auth-config/config-with-json-key.json
+++ b/core/src/test/resources/auth-config/config-with-json-key.json
@@ -1,0 +1,7 @@
+{
+    "auths": {
+        "https://registry.example.com": {
+            "auth": "X2pzb25fa2V5OnsKInR5cGUiOiAic2VydmljZV9hY2NvdW50IiwKInByb2plY3RfaWQiOiAiZXhhbXBsZS1wcm9qZWN0IiwKInByaXZhdGVfa2V5X2lkIjogImV4YW1wbGUta2V5LWlkIiwKInByaXZhdGVfa2V5IjogImV4YW1wbGUtcHJpdmF0ZS1rZXkiLAoiY2xpZW50X2VtYWlsIjogInVzZXJAZXhhbXBsZS5jb20iLAoiY2xpZW50X2lkIjogInVzZXJAZXhhbXBsZS5jb20iLAoiYXV0aF91cmkiOiAiaHR0cHM6Ly9yZWdpc3RyeS5leGFtcGxlLmNvbS9vL29hdXRoMi9hdXRoIiwKInRva2VuX3VyaSI6ICJodHRwczovL3JlZ2lzdHJ5LmV4YW1wbGUuY29tL3Rva2VuIiwKImF1dGhfcHJvdmlkZXJfeDUwOV9jZXJ0X3VybCI6ICJodHRwczovL3JlZ2lzdHJ5LmV4YW1wbGUuY29tIiwKImNsaWVudF94NTA5X2NlcnRfdXJsIjogImh0dHBzOi8vcmVnaXN0cnkuZXhhbXBsZS5jb20iCn0="
+        }
+    }
+}


### PR DESCRIPTION
Mimics the splitting logic from docker-java to support service account auth configuration via a [json key file](https://cloud.google.com/container-registry/docs/advanced-authentication?hl=en#json_key_file).

closes #1466