### PR TITLE
Add method for lazily evaluated environment variables

### DIFF
--- a/core/src/test/java/org/testcontainers/junit/DependenciesTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DependenciesTest.java
@@ -2,12 +2,18 @@ package org.testcontainers.junit;
 
 import lombok.Getter;
 import org.junit.Test;
+import org.rnorth.ducttape.unreliables.Unreliables;
 import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.lifecycle.Startables;
 
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.Socket;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -116,6 +122,25 @@ public class DependenciesTest {
         VisibleAssertions.assertEquals("C started", 1, c.getStartInvocationCount().intValue());
         VisibleAssertions.assertEquals("D started", 1, d.getStartInvocationCount().intValue());
     }
+    
+    @Test
+    public void lazyEnvVars() throws Exception {
+        GenericContainer<?> containerA = new GenericContainer<>("alpine:3.2")
+                .withExposedPorts(80)
+                .withEnv("MAGIC_NUMBER", "4")
+                .withCommand("/bin/sh", "-c", "while true; do echo \"$MAGIC_NUMBER\" | nc -l -p 80; done");
+        
+        GenericContainer<?> containerB = new GenericContainer<>("alpine:3.2")
+                .withExposedPorts(80)
+                .withEnv("CONTAINER_A_PORT", () -> "" + containerA.getMappedPort(80))
+                .withCommand("/bin/sh", "-c", "while true; do echo \"$CONTAINER_A_PORT\" | nc -l -p 80; done")
+                .dependsOn(containerA);
+        
+        containerB.start();
+        String containerBResponse = getReaderForContainerPort80(containerB).readLine();
+        VisibleAssertions.assertEquals("Container B could read container A's exposed port", 
+                "" + containerA.getMappedPort(80), containerBResponse);
+    }
 
     private static class InvocationCountingStartable implements Startable {
 
@@ -138,5 +163,15 @@ public class DependenciesTest {
         public void stop() {
             stopInvocationCount.getAndIncrement();
         }
+    }
+    
+    private BufferedReader getReaderForContainerPort80(GenericContainer container) {
+
+        return Unreliables.retryUntilSuccess(10, TimeUnit.SECONDS, () -> {
+            Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
+
+            Socket socket = new Socket(container.getContainerIpAddress(), container.getFirstMappedPort());
+            return new BufferedReader(new InputStreamReader(socket.getInputStream()));
+        });
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -22,6 +22,7 @@ import java.io.*;
 import java.net.Socket;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -218,6 +219,30 @@ public class GenericContainerRuleTest {
         String line = getReaderForContainerPort80(alpineEnvVarFromMap).readLine();
 
         assertEquals("Environment variables can be passed into a command from a map", "42 and 50", line);
+    }
+    
+    @Test
+    public void lazyEnvTest1() {
+        GenericContainer<?> c = new GenericContainer<>("alpine:3.2")
+                .withEnv("foo", "bar")
+                .withEnv("foo", () -> "lazybar");
+        assertEquals("Environment variables with same keys should override earlier set values", "lazybar", c.getEnvMap().get("foo"));
+    }
+    
+    @Test
+    public void lazyEnvTest2() {
+        GenericContainer<?> c = new GenericContainer<>("alpine:3.2")
+                .withEnv("foo", () -> "lazybar")
+                .withEnv("foo", "bar");
+        assertEquals("Environment variables with same keys should override earlier set values", "bar", c.getEnvMap().get("foo"));
+    }
+    
+    @Test
+    public void lazyEnvTest3() {
+        GenericContainer<?> c = new GenericContainer<>("alpine:3.2")
+                .withEnv("foo", () -> "lazybar");
+        c.setEnv(Collections.singletonList("other=bogus"));
+        assertEquals("Environment variables with same keys should override earlier set values", null, c.getEnvMap().get("foo"));
     }
 
     @Test


### PR DESCRIPTION
Sometimes containers are configured to interact with each other using environment variables. This is common for things like ports or hostnames. With testcontainers, ports are randomized and not known until _after_ the container starts, so it would be nice to be able to defer setting environment variables until right before the container starts.

For example, consider this two container dependency setup:
```java
    @Container
    public static OracleContainer oracle = new OracleContainer();

    @Container
    public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
        .withEnv("DB_PORT", oracle.getMappedPort(1234))
        .dependsOn(oracle)
        // etc...
```

Today, this would blow up because we try to call `oracle.getMappedPort(1234)` at `<clinit>` time -- before the DB container is started. However, if we defer getting the port until after the DB container is started like this, it works fine:
```java
    @Container
    public static MicroProfileApplication<?> app = new MicroProfileApplication<>()
        .withEnv("DB_PORT", () -> oracle.getMappedPort(1234))
        .dependsOn(oracle)
        // etc...
```

Originally encountered via https://github.com/dev-tools-for-enterprise-java/system-test/issues/23