### PR TITLE
Fix /proc/net/tcp* check in InternalCommandPortListeningCheck t…

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheck.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheck.java
@@ -29,7 +29,7 @@ public class InternalCommandPortListeningCheck implements java.util.concurrent.C
         for (int internalPort : internalPorts) {
             command += " && ";
             command += " (";
-            command += format("cat /proc/net/tcp{,6} | awk '{print $2}' | grep -i :%x", internalPort);
+            command += format("cat /proc/net/tcp* | awk '{print $2}' | grep -i :%x", internalPort);
             command += " || ";
             command += format("nc -vz -w 1 localhost %d", internalPort);
             command += " || ";

--- a/core/src/test/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheckTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheckTest.java
@@ -11,8 +11,8 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 public class InternalCommandPortListeningCheckTest {
 
-    // Linking a custom configuration into the container so that nginx is listening on port 8080. This is necessary to proof
-    // that the command formatting uses the correct casing for hexadecimal numberd (i.e. 1F90 and not 1f90).
+    // Linking a custom configuration into the container so that nginx is listening on port 8080. This is necessary to prove
+    // that the command formatting uses the correct casing for hexadecimal numbers (i.e. 1F90 and not 1f90).
     @Rule
     public GenericContainer nginx = new GenericContainer<>("nginx:1.9.4")
             .withClasspathResourceMapping("nginx_on_8080.conf", "/etc/nginx/conf.d/default.conf", BindMode.READ_ONLY);


### PR DESCRIPTION
I noted this when running this code locally; the first part of the check didn't work correctly. After looking more closely, it turned out that we use bashisms with `/bin/sh` which _might_ work but in many cases (e.g. Debian, Ubuntu-based containers) `/bin/sh` is a `dash` binary.

Here is the error. The first invocation illustrates how the statement works properly with bash and the second shows how it fails with dash:

```shell
$ denter tomcat
root@85217088bde8:/usr/local/tomcat# true &&  (cat /proc/net/tcp{,6} | awk '{print $2}' | grep -i :2490)
00000000:2490
root@85217088bde8:/usr/local/tomcat# sh
# true &&  (cat /proc/net/tcp{,6} | awk '{print $2}' | grep -i :2490)
cat: /proc/net/tcp{,6}: No such file or directory
```

I added a check to ensure that nothing is printed to `stderr` from this check, since `result.getExitCode() == 0` seems to be `true` even in cases where parts of this command line is failing. Digging deeper, it's the fallback to his part that typically covers scenarios like this.

```
            command += format("/bin/bash -c '</dev/tcp/localhost/%d'", internalPort);
```

I can consider reverting the `if (!result.getStderr().equals(""))` part if it's considered too dangerous, but IMHO it's good to have it there to spot errors like this in the future. I'll leave it up to the project maintainers to decide if this is safe or too risky.

----

I thought more about the `stderr` part; it will probably not work since I think in the lattermost fallback (`/bin/bash -c '</dev/tcp/localhost/%d`), an error _will_ actually be printed to stderr if the port is being used. So I'm fine with removing that part, but will wait with doing so until I hear more feedback on the PR in general.