### PR TITLE
Use "copy" strategy in `withClasspathResourceMapping` where appropriate

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -967,7 +967,11 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     public SELF withClasspathResourceMapping(final String resourcePath, final String containerPath, final BindMode mode, final SelinuxContext selinuxContext) {
         final MountableFile mountableFile = MountableFile.forClasspathResource(resourcePath);
 
-        this.addFileSystemBind(mountableFile.getResolvedPath(), containerPath, mode, selinuxContext);
+        if (mode == BindMode.READ_ONLY && selinuxContext == SelinuxContext.NONE) {
+            withCopyFileToContainer(mountableFile, containerPath);
+        } else {
+            addFileSystemBind(mountableFile.getResolvedPath(), containerPath, mode, selinuxContext);
+        }
 
         return self();
     }


### PR DESCRIPTION
## Context
The current implementation of `withClasspathResourceMapping` uses file mounting. 

While it works fine most of the time, there are some environments where the file mounting does not work (simple example: remote Docker daemon).

## The change
For read-only classpath mappings without Selinux we can use the copy strategy.

## Testing
I added tests for different combinations (read-only, read-only with `Selinux.NONE`, read-write, read-only with Selinux other than `NONE`) to make sure that we only use the strategy where we know for sure.

## What can go wrong
Some users may use `withClasspathResourceMapping` for large files. This won't break anything, but may make it slightly slower for them. 
Given that there is a workaround (e.g. use `READ_WRITE` instead of `READ_ONLY`) and the minority of such usages, I would say that's okay.