### PR TITLE
Add container stopping and stopped hooks

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -333,7 +333,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 imageName = "<unknown>";
             }
 
+            containerIsStopping(containerInfo);
             ResourceReaper.instance().stopAndRemoveContainer(containerId, imageName);
+            containerIsStopped(containerInfo);
         } finally {
             containerId = null;
             containerInfo = null;
@@ -380,6 +382,14 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @SuppressWarnings({"EmptyMethod", "UnusedParameters"})
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
+    }
+
+    @SuppressWarnings({"EmptyMethod", "UnusedParameters"})
+    protected void containerIsStopping(InspectContainerResponse containerInfo) {
+    }
+
+    @SuppressWarnings({"EmptyMethod", "UnusedParameters"})
+    protected void containerIsStopped(InspectContainerResponse containerInfo) {
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -384,10 +384,20 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
     }
 
+    /**
+     * A hook that is executed before the container is stopped with {@link #stop()}.
+     * Warning! This hook won't be executed if the container is terminated during
+     * the JVM's shutdown hook or by Ryuk.
+     */
     @SuppressWarnings({"EmptyMethod", "UnusedParameters"})
     protected void containerIsStopping(InspectContainerResponse containerInfo) {
     }
 
+    /**
+     * A hook that is executed after the container is stopped with {@link #stop()}.
+     * Warning! This hook won't be executed if the container is terminated during
+     * the JVM's shutdown hook or by Ryuk.
+     */
     @SuppressWarnings({"EmptyMethod", "UnusedParameters"})
     protected void containerIsStopped(InspectContainerResponse containerInfo) {
     }


### PR DESCRIPTION
Add pre-stop and post-stop hooks to the GenericContainer. This provides
symmetry to the equavilent starting/started hooks and allows custom
behvaior to be defined in sub-classes.