### PR TITLE
Add documentation for container dependencies

### DIFF
--- a/docs/examples/junit5/redis/src/test/java/generic/RedisContainerDependencyTest.java
+++ b/docs/examples/junit5/redis/src/test/java/generic/RedisContainerDependencyTest.java
@@ -1,0 +1,33 @@
+package generic;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+// class {
+@Testcontainers
+public class RedisContainerDependencyTest {
+
+    @Container
+    // redisserver {
+    public GenericContainer redis = new GenericContainer<>("redis:5.0.3-alpine")
+            .withExposedPorts(6379);
+    // }
+
+    @Container
+    // rediscli {
+    public GenericContainer redisCli = new GenericContainer<>("redis:5.0.3-alpine")
+            .withExposedPorts(6380)
+            .withCommand(String.format("redis-cli -h %s -p %d", redis.getContainerIpAddress(), redis.getFirstMappedPort()))
+            .dependsOn(redis);
+    // }
+
+    @Test
+    public void testSimplePutAndGet() {
+        // Use containers in our test
+    }
+}
+// }

--- a/docs/features/container_dependencies.md
+++ b/docs/features/container_dependencies.md
@@ -1,0 +1,19 @@
+# Container dependencies
+
+It is common that a container `A` (say Redis CLI) needs to wait for a container `B` (say Redis) to be spawned before running.
+
+In such a case you first declare your Redis container as you use to do:
+
+<!--codeinclude--> 
+[java](../examples/junit5/redis/src/test/java/generic/RedisContainerDependencyTest.java) inside_block:redisserver
+<!--/codeinclude-->
+
+And then declare your kafka container using testcontainers `dependsOn` keyword:
+
+<!--codeinclude--> 
+[java](../examples/junit5/redis/src/test/java/generic/RedisContainerDependencyTest.java) inside_block:rediscli
+<!--/codeinclude-->
+
+That way you can make sure that any container is started by testcontainers only when its dependencies are ready. 
+
+For more information on waiting strategies refer to [`Waiting for containers to start or be ready`](startup_and_waits.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
           - features/commands.md
           - features/files.md
           - features/startup_and_waits.md
+          - features/container_dependencies.md
           - features/container_logs.md
           - features/creating_images.md
           - features/configuration.md

--- a/settings.gradle
+++ b/settings.gradle
@@ -50,6 +50,7 @@ file('modules').eachDir { dir ->
 
 include ':docs:examples:junit4:generic'
 include ':docs:examples:junit4:redis'
+include ':docs:examples:junit5:generic'
 include ':docs:examples:junit5:redis'
 include ':docs:examples:spock:redis'
 


### PR DESCRIPTION
I'm submitting this PR to add a little more context and example around `dependsOn` keyword, as mentionned in issue #2166.