### PR TITLE
Slf4jLogConsumer improvements

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
@@ -47,8 +47,10 @@ public class Slf4jLogConsumer extends BaseConsumer<Slf4jLogConsumer> {
                 case END:
                     break;
                 case STDOUT:
+                    logger.info("{}{}", prefix.isEmpty() ? "" : (prefix + ": "), utf8String);
+                    break;
                 case STDERR:
-                    logger.info("{}{}: {}", prefix, outputType, utf8String);
+                    logger.error("{}{}", prefix.isEmpty() ? "" : (prefix + ": "), utf8String);
                     break;
                 default:
                     throw new IllegalArgumentException("Unexpected outputType " + outputType);

--- a/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
@@ -39,7 +39,7 @@ public class Slf4jLogConsumer extends BaseConsumer<Slf4jLogConsumer> {
         return this;
     }
 
-    public Slf4jLogConsumer separateOutputStreams() {
+    public Slf4jLogConsumer withSeparateOutputStreams() {
         this.separateOutputStreams = true;
         return this;
     }

--- a/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
@@ -1,6 +1,10 @@
 package org.testcontainers.containers.output;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.slf4j.Logger;
+import org.slf4j.MDC;
 
 /**
  * A consumer for container output that logs output to an SLF4J logger.
@@ -8,6 +12,7 @@ import org.slf4j.Logger;
 public class Slf4jLogConsumer extends BaseConsumer<Slf4jLogConsumer> {
     private final Logger logger;
     private String prefix = "";
+    private final Map<String, String> mdc = new HashMap<>();
 
     public Slf4jLogConsumer(Logger logger) {
         this.logger = logger;
@@ -18,21 +23,42 @@ public class Slf4jLogConsumer extends BaseConsumer<Slf4jLogConsumer> {
         return this;
     }
 
+    public Slf4jLogConsumer withMdc(String key, String value) {
+        mdc.put(key, value);
+        return this;
+    }
+
+    public Slf4jLogConsumer withMdc(Map<String, String> mdc) {
+        this.mdc.putAll(mdc);
+        return this;
+    }
+
     @Override
     public void accept(OutputFrame outputFrame) {
         OutputFrame.OutputType outputType = outputFrame.getType();
 
         String utf8String = outputFrame.getUtf8String();
         utf8String = utf8String.replaceAll(FrameConsumerResultCallback.LINE_BREAK_AT_END_REGEX, "");
-        switch (outputType) {
-            case END:
-                break;
-            case STDOUT:
-            case STDERR:
-                logger.info("{}{}: {}", prefix, outputType, utf8String);
-                break;
-            default:
-                throw new IllegalArgumentException("Unexpected outputType " + outputType);
+
+        Map<String, String> originalMdc = MDC.getCopyOfContextMap();
+        MDC.setContextMap(mdc);
+        try {
+            switch (outputType) {
+                case END:
+                    break;
+                case STDOUT:
+                case STDERR:
+                    logger.info("{}{}: {}", prefix, outputType, utf8String);
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unexpected outputType " + outputType);
+            }
+        } finally {
+            if (originalMdc == null) {
+                MDC.clear();
+            } else {
+                MDC.setContextMap(originalMdc);
+            }
         }
     }
 }


### PR DESCRIPTION
- Adds support for MDC
- Uses log levels based on output type