### PR TITLE
added read timeout to http wait strategy

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -118,7 +118,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
      */
     public HttpWaitStrategy withReadTimeout(Duration timeout) {
         if (timeout.toMillis() < 1) {
-            throw new RuntimeException("you cannot specify a value smaller than 1 ms");
+            throw new IllegalArgumentException("you cannot specify a value smaller than 1 ms");
         }
         this.readTimeout = timeout;
         return this;

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -13,7 +13,6 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -118,6 +117,9 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
      * @return this
      */
     public HttpWaitStrategy withReadTimeout(Duration timeout) {
+        if (timeout.toMillis() < 1) {
+            throw new RuntimeException("you cannot specify a value smaller than 1 ms");
+        }
         this.readTimeout = timeout;
         return this;
     }
@@ -157,7 +159,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
                 getRateLimiter().doWhenReady(() -> {
                     try {
                         final HttpURLConnection connection = (HttpURLConnection) new URL(uri).openConnection();
-                        connection.setReadTimeout(Math.toIntExact(readTimeout.get(ChronoUnit.MILLIS)));
+                        connection.setReadTimeout(Math.toIntExact(readTimeout.toMillis()));
 
                         // authenticate
                         if (!Strings.isNullOrEmpty(username)) {

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -2,7 +2,6 @@ package org.testcontainers.containers.wait.strategy;
 
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.rnorth.ducttape.TimeoutException;
 import org.testcontainers.containers.ContainerLaunchException;
@@ -14,6 +13,7 @@ import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -41,6 +41,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
     private Predicate<String> responsePredicate;
     private Predicate<Integer> statusCodePredicate = null;
     private Optional<Integer> livenessPort = Optional.empty();
+    private int readTimeout = 1000;
 
     /**
      * Waits for the given status code.
@@ -109,6 +110,17 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
     }
 
     /**
+     * Set the HTTP connections read timeout.
+     *
+     * @param timeout the timeout in millis
+     * @return this
+     */
+    public HttpWaitStrategy withReadTimeout(int timeout) {
+        this.readTimeout = timeout;
+        return this;
+    }
+
+    /**
      * Waits for the response to pass the given predicate
      * @param responsePredicate The predicate to test the response against
      * @return this
@@ -143,6 +155,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
                 getRateLimiter().doWhenReady(() -> {
                     try {
                         final HttpURLConnection connection = (HttpURLConnection) new URL(uri).openConnection();
+                        connection.setReadTimeout(readTimeout);
 
                         // authenticate
                         if (!Strings.isNullOrEmpty(username)) {

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -12,6 +12,8 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URL;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -41,7 +43,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
     private Predicate<String> responsePredicate;
     private Predicate<Integer> statusCodePredicate = null;
     private Optional<Integer> livenessPort = Optional.empty();
-    private int readTimeout = 1000;
+    private Duration readTimeout = Duration.ofSeconds(1);
 
     /**
      * Waits for the given status code.
@@ -115,7 +117,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
      * @param timeout the timeout in millis
      * @return this
      */
-    public HttpWaitStrategy withReadTimeout(int timeout) {
+    public HttpWaitStrategy withReadTimeout(Duration timeout) {
         this.readTimeout = timeout;
         return this;
     }
@@ -155,7 +157,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
                 getRateLimiter().doWhenReady(() -> {
                     try {
                         final HttpURLConnection connection = (HttpURLConnection) new URL(uri).openConnection();
-                        connection.setReadTimeout(readTimeout);
+                        connection.setReadTimeout(Math.toIntExact(readTimeout.get(ChronoUnit.MILLIS)));
 
                         // authenticate
                         if (!Strings.isNullOrEmpty(username)) {

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -114,7 +114,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
     /**
      * Set the HTTP connections read timeout.
      *
-     * @param timeout the timeout in millis
+     * @param timeout the timeout (minimum 1 millisecond)
      * @return this
      */
     public HttpWaitStrategy withReadTimeout(Duration timeout) {

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.rnorth.ducttape.RetryCountExceededException;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 
+import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
@@ -135,7 +136,7 @@ public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrat
     public void testWaitUntilReadyWithTimoutCausedByReadTimeout() {
         waitUntilReadyAndTimeout(
             startContainerWithCommand(createShellCommand("0 Connection Refused", GOOD_RESPONSE_BODY, 9090),
-                createHttpWaitStrategy(ready).forPort(9090).withReadTimeout(1),
+                createHttpWaitStrategy(ready).forPort(9090).withReadTimeout(Duration.ofMillis(1)),
                 9090
             ));
     }

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
@@ -131,6 +131,15 @@ public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrat
         ));
     }
 
+    @Test
+    public void testWaitUntilReadyWithTimoutCausedByReadTimeout() {
+        waitUntilReadyAndTimeout(
+            startContainerWithCommand(createShellCommand("0 Connection Refused", GOOD_RESPONSE_BODY, 9090),
+                createHttpWaitStrategy(ready).forPort(9090).withReadTimeout(1),
+                9090
+            ));
+    }
+
     /**
      * @param ready the AtomicBoolean on which to indicate success
      * @return the WaitStrategy under test
@@ -143,6 +152,7 @@ public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrat
 
     /**
      * Create a HttpWaitStrategy instance with a waitUntilReady implementation
+     *
      * @param ready Indicates that the WaitStrategy has completed waiting successfully.
      * @return the HttpWaitStrategy instance
      */
@@ -163,9 +173,9 @@ public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrat
 
     private String createShellCommand(String header, String responseBody, int port) {
         int length = responseBody.getBytes().length;
-        return "while true; do { echo -e \"HTTP/1.1 "+header+NEWLINE+
-                "Content-Type: text/html"+NEWLINE+
-                "Content-Length: "+length +NEWLINE+ "\";"
-                +" echo \""+responseBody+"\";} | nc -lp " + port + "; done";
+        return "while true; do { echo -e \"HTTP/1.1 " + header + NEWLINE +
+            "Content-Type: text/html" + NEWLINE +
+            "Content-Length: " + length + NEWLINE + "\";"
+            + " echo \"" + responseBody + "\";} | nc -lp " + port + "; done";
     }
 }


### PR DESCRIPTION
This commit adds the possibility to add a read timeout to the HTTP call
for the HTTP wait strategy.
This is necessary, because with the default Docker settings for Mac
can lead to a blocking call to `HttpURLConnection.connect()`. The follow
up issue is, that the container will never get healthy and due to
automated integration tests the tests are not able to run.
The main cause of the problem is the lazy connection establishment
during setting up the container. So the time between starting the
container and starting the wait strategy checks.

The read timeout lets the HTTP call fail, so the `retryUntilSuccess()`
is able to send another HTTP call in order to reestablish the connection
and not block the whole thread.