### PR TITLE
Add PGroonga as a Postgres container provider

### DIFF
--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PgroongaContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PgroongaContainerProvider.java
@@ -1,0 +1,39 @@
+package org.testcontainers.containers;
+
+import org.testcontainers.jdbc.ConnectionUrl;
+
+import java.util.Objects;
+
+/**
+ * Factory for pgroonga container, which is PostgreSQL with groonga extension.
+ * PGroonga makes PostgreSQL fast full text search platform for all languages!
+ */
+public class PgroongaContainerProvider extends JdbcDatabaseContainerProvider {
+
+    private static final String NAME = "pgroonga";
+    private static final String DEFAULT_TAG = "2.2.1-alpine-11-slim";
+    private static final String DEFAULT_IMAGE = "groonga/pgroonga";
+    public static final String USER_PARAM = "user";
+    public static final String PASSWORD_PARAM = "password";
+
+
+    @Override
+    public boolean supports(String databaseType) {
+        return databaseType.equals(NAME);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance() {
+        return newInstance(DEFAULT_TAG);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(String tag) {
+        return new PostgreSQLContainer(DEFAULT_IMAGE + ":" + tag);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+        return newInstanceFromConnectionUrl(connectionUrl, USER_PARAM, PASSWORD_PARAM);
+    }
+}

--- a/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
+++ b/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
@@ -1,2 +1,3 @@
 org.testcontainers.containers.PostgreSQLContainerProvider
 org.testcontainers.containers.PostgisContainerProvider
+org.testcontainers.containers.PgroongaContainerProvider


### PR DESCRIPTION
Just adding a new Postgres container provider to the postgresql module

#### Links

[PGroonga Documentation](https://pgroonga.github.io/)
[Docker Hub groonga/pgroonga](https://hub.docker.com/r/groonga)

#### Advantages

Like posgres and postgis, to be able to use pgroonga by setting it on the jdbc url
```
spring:
  datasource:
    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
    url: jdbc:tc:pgroonga://localhost/my_database
```

#### Default docker image

- [x] Should be a Docker Hub official image, or published by a reputable source (ideally the company or organisation that officially supports the technology)
- [x] Should have a verifiable open source Dockerfile and a way to view the history of changes
- [x] MUST show general good practices regarding container image tagging - e.g. we do not use `latest` tags, and we do not use tags that may be mutated in the future
- [x] MUST be legal for Testcontainers developers and Testcontainers users to pull and use. Mechanisms exist to allow EULA acceptance to be signalled, but images that can be used without a licence are greatly preferred.

#### Module dependencies

- [x] The module should use as few dependencies as possible, 
- [x] Regarding libraries, either:
    - they should be `compileOnly` if they are likely to already be on the classpath for users' tests (e.g. client libraries or drivers) 
    - they can be `implementation` (and thus transitive dependencies) if they are very unlikely to conflict with users' dependencies.
- [x] If client libraries are used to test or use the module, these MUST be legal for Testcontainers developers and Testcontainers users to download and use.

#### API (e.g. `MyModuleContainer` class)

- [x] Favour doing the right thing, and least surprising thing, by default
- [x] Ensure that method and parameter names are easy to understand. Many users will ignore documentation, so IDE-based substitutes (autocompletion and Javadocs) should be intuitive. 
- [x] The module's public API should only handle standard JDK data types and MUST not expose data types that come from `compileOnly` dependencies. This is to reduce the risk of compatibility problems with future versions of third party libraries.
 
#### Documentation

- [x] Every module MUST have a dedicated documentation page containing:
    - [x] A high level overview
    - [x] A usage example
    - [x] If appropriate, basic API documentation or further usage guidelines
    - [x] Dependency information
    - [x] Acknowledgements, if appropriate
- [x] Consider that many users will not read the documentation pages - even if the first person to add it to a project does, people reading/updating the code in the future may not. Try and avoid the need for critical knowledge that is only present in documentation.