### PR TITLE
update latest version with 1.12.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,4 +82,4 @@ nav:
           - contributing.md
           - contributing_docs.md
 extra:
-    latest_version: 1.11.3
+    latest_version: 1.12.0


### PR DESCRIPTION
Since `1.11.3` is displayed at [testcontainers](https://www.testcontainers.org/), I updated with latest version. (1.12.0)