### PR TITLE
Use `inspectNetworkCmd` to get the gateway's IP

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientConfigUtils.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientConfigUtils.java
@@ -43,8 +43,10 @@ public class DockerClientConfigUtils {
             .map(StringUtils::trimToEmpty)
             .filter(StringUtils::isNotBlank);
 
-
-
+    /**
+     * Use {@link DockerClientFactory#dockerHostIpAddress()}
+     */
+    @Deprecated
     public static String getDockerHostIpAddress(DockerClientConfig config) {
         switch (config.getDockerHost().getScheme()) {
             case "http":

--- a/core/src/test/java/org/testcontainers/dockerclient/DockerClientConfigUtilsTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/DockerClientConfigUtilsTest.java
@@ -1,9 +1,10 @@
 package org.testcontainers.dockerclient;
 
-import com.github.dockerjava.core.DefaultDockerClientConfig;
-import com.github.dockerjava.core.DockerClientConfig;
-import org.junit.Ignore;
+import com.github.dockerjava.api.DockerClient;
 import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
+
+import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -11,44 +12,29 @@ import static org.junit.Assert.assertNull;
 
 public class DockerClientConfigUtilsTest {
 
+    DockerClient client = DockerClientFactory.lazyClient();
+
     @Test
     public void getDockerHostIpAddressShouldReturnLocalhostWhenUnixSocket() {
-        DockerClientConfig configuration = DefaultDockerClientConfig.createDefaultConfigBuilder()
-                .withDockerHost("unix:///var/run/docker.sock")
-                .withDockerTlsVerify(false) // TODO - check wrt. https://github.com/docker-java/docker-java/issues/588
-                .build();
-        String actual = DockerClientConfigUtils.getDockerHostIpAddress(configuration);
+        String actual = DockerClientProviderStrategy.resolveDockerHostIpAddress(client, URI.create("unix:///var/run/docker.sock"));
         assertEquals("localhost", actual);
     }
 
-    @Test @Ignore
-    public void getDockerHostIpAddressShouldReturnDockerHostIpWhenHttpUri() {
-        DockerClientConfig configuration = DefaultDockerClientConfig.createDefaultConfigBuilder().withDockerHost("http://12.23.34.45").build();
-        String actual = DockerClientConfigUtils.getDockerHostIpAddress(configuration);
-        assertEquals("12.23.34.45", actual);
-    }
-
-    @Test @Ignore
+    @Test
     public void getDockerHostIpAddressShouldReturnDockerHostIpWhenHttpsUri() {
-        DockerClientConfig configuration = DefaultDockerClientConfig.createDefaultConfigBuilder().withDockerHost("https://12.23.34.45").build();
-        String actual = DockerClientConfigUtils.getDockerHostIpAddress(configuration);
+        String actual = DockerClientProviderStrategy.resolveDockerHostIpAddress(client, URI.create("http://12.23.34.45"));
         assertEquals("12.23.34.45", actual);
     }
 
     @Test
     public void getDockerHostIpAddressShouldReturnDockerHostIpWhenTcpUri() {
-        DockerClientConfig configuration = DefaultDockerClientConfig.createDefaultConfigBuilder()
-                .withDockerHost("tcp://12.23.34.45")
-                .withDockerTlsVerify(false) // TODO - check wrt. https://github.com/docker-java/docker-java/issues/588
-                .build();
-        String actual = DockerClientConfigUtils.getDockerHostIpAddress(configuration);
+        String actual = DockerClientProviderStrategy.resolveDockerHostIpAddress(client, URI.create("tcp://12.23.34.45"));
         assertEquals("12.23.34.45", actual);
     }
 
-    @Test @Ignore
+    @Test
     public void getDockerHostIpAddressShouldReturnNullWhenUnsupportedUriScheme() {
-        DockerClientConfig configuration = DefaultDockerClientConfig.createDefaultConfigBuilder().withDockerHost("gopher://12.23.34.45").build();
-        String actual = DockerClientConfigUtils.getDockerHostIpAddress(configuration);
+        String actual = DockerClientProviderStrategy.resolveDockerHostIpAddress(client, URI.create("gopher://12.23.34.45"));
         assertNull(actual);
     }
 


### PR DESCRIPTION
To avoid running a container with `ip|awk`, we can simply inspect the `bridge` network instead.

This idea was discovered while hacking on https://github.com/testcontainers/testcontainers-rs/pull/139