### PR TITLE
Make junit dependency test scope

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,7 +56,6 @@ task jarFileTest(type: Test) {
 project.tasks.check.dependsOn(jarFileTest)
 
 dependencies {
-    compile 'junit:junit:4.12'
     compile 'org.slf4j:slf4j-api:1.7.26'
     compile 'org.jetbrains:annotations:17.0.0'
     compile 'javax.annotation:javax.annotation-api:1.3.2'
@@ -102,6 +101,7 @@ dependencies {
         exclude(group: 'org.slf4j')
     }
 
+    testCompile 'junit:junit:4.12'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.9'
     testCompile 'redis.clients:jedis:3.0.1'
     testCompile 'com.rabbitmq:amqp-client:5.7.2'


### PR DESCRIPTION
The junit dependency was in compile scope and should be in test scope.