### PR TITLE
Expose containers defaults

### DIFF
--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -26,16 +26,19 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
 
     public static final String IMAGE = "cassandra";
     public static final Integer CQL_PORT = 9042;
-    private static final String CONTAINER_CONFIG_LOCATION = "/etc/cassandra";
-    private static final String USERNAME = "cassandra";
-    private static final String PASSWORD = "cassandra";
+    public static final String CONTAINER_CONFIG_LOCATION = "/etc/cassandra";
+
+    public static final String DEFAULT_USERNAME = "cassandra";
+    public static final String DEFAULT_PASSWORD = "cassandra";
+    public static final String DEFAULT_TAG = "3.11.2";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE + ":" + DEFAULT_TAG;
 
     private String configLocation;
     private String initScriptPath;
     private boolean enableJmxReporting;
 
     public CassandraContainer() {
-        this(IMAGE + ":3.11.2");
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public CassandraContainer(String dockerImageName) {
@@ -135,7 +138,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      * user management should be modified
      */
     public String getUsername() {
-        return USERNAME;
+        return DEFAULT_USERNAME;
     }
 
     /**
@@ -147,7 +150,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      * user management should be modified
      */
     public String getPassword() {
-        return PASSWORD;
+        return DEFAULT_PASSWORD;
     }
 
     /**

--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
@@ -8,20 +8,21 @@ public class ClickHouseContainer extends JdbcDatabaseContainer {
     public static final String NAME = "clickhouse";
     public static final String IMAGE = "yandex/clickhouse-server";
     public static final String DEFAULT_TAG = "18.10.3";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE + ":" + DEFAULT_TAG;
 
     public static final Integer HTTP_PORT = 8123;
     public static final Integer NATIVE_PORT = 9000;
 
-    private static final String DRIVER_CLASS_NAME = "ru.yandex.clickhouse.ClickHouseDriver";
-    private static final String JDBC_URL_PREFIX = "jdbc:" + NAME + "://";
-    private static final String TEST_QUERY = "SELECT 1";
+    public static final String DRIVER_CLASS_NAME = "ru.yandex.clickhouse.ClickHouseDriver";
+    public static final String JDBC_URL_PREFIX = "jdbc:" + NAME + "://";
+    public static final String TEST_QUERY = "SELECT 1";
 
-    private String databaseName = "default";
-    private String username = "default";
-    private String password = "";
+    public static final String DEFAULT_DATABASE_NAME = "default";
+    public static final String DEFAULT_USERNAME = "default";
+    public static final String DEFAULT_PASSWORD = "";
 
     public ClickHouseContainer() {
-        super(IMAGE + ":" + DEFAULT_TAG);
+        super(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public ClickHouseContainer(String dockerImageName) {
@@ -51,17 +52,17 @@ public class ClickHouseContainer extends JdbcDatabaseContainer {
 
     @Override
     public String getJdbcUrl() {
-        return JDBC_URL_PREFIX + getContainerIpAddress() + ":" + getMappedPort(HTTP_PORT) + "/" + databaseName;
+        return JDBC_URL_PREFIX + getContainerIpAddress() + ":" + getMappedPort(HTTP_PORT) + "/" + DEFAULT_DATABASE_NAME;
     }
 
     @Override
     public String getUsername() {
-        return username;
+        return DEFAULT_USERNAME;
     }
 
     @Override
     public String getPassword() {
-        return password;
+        return DEFAULT_PASSWORD;
     }
 
     @Override

--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -8,18 +8,20 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
     public static final String NAME = "cockroach";
     public static final String IMAGE = "cockroachdb/cockroach";
     public static final String IMAGE_TAG = "v19.1.1";
-    private static final String JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver";
-    private static final String JDBC_URL_PREFIX = "jdbc:postgresql";
-    private static final String TEST_QUERY_STRING = "SELECT 1";
-    private static final int REST_API_PORT = 8080;
-    private static final int DB_PORT = 26257;
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE + ":" + IMAGE_TAG;
 
-    private String databaseName = "postgres";
-    private String username = "root";
-    private String password = "";
+    public static final String JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver";
+    public static final String JDBC_URL_PREFIX = "jdbc:postgresql";
+    public static final String TEST_QUERY_STRING = "SELECT 1";
+    public static final int REST_API_PORT = 8080;
+    public static final int DB_PORT = 26257;
+
+    public static final String DEFAULT_DATABASE_NAME = "postgres";
+    public static final String DEFAULT_USERNAME = "root";
+    public static final String DEFAULT_PASSWORD = "";
 
     public CockroachContainer() {
-        this(IMAGE + ":" + IMAGE_TAG);
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public CockroachContainer(final String dockerImageName) {
@@ -43,17 +45,17 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
 
     @Override
     public String getJdbcUrl() {
-        return JDBC_URL_PREFIX + "://" + getContainerIpAddress() + ":" + getMappedPort(DB_PORT) + "/" + databaseName;
+        return JDBC_URL_PREFIX + "://" + getContainerIpAddress() + ":" + getMappedPort(DB_PORT) + "/" + DEFAULT_DATABASE_NAME;
     }
 
     @Override
     public String getUsername() {
-        return username;
+        return DEFAULT_USERNAME;
     }
 
     @Override
     public String getPassword() {
-        return password;
+        return DEFAULT_PASSWORD;
     }
 
     @Override

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -63,19 +63,26 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     public static final String VERSION = "5.5.1";
     public static final String DOCKER_IMAGE_NAME = "couchbase/server:";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = DOCKER_IMAGE_NAME + VERSION;
+
     public static final ObjectMapper MAPPER = new ObjectMapper();
     public static final String STATIC_CONFIG = "/opt/couchbase/etc/couchbase/static_config";
     public static final String CAPI_CONFIG = "/opt/couchbase/etc/couchdb/default.d/capi.ini";
 
+    public static final String DEFAULT_MEMORY_QUOTA = "300";
+    public static final String DEFAULT_INDEX_MEMORY_QUOTA = "300";
+    public static final String DEFAULT_CLUSTER_USERNAME = "Administrator";
+    public static final String DEFAULT_CLUSTER_PASSWORD = "password";
+
     private static final int REQUIRED_DEFAULT_PASSWORD_LENGTH = 6;
 
-    private String memoryQuota = "300";
+    private String memoryQuota = DEFAULT_MEMORY_QUOTA;
 
-    private String indexMemoryQuota = "300";
+    private String indexMemoryQuota = DEFAULT_INDEX_MEMORY_QUOTA;
 
-    private String clusterUsername = "Administrator";
+    private String clusterUsername = DEFAULT_CLUSTER_USERNAME;
 
-    private String clusterPassword = "password";
+    private String clusterPassword = DEFAULT_CLUSTER_PASSWORD;
 
     private boolean keyValue = true;
 
@@ -104,7 +111,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     private SocatContainer proxy;
 
     public CouchbaseContainer() {
-        this(DOCKER_IMAGE_NAME + VERSION);
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public CouchbaseContainer(String containerName) {

--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -1,34 +1,31 @@
 package org.testcontainers.containers;
 
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import org.testcontainers.DockerClientFactory;
-import org.testcontainers.containers.output.OutputFrame;
-import org.testcontainers.containers.output.WaitingConsumer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.LicenseAcceptance;
-import org.testcontainers.utility.LogUtils;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 
 public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
 
     public static final String NAME = "db2";
     public static final String DEFAULT_DB2_IMAGE_NAME = "ibmcom/db2";
     public static final String DEFAULT_TAG = "11.5.0.0a";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = DEFAULT_DB2_IMAGE_NAME + ":" + DEFAULT_TAG;
     public static final int DB2_PORT = 50000;
 
-    private String databaseName = "test";
-    private String username = "db2inst1";
-    private String password = "foobar1234";
+    public static final String DEFAULT_DATABASE_NAME = "test";
+    public static final String DEFAULT_USERNAME = "db2inst1";
+    public static final String DEFAULT_PASSWORD = "foobar1234";
+
+    private String databaseName = DEFAULT_DATABASE_NAME;
+    private String username = DEFAULT_USERNAME;
+    private String password = DEFAULT_PASSWORD;
 
     public Db2Container() {
-        this(DEFAULT_DB2_IMAGE_NAME + ":" + DEFAULT_TAG);
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public Db2Container(String imageName) {

--- a/modules/dynalite/src/main/java/org/testcontainers/dynamodb/DynaliteContainer.java
+++ b/modules/dynalite/src/main/java/org/testcontainers/dynamodb/DynaliteContainer.java
@@ -13,8 +13,8 @@ import org.testcontainers.containers.GenericContainer;
  */
 public class DynaliteContainer extends GenericContainer<DynaliteContainer> {
 
-    private static final String IMAGE_NAME = "quay.io/testcontainers/dynalite:v1.2.1-1";
-    private static final int MAPPED_PORT = 4567;
+    public static final String IMAGE_NAME = "quay.io/testcontainers/dynalite:v1.2.1-1";
+    public static final int MAPPED_PORT = 4567;
 
     public DynaliteContainer() {
         this(IMAGE_NAME);

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -19,25 +19,27 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     /**
      * Elasticsearch Default HTTP port
      */
-    private static final int ELASTICSEARCH_DEFAULT_PORT = 9200;
+    public static final int ELASTICSEARCH_DEFAULT_PORT = 9200;
 
     /**
      * Elasticsearch Default Transport port
      */
-    private static final int ELASTICSEARCH_DEFAULT_TCP_PORT = 9300;
+    public static final int ELASTICSEARCH_DEFAULT_TCP_PORT = 9300;
 
     /**
      * Elasticsearch Docker base URL
      */
-    private static final String ELASTICSEARCH_DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
+    public static final String ELASTICSEARCH_DEFAULT_IMAGE = "docker.elastic.co/elasticsearch/elasticsearch";
 
     /**
      * Elasticsearch Default version
      */
-    protected static final String ELASTICSEARCH_DEFAULT_VERSION = "6.4.1";
+    public static final String ELASTICSEARCH_DEFAULT_VERSION = "6.4.1";
+
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = ELASTICSEARCH_DEFAULT_IMAGE + ":" + ELASTICSEARCH_DEFAULT_VERSION;
 
     public ElasticsearchContainer() {
-        this(ELASTICSEARCH_DEFAULT_IMAGE + ":" + ELASTICSEARCH_DEFAULT_VERSION);
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     /**

--- a/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
+++ b/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
@@ -16,15 +16,22 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
     public static final String VERSION = "1.4.3";
     public static final Integer INFLUXDB_PORT = 8086;
 
-    private static final String IMAGE_NAME = "influxdb";
+    public static final String IMAGE_NAME = "influxdb";
+
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE_NAME + ":" + VERSION;
+
+    public static final String DEFAULT_ADMIN = "admin";
+    public static final String DEFALT_ADMIN_PASSWORD = "admin";
+    public static final String DEFAULT_USERNAME = "any";
+    public static final String DEFAULT_PASSWORD = "any";
 
     private boolean authEnabled = true;
-    private String admin = "admin";
-    private String adminPassword = "password";
+    private String admin = DEFAULT_ADMIN;
+    private String adminPassword = DEFALT_ADMIN_PASSWORD;
 
     private String database;
-    private String username = "any";
-    private String password = "any";
+    private String username = DEFAULT_USERNAME;
+    private String password = DEFAULT_PASSWORD;
 
 
     public InfluxDBContainer() {
@@ -32,7 +39,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
     }
 
     public InfluxDBContainer(final String version) {
-        super(IMAGE_NAME + ":" + version);
+        super(DEFAULT_DOCKER_IMAGE_NAME);
         waitStrategy = new WaitAllStrategy()
             .withStrategy(Wait.forHttp("/ping").withBasicCredentials(username, password).forStatusCode(204))
             .withStrategy(Wait.forListeningPort());

--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -19,6 +19,8 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
     public static final int ZOOKEEPER_PORT = 2181;
 
+    public static final String DEFAULT_TAG = "5.2.1";
+
     private static final int PORT_NOT_ASSIGNED = -1;
 
     protected String externalZookeeperConnect = null;
@@ -26,7 +28,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
     private int port = PORT_NOT_ASSIGNED;
 
     public KafkaContainer() {
-        this("5.2.1");
+        this(DEFAULT_TAG);
     }
 
     public KafkaContainer(String confluentPlatformVersion) {

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -10,16 +10,23 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
     public static final String NAME = "mariadb";
     public static final String IMAGE = "mariadb";
     public static final String DEFAULT_TAG = "10.3.6";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE + ":" + DEFAULT_TAG;
 
-    private static final Integer MARIADB_PORT = 3306;
-    private String databaseName = "test";
-    private String username = "test";
-    private String password = "test";
-    private static final String MARIADB_ROOT_USER = "root";
     private static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "TC_MY_CNF";
+    public static final Integer MARIADB_PORT = 3306;
+
+    public static final String DEFAULT_DATABASE_NAME = "test";
+    public static final String DEFAULT_USERNAME = "test";
+    public static final String DEFAULT_PASSWORD = "test";
+
+    private String databaseName = DEFAULT_DATABASE_NAME;
+    private String username = DEFAULT_USERNAME;
+    private String password = DEFAULT_PASSWORD;
+
+    private static final String MARIADB_ROOT_USER = "root";
 
     public MariaDBContainer() {
-        super(IMAGE + ":" + DEFAULT_TAG);
+        super(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public MariaDBContainer(String dockerImageName) {
@@ -83,7 +90,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
-    
+
     @Override
     public SELF withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -13,10 +13,15 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     public static final String NAME = "sqlserver";
     public static final String IMAGE = "mcr.microsoft.com/mssql/server";
     public static final String DEFAULT_TAG = "2017-CU12";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE + ":" + DEFAULT_TAG;
 
     public static final Integer MS_SQL_SERVER_PORT = 1433;
-    private String username = "SA";
-    private String password = "A_Str0ng_Required_Password";
+
+    public static final String DEFAULT_USERNAME = "SA";
+    public static final String DEFAULT_PASSWORD = "A_Str0ng_Required_Password";
+
+    private String username = DEFAULT_USERNAME;
+    private String password = DEFAULT_PASSWORD;
 
     private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
     private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 240;
@@ -29,7 +34,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     };
 
     public MSSQLServerContainer() {
-        this(IMAGE + ":" + DEFAULT_TAG);
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public MSSQLServerContainer(final String dockerImageName) {

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -13,16 +13,23 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     public static final String NAME = "mysql";
     public static final String IMAGE = "mysql";
     public static final String DEFAULT_TAG = "5.7.22";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE + ":" + DEFAULT_TAG;
 
     private static final String MY_CNF_CONFIG_OVERRIDE_PARAM_NAME = "TC_MY_CNF";
     public static final Integer MYSQL_PORT = 3306;
-    private String databaseName = "test";
-    private String username = "test";
-    private String password = "test";
+
+    public static final String DEFAULT_DATABASE_NAME = "test";
+    public static final String DEFAULT_USERNAME = "test";
+    public static final String DEFAULT_PASSWORD = "test";
+
+    private String databaseName = DEFAULT_DATABASE_NAME;
+    private String username = DEFAULT_USERNAME;
+    private String password = DEFAULT_PASSWORD;
+
     private static final String MYSQL_ROOT_USER = "root";
 
     public MySQLContainer() {
-        super(IMAGE + ":" + DEFAULT_TAG);
+        super(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public MySQLContainer(String dockerImageName) {

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -25,36 +25,36 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
     /**
      * The image defaults to the official Neo4j image: <a href="https://hub.docker.com/_/neo4j/">Neo4j</a>.
      */
-    private static final String DEFAULT_IMAGE_NAME = "neo4j";
+    public static final String DEFAULT_IMAGE_NAME = "neo4j";
 
     /**
      * The default tag (version) to use.
      */
-    private static final String DEFAULT_TAG = "3.5.0";
+    public static final String DEFAULT_TAG = "3.5.0";
 
-    private static final String DOCKER_IMAGE_NAME = DEFAULT_IMAGE_NAME + ":" + DEFAULT_TAG;
+    public static final String DOCKER_IMAGE_NAME = DEFAULT_IMAGE_NAME + ":" + DEFAULT_TAG;
 
     /**
      * Default port for the binary Bolt protocol.
      */
-    private static final int DEFAULT_BOLT_PORT = 7687;
+    public static final int DEFAULT_BOLT_PORT = 7687;
 
     /**
      * The port of the transactional HTTPS endpoint: <a href="https://neo4j.com/docs/rest-docs/current/">Neo4j REST API</a>.
      */
-    private static final int DEFAULT_HTTPS_PORT = 7473;
+    public static final int DEFAULT_HTTPS_PORT = 7473;
 
     /**
      * The port of the transactional HTTP endpoint: <a href="https://neo4j.com/docs/rest-docs/current/">Neo4j REST API</a>.
      */
-    private static final int DEFAULT_HTTP_PORT = 7474;
+    public static final int DEFAULT_HTTP_PORT = 7474;
 
     /**
      * The official image requires a change of password by default from "neo4j" to something else. This defaults to "password".
      */
-    private static final String DEFAULT_ADMIN_PASSWORD = "password";
+    public static final String DEFAULT_ADMIN_PASSWORD = "password";
 
-    private static final String AUTH_FORMAT = "neo4j/%s";
+    public static final String AUTH_FORMAT = "neo4j/%s";
 
     private String adminPassword = DEFAULT_ADMIN_PASSWORD;
 

--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -13,10 +13,13 @@ import java.util.Set;
  */
 public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer {
 
-    private static final int NGINX_DEFAULT_PORT = 80;
+    public static final int NGINX_DEFAULT_PORT = 80;
+    public static final String DEFAULT_IMAGE = "nginx";
+    public static final String DEFAULT_TAG = "1.9.4";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = DEFAULT_IMAGE + ":" + DEFAULT_TAG;
 
     public NginxContainer() {
-        super("nginx:1.9.4");
+        super(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     @NotNull

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -17,8 +17,11 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
     private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
     private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 120;
 
-    private String username = "system";
-    private String password = "oracle";
+    public static final String DEFAULT_USERNAME = "system";
+    public static final String DEFAULT_PASSWORD = "oracle";
+
+    private String username = DEFAULT_USERNAME;
+    private String password = DEFAULT_PASSWORD;
 
     private static String resolveImageName() {
         String image = TestcontainersConfiguration.getInstance()

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -16,16 +16,22 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     public static final String NAME = "postgresql";
     public static final String IMAGE = "postgres";
     public static final String DEFAULT_TAG = "9.6.12";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = IMAGE + ":" + DEFAULT_TAG;
 
     public static final Integer POSTGRESQL_PORT = 5432;
-    private String databaseName = "test";
-    private String username = "test";
-    private String password = "test";
+
+    public static final String DEFAULT_DATABASE_NAME = "test";
+    public static final String DEFAULT_USERNAME = "test";
+    public static final String DEFAULT_PASSWORD = "test";
+
+    private String databaseName = DEFAULT_DATABASE_NAME;
+    private String username = DEFAULT_USERNAME;
+    private String password = DEFAULT_PASSWORD;
 
     private static final String FSYNC_OFF_OPTION = "fsync=off";
 
     public PostgreSQLContainer() {
-        this(IMAGE + ":" + DEFAULT_TAG);
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public PostgreSQLContainer(final String dockerImageName) {

--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -12,10 +12,10 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     public static final int BROKER_HTTP_PORT = 8080;
     public static final String METRICS_ENDPOINT = "/metrics";
 
-    private static final String PULSAR_VERSION = "2.2.0";
+    public static final String DEFAULT_PULSAR_VERSION = "2.2.0";
 
     public PulsarContainer() {
-        this(PULSAR_VERSION);
+        this(DEFAULT_PULSAR_VERSION);
     }
 
     public PulsarContainer(String pulsarVersion) {

--- a/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
+++ b/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
@@ -27,23 +27,27 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
     /**
      * The image defaults to the official RabbitmQ image: <a href="https://hub.docker.com/_/rabbitmq/">RabbitMQ</a>.
      */
-    private static final String DEFAULT_IMAGE_NAME = "rabbitmq";
-    private static final String DEFAULT_TAG = "3.7-management-alpine";
+    public static final String DEFAULT_IMAGE_NAME = "rabbitmq";
+    public static final String DEFAULT_TAG = "3.7-management-alpine";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = DEFAULT_IMAGE_NAME + ":" + DEFAULT_TAG;
 
-    private static final int DEFAULT_AMQP_PORT = 5672;
-    private static final int DEFAULT_AMQPS_PORT = 5671;
-    private static final int DEFAULT_HTTPS_PORT = 15671;
-    private static final int DEFAULT_HTTP_PORT = 15672;
+    public static final int DEFAULT_AMQP_PORT = 5672;
+    public static final int DEFAULT_AMQPS_PORT = 5671;
+    public static final int DEFAULT_HTTPS_PORT = 15671;
+    public static final int DEFAULT_HTTP_PORT = 15672;
 
-    private String adminPassword = "guest";
-    private String adminUsername = "guest";
+    public static final String DEFAULT_ADMIN_PASSWORD = "guest";
+    public static final String DEFAULT_ADMIN_USERNAME = "guest";
+
+    private String adminPassword = DEFAULT_ADMIN_PASSWORD;
+    private String adminUsername = DEFAULT_ADMIN_USERNAME;
     private final List<List<String>> values = new ArrayList<>();
 
     /**
      * Creates a Testcontainer using the official RabbitMQ docker image.
      */
     public RabbitMQContainer() {
-        this(DEFAULT_IMAGE_NAME + ":" + DEFAULT_TAG);
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     /**

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -44,12 +44,12 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  */
 public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SELF>> extends GenericContainer<SELF> implements VncService, LinkableContainer, TestLifecycleAware {
 
-    private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:%s";
-    private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:%s";
+    public static final String CHROME_IMAGE = "selenium/standalone-chrome-debug";
+    public static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug";
 
-    private static final String DEFAULT_PASSWORD = "secret";
-    private static final int SELENIUM_PORT = 4444;
-    private static final int VNC_PORT = 5900;
+    public static final String DEFAULT_PASSWORD = "secret";
+    public static final int SELENIUM_PORT = 4444;
+    public static final int VNC_PORT = 5900;
 
     private static final String NO_PROXY_KEY = "no_proxy";
 
@@ -183,9 +183,9 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         String browserName = capabilities.getBrowserName();
         switch (browserName) {
             case BrowserType.CHROME:
-                return String.format(CHROME_IMAGE, seleniumVersion);
+                return CHROME_IMAGE + ":" + seleniumVersion;
             case BrowserType.FIREFOX:
-                return String.format(FIREFOX_IMAGE, seleniumVersion);
+                return FIREFOX_IMAGE + ":" + seleniumVersion;
             default:
                 throw new UnsupportedOperationException("Browser name must be 'chrome' or 'firefox'; provided '" + browserName + "' is not supported");
         }

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -20,7 +20,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
 
-    private static final String IMAGE_NAME = "shopify/toxiproxy:2.1.0";
+    public static final String IMAGE_NAME = "shopify/toxiproxy:2.1.0";
     private static final int TOXIPROXY_CONTROL_PORT = 8474;
     private static final int FIRST_PROXIED_PORT = 8666;
     private static final int LAST_PROXIED_PORT = 8666 + 31;

--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -22,14 +22,18 @@ import static com.github.dockerjava.api.model.Capability.IPC_LOCK;
  */
 public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericContainer<SELF> {
 
-    private static final int VAULT_PORT = 8200;
+    public static final String DEFAULT_IMAGE = "vault";
+    public static final String DEFAULT_TAG = "1.1.3";
+    public static final String DEFAULT_DOCKER_IMAGE_NAME = DEFAULT_IMAGE + ":" + DEFAULT_TAG;
+
+    public static final int VAULT_PORT = 8200;
 
     private Map<String, List<String>> secretsMap = new HashMap<>();
 
     private int port = VAULT_PORT;
 
     public VaultContainer() {
-        this("vault:1.1.3");
+        this(DEFAULT_DOCKER_IMAGE_NAME);
     }
 
     public VaultContainer(String dockerImageName) {


### PR DESCRIPTION
In this pull request, I made almost all containers default values ​​public. The main reason for this change is to reuse these defaults in the testcontainers-scala. At the current moment, many defaults are just copy-pasted in the testcontainers-scala.

There is nothing secret in the defaults. And sometimes they could be useful when you are creating custom containers on top of already created containers. In this case, reusing default values ​​could be desirable.

During implementation, I faced a lot of naming inconsistencies. I left them mostly unchanged - this is not the purpose of this pull request.