### PR TITLE
Tentative fix for readBytes timeout on Windows

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/NamedPipeSocketFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/NamedPipeSocketFactory.java
@@ -55,16 +55,25 @@ public class NamedPipeSocketFactory extends SocketFactory {
                 is = new InputStream() {
                     @Override
                     public int read(byte[] bytes, int off, int len) throws IOException {
+                        if (OkHttpInvocationBuilder.CLOSING.get()) {
+                            return 0;
+                        }
                         return file.read(bytes, off, len);
                     }
 
                     @Override
                     public int read() throws IOException {
+                        if (OkHttpInvocationBuilder.CLOSING.get()) {
+                            return 0;
+                        }
                         return file.read();
                     }
 
                     @Override
                     public int read(byte[] bytes) throws IOException {
+                        if (OkHttpInvocationBuilder.CLOSING.get()) {
+                            return 0;
+                        }
                         return file.read(bytes);
                     }
                 };


### PR DESCRIPTION
It seems that #1886 needs some work in NamedPipeSocketFactory. 

Trying an approach...