### PR TITLE
Changed Class.getClass.getClassLoader() and object.getClass().getClas…

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/AuditLoggingDockerClient.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/AuditLoggingDockerClient.java
@@ -90,7 +90,7 @@ public class AuditLoggingDockerClient implements DockerClient {
                                                              BiConsumer<T, Exception> failureConsumer) {
 
         return (T) Proxy.newProxyInstance(
-                clazz.getClassLoader(),
+                Thread.currentThread().getContextClassLoader(),
                 new Class<?>[]{clazz},
                 (proxy, method, args) -> {
 

--- a/core/src/test/java/org/testcontainers/images/builder/dockerfile/statement/AbstractStatementTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/dockerfile/statement/AbstractStatementTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractStatementTest {
         String[] expectedLines = new String[0];
         try {
             String path = "fixtures/statements/" + getClass().getSimpleName() + "/" + testName.getMethodName();
-            InputStream inputStream = getClass().getClassLoader().getResourceAsStream(path);
+            InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(path);
 
             Preconditions.check("inputStream is null for path " + path, inputStream != null);
 

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -293,7 +293,7 @@ public abstract class ScriptUtils {
 	 */
 	public static void runInitScript(DatabaseDelegate databaseDelegate, String initScriptPath) {
 		try {
-			URL resource = ScriptUtils.class.getClassLoader().getResource(initScriptPath);
+			URL resource = Thread.currentThread().getContextClassLoader().getResource(initScriptPath);
 			if (resource == null) {
 				LOGGER.warn("Could not load classpath init script: {}", initScriptPath);
 				throw new ScriptLoadException("Could not load classpath init script: " + initScriptPath + ". Resource not found.");

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
@@ -255,7 +255,7 @@ public class RabbitMQContainerTest {
     private SSLContext createSslContext(String keystoreFile, String keystorePassword, String truststoreFile, String truststorePassword)
         throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException, KeyManagementException
     {
-        ClassLoader classLoader = getClass().getClassLoader();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
 
         KeyStore ks = KeyStore.getInstance("PKCS12");
         ks.load(new FileInputStream(new File(classLoader.getResource(keystoreFile).getFile())), keystorePassword.toCharArray());

--- a/modules/selenium/src/test/java/org/testcontainers/junit/SeleniumUtilsTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/SeleniumUtilsTest.java
@@ -31,7 +31,7 @@ public class SeleniumUtilsTest {
      */
     private void checkSeleniumVersionDetected(String urlManifest, String expectedVersion) throws IOException {
         Manifest manifest = new Manifest();
-        manifest.read(this.getClass().getClassLoader().getResourceAsStream(urlManifest));
+        manifest.read(Thread.currentThread().getContextClassLoader().getResourceAsStream(urlManifest));
         String seleniumVersion = SeleniumUtils.getSeleniumVersionFromManifest(manifest);
         assertEquals("Check if Selenium Version detected is the correct one.", expectedVersion, seleniumVersion);
     }


### PR DESCRIPTION
…sLoader()

to use Thread.currentThread().getContextClassLoader() instead. The reason for
this is that it allows the use of parameterized tests where, for instance, we
want to check the behavior of our code when using multiple versions of the
JDBC driver.

That's not possible with the current approach since it will only
allow the use of a driver in the classpath. With the change the
developer can create a new URLClassLoader that points to the specific
JDBC driver and set it with Thread.currentThread().setContextClassLoader().

An alternative is modifying the JDBC container so it will accept a Driver
instance. This could be done in addition to this change.