### PR TITLE
Always copy to "/" (root). Fixes #1954

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1154,16 +1154,13 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         ) {
             tarArchive.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
 
-            int lastSlashIndex = StringUtils.removeEnd(containerPath, "/").lastIndexOf("/");
-            String extractArchiveTo = containerPath.substring(0, lastSlashIndex + 1);
-            String pathInArchive = containerPath.substring(lastSlashIndex + 1);
-            transferable.transferTo(tarArchive, pathInArchive);
+            transferable.transferTo(tarArchive, containerPath);
             tarArchive.finish();
 
             dockerClient
                 .copyArchiveToContainerCmd(containerId)
                 .withTarInputStream(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()))
-                .withRemotePath(extractArchiveTo)
+                .withRemotePath("/")
                 .exec();
         }
     }

--- a/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
@@ -59,4 +59,18 @@ public class CopyFileToContainerTest {
         assertFalse("uses mount for read-only with Selinux", copyMap.containsValue("/readOnlyShared"));
         assertFalse("uses mount for read-write", copyMap.containsValue("/readWrite"));
     }
+
+    @Test
+    public void shouldCreateFoldersStructureWithCopy() throws Exception {
+        String resource = "/test_copy_to_container.txt";
+        try (
+            GenericContainer container = new GenericContainer<>()
+                .withCommand("sleep", "3000")
+                .withClasspathResourceMapping(resource, "/a/b/c/file", BindMode.READ_ONLY)
+        ) {
+            container.start();
+            String filesList = container.execInContainer("ls", "/a/b/c/").getStdout();
+            assertTrue("file list contains the file", filesList.contains("file"));
+        }
+    }
 }


### PR DESCRIPTION
As seen in https://github.com/testcontainers/testcontainers-java/pull/1814, we introduced a regression in 1.12.1.

This PR makes the copy API always target the root and then uses the full path in the archive we send to the daemon.