### PR TITLE
fixed sql splitting issue

### DIFF
--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.26'
     implementation 'com.squareup.okhttp3:okhttp:3.14.2'
     implementation 'org.json:json:20180813'
-    testImplementation 'org.postgresql:postgresql:42.2.5'
+    testImplementation 'org.postgresql:postgresql:42.2.6'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -163,10 +163,10 @@ public abstract class ScriptUtils {
 			}
 			final boolean inComment = inLineComment || inBlockComment;
 
-			if (!inLiteral && !inComment && containsKeywordsAtOffset(lowerCaseScriptContent, "BEGIN", i)) {
+			if (!inLiteral && !inComment && containsKeywordsAtOffset(lowerCaseScriptContent, "BEGIN", i, separator, commentPrefix, blockCommentStartDelimiter)) {
 				compoundStatementDepth++;
 			}
-			if (!inLiteral && !inComment && containsKeywordsAtOffset(lowerCaseScriptContent, "END", i)) {
+			if (!inLiteral && !inComment && containsKeywordsAtOffset(lowerCaseScriptContent, "END", i, separator, commentPrefix, blockCommentStartDelimiter)) {
 				compoundStatementDepth--;
 			}
 			final boolean inCompoundStatement = compoundStatementDepth != 0;
@@ -224,8 +224,13 @@ public abstract class ScriptUtils {
 		}
 	}
 
-	private static boolean isValidName(char c) {
-	    return (c >= 'a' && c <= 'z') || c == '_';
+	private static boolean isSeperator(char c, String separator, String commentPrefix,
+                                       String blockCommentStartDelimiter) {
+	    return c == ' ' || c == '\r' || c == '\n' || c == '\t' ||
+            c == separator.charAt(0) || c == separator.charAt(separator.length() - 1) ||
+            c == commentPrefix.charAt(0) || c == commentPrefix.charAt(commentPrefix.length() - 1) ||
+            c == blockCommentStartDelimiter.charAt(0) ||
+            c == blockCommentStartDelimiter.charAt(blockCommentStartDelimiter.length() - 1);
     }
 
 	private static boolean containsSubstringAtOffset(String lowercaseString, String substring, int offset) {
@@ -234,12 +239,16 @@ public abstract class ScriptUtils {
 		return lowercaseString.startsWith(lowercaseSubstring, offset);
 	}
 
-    private static boolean containsKeywordsAtOffset(String lowercaseString, String keywords, int offset) {
+    private static boolean containsKeywordsAtOffset(String lowercaseString, String keywords, int offset,
+                                                    String separator, String commentPrefix,
+                                                    String blockCommentStartDelimiter) {
         String lowercaseKeywords = keywords.toLowerCase();
 
-        boolean backSeperated = (offset == 0) || !isValidName(lowercaseString.charAt(offset - 1));
+        boolean backSeperated = (offset == 0) || isSeperator(lowercaseString.charAt(offset - 1),
+            separator, commentPrefix, blockCommentStartDelimiter);
         boolean frontSeperated = (offset >= (lowercaseString.length() - keywords.length())) ||
-            !isValidName(lowercaseString.charAt(offset + keywords.length()));
+            isSeperator(lowercaseString.charAt(offset + keywords.length()),
+                separator, commentPrefix, blockCommentStartDelimiter);
 
         return backSeperated && frontSeperated && lowercaseString.startsWith(lowercaseKeywords, offset);
     }

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -199,6 +199,7 @@ public abstract class ScriptUtils {
 					int indexOfCommentEnd = script.indexOf(blockCommentEndDelimiter, i);
 					if (indexOfCommentEnd > i) {
 						i = indexOfCommentEnd + blockCommentEndDelimiter.length() - 1;
+                        inBlockComment = false;
 						continue;
 					}
 					else {

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -228,8 +228,7 @@ public abstract class ScriptUtils {
                                        String blockCommentStartDelimiter) {
 	    return c == ' ' || c == '\r' || c == '\n' || c == '\t' ||
             c == separator.charAt(0) || c == separator.charAt(separator.length() - 1) ||
-            c == commentPrefix.charAt(0) || c == commentPrefix.charAt(commentPrefix.length() - 1) ||
-            c == blockCommentStartDelimiter.charAt(0) ||
+            c == commentPrefix.charAt(0) || c == blockCommentStartDelimiter.charAt(0) ||
             c == blockCommentStartDelimiter.charAt(blockCommentStartDelimiter.length() - 1);
     }
 

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -225,7 +225,7 @@ public abstract class ScriptUtils {
 	}
 
 	private static boolean isValidName(char c) {
-	    return (c >= 97 && c <= 122) || c == '_';
+	    return (c >= 'a' && c <= 'z') || c == '_';
     }
 
 	private static boolean containsSubstringAtOffset(String lowercaseString, String substring, int offset) {
@@ -237,11 +237,11 @@ public abstract class ScriptUtils {
     private static boolean containsKeywordsAtOffset(String lowercaseString, String keywords, int offset) {
         String lowercaseKeywords = keywords.toLowerCase();
 
-        boolean frontSeperated = (offset == 0) || !isValidName(lowercaseString.charAt(offset - 1));
-        boolean backSeperated = (offset >= (lowercaseString.length() - keywords.length())) ||
+        boolean backSeperated = (offset == 0) || !isValidName(lowercaseString.charAt(offset - 1));
+        boolean frontSeperated = (offset >= (lowercaseString.length() - keywords.length())) ||
             !isValidName(lowercaseString.charAt(offset + keywords.length()));
 
-        return frontSeperated && backSeperated && lowercaseString.startsWith(lowercaseKeywords, offset);
+        return backSeperated && frontSeperated && lowercaseString.startsWith(lowercaseKeywords, offset);
     }
 
 	private static void checkArgument(boolean expression, String errorMessage) {

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -224,6 +224,10 @@ public abstract class ScriptUtils {
 		}
 	}
 
+	private static boolean isValidName(char c) {
+	    return (c >= 97 && c <= 122) || c == '_';
+    }
+
 	private static boolean containsSubstringAtOffset(String lowercaseString, String substring, int offset) {
 		String lowercaseSubstring = substring.toLowerCase();
 
@@ -231,15 +235,13 @@ public abstract class ScriptUtils {
 	}
 
     private static boolean containsKeywordsAtOffset(String lowercaseString, String keywords, int offset) {
-        String lowercaseSubstring = keywords.toLowerCase();
+        String lowercaseKeywords = keywords.toLowerCase();
 
-        boolean isSeperated = offset == 0;
-        if (offset > 0) {
-            char seperator = lowercaseString.charAt(offset - 1);
-            isSeperated = seperator == '\n' || seperator == '\t' || seperator == ' ';
-        }
+        boolean frontSeperated = (offset == 0) || !isValidName(lowercaseString.charAt(offset - 1));
+        boolean backSeperated = (offset >= (lowercaseString.length() - keywords.length())) ||
+            !isValidName(lowercaseString.charAt(offset + keywords.length()));
 
-        return lowercaseString.startsWith(lowercaseSubstring, offset) && isSeperated;
+        return frontSeperated && backSeperated && lowercaseString.startsWith(lowercaseKeywords, offset);
     }
 
 	private static void checkArgument(boolean expression, String errorMessage) {

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -163,10 +163,10 @@ public abstract class ScriptUtils {
 			}
 			final boolean inComment = inLineComment || inBlockComment;
 
-			if (!inLiteral && !inComment && containsSubstringAtOffset(lowerCaseScriptContent, "BEGIN", i)) {
+			if (!inLiteral && !inComment && containsKeywordsAtOffset(lowerCaseScriptContent, "BEGIN", i)) {
 				compoundStatementDepth++;
 			}
-			if (!inLiteral && !inComment && containsSubstringAtOffset(lowerCaseScriptContent, "END", i)) {
+			if (!inLiteral && !inComment && containsKeywordsAtOffset(lowerCaseScriptContent, "END", i)) {
 				compoundStatementDepth--;
 			}
 			final boolean inCompoundStatement = compoundStatementDepth != 0;
@@ -228,6 +228,18 @@ public abstract class ScriptUtils {
 
 		return lowercaseString.startsWith(lowercaseSubstring, offset);
 	}
+
+    private static boolean containsKeywordsAtOffset(String lowercaseString, String keywords, int offset) {
+        String lowercaseSubstring = keywords.toLowerCase();
+
+        boolean isSeperated = offset == 0;
+        if (offset > 0) {
+            char seperator = lowercaseString.charAt(offset - 1);
+            isSeperated = seperator == '\n' || seperator == '\t' || seperator == ' ';
+        }
+
+        return lowercaseString.startsWith(lowercaseSubstring, offset) && isSeperated;
+    }
 
 	private static void checkArgument(boolean expression, String errorMessage) {
 		if (!expression) {

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
@@ -54,9 +54,10 @@ public class ScriptUtilsTest {
         final List<String> statements = new ArrayList<>();
         ScriptUtils.splitSqlScript("resourcename", script, ";", "--", "/*", "*/", statements);
 
-        assertEquals(3, statements.size());
+        assertEquals(4, statements.size());
         assertEquals("CREATE TABLE gender (gender VARCHAR(255))", statements.get(1));
-        assertEquals("CREATE TABLE foo (bar VARCHAR(255))", statements.get(2));
+        assertEquals("CREATE TABLE ending (ending VARCHAR(255))", statements.get(2));
+        assertEquals("CREATE TABLE foo (bar VARCHAR(255))", statements.get(3));
     }
 
     @Test

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
@@ -45,4 +45,17 @@ public class ScriptUtilsTest {
         assertEquals("SELECT * from `bar`", statements.get(4));
         assertEquals("INSERT INTO bar (foo) VALUES ('hello world')", statements.get(6));
     }
+
+
+    @Test
+    public void testKeywordsInName() throws IOException {
+        final String script = Resources.toString(Resources.getResource("parse-end.sql"), Charsets.UTF_8);
+
+        final List<String> statements = new ArrayList<>();
+        ScriptUtils.splitSqlScript("resourcename", script, ";", "--", "/*", "*/", statements);
+
+        assertEquals(3, statements.size());
+        assertEquals("CREATE TABLE gender (gender VARCHAR(255))", statements.get(1));
+        assertEquals("CREATE TABLE foo (bar VARCHAR(255))", statements.get(2));
+    }
 }

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
@@ -58,4 +58,16 @@ public class ScriptUtilsTest {
         assertEquals("CREATE TABLE gender (gender VARCHAR(255))", statements.get(1));
         assertEquals("CREATE TABLE foo (bar VARCHAR(255))", statements.get(2));
     }
+
+    @Test
+    public void testComments() throws IOException {
+        final String script = Resources.toString(Resources.getResource("parse-comment.sql"), Charsets.UTF_8);
+
+        final List<String> statements = new ArrayList<>();
+        ScriptUtils.splitSqlScript("resourcename", script, ";", "--", "/*", "*/", statements);
+
+        assertEquals(3, statements.size());
+        assertEquals("INSERT INTO bar (foo) values ('--1')", statements.get(1));
+        assertEquals("INSERT INTO bar (foo) values ('--2')", statements.get(2));
+    }
 }

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptUtilsTest.java
@@ -54,10 +54,11 @@ public class ScriptUtilsTest {
         final List<String> statements = new ArrayList<>();
         ScriptUtils.splitSqlScript("resourcename", script, ";", "--", "/*", "*/", statements);
 
-        assertEquals(4, statements.size());
+        assertEquals(10, statements.size());
         assertEquals("CREATE TABLE gender (gender VARCHAR(255))", statements.get(1));
         assertEquals("CREATE TABLE ending (ending VARCHAR(255))", statements.get(2));
-        assertEquals("CREATE TABLE foo (bar VARCHAR(255))", statements.get(3));
+        assertEquals("CREATE TABLE end2 (end2 VARCHAR(255))", statements.get(3));
+        assertEquals("CREATE TABLE foo (bar VARCHAR(255))", statements.get(9));
     }
 
     @Test

--- a/modules/database-commons/src/test/resources/parse-comment.sql
+++ b/modules/database-commons/src/test/resources/parse-comment.sql
@@ -1,0 +1,5 @@
+CREATE TABLE bar (foo VARCHAR(255));
+
+/* Insert Values */
+INSERT INTO bar (foo) values ('--1');
+INSERT INTO bar (foo) values ('--2');

--- a/modules/database-commons/src/test/resources/parse-end.sql
+++ b/modules/database-commons/src/test/resources/parse-end.sql
@@ -2,5 +2,23 @@ CREATE TABLE bar (foo VARCHAR(255));
 
 CREATE TABLE gender (gender VARCHAR(255));
 CREATE TABLE ending (ending VARCHAR(255));
+CREATE TABLE end2 (end2 VARCHAR(255));
+CREATE TABLE end_2 (end2 VARCHAR(255));
+
+BEGIN
+  INSERT INTO ending values ('ending');
+END;
+
+BEGIN
+  INSERT INTO ending values ('ending');
+END/*hello*/;
+
+BEGIN--Hello
+  INSERT INTO ending values ('ending');
+END;
+
+/*Hello*/BEGIN
+  INSERT INTO ending values ('ending');
+END;
 
 CREATE TABLE foo (bar VARCHAR(255));

--- a/modules/database-commons/src/test/resources/parse-end.sql
+++ b/modules/database-commons/src/test/resources/parse-end.sql
@@ -1,0 +1,5 @@
+CREATE TABLE bar (foo VARCHAR(255));
+
+CREATE TABLE gender (gender VARCHAR(255));
+
+CREATE TABLE foo (bar VARCHAR(255));

--- a/modules/database-commons/src/test/resources/parse-end.sql
+++ b/modules/database-commons/src/test/resources/parse-end.sql
@@ -1,5 +1,6 @@
 CREATE TABLE bar (foo VARCHAR(255));
 
 CREATE TABLE gender (gender VARCHAR(255));
+CREATE TABLE ending (ending VARCHAR(255));
 
 CREATE TABLE foo (bar VARCHAR(255));


### PR DESCRIPTION
# Issue 1
for below sql statement, the split function will fail because the table name contains "END".

```
CREATE TABLE bar (foo VARCHAR(255));
CREATE TABLE gender (gender VARCHAR(255));
CREATE TABLE foo (bar VARCHAR(255));
```

fixed this issue by checking whether the keywords (END or BEGIN) is separated by any controlling char. eg. '\t', '\n' or ' '.

# Issue 2
for below sql statement, the split function will fail because of incorrect inBlockComment flag.

```
CREATE TABLE bar (foo VARCHAR(255));
/* Insert Values */
INSERT INTO bar (foo) values ('--1');
INSERT INTO bar (foo) values ('--2');
```

fixed this issue by setting inBlockComment to false after skipping the block comment.