### PR TITLE
Add Maven Central as a fallback for dependency download

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ subprojects {
 
     repositories {
         jcenter()
+        mavenCentral()
     }
 
     shadowJar {


### PR DESCRIPTION
To reduce flaky CI builds when JCenter is experiencing a blip

[Example failure from Travis](https://travis-ci.org/testcontainers/testcontainers-java/jobs/568039196):
```
> Task :rabbitmq:compileTestJava FAILED
FAILURE: Build failed with an exception.
* What went wrong:
Could not resolve all files for configuration ':rabbitmq:testCompileClasspath'.
> Could not resolve org.assertj:assertj-core:3.12.2.
  Required by:
      project :rabbitmq
   > Could not resolve org.assertj:assertj-core:3.12.2.
      > Could not parse POM https://jcenter.bintray.com/org/assertj/assertj-core/3.12.2/assertj-core-3.12.2.pom
         > Could not resolve org.junit:junit-bom:5.4.0.
            > Could not resolve org.junit:junit-bom:5.4.0.
               > Could not get resource 'https://jcenter.bintray.com/org/junit/junit-bom/5.4.0/junit-bom-5.4.0.pom'.
                  > Could not GET 'https://jcenter.bintray.com/org/junit/junit-bom/5.4.0/junit-bom-5.4.0.pom'.
                     > Read timed out
```

I'd estimate this kind of failure accounts for ~20% of the CI jobs that I have to re-run, and it's a waste to have to do so.

If we use Maven Central as a fallback, I believe that our builds should be more stable.