### PR TITLE
Add support for DockerClient event streaming

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/OkHttpInvocationBuilder.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/OkHttpInvocationBuilder.java
@@ -101,8 +101,15 @@ class OkHttpInvocationBuilder implements InvocationBuilder {
 
     @Override
     public <T> void get(TypeReference<T> typeReference, ResultCallback<T> resultCallback) {
-        // FIXME
-        throw new IllegalStateException("doesn't seem to be used in docker-java");
+        Request request = requestBuilder
+            .get()
+            .build();
+
+        executeAndStream(
+            request,
+            resultCallback,
+            new JsonSink<T>(objectMapper, typeReference, resultCallback)
+        );
     }
 
     @Override

--- a/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/UnixSocketFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/UnixSocketFactory.java
@@ -37,6 +37,14 @@ public class UnixSocketFactory extends SocketFactory {
                     public void close() throws IOException {
                         shutdownInput();
                     }
+
+                    @Override
+                    public int read(byte[] b, int off, int len) throws IOException {
+                        if (OkHttpInvocationBuilder.CLOSING.get()) {
+                            return 0;
+                        }
+                        return super.read(b, off, len);
+                    }
                 };
             }
 

--- a/core/src/test/java/org/testcontainers/dockerclient/EventStreamTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/EventStreamTest.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.model.Event;
 import com.github.dockerjava.core.command.EventsResultCallback;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
-import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
@@ -13,6 +12,8 @@ import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 /**
  * Test that event streaming from the {@link DockerClient} works correctly
@@ -24,41 +25,39 @@ public class EventStreamTest {
      */
     @Test
     public void test() throws IOException, InterruptedException {
-        DockerClient client = DockerClientFactory.instance().client();
-        Instant startTime = Instant.now();
-        final AtomicBoolean received = new AtomicBoolean(false);
+        AtomicBoolean received = new AtomicBoolean(false);
 
-        // Start a one-shot Container
         try (
             GenericContainer container = new GenericContainer<>()
-                .withCommand("/bin/sh", "-c", "sleep 0")
-                .withStartupCheckStrategy(new OneShotStartupCheckStrategy())) {
-
+                .withCommand("true")
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+        ) {
             container.start();
-            Instant endTime = Instant.now();
+            String createdAt = container.getContainerInfo().getCreated();
+            String finishedAt = container.getCurrentContainerInfo().getState().getFinishedAt();
 
             // Request all events between startTime and endTime for the container
-            try (EventsResultCallback response = client.eventsCmd()
-                .withContainerFilter(container.getContainerId())
-                .withEventFilter("create")
-                .withSince(Long.toString(startTime.getEpochSecond()))
-                .withUntil(Long.toString(endTime.getEpochSecond()))
-                .exec(new EventsResultCallback() {
-                    @Override
-                    public void onNext(@NotNull Event event) {
-                        // Check that a create event for the container is received
-                        if (event.getId().equals(container.getContainerId()) && event.getStatus().equals("create")) {
-                            received.set(true);
+            try (
+                EventsResultCallback response = DockerClientFactory.instance().client().eventsCmd()
+                    .withContainerFilter(container.getContainerId())
+                    .withEventFilter("create")
+                    .withSince(Instant.parse(createdAt).getEpochSecond() + "")
+                    .withUntil(Instant.parse(finishedAt).getEpochSecond() + "")
+                    .exec(new EventsResultCallback() {
+                        @Override
+                        public void onNext(@NotNull Event event) {
+                            // Check that a create event for the container is received
+                            if (event.getId().equals(container.getContainerId()) && event.getStatus().equals("create")) {
+                                received.set(true);
+                            }
                         }
-                    }
-                })) {
-
+                    })
+            ) {
                 response.awaitCompletion();
             }
-
         }
 
-        VisibleAssertions.assertTrue("Events has been captured", received.get());
+        assertTrue("Events has been captured", received.get());
     }
 
 }

--- a/core/src/test/java/org/testcontainers/dockerclient/EventStreamTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/EventStreamTest.java
@@ -1,0 +1,64 @@
+package org.testcontainers.dockerclient;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Event;
+import com.github.dockerjava.core.command.EventsResultCallback;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.rnorth.visibleassertions.VisibleAssertions;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Test that event streaming from the {@link DockerClient} works correctly
+ */
+public class EventStreamTest {
+
+    /**
+     * Test that docker events can be streamed from the client.
+     */
+    @Test
+    public void test() throws IOException, InterruptedException {
+        DockerClient client = DockerClientFactory.instance().client();
+        Instant startTime = Instant.now();
+        final AtomicBoolean received = new AtomicBoolean(false);
+
+        // Start a one-shot Container
+        try (
+            GenericContainer container = new GenericContainer<>()
+                .withCommand("/bin/sh", "-c", "sleep 0")
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy())) {
+
+            container.start();
+            Instant endTime = Instant.now();
+
+            // Request all events between startTime and endTime for the container
+            try (EventsResultCallback response = client.eventsCmd()
+                .withContainerFilter(container.getContainerId())
+                .withEventFilter("create")
+                .withSince(Long.toString(startTime.getEpochSecond()))
+                .withUntil(Long.toString(endTime.getEpochSecond()))
+                .exec(new EventsResultCallback() {
+                    @Override
+                    public void onNext(@NotNull Event event) {
+                        // Check that a create event for the container is received
+                        if (event.getId().equals(container.getContainerId()) && event.getStatus().equals("create")) {
+                            received.set(true);
+                        }
+                    }
+                })) {
+
+                response.awaitCompletion();
+            }
+
+        }
+
+        VisibleAssertions.assertTrue("Events has been captured", received.get());
+    }
+
+}


### PR DESCRIPTION
I noticed that event streaming from the DockerClient as specified in the docker-java wiki (https://github.com/docker-java/docker-java/wiki#handle-events) doesn't work, as get(TypeReference<T> typeReference, ResultCallback<T> resultCallback) is not implemented in OkHttpInvocationBuilder.java 