### PR TITLE
Add port as exposed in `withFixedExposedPort`

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1083,6 +1083,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * @param protocol
      */
     protected void addFixedExposedPort(int hostPort, int containerPort, InternetProtocol protocol) {
+        addExposedPort(containerPort);
         portBindings.add(String.format("%d:%d/%s", hostPort, containerPort, protocol.toDockerNotation()));
     }
 

--- a/core/src/test/java/org/testcontainers/containers/FixedHostPortGenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/FixedHostPortGenericContainerTest.java
@@ -1,0 +1,19 @@
+package org.testcontainers.containers;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FixedHostPortGenericContainerTest {
+    @Test
+    public void shouldExposePort() throws Exception {
+        try (FixedHostPortGenericContainer<?> container = new FixedHostPortGenericContainer<>("alpine:3.7")) {
+            container
+                .withCommand("sh", "-c", "while true; do nc -lp 8734; done")
+                .withFixedExposedPort(53834, 8734);
+
+            assertThat(container.getExposedPorts())
+                .contains(8734);
+        }
+    }
+}


### PR DESCRIPTION
As the `withFixedExposedPort` method name suggests, container port
should be exposed. Ensure it really is exposed, even if docker image did
not `EXPOSE`-d it.

Fixes https://github.com/testcontainers/testcontainers-java/issues/603