### PR TITLE
add precondition check to make sure vault token is valid

### DIFF
--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.vault;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.rnorth.ducttape.Preconditions;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
@@ -74,6 +75,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @return this
      */
     public SELF withVaultToken(String token) {
+        Preconditions.check("custom token ID cannot have the 's.' prefix", !token.startsWith("s."));
         withEnv("VAULT_DEV_ROOT_TOKEN_ID", token);
         withEnv("VAULT_TOKEN", token);
         return self();

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
@@ -29,6 +29,12 @@ public class VaultContainerTest {
             "secret_three=password3",
             "secret_four=password4");
 
+    @Test(expected = IllegalArgumentException.class)
+    public void configureContainerWithInvalidToken() {
+        new VaultContainer<>()
+                .withVaultToken("s.6w3CpXn5vChbnpLtBlCJCUxs");
+    }
+
     @Test
     public void readFirstSecretPathWithCli() throws IOException, InterruptedException {
         GenericContainer.ExecResult result = vaultContainer.execInContainer("vault", "kv", "get", "-format=json", "secret/testing1");


### PR DESCRIPTION
Apparently, custom (user defined) vault tokens cannot be formatted like the vault generated ones with a 's.' prefix (e.g. 's.6w3CpXn5vChbnpLtBlCJCUxs').
See: [https://github.com/hashicorp/vault/blob/e8c1ef5a0ab76fdad55ccfce11b2494fbad89416/vault/token_store.go#L820](url)

Trying to provide such as vault token and initialise vault in DEV mode with it result in a the following generic error:
Error initialising Dev mode: failed to create root token with ID "s.6w3CpXn5vChbnpLtBlCJCUxs": 1 error occurred:
	* invalid request

In order to fail-fast and avoid this not-so-helpful-error(unless you look at the source code),
i added an assertion to vault container.
  