### PR TITLE
🚧 add WSL 2 Named pipe strategy

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/WslNpipeSocketClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/WslNpipeSocketClientProviderStrategy.java
@@ -2,24 +2,23 @@ package org.testcontainers.dockerclient;
 
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientConfig;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 
-import java.net.URI;
-
 @Slf4j
-public class NpipeSocketClientProviderStrategy extends DockerClientProviderStrategy {
+public class WslNpipeSocketClientProviderStrategy extends DockerClientProviderStrategy {
 
-    protected static final String DOCKER_SOCK_PATH = "//./pipe/docker_engine";
+    protected static final String DOCKER_SOCK_PATH = "//./pipe/docker_wsl";
     private static final String SOCKET_LOCATION = "npipe://" + DOCKER_SOCK_PATH;
 
     private static final String PING_TIMEOUT_DEFAULT = "10";
     private static final String PING_TIMEOUT_PROPERTY_NAME = "testcontainers.npipesocketprovider.timeout";
 
-    public static final int PRIORITY = EnvironmentAndSystemPropertyClientProviderStrategy.PRIORITY - 30;
+    public static final int PRIORITY = EnvironmentAndSystemPropertyClientProviderStrategy.PRIORITY - 20;
 
     @Override
     protected boolean isApplicable() {
@@ -61,7 +60,7 @@ public class NpipeSocketClientProviderStrategy extends DockerClientProviderStrat
 
     @Override
     public String getDescription() {
-        return "local Npipe socket (" + SOCKET_LOCATION + ")";
+        return "local WSL Npipe socket (" + SOCKET_LOCATION + ")";
     }
 
     @Override

--- a/core/src/main/resources/META-INF/services/org.testcontainers.dockerclient.DockerClientProviderStrategy
+++ b/core/src/main/resources/META-INF/services/org.testcontainers.dockerclient.DockerClientProviderStrategy
@@ -4,3 +4,4 @@ org.testcontainers.dockerclient.ProxiedUnixSocketClientProviderStrategy
 org.testcontainers.dockerclient.DockerMachineClientProviderStrategy
 org.testcontainers.dockerclient.WindowsClientProviderStrategy
 org.testcontainers.dockerclient.NpipeSocketClientProviderStrategy
+org.testcontainers.dockerclient.WslNpipeSocketClientProviderStrategy


### PR DESCRIPTION
Adding WSL 2 support
resolves #1766 

https://engineering.docker.com/2019/10/new-docker-desktop-wsl2-backend/

Currently seeing this issue 

```
20:41:33.476 DEBUG org.testcontainers.utility.TestcontainersConfiguration - Testcontainers configuration overrides will be loaded from file:/C:/Users/josep/.testcontainers.properties
20:41:33.482 DEBUG org.testcontainers.utility.TestcontainersConfiguration - Testcontainers configuration overrides loaded from TestcontainersConfiguration(properties={docker.client.strategy=org.testcontainers.dockerclient.WslNpipeSocketClientProviderStrategy})
20:41:33.516 INFO  org.testcontainers.dockerclient.DockerClientProviderStrategy - Loaded org.testcontainers.dockerclient.WslNpipeSocketClientProviderStrategy from ~/.testcontainers.properties, will try it first
20:41:33.574 INFO  org.testcontainers.dockerclient.DockerClientProviderStrategy - Will use 'okhttp' transport
20:41:33.749 DEBUG org.testcontainers.dockerclient.DockerClientProviderStrategy - Pinging docker daemon...
20:41:34.041 INFO  org.testcontainers.dockerclient.WslNpipeSocketClientProviderStrategy - Accessing docker with local WSL Npipe socket (npipe:////./pipe/docker_wsl)
20:41:34.041 INFO  org.testcontainers.dockerclient.DockerClientProviderStrategy - Found Docker environment with local WSL Npipe socket (npipe:////./pipe/docker_wsl)
20:41:34.041 DEBUG org.testcontainers.dockerclient.DockerClientProviderStrategy - Checking Docker OS type for local WSL Npipe socket (npipe:////./pipe/docker_wsl)
20:41:34.375 INFO  org.testcontainers.DockerClientFactory - Docker host IP address is localhost
20:41:34.673 INFO  org.testcontainers.DockerClientFactory - Connected to docker: 
  Server Version: 19.03.1
  API Version: 1.40
  Operating System: Ubuntu 18.04.2 LTS
  Total Memory: 31040 MB
20:41:34.725 DEBUG org.testcontainers.utility.RegistryAuthLocator - Looking up auth config for image: quay.io/testcontainers/ryuk:0.2.3
20:41:34.726 DEBUG org.testcontainers.utility.RegistryAuthLocator - RegistryAuthLocator has configFile: C:\Users\josep\.docker\config.json (exists) and commandPathPrefix: 
20:41:34.732 DEBUG org.testcontainers.utility.RegistryAuthLocator - registryName [quay.io] for dockerImageName [quay.io/testcontainers/ryuk:0.2.3]
20:41:34.732 DEBUG org.testcontainers.utility.RegistryAuthLocator - Executing docker credential provider: docker-credential-desktop to locate auth config for: quay.io
20:41:34.915 DEBUG org.testcontainers.utility.RegistryAuthLocator - Got credentials not found error message from docker credential helper - credentials not found in native keychain
20:41:34.915 INFO  org.testcontainers.utility.RegistryAuthLocator - Credential helper/store (docker-credential-desktop) does not have credentials for quay.io
20:41:34.916 DEBUG org.testcontainers.utility.RegistryAuthLocator - no matching Auth Configs - falling back to defaultAuthConfig [null]
20:41:34.916 DEBUG org.testcontainers.dockerclient.auth.AuthDelegatingDockerClientConfig - Effective auth config [null]

java.lang.ExceptionInInitializerError
        Caused by:
        com.github.dockerjava.api.exception.InternalServerErrorException: rpc error: code = Unknown desc = wslpath failed; stderr is "wslpath: //var/run/docker.sock:/var/run/docker.sock\n": exit status 1
            at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.execute(OkHttpInvocationBuilder.java:276)
            at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.execute(OkHttpInvocationBuilder.java:254)
            at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.post(OkHttpInvocationBuilder.java:125)
            at com.github.dockerjava.core.exec.CreateContainerCmdExec.execute(CreateContainerCmdExec.java:33)
            at com.github.dockerjava.core.exec.CreateContainerCmdExec.execute(CreateContainerCmdExec.java:13)
            at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
            at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
            at com.github.dockerjava.core.command.CreateContainerCmdImpl.exec(CreateContainerCmdImpl.java:1139)
            at org.testcontainers.utility.ResourceReaper.start(ResourceReaper.java:82)
            at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:131)
            at org.testcontainers.containers.GenericContainer.<init>(GenericContainer.java:175)
            at org.testcontainers.vault.VaultContainer.<init>(VaultContainer.java:38)
            at org.testcontainers.vault.VaultContainer.<init>(VaultContainer.java:34)
            at org.testcontainers.vault.VaultContainerTest.<clinit>(VaultContainerTest.java:26)
```

Not experienced enough the inner workings of either test containers nor docker as to why this is an issue.