### PR TITLE
Simplify various code structures

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,7 +76,7 @@ dependencies {
         exclude(group: "log4j", module: "log4j")
     }
 
-    compile "net.java.dev.jna:jna-platform:5.4.0"
+    compile "net.java.dev.jna:jna-platform:5.5.0"
 
     shaded ('org.scala-sbt.ipcsocket:ipcsocket:1.0.0') {
         exclude(group: "net.java.dev.jna")

--- a/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
+++ b/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
@@ -14,6 +14,7 @@ import org.testcontainers.utility.TestEnvironment;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Provides utility methods for executing commands in containers
@@ -32,7 +33,7 @@ public class ExecInContainerPattern {
      */
     public Container.ExecResult execInContainer(InspectContainerResponse containerInfo, String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {
-        return execInContainer(containerInfo, Charset.forName("UTF-8"), command);
+        return execInContainer(containerInfo, StandardCharsets.UTF_8, command);
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/FailureDetectingExternalResource.java
+++ b/core/src/main/java/org/testcontainers/containers/FailureDetectingExternalResource.java
@@ -23,7 +23,7 @@ public class FailureDetectingExternalResource implements TestRule {
             @Override
             public void evaluate() throws Throwable {
 
-                List<Throwable> errors = new ArrayList<Throwable>();
+                List<Throwable> errors = new ArrayList<>();
 
                 try {
                     starting(description);

--- a/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/OkHttpDockerCmdExecFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/OkHttpDockerCmdExecFactory.java
@@ -129,7 +129,7 @@ public class OkHttpDockerCmdExecFactory extends AbstractDockerCmdExecFactory {
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
 
     }
 

--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -2,10 +2,8 @@ package org.testcontainers.images.builder;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.BuildImageCmd;
-import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.model.BuildResponseItem;
 import com.github.dockerjava.core.command.BuildImageResultCallback;
-import com.google.common.collect.Sets;
 import lombok.Cleanup;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +29,6 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
 @Slf4j

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -94,7 +94,7 @@ public final class ResourceReaper {
                 .findFirst()
                 .map(Ports.Binding::getHostPortSpec)
                 .map(Integer::parseInt)
-                .get();
+                .orElseThrow(() -> new IllegalStateException("Could not fetch Ryuk's port"));
 
         CountDownLatch ryukScheduledLatch = new CountDownLatch(1);
 
@@ -341,12 +341,12 @@ public final class ResourceReaper {
     public void unregisterContainer(String identifier) {
         registeredContainers.remove(identifier);
     }
-    
+
     public void registerImageForCleanup(String dockerImageName) {
         setHook();
         registeredImages.add(dockerImageName);
     }
-    
+
     private void removeImage(String dockerImageName) {
         LOGGER.trace("Removing image tagged {}", dockerImageName);
         try {


### PR DESCRIPTION
Was casually browsing the codebase and fixed some things along the way:

1. Removed unused imports from `ImageFromDockerfile` class
2. Simplified conversions from `Collection<T>` to `T[]` avoiding intermediate conversion to `Stream` instances, and made sure that target arrays are initialized with the size of 0
3. Replaced charset lookups with one of the predefined constants 
4. Introduced idiomatic `Optional` usage
5. Replaced `Optional::get` call with explicit handling of empty `Optional`