### PR TITLE
Increase default image pull pause timeout

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -83,7 +83,7 @@ public class TestcontainersConfiguration {
     }
 
     public Integer getImagePullPauseTimeout() {
-        return Integer.parseInt((String) properties.getOrDefault("pull.pause.timeout", "30"));
+        return Integer.parseInt((String) properties.getOrDefault("pull.pause.timeout", "60"));
     }
 
     @Synchronized

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -61,5 +61,5 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 
 ## Customizing image pull behaviour
 
-> **pull.pause.timeout = 30**
+> **pull.pause.timeout = 60**
 > By default Testcontainers will abort the pull of an image if the pull appears stalled (no data transferred) for longer than this duration (in seconds).


### PR DESCRIPTION
Due to apparent slower pulls of large layers in Azure CI (and possibly other environments)