### PR TITLE
Disable Travis for all but master branch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+if: branch = master
+
 language: java
 jdk:
   - oraclejdk8


### PR DESCRIPTION
FYI @kiview - this PR is to disable Travis for PRs. As discussed previously on Slack, Travis is our least reliable CI environment, and having three (!) CI tools makes it hard to spot signal from noise.

I've left the master branch build in place, as well as the master+tag mode which is used for bintray publication.