### PR TITLE
Amend container shutdown to catch and log for all Exception classes

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -10,6 +10,7 @@ import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Volume;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
@@ -220,7 +221,9 @@ public final class ResourceReaper {
             LOGGER.trace("Was going to stop container but it apparently no longer exists: {}", containerId);
             return;
         } catch (Exception e) {
-            LOGGER.trace("Error encountered when checking container for shutdown (ID: {}) - it may not have been stopped, or may already be stopped: {}", containerId, e.getMessage());
+            LOGGER.trace("Error encountered when checking container for shutdown (ID: {}) - it may not have been stopped, or may already be stopped. Root cause: {}",
+                containerId,
+                Throwables.getRootCause(e).getMessage());
             return;
         }
 
@@ -230,7 +233,9 @@ public final class ResourceReaper {
                 dockerClient.killContainerCmd(containerId).exec();
                 LOGGER.trace("Stopped container: {}", imageName);
             } catch (Exception e) {
-                LOGGER.trace("Error encountered shutting down container (ID: {}) - it may not have been stopped, or may already be stopped: {}", containerId, e.getMessage());
+                LOGGER.trace("Error encountered shutting down container (ID: {}) - it may not have been stopped, or may already be stopped. Root cause: {}",
+                    containerId,
+                    Throwables.getRootCause(e).getMessage());
             }
         }
 
@@ -246,7 +251,9 @@ public final class ResourceReaper {
             dockerClient.removeContainerCmd(containerId).withRemoveVolumes(true).withForce(true).exec();
             LOGGER.debug("Removed container and associated volume(s): {}", imageName);
         } catch (Exception e) {
-            LOGGER.trace("Error encountered shutting down container (ID: {}) - it may not have been stopped, or may already be stopped: {}", containerId, e.getMessage());
+            LOGGER.trace("Error encountered shutting down container (ID: {}) - it may not have been stopped, or may already be stopped. Root cause: {}",
+                containerId,
+                Throwables.getRootCause(e).getMessage());
         }
     }
 


### PR DESCRIPTION
Replacement for #1420 to fix incomplete error handling
Refs #1379

We found that unfortunately #1420 had some issues:
* It would rethrow an exception in some cases, making tests fail unnecessarily
* the code which parsed `ConflictException` messages didn't actually correctly detect the error message in the exception.
* in addition, the exception types being caught were actually thrown off by the use of a Proxy

We decided to simplify and just catch `Exception`, since we don't actually care about what might have caused container deletion to fail.

It is causing exceptions like these, failing tests:
```
Gradle Test Executor 1 > org.testcontainers.junit.GenericContainerRuleTest > sharedMemorySetTest FAILED
    java.lang.reflect.UndeclaredThrowableException
        at com.sun.proxy.$Proxy35.exec(Unknown Source)
        at org.testcontainers.utility.ResourceReaper.stopContainer(ResourceReaper.java:233)
        at org.testcontainers.utility.ResourceReaper.stopAndRemoveContainer(ResourceReaper.java:212)
        at org.testcontainers.containers.GenericContainer.stop(GenericContainer.java:396)
        at org.testcontainers.lifecycle.Startable.close(Startable.java:18)
        at org.testcontainers.junit.GenericContainerRuleTest.sharedMemorySetTest(GenericContainerRuleTest.java:413)
        Caused by:
        java.lang.reflect.InvocationTargetException
            at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
            at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
            at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
            at java.lang.reflect.Method.invoke(Method.java:498)
            at org.testcontainers.dockerclient.AuditLoggingDockerClient.lambda$wrappedCommand$14(AuditLoggingDockerClient.java:98)
            ... 6 more
            Caused by:
            com.github.dockerjava.api.exception.ConflictException: {"message":"Cannot kill container: 6f87edb101f9d5534a872e0c3182c789ef0d8d029f1f42311c4ece540db3a2ff: Container 6f87edb101f9d5534a872e0c3182c789ef0d8d029f1f42311c4ece540db3a2ff is not running"}
                at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.execute(OkHttpInvocationBuilder.java:274)
                at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.execute(OkHttpInvocationBuilder.java:254)
                at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.post(OkHttpInvocationBuilder.java:115)
                at com.github.dockerjava.core.exec.KillContainerCmdExec.execute(KillContainerCmdExec.java:30)
                at com.github.dockerjava.core.exec.KillContainerCmdExec.execute(KillContainerCmdExec.java:11)
                at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
                at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
                at com.github.dockerjava.core.command.KillContainerCmdImpl.exec(KillContainerCmdImpl.java:50)
                ... 11 more
```