### PR TITLE
Add InfluxDBContainerTest#isHealthy test

### DIFF
--- a/modules/influxdb/src/test/java/org/testcontainers/containers/InfluxDBContainerTest.java
+++ b/modules/influxdb/src/test/java/org/testcontainers/containers/InfluxDBContainerTest.java
@@ -7,11 +7,17 @@ import org.junit.Test;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class InfluxDBContainerTest {
 
     @ClassRule
     public static InfluxDBContainer influxDBContainer = new InfluxDBContainer();
+
+    @Test
+    public void isHealthy() {
+        assertTrue(influxDBContainer.isHealthy());
+    }
 
     @Test
     public void getUrl() {


### PR DESCRIPTION
Reproducer for: https://github.com/testcontainers/testcontainers-java/issues/2205

----

iThe container starts just fine but the `isHealthy()` still throws an NPE:

```
Gradle Test Executor 1 > org.testcontainers.containers.InfluxDBContainerTest > isHealthy FAILED
    java.lang.NullPointerException
        at org.testcontainers.containers.ContainerState.isHealthy(ContainerState.java:74)
        at org.testcontainers.containers.InfluxDBContainerTest.isHealthy(InfluxDBContainerTest.java:20)
```

Looks like that `State` doesn't return `Health` element.

---- 

Container logs:
```
[I] 2019-12-21T14:04:44Z Using configuration at: /etc/influxdb/influxdb.conf
[I] 2019-12-21T14:04:44Z Using data dir: /var/lib/influxdb/data service=store
[I] 2019-12-21T14:04:44Z opened service service=subscriber
[I] 2019-12-21T14:04:44Z Starting monitor system service=monitor
[I] 2019-12-21T14:04:44Z 'build' registered for diagnostics monitoring service=monitor
[I] 2019-12-21T14:04:44Z 'runtime' registered for diagnostics monitoring service=monitor
[I] 2019-12-21T14:04:44Z 'network' registered for diagnostics monitoring service=monitor
[I] 2019-12-21T14:04:44Z 'system' registered for diagnostics monitoring service=monitor
[I] 2019-12-21T14:04:44Z Starting precreation service with check interval of 10m0s, advance period of 30m0s service=shard-precreation
[I] 2019-12-21T14:04:44Z Starting snapshot service service=snapshot
[I] 2019-12-21T14:04:44Z Starting continuous query service service=continuous_querier
[I] 2019-12-21T14:04:44Z Starting HTTP service service=httpd
[I] 2019-12-21T14:04:44Z Authentication enabled:true service=httpd
[I] 2019-12-21T14:04:44Z Storing statistics in database '_internal' retention policy 'monitor', at interval 10s service=monitor
[I] 2019-12-21T14:04:44Z Listening on HTTP:[::]:8086 service=httpd
[I] 2019-12-21T14:04:44Z Starting retention policy enforcement service with check interval of 30m0s service=retention
[I] 2019-12-21T14:04:44Z Sending usage statistics to usage.influxdata.com
[I] 2019-12-21T14:04:44Z Listening for signals
[httpd] 172.17.0.1 - any [21/Dec/2019:14:04:45 +0000] "GET /ping HTTP/1.1" 204 0 "-" "Java/11.0.4" d76297cd-23fa-11ea-8001-000000000000 352
```

`docker inspect e387bcb272b3 | jq ".[].State"`

```
{
  "Status": "running",
  "Running": true,
  "Paused": false,
  "Restarting": false,
  "OOMKilled": false,
  "Dead": false,
  "Pid": 52670,
  "ExitCode": 0,
  "Error": "",
  "StartedAt": "2019-12-21T14:10:28.6549419Z",
  "FinishedAt": "0001-01-01T00:00:00Z"
}
```