### PR TITLE
Exclude jna transitive dependency from visible-assertions to reconcile versions

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,7 +67,10 @@ dependencies {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
 
-    compile 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
+    compile ('org.rnorth.visible-assertions:visible-assertions:2.1.2') {
+        // Excluded in favor of jna-platform below
+        exclude(group: "net.java.dev.jna", module: "jna")
+    }
 
     compile ('org.rnorth:tcp-unix-socket-proxy:1.0.2') {
         exclude(group: "log4j", module: "log4j")


### PR DESCRIPTION
We use the [dependencyConvergence](https://maven.apache.org/enforcer/enforcer-rules/dependencyConvergence.html) rule as part of the `maven-enforcer-plugin` to ensure that there is no ambiguity in the versions of our dependency tree. 

As of https://github.com/testcontainers/testcontainers-java/pull/1437, Testcontainers appears to be bringing in two different transitive versions of `net.java.dev.jna:jna`:
- `5.2.0` via `org.rnorth.visible-assertions:visible-assertions:2.1.2`
- `5.3.1` via `net.java.dev.jna:jna-platform:5.3.1`

The latter is controlled in the project directly and seems like the one that is desired?

Here is an example of the error that is received when we don't exclude `jna` from the `testcontainers` dependency in our pom.xml and include `jna` directly ourselves:
```
Dependency convergence error for net.java.dev.jna:jna:5.2.0 paths to dependency are:
+-my.group:my.artifact:my.version
  +-org.testcontainers:testcontainers:1.12.0
    +-org.rnorth.visible-assertions:visible-assertions:2.1.2
      +-net.java.dev.jna:jna:5.2.0
and
+-my.group:my.artifact:my.version
  +-org.testcontainers:testcontainers:1.12.0
    +-net.java.dev.jna:jna-platform:5.3.1
      +-net.java.dev.jna:jna:5.3.1
```