### PR TITLE
#1603 Add configuration to override localstack image location

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -1,11 +1,14 @@
 package org.testcontainers.utility;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.net.MalformedURLException;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -18,8 +21,9 @@ import java.util.stream.Stream;
 public class TestcontainersConfiguration {
 
     private static String PROPERTIES_FILE_NAME = "testcontainers.properties";
+    private static String SYSTEM_PROPERTY_USER_HOME = "user.home";
 
-    private static File GLOBAL_CONFIG_FILE = new File(System.getProperty("user.home"), "." + PROPERTIES_FILE_NAME);
+    private static File GLOBAL_CONFIG_FILE = new File(System.getProperty(SYSTEM_PROPERTY_USER_HOME), "." + PROPERTIES_FILE_NAME);
 
     @Getter(lazy = true)
     private static final TestcontainersConfiguration instance = loadConfiguration();
@@ -144,5 +148,18 @@ public class TestcontainersConfiguration {
         }
 
         return config;
+    }
+
+    /**
+     * <p>Only for testing to workaround the limitations of static, lazy singletons enforced by lombok</p>
+     * @param directoryForGlobalProps if null, defaults to {@code System.property("user.home") }
+     */
+    @VisibleForTesting
+    public void resetConfiguration(@Nullable String directoryForGlobalProps) {
+        String localToUser = Optional.ofNullable(directoryForGlobalProps)
+            .orElse(System.getProperty(SYSTEM_PROPERTY_USER_HOME));
+        GLOBAL_CONFIG_FILE = new File(localToUser + "." + PROPERTIES_FILE_NAME);
+        properties.clear();
+        loadConfiguration();
     }
 }

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -74,6 +74,10 @@ public class TestcontainersConfiguration {
         return (String) properties.getOrDefault("pulsar.container.image", "apachepulsar/pulsar");
     }
 
+    public String getLocalStackImage() {
+        return (String) properties.getOrDefault("localstack.container.image", "localstack/localstack:0.8.6");
+    }
+
     public boolean isDisableChecks() {
         return Boolean.parseBoolean((String) properties.getOrDefault("checks.disable", "false"));
     }
@@ -152,6 +156,7 @@ public class TestcontainersConfiguration {
 
     /**
      * <p>Only for testing to workaround the limitations of static, lazy singletons enforced by lombok</p>
+     *
      * @param directoryForGlobalProps if null, defaults to {@code System.property("user.home") }
      */
     @VisibleForTesting

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -32,7 +32,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **tinyimage.container.image = alpine:3.5**  
 > Used by Testcontainers' core
 
-> **vncrecorder.container.image = quay.io/testcontainers/vnc-recorder:1.1.0**  
+> **vncrecorder.container.image = quay.io/testcontainers/vnc-recorder:1.1.0**    
 > Used by VNC recorder in Testcontainers' Seleniun integration
 
 > **ambassador.container.image = richnorth/ambassador:latest**  
@@ -41,6 +41,9 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 
 > **kafka.container.image = confluentinc/cp-kafka**  
 > Used by KafkaContainer 
+
+> **localstack.container.image = localstack/localstack:0.8.6**  
+> Use by LocalStackContainer
 
 ## Customizing Ryuk resource reaper
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -32,7 +32,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **tinyimage.container.image = alpine:3.5**  
 > Used by Testcontainers' core
 
-> **vncrecorder.container.image = quay.io/testcontainers/vnc-recorder:1.1.0**    
+> **vncrecorder.container.image = quay.io/testcontainers/vnc-recorder:1.1.0**  
 > Used by VNC recorder in Testcontainers' Seleniun integration
 
 > **ambassador.container.image = richnorth/ambassador:latest**  

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -37,7 +37,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     }
 
     public LocalStackContainer(String version) {
-        super("localstack/localstack:" + version);
+        super(TestcontainersConfiguration.getInstance().getLocalStackImage().split(":")[0] + ":" + version);
 
         withFileSystemBind("//var/run/docker.sock", "/var/run/docker.sock");
         waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -10,6 +10,7 @@ import lombok.experimental.FieldDefaults;
 import org.rnorth.ducttape.Preconditions;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -28,12 +29,11 @@ import java.util.stream.Collectors;
  */
 public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
-    public static final String VERSION = "0.8.6";
 
     private final List<Service> services = new ArrayList<>();
 
     public LocalStackContainer() {
-        this(VERSION);
+        this(TestcontainersConfiguration.getInstance().getLocalStackImage().split(":")[1]);
     }
 
     public LocalStackContainer(String version) {

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -33,16 +33,20 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     private final List<Service> services = new ArrayList<>();
 
     public LocalStackContainer() {
-        this(TestcontainersConfiguration.getInstance().getLocalStackImage().split(":")[1]);
+        super(TestcontainersConfiguration.getInstance().getLocalStackImage());
+        sharedSetup();
     }
 
     public LocalStackContainer(String version) {
-        super(TestcontainersConfiguration.getInstance().getLocalStackImage().split(":")[0] + ":" + version);
+        super("localstack/localstack:" + version);
+        sharedSetup();
+    }
 
+    private void sharedSetup() {
         withFileSystemBind("//var/run/docker.sock", "/var/run/docker.sock");
         waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
     }
-
+    
     @Override
     protected void configure() {
         super.configure();

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalStackImageTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalStackImageTest.java
@@ -34,6 +34,13 @@ public class LocalStackImageTest {
         Assert.assertEquals(alt, container.getDockerImageName());
     }
 
+    @Test
+    public void defaultImageDifferentVersion() {
+        String altVersion = "0.9.5";
+        LocalStackContainer container = new LocalStackContainer(altVersion);
+        Assert.assertEquals("localstack/localstack:" + altVersion, container.getDockerImageName());
+    }
+
     @AfterClass
     public static void cleanup() {
         TestcontainersConfiguration instance = TestcontainersConfiguration.getInstance();

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalStackImageTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalStackImageTest.java
@@ -1,0 +1,43 @@
+package org.testcontainers.containers.localstack;
+
+import org.junit.*;
+import org.junit.rules.TemporaryFolder;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+
+public class LocalStackImageTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Before
+    public void setupConfig() throws IOException {
+        File tempDir = folder.newFolder();
+        TestcontainersConfiguration instance = TestcontainersConfiguration.getInstance();
+        instance.resetConfiguration(tempDir.getAbsolutePath());
+    }
+
+    @Test
+    public void defaultImageTest() throws IOException {
+        String defaultValue = "localstack/localstack:0.8.6";
+        LocalStackContainer container = new LocalStackContainer();
+        Assert.assertEquals(defaultValue, container.getDockerImageName());
+    }
+
+    @Test
+    public void differentImageTest() throws IOException {
+        String alt = "redis:3.0.2";
+        TestcontainersConfiguration.getInstance().updateGlobalConfig("localstack.container.image", alt);
+        LocalStackContainer container = new LocalStackContainer();
+        Assert.assertEquals(alt, container.getDockerImageName());
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        TestcontainersConfiguration instance = TestcontainersConfiguration.getInstance();
+        instance.resetConfiguration(null);
+
+    }
+}


### PR DESCRIPTION
Adds support for property`localstack.container.image` in `testcontainer.properties`. 

Also moves the default `VERSION` in LocalStackContainer to be read from TestcontainersConfiguration.