### PR TITLE
Update example dependency specified in junit_5.md

### DIFF
--- a/docs/test_framework_integration/junit_5.md
+++ b/docs/test_framework_integration/junit_5.md
@@ -126,7 +126,7 @@ This extension has only be tested with sequential test execution. Using it with 
 Add the following dependency to your `pom.xml`/`build.gradle` file:
 
 ```groovy tab='Gradle'
-testCompile "org.testcontainers:junit-jupiter:{{latest_version}}"
+testImplementation "org.testcontainers:junit-jupiter:{{latest_version}}"
 ```
 
 ```xml tab='Maven'


### PR DESCRIPTION
`testCompile` is [deprecated and has been superseded](https://docs.gradle.org/5.6.1/userguide/java_plugin.html#tab:configurations) by `testImplementation`