### PR TITLE
resolve #1824 | Change gradle dependencies scope

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,8 +58,8 @@ project.tasks.check.dependsOn(jarFileTest)
 dependencies {
     compile 'junit:junit:4.12'
     compile 'org.slf4j:slf4j-api:1.7.28'
-    compile 'org.jetbrains:annotations:17.0.0'
-    compile 'javax.annotation:javax.annotation-api:1.3.2'
+    compileOnly 'org.jetbrains:annotations:17.0.0'
+    compileOnly 'javax.annotation:javax.annotation-api:1.3.2'
     compile 'org.apache.commons:commons-compress:1.19'
     // Added for JDK9 compatibility since it's missing this package
     compile 'javax.xml.bind:jaxb-api:2.3.1'


### PR DESCRIPTION
Move static analysis dependencies in compileOnly scope