### PR TITLE
Improve couchbase container startup resilience

### DIFF
--- a/modules/couchbase/src/test/resources/logback-test.xml
+++ b/modules/couchbase/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
 


### PR DESCRIPTION
Wait before CouchbaseContainer setup is run to reduce risk of apparent partial configuration/race conditions, and increase general wait strategy timeout.

Also add trace level logging, used in diagnosis and possibly useful in
future.

Possible fix for #1453.

Currently running tests repeatedly to determine whether this has truly gone away.