### PR TITLE
Improve cohesion and encapsulation of DockerImageName

### DIFF
--- a/core/src/main/java/org/testcontainers/images/builder/dockerfile/traits/FromStatementTrait.java
+++ b/core/src/main/java/org/testcontainers/images/builder/dockerfile/traits/FromStatementTrait.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 public interface FromStatementTrait<SELF extends FromStatementTrait<SELF> & DockerfileBuilderTrait<SELF>> {
 
     default SELF from(String dockerImageName) {
-        new DockerImageName(dockerImageName).assertValid();
+        new DockerImageName(dockerImageName);
 
         return ((SELF) this).withStatement(new SingleArgumentStatement("FROM", dockerImageName));
     }

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -4,9 +4,11 @@ package org.testcontainers.utility;
 import com.google.common.net.HostAndPort;
 import lombok.EqualsAndHashCode;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 @EqualsAndHashCode(exclude = "rawName")
 public final class DockerImageName {
@@ -83,7 +85,7 @@ public final class DockerImageName {
     }
 
     private static Versioning parseVersioning(String tag) {
-        return tag.startsWith("sha256:") ? new Sha256Versioning(tag.replace("sha256:", "")) : new TagVersioning(tag);
+        return requireNonNull(tag).startsWith("sha256:") ? new Sha256Versioning(tag.replace("sha256:", "")) : new TagVersioning(tag);
     }
 
     private static Pattern getRepoNamePattern() {

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -3,6 +3,7 @@ package org.testcontainers.utility;
 
 import com.google.common.net.HostAndPort;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 import java.util.regex.Pattern;
 
@@ -71,7 +72,7 @@ public final class DockerImageName {
      *
      * @throws IllegalArgumentException if not valid
      */
-    public void assertValid() {
+    private void assertValid() {
         HostAndPort.fromString(registry);
         if (!REPO_NAME.matcher(repo).matches()) {
             throw new IllegalArgumentException(format("%s is not a valid Docker image name (in %s)", repo, rawName));

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -7,14 +7,12 @@ import lombok.EqualsAndHashCode;
 
 import java.util.regex.Pattern;
 
+import static java.lang.String.format;
+
 @EqualsAndHashCode(exclude = "rawName")
 public final class DockerImageName {
 
-    /* Regex patterns used for validation */
-    private static final String ALPHA_NUMERIC = "[a-z0-9]+";
-    private static final String SEPARATOR = "([\\.]{1}|_{1,2}|-+)";
-    private static final String REPO_NAME_PART = ALPHA_NUMERIC + "(" + SEPARATOR + ALPHA_NUMERIC + ")*";
-    private static final Pattern REPO_NAME = Pattern.compile(REPO_NAME_PART + "(/" + REPO_NAME_PART + ")*");
+    private static final Pattern REPO_NAME = getRepoNamePattern();
 
     private final String rawName;
     private final String registry;
@@ -124,6 +122,14 @@ public final class DockerImageName {
         return registry;
     }
 
+    private static Pattern getRepoNamePattern() {
+        String alphaNumeric = "[a-z0-9]+";
+        String separator = "([\\.]{1}|_{1,2}|-+)";
+        String repoNamePart = format("%s(%s%s)*", alphaNumeric, separator, alphaNumeric);
+
+        return Pattern.compile(format("%s(/%s)*", repoNamePart, repoNamePart));
+    }
+
     private interface Versioning {
         boolean isValid();
         String getSeparator();
@@ -155,7 +161,7 @@ public final class DockerImageName {
     }
 
     @Data
-    private class Sha256Versioning implements Versioning {
+    private static class Sha256Versioning implements Versioning {
         public static final String HASH_REGEX = "[0-9a-fA-F]{32,}";
         private final String hash;
 

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -63,14 +63,10 @@ public final class DockerImageName {
             remoteName = name.substring(slashIndex + 1);
         }
 
-        if (tag.startsWith("sha256:")) {
-            repo = remoteName;
-            versioning = new Sha256Versioning(tag.replace("sha256:", ""));
-        } else {
-            repo = remoteName;
-            versioning = new TagVersioning(tag);
-        }
+        repo = remoteName;
+        versioning = parseVersioning(tag);
     }
+
 
     /**
      * @return the unversioned (non 'tag') part of this name
@@ -92,11 +88,9 @@ public final class DockerImageName {
 
     @Override
     public String toString() {
-        if (versioning == null) {
-            return getUnversionedPart();
-        } else {
-            return getUnversionedPart() + versioning.getSeparator() + versioning.toString();
-        }
+        return versioning == null
+            ? getUnversionedPart()
+            : format("%s%s%s", getUnversionedPart(), versioning.getSeparator(), versioning.toString());
     }
 
     /**
@@ -120,6 +114,10 @@ public final class DockerImageName {
 
     public String getRegistry() {
         return registry;
+    }
+
+    private static Versioning parseVersioning(String tag) {
+        return tag.startsWith("sha256:") ? new Sha256Versioning(tag.replace("sha256:", "")) : new TagVersioning(tag);
     }
 
     private static Pattern getRepoNamePattern() {

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -7,7 +7,6 @@ import lombok.EqualsAndHashCode;
 import java.util.regex.Pattern;
 
 import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
 
 @EqualsAndHashCode(exclude = "rawName")
 public final class DockerImageName {
@@ -39,11 +38,14 @@ public final class DockerImageName {
 
         registry = registryWithRemote.getRegistry();
         repo = registryWithRemote.getRemoteName();
-        versioning = parseVersioning(tag);
+        versioning = Versioning.from(tag);
 
         assertValid();
     }
 
+    public String getRegistry() {
+        return registry;
+    }
 
     /**
      * @return the unversioned (non 'tag') part of this name
@@ -82,14 +84,6 @@ public final class DockerImageName {
         if (!versioning.isValid()) {
             throw new IllegalArgumentException(format("%s is not a valid image versioning identifier (in %s)", versioning, rawName));
         }
-    }
-
-    public String getRegistry() {
-        return registry;
-    }
-
-    private static Versioning parseVersioning(String tag) {
-        return requireNonNull(tag).startsWith("sha256:") ? new Sha256Versioning(tag.replace("sha256:", "")) : new TagVersioning(tag);
     }
 
     private static Pattern getRepoNamePattern() {

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -2,25 +2,22 @@ package org.testcontainers.utility;
 
 
 import com.google.common.net.HostAndPort;
-import lombok.EqualsAndHashCode;
+import lombok.Data;
 
 import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 
-@EqualsAndHashCode(exclude = "rawName")
+@Data
 public final class DockerImageName {
 
     private static final Pattern REPO_NAME = getRepoNamePattern();
 
-    private final String rawName;
     private final String registry;
     private final String repo;
     private final Versioning versioning;
 
     public DockerImageName(String name) {
-        this.rawName = name;
-
         RegistryWithRemote registryWithRemote = RegistryWithRemote.from(name);
         RepositoryWithVersioning repositoryWithVersioning = RepositoryWithVersioning.from(registryWithRemote.getRemoteName());
 
@@ -28,19 +25,17 @@ public final class DockerImageName {
         repo = repositoryWithVersioning.getRepository();
         versioning = repositoryWithVersioning.getVersioning();
 
-        assertValid();
+        assertValid(name);
     }
 
     public DockerImageName(String name, String tag) {
-        this.rawName = name;
-
         RegistryWithRemote registryWithRemote = RegistryWithRemote.from(name);
 
         registry = registryWithRemote.getRegistry();
         repo = registryWithRemote.getRemoteName();
         versioning = Versioning.from(tag);
 
-        assertValid();
+        assertValid(name);
     }
 
     public String getRegistry() {
@@ -73,7 +68,7 @@ public final class DockerImageName {
      *
      * @throws IllegalArgumentException if not valid
      */
-    private void assertValid() {
+    private void assertValid(String rawName) {
         HostAndPort.fromString(registry);
         if (!REPO_NAME.matcher(repo).matches()) {
             throw new IllegalArgumentException(format("%s is not a valid Docker image name (in %s)", repo, rawName));

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -4,7 +4,6 @@ package org.testcontainers.utility;
 import com.google.common.net.HostAndPort;
 import lombok.EqualsAndHashCode;
 
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import static java.lang.String.format;
@@ -29,15 +28,20 @@ public final class DockerImageName {
         registry = registryWithRemote.getRegistry();
         repo = repositoryWithVersioning.getRepository();
         versioning = repositoryWithVersioning.getVersioning();
+
+        assertValid();
     }
 
     public DockerImageName(String name, String tag) {
         this.rawName = name;
 
         RegistryWithRemote registryWithRemote = RegistryWithRemote.from(name);
+
         registry = registryWithRemote.getRegistry();
         repo = registryWithRemote.getRemoteName();
         versioning = parseVersioning(tag);
+
+        assertValid();
     }
 
 

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -3,7 +3,6 @@ package org.testcontainers.utility;
 
 import com.google.common.net.HostAndPort;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 
 import java.util.regex.Pattern;
 

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -72,11 +72,7 @@ public final class DockerImageName {
      * @return the unversioned (non 'tag') part of this name
      */
     public String getUnversionedPart() {
-        if (!"".equals(registry)) {
-            return registry + "/" + repo;
-        } else {
-            return repo;
-        }
+        return "".equals(registry) ? repo : registry + "/" + repo;
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/utility/RegistryWithRemote.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryWithRemote.java
@@ -1,0 +1,22 @@
+package org.testcontainers.utility;
+
+import lombok.Data;
+
+@Data
+class RegistryWithRemote {
+    private final String registry;
+    private final String remoteName;
+
+    static RegistryWithRemote from(String name) {
+        final int slashIndex = name.indexOf('/');
+
+        if (slashIndex == -1 ||
+            (!name.substring(0, slashIndex).contains(".") &&
+                !name.substring(0, slashIndex).contains(":") &&
+                !name.substring(0, slashIndex).equals("localhost"))) {
+            return new RegistryWithRemote("", name);
+        } else {
+            return new RegistryWithRemote(name.substring(0, slashIndex), name.substring(slashIndex + 1));
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/utility/RepositoryWithVersioning.java
+++ b/core/src/main/java/org/testcontainers/utility/RepositoryWithVersioning.java
@@ -1,0 +1,26 @@
+package org.testcontainers.utility;
+
+import lombok.Data;
+
+@Data
+class RepositoryWithVersioning {
+    private static final String SHA_256 = "@sha256:";
+    private static final String SEPARATOR = ":";
+
+    private final String repository;
+    private final Versioning versioning;
+
+    static RepositoryWithVersioning from(String remoteName) {
+        if (remoteName.contains(SHA_256)) {
+            return new RepositoryWithVersioning(
+                remoteName.split(SHA_256)[0],
+                new Sha256Versioning(remoteName.split(SHA_256)[1]));
+        } else if (remoteName.contains(SEPARATOR)) {
+            return new RepositoryWithVersioning(
+                remoteName.split(SEPARATOR)[0],
+                new TagVersioning(remoteName.split(SEPARATOR)[1]));
+        } else {
+            return new RepositoryWithVersioning(remoteName, new TagVersioning("latest"));
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/utility/Sha256Versioning.java
+++ b/core/src/main/java/org/testcontainers/utility/Sha256Versioning.java
@@ -1,0 +1,28 @@
+package org.testcontainers.utility;
+
+import lombok.Data;
+
+@Data
+class Sha256Versioning implements Versioning {
+    public static final String HASH_REGEX = "[0-9a-fA-F]{32,}";
+    private final String hash;
+
+    Sha256Versioning(String hash) {
+        this.hash = hash;
+    }
+
+    @Override
+    public boolean isValid() {
+        return hash.matches(HASH_REGEX);
+    }
+
+    @Override
+    public String getSeparator() {
+        return "@";
+    }
+
+    @Override
+    public String toString() {
+        return "sha256:" + hash;
+    }
+}

--- a/core/src/main/java/org/testcontainers/utility/TagVersioning.java
+++ b/core/src/main/java/org/testcontainers/utility/TagVersioning.java
@@ -1,0 +1,28 @@
+package org.testcontainers.utility;
+
+import lombok.Data;
+
+@Data
+class TagVersioning implements Versioning {
+    public static final String TAG_REGEX = "[\\w][\\w\\.\\-]{0,127}";
+    private final String tag;
+
+    TagVersioning(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public boolean isValid() {
+        return tag.matches(TAG_REGEX);
+    }
+
+    @Override
+    public String getSeparator() {
+        return ":";
+    }
+
+    @Override
+    public String toString() {
+        return tag;
+    }
+}

--- a/core/src/main/java/org/testcontainers/utility/Versioning.java
+++ b/core/src/main/java/org/testcontainers/utility/Versioning.java
@@ -1,6 +1,12 @@
 package org.testcontainers.utility;
 
+import static java.util.Objects.requireNonNull;
+
 interface Versioning {
     boolean isValid();
     String getSeparator();
+
+    static Versioning from(String tag) {
+        return requireNonNull(tag).startsWith("sha256:") ? new Sha256Versioning(tag.replace("sha256:", "")) : new TagVersioning(tag);
+    }
 }

--- a/core/src/main/java/org/testcontainers/utility/Versioning.java
+++ b/core/src/main/java/org/testcontainers/utility/Versioning.java
@@ -1,0 +1,6 @@
+package org.testcontainers.utility;
+
+interface Versioning {
+    boolean isValid();
+    String getSeparator();
+}

--- a/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
@@ -35,7 +35,7 @@ public class DockerImageNameTest {
 
         @Test
         public void testValidNameAccepted() {
-            new DockerImageName(imageName).assertValid();
+            new DockerImageName(imageName);
         }
     }
 
@@ -56,7 +56,7 @@ public class DockerImageNameTest {
 
         @Test(expected = IllegalArgumentException.class)
         public void testInvalidNameRejected() {
-            new DockerImageName(imageName).assertValid();
+            new DockerImageName(imageName);
         }
     }
 


### PR DESCRIPTION
`DockerImageName` class contained a lot of duplicated parsing logic. 

1. Extracted smaller methods, objects, and reorganized logic so that it stays with related objects.
2. Moved validation to the construction phase.
3. Improved encapsulation by restricting access to as many classes, fields, methods as possible

The second constructor could be removed if this is not supposed to be a public API.