### PR TITLE
Lazily create/set Network in KafkaContainer

### DIFF
--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -3,9 +3,7 @@ package org.testcontainers.containers;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.core.command.ExecStartResultCallback;
-import lombok.NonNull;
 import lombok.SneakyThrows;
-import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.util.concurrent.TimeUnit;
@@ -26,7 +24,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
     private int port = PORT_NOT_ASSIGNED;
 
-    private boolean implicitNetwork = true;
+    private boolean useImplicitNetwork = true;
 
     public KafkaContainer() {
         this("5.2.1");
@@ -35,9 +33,6 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
     public KafkaContainer(String confluentPlatformVersion) {
         super(TestcontainersConfiguration.getInstance().getKafkaImage() + ":" + confluentPlatformVersion);
 
-        // TODO Only for backward compatibility
-        withNetwork(Network.newNetwork());
-        withNetworkAliases("kafka-" + Base58.randomString(6));
         withExposedPorts(KAFKA_PORT);
 
         // Use two listeners with different names, it will force Kafka to communicate with itself via internal
@@ -55,14 +50,13 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
     @Override
     public KafkaContainer withNetwork(Network network) {
-        implicitNetwork = false;
+        useImplicitNetwork = false;
         return super.withNetwork(network);
     }
 
     @Override
-    @NonNull
     public Network getNetwork() {
-        if (implicitNetwork) {
+        if (useImplicitNetwork) {
             // TODO Only for backward compatibility, to be removed soon
             logger().warn(
                 "Deprecation warning! " +

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -31,16 +31,20 @@ public class KafkaContainerTest {
         }
     }
 
+    /**
+     * @deprecated the {@link Network} should be set explicitly with {@link KafkaContainer#withNetwork(Network)}.
+     */
     @Test
+    @Deprecated
     public void testExternalZookeeperWithKafkaNetwork() throws Exception {
         try (
-                KafkaContainer kafka = new KafkaContainer()
-                        .withExternalZookeeper("zookeeper:2181");
+            KafkaContainer kafka = new KafkaContainer()
+                .withExternalZookeeper("zookeeper:2181");
 
-                GenericContainer zookeeper = new GenericContainer("confluentinc/cp-zookeeper:4.0.0")
-                        .withNetwork(kafka.getNetwork())
-                        .withNetworkAliases("zookeeper")
-                        .withEnv("ZOOKEEPER_CLIENT_PORT", "2181");
+            GenericContainer zookeeper = new GenericContainer("confluentinc/cp-zookeeper:4.0.0")
+                .withNetwork(kafka.getNetwork())
+                .withNetworkAliases("zookeeper")
+                .withEnv("ZOOKEEPER_CLIENT_PORT", "2181");
         ) {
             Stream.of(kafka, zookeeper).parallel().forEach(GenericContainer::start);
 
@@ -51,16 +55,16 @@ public class KafkaContainerTest {
     @Test
     public void testExternalZookeeperWithExternalNetwork() throws Exception {
         try (
-                Network network = Network.newNetwork();
+            Network network = Network.newNetwork();
 
-                KafkaContainer kafka = new KafkaContainer()
-                        .withNetwork(network)
-                        .withExternalZookeeper("zookeeper:2181");
+            KafkaContainer kafka = new KafkaContainer()
+                .withNetwork(network)
+                .withExternalZookeeper("zookeeper:2181");
 
-                GenericContainer zookeeper = new GenericContainer("confluentinc/cp-zookeeper:4.0.0")
-                        .withNetwork(network)
-                        .withNetworkAliases("zookeeper")
-                        .withEnv("ZOOKEEPER_CLIENT_PORT", "2181");
+            GenericContainer zookeeper = new GenericContainer("confluentinc/cp-zookeeper:4.0.0")
+                .withNetwork(network)
+                .withNetworkAliases("zookeeper")
+                .withEnv("ZOOKEEPER_CLIENT_PORT", "2181");
         ) {
             Stream.of(kafka, zookeeper).parallel().forEach(GenericContainer::start);
 
@@ -70,24 +74,24 @@ public class KafkaContainerTest {
 
     protected void testKafkaFunctionality(String bootstrapServers) throws Exception {
         try (
-                KafkaProducer<String, String> producer = new KafkaProducer<>(
-                        ImmutableMap.of(
-                                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
-                                ProducerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString()
-                        ),
-                        new StringSerializer(),
-                        new StringSerializer()
-                );
+            KafkaProducer<String, String> producer = new KafkaProducer<>(
+                ImmutableMap.of(
+                    ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+                    ProducerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString()
+                ),
+                new StringSerializer(),
+                new StringSerializer()
+            );
 
-                KafkaConsumer<String, String> consumer = new KafkaConsumer<>(
-                        ImmutableMap.of(
-                                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
-                                ConsumerConfig.GROUP_ID_CONFIG, "tc-" + UUID.randomUUID(),
-                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
-                        ),
-                        new StringDeserializer(),
-                        new StringDeserializer()
-                );
+            KafkaConsumer<String, String> consumer = new KafkaConsumer<>(
+                ImmutableMap.of(
+                    ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers,
+                    ConsumerConfig.GROUP_ID_CONFIG, "tc-" + UUID.randomUUID(),
+                    ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"
+                ),
+                new StringDeserializer(),
+                new StringDeserializer()
+            );
         ) {
             String topicName = "messages";
             consumer.subscribe(Arrays.asList(topicName));
@@ -102,9 +106,9 @@ public class KafkaContainerTest {
                 }
 
                 assertThat(records)
-                        .hasSize(1)
-                        .extracting(ConsumerRecord::topic, ConsumerRecord::key, ConsumerRecord::value)
-                        .containsExactly(tuple(topicName, "testcontainers", "rulezzz"));
+                    .hasSize(1)
+                    .extracting(ConsumerRecord::topic, ConsumerRecord::key, ConsumerRecord::value)
+                    .containsExactly(tuple(topicName, "testcontainers", "rulezzz"));
 
                 return true;
             });


### PR DESCRIPTION
To make `KafkaContainer` work with #1781 without having to nullify the network, we should start removed the old, deprecated behaviour where the network was implicitly created in the constructor.