### PR TITLE
Allow tests to be disabled when Docker is unavailable

### DIFF
--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     testCompile 'com.zaxxer:HikariCP:3.3.1'
     testCompile 'redis.clients:jedis:3.0.1'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.9'
+    testCompile ('org.mockito:mockito-core:2.28.2') {
+        exclude(module: 'hamcrest-core')
+    }
 
     testRuntime 'org.postgresql:postgresql:42.2.6'
     testRuntime 'mysql:mysql-connector-java:8.0.16'

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
@@ -53,4 +53,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(TestcontainersExtension.class)
 public @interface Testcontainers {
+
+    /**
+     * Whether tests should be disabled (rather than failing) when Docker is not available.
+     */
+    boolean disabledWithoutDocker() default false;
 }

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.extension.*;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 import org.junit.platform.commons.support.AnnotationSupport;
+import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.lifecycle.Startable;
 
 import java.lang.reflect.Field;
@@ -16,7 +18,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, TestInstancePostProcessor {
+class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, ExecutionCondition, TestInstancePostProcessor {
 
     private static final Namespace NAMESPACE = Namespace.create(TestcontainersExtension.class);
 
@@ -46,6 +48,43 @@ class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, 
             .flatMap(this::findRestartContainers)
             .forEach(adapter -> context.getStore(NAMESPACE)
                 .getOrComputeIfAbsent(adapter.getKey(), k -> adapter.start()));
+    }
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        return findTestcontainers(context).map(this::evaluate)
+            .orElseThrow(() -> new ExtensionConfigurationException("@Testcontainers not found"));
+    }
+
+    private Optional<Testcontainers> findTestcontainers(ExtensionContext context) {
+        Optional<ExtensionContext> current = Optional.of(context);
+        while (current.isPresent()) {
+            Optional<Testcontainers> testcontainers = AnnotationUtils.findAnnotation(current.get().getRequiredTestClass(), Testcontainers.class);
+            if (testcontainers.isPresent()) {
+                return testcontainers;
+            }
+            current = current.get().getParent();
+        }
+        return Optional.empty();
+    }
+
+    private ConditionEvaluationResult evaluate(Testcontainers testcontainers) {
+        if (testcontainers.disabledWithoutDocker()) {
+            if (isDockerAvailable()) {
+                return ConditionEvaluationResult.enabled("Docker is available");
+            }
+            return ConditionEvaluationResult.disabled("disabledWithoutDocker is true and Docker is not available");
+        }
+        return ConditionEvaluationResult.enabled("disabledWithoutDocker is false");
+    }
+
+    boolean isDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+            return true;
+        } catch (Throwable ex) {
+            return false;
+        }
     }
 
     private Set<Object> collectParentTestInstances(final ExtensionContext context) {

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExtensionTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExtensionTests.java
@@ -1,0 +1,72 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestcontainersExtensionTests {
+
+    @Test
+    void whenDisabledWithoutDockerAndDockerIsAvailableTestsAreEnabled() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(true)
+            .evaluateExecutionCondition(extensionContext(DisabledWithoutDocker.class));
+        assertFalse(result.isDisabled());
+    }
+
+    @Test
+    void whenDisabledWithoutDockerAndDockerIsUnavailableTestsAreDisabled() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(false)
+            .evaluateExecutionCondition(extensionContext(DisabledWithoutDocker.class));
+        assertTrue(result.isDisabled());
+    }
+
+    @Test
+    void whenEnabledWithoutDockerAndDockerIsAvailableTestsAreEnabled() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(true)
+            .evaluateExecutionCondition(extensionContext(EnabledWithoutDocker.class));
+        assertFalse(result.isDisabled());
+    }
+
+    @Test
+    void whenEnabledWithoutDockerAndDockerIsUnavailableTestsAreEnabled() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(false)
+            .evaluateExecutionCondition(extensionContext(EnabledWithoutDocker.class));
+        assertFalse(result.isDisabled());
+    }
+
+    private ExtensionContext extensionContext(Class clazz) {
+        ExtensionContext extensionContext = mock(ExtensionContext.class);
+        when(extensionContext.getRequiredTestClass()).thenReturn(clazz);
+        return extensionContext;
+    }
+
+    @Testcontainers(disabledWithoutDocker = true)
+    static final class DisabledWithoutDocker {
+
+    }
+
+    @Testcontainers
+    static final class EnabledWithoutDocker {
+
+    }
+
+    static final class TestTestcontainersExtension extends TestcontainersExtension {
+
+        private final boolean dockerAvailable;
+
+        private TestTestcontainersExtension(boolean dockerAvailable) {
+            this.dockerAvailable = dockerAvailable;
+        }
+
+        boolean isDockerAvailable() {
+            return dockerAvailable;
+        }
+
+    }
+
+}


### PR DESCRIPTION
We've been using Testcontainers in Spring Boot's test suite for some time now (thank you!) and are in the process of switching our tests to JUnit 5. As part of that, I wrote a customisation of `@Testcontainers` that uses JUnit 5's support conditional execution to disable the tests if Docker's unavailable. We find this really useful for people, particularly contributors, who want to build Boot and run its tests, but do not have Docker installed. The two files proposed here are what I've written for Boot. `@DisabledWithoutDockerTestContainers` can be used as a replacement for `@Testcontainers`, providing the above-described conditional execution.

I've marked this PR as a draft as it's really just an initial proposal to see if there's interest from the Testcontainers community in having something like this be part of Testcontainers itself. I'm by no means wedded to the approach I've taken here and, if there is interest, I'm happy to modify things in whatever direction is desired. FWIW, rather than a new annotation, I also considered an attribute on `@Testcontainers` to opt in to the conditional execution with the existing extension then implementing `ExecutionCondition`.