### PR TITLE
Remove internet connectivity dependency from test

### DIFF
--- a/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
+++ b/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
@@ -28,7 +28,7 @@ public class OutputStreamTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OutputStreamTest.class);
 
-    @Test
+    @Test(timeout = 60_000L)
     public void testFetchStdout() throws TimeoutException {
 
         WaitingConsumer consumer = new WaitingConsumer();
@@ -39,7 +39,7 @@ public class OutputStreamTest {
                 30, TimeUnit.SECONDS);
     }
 
-    @Test
+    @Test(timeout = 60_000L)
     public void testFetchStdoutWithTimeout() throws TimeoutException {
 
         WaitingConsumer consumer = new WaitingConsumer();
@@ -53,7 +53,7 @@ public class OutputStreamTest {
         });
     }
 
-    @Test
+    @Test(timeout = 60_000L)
     public void testFetchStdoutWithNoLimit() throws TimeoutException {
 
         WaitingConsumer consumer = new WaitingConsumer();
@@ -63,7 +63,7 @@ public class OutputStreamTest {
         consumer.waitUntil(frame -> frame.getType() == STDOUT && frame.getUtf8String().contains("seq=2"));
     }
 
-    @Test
+    @Test(timeout = 60_000L)
     public void testLogConsumer() throws TimeoutException {
 
         WaitingConsumer waitingConsumer = new WaitingConsumer();
@@ -75,7 +75,7 @@ public class OutputStreamTest {
         waitingConsumer.waitUntil(frame -> frame.getType() == STDOUT && frame.getUtf8String().contains("seq=2"));
     }
 
-    @Test
+    @Test(timeout = 60_000L)
     public void testToStringConsumer() throws TimeoutException {
 
         WaitingConsumer waitingConsumer = new WaitingConsumer();

--- a/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
+++ b/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
@@ -24,7 +24,7 @@ public class OutputStreamTest {
 
     @Rule
     public GenericContainer container = new GenericContainer("alpine:3.2")
-            .withCommand("ping -c 5 www.google.com");
+            .withCommand("ping -c 5 127.0.0.1");
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OutputStreamTest.class);
 

--- a/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
+++ b/core/src/test/java/org/testcontainers/junit/OutputStreamTest.java
@@ -40,7 +40,7 @@ public class OutputStreamTest {
     }
 
     @Test(timeout = 60_000L)
-    public void testFetchStdoutWithTimeout() throws TimeoutException {
+    public void testFetchStdoutWithTimeout() {
 
         WaitingConsumer consumer = new WaitingConsumer();
 


### PR DESCRIPTION
This may be a local firewall-related issue, but I found these tests were hanging because the container under test was trying, and failing, to ping a Google server.

Since the target of the ping - even the use of ping itself - is irrelevant, I've changed the test to simply ping 127.0.0.1.

Additionally, I've added an explicit timeout to each test method so that any related network problems in the future will cause these tests to fail rather than hang.