### PR TITLE
Replace deprecated RestClient.performRequest()

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -22,7 +22,7 @@ credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredential
 RestClient restClient = RestClient.builder(HttpHost.create(container.getHttpHostAddress()))
         .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider))
         .build();
-Response response = restClient.performRequest("GET", "/");
+Response response = restClient.performRequest(new Request("GET", "/"));
 
 // ... or the transport client
 TransportAddress transportAddress = new TransportAddress(container.getTcpHost());


### PR DESCRIPTION
This PR replaces deprecated `RestClient.performRequest(String method, String endpoint, Header... headers)` with `performRequest(Request request)` in doc.