### PR TITLE
Bump docker java 3.1.4

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,7 +79,7 @@ dependencies {
         exclude(group: "net.java.dev.jna")
     }
 
-    shaded ('com.github.docker-java:docker-java:3.1.0-rc-4') {
+    shaded ('com.github.docker-java:docker-java:3.1.2') {
         exclude(group: 'org.glassfish.jersey.core')
         exclude(group: 'org.glassfish.jersey.connectors')
         exclude(group: 'org.glassfish.jersey.inject')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,7 +79,7 @@ dependencies {
         exclude(group: "net.java.dev.jna")
     }
 
-    shaded ('com.github.docker-java:docker-java:3.1.3') {
+    shaded ('com.github.docker-java:docker-java:3.1.4') {
         exclude(group: 'org.glassfish.jersey.core')
         exclude(group: 'org.glassfish.jersey.connectors')
         exclude(group: 'org.glassfish.jersey.inject')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,7 +79,7 @@ dependencies {
         exclude(group: "net.java.dev.jna")
     }
 
-    shaded ('com.github.docker-java:docker-java:3.1.2') {
+    shaded ('com.github.docker-java:docker-java:3.1.3') {
         exclude(group: 'org.glassfish.jersey.core')
         exclude(group: 'org.glassfish.jersey.connectors')
         exclude(group: 'org.glassfish.jersey.inject')


### PR DESCRIPTION
Bump to docker-java dependency to fix https://github.com/testcontainers/testcontainers-java/issues/1548

Replaces https://github.com/testcontainers/testcontainers-java/pull/1340 since I have no permissions to update that MR.