### PR TITLE
#1802: added JdbcDatabaseContainer#withUrlParam

### DIFF
--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -43,7 +43,14 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
 
     @Override
     public String getJdbcUrl() {
-        return JDBC_URL_PREFIX + "://" + getContainerIpAddress() + ":" + getMappedPort(DB_PORT) + "/" + databaseName;
+        return String.format(
+            "%s://%s:%s/%s%s",
+            JDBC_URL_PREFIX,
+            getContainerIpAddress(),
+            getMappedPort(DB_PORT),
+            databaseName,
+            buildUrlParams("?", "&")
+        );
     }
 
     @Override

--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -81,7 +81,13 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:db2://" + getContainerIpAddress() + ":" + getMappedPort(DB2_PORT) + "/" + databaseName;
+        return String.format(
+            "jdbc:db2://%s:%s/%s%s",
+            getContainerIpAddress(),
+            getMappedPort(DB2_PORT),
+            databaseName,
+            buildUrlParams(":", ";")
+        );
     }
 
     @Override

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleCockroachDBTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleCockroachDBTest.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 
+import static org.junit.Assert.assertTrue;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
 public class SimpleCockroachDBTest extends AbstractContainerDatabaseTest {
@@ -39,6 +40,19 @@ public class SimpleCockroachDBTest extends AbstractContainerDatabaseTest {
 
             String firstColumnValue = resultSet.getString(1);
             assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+        }
+    }
+
+    @Test
+    public void testCreateJdbcUrlWithUrlParam() {
+        CockroachContainer container = new CockroachContainer()
+            .withUrlParam("sslmode", "disable");
+        try {
+            container.start();
+            String actual = container.getJdbcUrl();
+            assertTrue("Jdbc url should contains params", actual.contains("?sslmode=disable"));
+        } finally {
+            container.stop();
         }
     }
 }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleDb2Test.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleDb2Test.java
@@ -5,12 +5,14 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.Db2Container;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 
 public class SimpleDb2Test {
@@ -36,4 +38,16 @@ public class SimpleDb2Test {
         assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
     }
 
+    @Test
+    public void testCreateJdbcUrlWithUrlParam() {
+        JdbcDatabaseContainer container = new Db2Container()
+            .withUrlParam("traceLevel", "TRACE_ALL");
+        try {
+            container.start();
+            String actual = container.getJdbcUrl();
+            assertTrue("Jdbc url should contains params", actual.contains(":traceLevel=TRACE_ALL"));
+        } finally {
+            container.stop();
+        }
+    }
 }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
