### PR TITLE
Add Automatic-Module-Name to MANIFEST

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,14 @@ subprojects {
         }
     }
 
+    jar {
+        manifest {
+            attributes(
+                "Automatic-Module-Name": "testcontainers.${project.name}"
+            )
+        }
+    }
+
     shadowJar {
         configurations = []
         classifier = null


### PR DESCRIPTION
This adds `Automatic-Module-Name` to the MANIFEST, using Gradle; for example:

```
jar {
    manifest {
        attributes(
            "Automatic-Module-Name": "testcontainers.postgresql"
        )
    }
}
```

Fixes #1523 