### PR TITLE
Remove usage of deprecated IOUtils#closeQuietly

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -28,7 +28,6 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.utils.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.runner.Description;

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.google.common.base.Throwables;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.Nullable;
 import org.rnorth.ducttape.TimeoutException;
@@ -17,6 +16,8 @@ import org.testcontainers.dockerclient.auth.AuthDelegatingDockerClientConfig;
 import org.testcontainers.dockerclient.transport.okhttp.OkHttpDockerCmdExecFactory;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -183,7 +184,11 @@ public abstract class DockerClientProviderStrategy {
                 });
             });
         } catch (TimeoutException e) {
-            IOUtils.closeQuietly(client);
+            try {
+                client.close();
+            } catch (IOException ignored) {
+                // ignore
+            }
             throw e;
         }
     }

--- a/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/OkHttpDockerCmdExecFactory.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/transport/okhttp/OkHttpDockerCmdExecFactory.java
@@ -14,10 +14,10 @@ import okhttp3.ConnectionPool;
 import okhttp3.Dns;
 import okhttp3.HttpUrl;
 import okhttp3.OkHttpClient;
-import org.apache.commons.io.IOUtils;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
@@ -121,7 +121,11 @@ public class OkHttpDockerCmdExecFactory extends AbstractDockerCmdExecFactory {
                 WebTarget webResource = getBaseResource().path("/_ping");
 
                 // TODO contribute to docker-java, make it close the stream
-                IOUtils.closeQuietly(webResource.request().get());
+                try {
+                    webResource.request().get().close();
+                } catch (IOException ignored) {
+                    // ignore
+                }
 
                 return null;
             }

--- a/core/src/test/java/org/testcontainers/images/builder/dockerfile/statement/AbstractStatementTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/dockerfile/statement/AbstractStatementTest.java
@@ -7,7 +7,10 @@ import org.junit.Rule;
 import org.junit.rules.TestName;
 import org.rnorth.ducttape.Preconditions;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.fail;
@@ -27,8 +30,10 @@ public abstract class AbstractStatementTest {
 
             Preconditions.check("inputStream is null for path " + path, inputStream != null);
 
-            String content = IOUtils.toString(inputStream);
-            IOUtils.closeQuietly(inputStream);
+            String content = IOUtils.toString(inputStream, Charset.defaultCharset());
+            try {
+                inputStream.close();
+            } catch (final IOException ignored) { }
             expectedLines = StringUtils.chomp(content.replaceAll("\r\n", "\n").trim()).split("\n");
         } catch (Exception e) {
             fail("can't load fixture '" + testName.getMethodName() + "'\n" + ExceptionUtils.getFullStackTrace(e));


### PR DESCRIPTION
Remove usage of deprecated(for removal) `IOUtils#closeQuietly`.

Additionally, I'm not sure if `DockerClientProviderStrategy#ping` should be responsible for closing the externally-provided client. I think the responsibility for closing the client should be shifted to the caller.