### PR TITLE
Add new withDockerfile methods to ImageFromDockerfile

### DIFF
--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -154,7 +154,6 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
 
     protected void configure(BuildImageCmd buildImageCmd) {
         buildImageCmd.withTag(this.getDockerImageName());
-        // always use withDockerfile because it honors .dockerignores and withDockerfilePath does not
         this.dockerFilePath.ifPresent(buildImageCmd::withDockerfilePath);
         this.dockerfile.ifPresent(p -> buildImageCmd.withDockerfile(p.toFile()));
         this.buildArgs.forEach(buildImageCmd::withBuildArg);

--- a/core/src/test/java/org/testcontainers/images/builder/DockerfileBuildTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/DockerfileBuildTest.java
@@ -6,6 +6,7 @@ import org.junit.runners.Parameterized;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -44,6 +45,20 @@ public class DockerfileBuildTest {
                     .withDockerfilePath("./Dockerfile-buildarg")
                     .withBuildArg("CUSTOM_ARG", "test7890")
             },
+            
+           // Dockerfile build using withDockerfile(File)
+            new Object[]{"test4567",
+                new ImageFromDockerfile()
+                    .withFileFromPath(".", RESOURCE_PATH)
+                    .withDockerfile(new File(RESOURCE_PATH.toFile(), "Dockerfile-alt"))
+            },
+            
+         // Dockerfile build using withDockerfile(String)
+            new Object[]{"test4567",
+                new ImageFromDockerfile()
+                    .withFileFromPath(".", RESOURCE_PATH)
+                    .withDockerfile("src/test/resources/dockerfile-build-test/Dockerfile-alt")
+            },
         };
     }
 
@@ -64,4 +79,5 @@ public class DockerfileBuildTest {
             assertTrue("expected file content indicates that dockerfile build steps have been run", logs.contains(expectedFileContent));
         }
     }
+    
 }

--- a/core/src/test/java/org/testcontainers/images/builder/DockerfileBuildTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/DockerfileBuildTest.java
@@ -15,7 +15,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 @RunWith(Parameterized.class)
 public class DockerfileBuildTest {
 
-    private static final Path RESOURCE_PATH = Paths.get("src/test/resources/dockerfile-build-test");
+    static final Path RESOURCE_PATH = Paths.get("src/test/resources/dockerfile-build-test");
 
     public String expectedFileContent;
     public ImageFromDockerfile image;
@@ -50,14 +50,7 @@ public class DockerfileBuildTest {
             new Object[]{"test4567",
                 new ImageFromDockerfile()
                     .withFileFromPath(".", RESOURCE_PATH)
-                    .withDockerfile(new File(RESOURCE_PATH.toFile(), "Dockerfile-alt"))
-            },
-            
-         // Dockerfile build using withDockerfile(String)
-            new Object[]{"test4567",
-                new ImageFromDockerfile()
-                    .withFileFromPath(".", RESOURCE_PATH)
-                    .withDockerfile("src/test/resources/dockerfile-build-test/Dockerfile-alt")
+                    .withDockerfile(RESOURCE_PATH.resolve("Dockerfile-alt"))
             },
         };
     }
@@ -72,7 +65,6 @@ public class DockerfileBuildTest {
         try (final GenericContainer container = new GenericContainer(image)
             .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
             .withCommand("cat", "/test.txt")) {
-
             container.start();
 
             final String logs = container.getLogs();

--- a/core/src/test/java/org/testcontainers/images/builder/DockerignoreTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/DockerignoreTest.java
@@ -1,0 +1,45 @@
+package org.testcontainers.images.builder;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.fail;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.Test;
+
+import com.github.dockerjava.api.exception.DockerClientException;
+
+public class DockerignoreTest {
+    
+    private static final Path INVALID_DOCKERIGNORE_PATH = Paths.get("src/test/resources/dockerfile-build-invalid");
+    
+    @Test
+    public void testDockerignoreWithFile() throws Exception {
+        try {
+            new ImageFromDockerfile()
+                .withFileFromPath(".", INVALID_DOCKERIGNORE_PATH)
+                .withDockerfile(new File("src/test/resources/dockerfile-build-invalid/Dockerfile"))
+                .get();
+            fail("Should not be able to build an image with an invalid .dockerignore file");
+        } catch(DockerClientException e) {
+            if (!e.getMessage().contains("Invalid pattern"))
+                throw e;
+        }
+    }
+    
+    @Test
+    public void testDockerignoreWithString() throws Exception {
+        try {
+            new ImageFromDockerfile()
+                .withFileFromPath(".", INVALID_DOCKERIGNORE_PATH)
+                .withDockerfile("src/test/resources/dockerfile-build-invalid/Dockerfile")
+                .get();
+            fail("Should not be able to build an image with an invalid .dockerignore file");
+        } catch(DockerClientException e) {
+            if (!e.getMessage().contains("Invalid pattern"))
+                throw e;
+        }
+    }
+
+}

--- a/core/src/test/resources/dockerfile-build-invalid/.dockerignore
+++ b/core/src/test/resources/dockerfile-build-invalid/.dockerignore
@@ -1,0 +1,3 @@
+# This is an invalid dockerignore file
+*~
+[a-b-c]

--- a/core/src/test/resources/dockerfile-build-invalid/Dockerfile
+++ b/core/src/test/resources/dockerfile-build-invalid/Dockerfile
@@ -1,0 +1,1 @@
+FROM alpine:3.2

--- a/core/src/test/resources/dockerfile-build-test/.dockerignore
+++ b/core/src/test/resources/dockerfile-build-test/.dockerignore
@@ -1,0 +1,1 @@
+should_be_ignored.txt

--- a/core/src/test/resources/dockerfile-build-test/Dockerfile-currentdir
+++ b/core/src/test/resources/dockerfile-build-test/Dockerfile-currentdir
@@ -1,0 +1,2 @@
+FROM alpine:3.2
+COPY . /

--- a/core/src/test/resources/dockerfile-build-test/should_be_ignored.txt
+++ b/core/src/test/resources/dockerfile-build-test/should_be_ignored.txt
@@ -1,0 +1,1 @@
+this file should be ignored by a .dockerignore file

--- a/core/src/test/resources/dockerfile-build-test/should_not_be_ignored.txt
+++ b/core/src/test/resources/dockerfile-build-test/should_not_be_ignored.txt
@@ -1,0 +1,1 @@
+this file should not be ignored by a .dockerignore file


### PR DESCRIPTION
These methods are preferable to the existing withDockerfilePath
methods because the docker-java API will honor .dockerignore files
if withDockerfile(File) is used.