@@ -1,6 +1,5 @@
 package org.testcontainers.junit;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -11,6 +10,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
 /**
@@ -54,7 +54,7 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
         try {
             container.start();
             String actual = container.getJdbcUrl();
-            Assert.assertTrue("Jdbc url should contains params", actual.contains(";integratedSecurity=false"));
+            assertTrue("Jdbc url should contains params", actual.contains(";integratedSecurity=false"));
         } finally {
             container.stop();
         }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMSSQLServerTest.java
@@ -1,7 +1,9 @@
 package org.testcontainers.junit;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MSSQLServerContainer;
 
 import javax.sql.DataSource;
@@ -43,5 +45,18 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
         resultSet.next();
         int resultSetInt = resultSet.getInt("ID");
         assertEquals("A basic SELECT query succeeds", 3, resultSetInt);
+    }
+
+    @Test
+    public void testCreateJdbcUrlWithUrlParam() {
+        JdbcDatabaseContainer container = new MSSQLServerContainer()
+            .withUrlParam("integratedSecurity", "false");
+        try {
+            container.start();
+            String actual = container.getJdbcUrl();
+            Assert.assertTrue("Jdbc url should contains params", actual.contains(";integratedSecurity=false"));
+        } finally {
+            container.stop();
+        }
     }
 }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMariaDBTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMariaDBTest.java
@@ -2,6 +2,7 @@ package org.testcontainers.junit;
 
 import org.apache.commons.lang.SystemUtils;
 import org.junit.Test;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MariaDBContainer;
 
 import java.sql.ResultSet;
@@ -78,6 +79,20 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
             assertEquals("Auto increment increment should be overriden by command line", "10", result);
         } finally {
             mariadbCustomConfig.stop();
+        }
+    }
+
+    @Test
+    public void testCreateJdbcUrlWithUrlParam() {
+        JdbcDatabaseContainer container = new MariaDBContainer("mariadb:10.1.16")
+            .withDatabaseName("TEST")
+            .withUrlParam("TZ", "Europe/Zurich");
+        try {
+            container.start();
+            String actual = container.getJdbcUrl();
+            assertTrue("Jdbc url should contains params", actual.contains("?TZ=Europe/Zurich"));
+        } finally {
+            container.stop();
         }
     }
 }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
@@ -1,10 +1,12 @@
 package org.testcontainers.junit;
 
 import org.apache.commons.lang.SystemUtils;
+import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
@@ -132,6 +134,20 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
             container.start();
             fail("ContainerLaunchException expected to be thrown");
         } catch (ContainerLaunchException e) {
+        } finally {
+            container.stop();
+        }
+    }
+
+    @Test
+    public void testCreateJdbcUrlWithUrlParam() {
+        JdbcDatabaseContainer container = new MySQLContainer("mysql:5.5")
+            .withDatabaseName("TEST")
+            .withUrlParam("TZ", "Europe/Zurich");
+        try {
+            container.start();
+            String actual = container.getJdbcUrl();
+            Assert.assertTrue(actual.contains("?TZ=Europe/Zurich"));
         } finally {
             container.stop();
         }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleMySQLTest.java
@@ -1,7 +1,6 @@
 package org.testcontainers.junit;
 
 import org.apache.commons.lang.SystemUtils;
-import org.junit.Assert;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,7 +146,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
         try {
             container.start();
             String actual = container.getJdbcUrl();
-            Assert.assertTrue(actual.contains("?TZ=Europe/Zurich"));
+            assertTrue("Jdbc url should contains params", actual.contains("?TZ=Europe/Zurich"));
         } finally {
             container.stop();
         }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java
@@ -1,6 +1,7 @@
 package org.testcontainers.junit;
 
 import org.junit.Test;
+import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.sql.ResultSet;
@@ -8,6 +9,7 @@ import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
 
+import static org.junit.Assert.assertTrue;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertNotEquals;
 
@@ -60,6 +62,20 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
             String firstColumnValue = resultSet.getString(1);
             assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+        }
+    }
+
+    @Test
+    public void testCreateJdbcUrlWithUrlParam() {
+        JdbcDatabaseContainer container = new PostgreSQLContainer()
+            .withDatabaseName("TEST")
+            .withUrlParam("ssl", "false");
+        try {
+            container.start();
+            String actual = container.getJdbcUrl();
+            assertTrue("Jdbc url should contains params", actual.contains("?loggerLevel=OFF&ssl=false"));
+        } finally {
+            container.stop();
         }
     }
 }

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
 /**
  * Base class for containers that expose a JDBC connection
@@ -110,6 +111,21 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     public SELF withInitScript(String initScriptPath) {
         this.initScriptPath = initScriptPath;
         return self();
+    }
+
+    public SELF withUrlParam(String key, String value) {
+        this.parameters.put(key, value);
+        return self();
+    }
+
+    protected String buildUrlParams(String firstSymbol, String paramDelimiter) {
+        if (parameters.isEmpty()) {
+            return "";
+        }
+        return firstSymbol + parameters.entrySet()
+            .stream()
+            .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+            .collect(Collectors.joining(paramDelimiter));
     }
 
     @Override

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -56,7 +56,13 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:mariadb://" + getContainerIpAddress() + ":" + getMappedPort(MARIADB_PORT) + "/" + databaseName;
+        return String.format(
+            "jdbc:mariadb://%s:%s/%s%s",
+            getContainerIpAddress(),
+            getMappedPort(MARIADB_PORT),
+            databaseName,
+            buildUrlParams("?", "&")
+        );
     }
 
     @Override
@@ -83,7 +89,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
-    
+
     @Override
     public SELF withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -60,7 +60,12 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:sqlserver://" + getContainerIpAddress() + ":" + getMappedPort(MS_SQL_SERVER_PORT);
+        return String.format(
+            "jdbc:sqlserver://%s:%s%s",
+            getContainerIpAddress(),
+            getMappedPort(MS_SQL_SERVER_PORT),
+            buildUrlParams(";", ";")
+        );
     }
 
     @Override

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -66,7 +66,13 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:mysql://" + getContainerIpAddress() + ":" + getMappedPort(MYSQL_PORT) + "/" + databaseName;
+        return String.format(
+            "jdbc:mysql://%s:%s/%s%s",
+            getContainerIpAddress(),
+            getMappedPort(MYSQL_PORT),
+            databaseName,
+            buildUrlParams("?", "&")
+        );
     }
 
     @Override

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -59,7 +59,13 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     @Override
     public String getJdbcUrl() {
         // Disable Postgres driver use of java.util.logging to reduce noise at startup time
-        return "jdbc:postgresql://" + getContainerIpAddress() + ":" + getMappedPort(POSTGRESQL_PORT) + "/" + databaseName + "?loggerLevel=OFF";
+        return String.format(
+            "jdbc:postgresql://%s:%s/%s?loggerLevel=OFF%s",
+            getContainerIpAddress(),
+            getMappedPort(POSTGRESQL_PORT),
+            databaseName,
+            buildUrlParams("&","&")
+        );
     }
 
     @Override


### PR DESCRIPTION
Added JdbcDatabaseContainer#withUrlParam
Added support JdbcDatabaseContainer#getJdbcUrl with url params for:
* CockroachContainer
* Db2Container
* MariaDBContainer
* MSSQLServerContainer
* MySQLContainer
* PostgreSQLContainer

For OracleContainer and ClickHouseContainer not implemented because not found in the documentation how to set URL params for this databases