### PR TITLE
Revert "Bump pulsar-client from 2.3.2 to 2.4.0 in /modules/pulsar"

### DIFF
--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     compile project(':testcontainers')
 
-    testCompile group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.4.0'
+    testCompile group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.3.2'
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.12.2'
 }


### PR DESCRIPTION
Reverts testcontainers/testcontainers-java#1587

That PR seems to have broken master, despite having passed it's build and being automerged by dependabot:
```
> Task :pulsar:test
Gradle Test Executor 2 > org.testcontainers.containers.PulsarContainerTest > testUsage STARTED
Gradle Test Executor 2 > org.testcontainers.containers.PulsarContainerTest > testUsage FAILED
    org.apache.pulsar.client.api.PulsarClientException$BrokerMetadataException: Policies not found for public/default namespace
        at org.apache.pulsar.client.api.PulsarClientException.unwrap(PulsarClientException.java:273)
        at org.apache.pulsar.client.impl.ConsumerBuilderImpl.subscribe(ConsumerBuilderImpl.java:90)
        at org.testcontainers.containers.PulsarContainerTest.testPulsarFunctionality(PulsarContainerTest.java:35)
        at org.testcontainers.containers.PulsarContainerTest.testUsage(PulsarContainerTest.java:22)
1 test completed, 1 failed
> Task :pulsar:test FAILED
FAILURE: Build failed with an exception.
```

Let's just revert the upgrade now and look into why it failed later.