### PR TITLE
Add custom exception message when HealthState not present in `docker inspect` response

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.HealthState;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.model.ExposedPort;
@@ -89,9 +90,12 @@ public interface ContainerState {
 
         try {
             InspectContainerResponse inspectContainerResponse = getCurrentContainerInfo();
-            String healthStatus = inspectContainerResponse.getState().getHealth().getStatus();
+            HealthState health = inspectContainerResponse.getState().getHealth();
+            if (health == null) {
+                throw new RuntimeException("This container's image does not have a healthcheck declared, so health cannot be determined. Either amend the image or use another approach to determine whether containers are healthy.");
+            }
 
-            return healthStatus.equals(STATE_HEALTHY);
+            return STATE_HEALTHY.equals(health.getStatus());
         } catch (DockerException e) {
             return false;
         }


### PR DESCRIPTION
https://github.com/testcontainers/testcontainers-java/issues/2205

I don't think much more can be done without touching the public API. Catching `NullPointerException` and returning false instead is likely to introduce confusion. Not sure if defaulting to true is better for the same reason.