### PR TITLE
Allow containers to get restarted

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -398,6 +398,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         } finally {
             containerId = null;
             containerInfo = null;
+            portBindings.clear();
         }
     }
 


### PR DESCRIPTION
I recently wrote to issue #1532 that I've a code-fix. The problem was that in the portBindings List the static port was not cleared during the stop, so by the next start the port was already used. A portBindings.clear() in the stop() method resolved this problem.

Signed-off-by: Benedikt Aichlseder <benedikt.aichlseder@frauscher.com>