### PR TITLE
Speed up open port detection by running the checks as a single command

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/internal/ExternalPortListeningCheck.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/internal/ExternalPortListeningCheck.java
@@ -20,13 +20,13 @@ public class ExternalPortListeningCheck implements Callable<Boolean> {
     public Boolean call() {
         String address = containerState.getContainerIpAddress();
 
-        for (Integer externalPort : externalLivenessCheckPorts) {
+        externalLivenessCheckPorts.parallelStream().forEach(externalPort -> {
             try {
                 new Socket(address, externalPort).close();
             } catch (IOException e) {
                 throw new IllegalStateException("Socket not listening yet: " + externalPort);
             }
-        }
+        });
         return true;
     }
 }

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
@@ -25,7 +25,9 @@ public class HostPortWaitStrategy extends AbstractWaitStrategy {
     protected void waitUntilReady() {
         final Set<Integer> externalLivenessCheckPorts = getLivenessCheckPorts();
         if (externalLivenessCheckPorts.isEmpty()) {
-            log.debug("Liveness check ports of {} is empty. Not waiting.", waitStrategyTarget.getContainerInfo().getName());
+            if (log.isDebugEnabled()) {
+                log.debug("Liveness check ports of {} is empty. Not waiting.", waitStrategyTarget.getContainerInfo().getName());
+            }
             return;
         }
 

--- a/core/src/test/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheckTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheckTest.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 
-import static org.rnorth.visibleassertions.VisibleAssertions.assertThrows;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertFalse;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 public class InternalCommandPortListeningCheckTest {
@@ -30,8 +30,8 @@ public class InternalCommandPortListeningCheckTest {
     public void nonListening() {
         final InternalCommandPortListeningCheck check = new InternalCommandPortListeningCheck(nginx, ImmutableSet.of(8080, 1234));
 
-        assertThrows("InternalCommandPortListeningCheck detects a non-listening port among many",
-                IllegalStateException.class,
-                (Runnable) check::call);
+        final Boolean result = check.call();
+
+        assertFalse("InternalCommandPortListeningCheck detects a non-listening port among many", result);
     }
 }


### PR DESCRIPTION
While working on #1781 (and it is all about the ultra fast tests) I noticed that the port checks take quite some time.

This change will:
1. Make external port checks run in parallel
1. Make internal port checks run as a single `docker exec` command rather than `NUM_PORTS * NUM_STRATEGIES` commands (3, 6, 9...)

## Measurements
Even for 1 port, it is:

Before (1,443ms):
```
22:32:02.699 INFO  🐳 [nginx:1.9.4] - Creating container for image: nginx:1.9.4
22:32:02.875 INFO  🐳 [nginx:1.9.4] - Starting container with ID: 28a8774b9f299851811fcd8bc900910f9a6cf148c95aa88bc3b57d69f0f50939
22:32:03.562 INFO  🐳 [nginx:1.9.4] - Container nginx:1.9.4 is starting: 28a8774b9f299851811fcd8bc900910f9a6cf148c95aa88bc3b57d69f0f50939
22:32:03.583 DEBUG org.testcontainers.containers.ExecInContainerPattern - /interesting_knuth: Running "exec" command: /bin/sh -c cat /proc/net/tcp{,6} | awk '{print $2}' | grep -i :1f90
22:32:03.767 DEBUG org.testcontainers.containers.ExecInContainerPattern - /interesting_knuth: Running "exec" command: /bin/sh -c nc -vz -w 1 localhost 8080
22:32:03.950 DEBUG org.testcontainers.containers.ExecInContainerPattern - /interesting_knuth: Running "exec" command: /bin/bash -c </dev/tcp/localhost/8080
22:32:04.142 INFO  🐳 [nginx:1.9.4] - Container nginx:1.9.4 started
```

After (1,060ms):
```
22:31:27.313 INFO  🐳 [nginx:1.9.4] - Creating container for image: nginx:1.9.4
22:31:27.497 INFO  🐳 [nginx:1.9.4] - Starting container with ID: 2ab798d807aed3dc15afead9ff7aef82e6ff5f95087d9bf1866893f5587cf553
22:31:28.180 INFO  🐳 [nginx:1.9.4] - Container nginx:1.9.4 is starting: 2ab798d807aed3dc15afead9ff7aef82e6ff5f95087d9bf1866893f5587cf553
22:31:28.204 DEBUG org.testcontainers.containers.ExecInContainerPattern - /flamboyant_chaum: Running "exec" command: /bin/sh -c true &&  (cat /proc/net/tcp{,6} | awk '{print $2}' | grep -i :1f90 || nc -vz -w 1 localhost 8080 || /bin/bash -c '</dev/tcp/localhost/8080')
22:31:28.373 INFO  🐳 [nginx:1.9.4] - Container nginx:1.9.4 started
```