### PR TITLE
Make LocalStack image configurable

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -81,6 +81,10 @@ public class TestcontainersConfiguration {
         return (String) properties.getOrDefault("pulsar.container.image", "apachepulsar/pulsar");
     }
 
+    public String getLocalStackImage() {
+        return (String) properties.getOrDefault("localstack.container.image", "localstack/localstack");
+    }
+
     public boolean isDisableChecks() {
         return Boolean.parseBoolean((String) environmentProperties.getOrDefault("checks.disable", "false"));
     }

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -42,6 +42,9 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **kafka.container.image = confluentinc/cp-kafka**  
 > Used by KafkaContainer 
 
+> **localstack.container.image = localstack/localstack**  
+> Used by LocalStack
+
 ## Customizing Ryuk resource reaper
 
 > **ryuk.container.image = quay.io/testcontainers/ryuk:0.2.3**

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -10,6 +10,7 @@ import lombok.experimental.FieldDefaults;
 import org.rnorth.ducttape.Preconditions;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -37,7 +38,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     }
 
     public LocalStackContainer(String version) {
-        super("localstack/localstack:" + version);
+        super(TestcontainersConfiguration.getInstance().getLocalStackImage() + ":" + version);
 
         withFileSystemBind("//var/run/docker.sock", "/var/run/docker.sock");
         waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));


### PR DESCRIPTION
Hi,
In order to use Test Containers and LocalStack at my company, we need to resolve images from our corporate registry. Currently, LocalStackContainer's image is hard coded. This PR makes it configurable. I followed the lead of a prior commit that made KafkaContainer's image configurable: https://github.com/testcontainers/testcontainers-java/commit/4e15af82

I noticed a prior PR attempted to do this: https://github.com/testcontainers/testcontainers-java/pull/1604
But
1) Its development seems to have been stalled for the past couple months
2) It's slightly more complex than necessary

Thanks for your time!