### PR TITLE
Vault: add a fluent API for configuring Vault's logging level

### DIFF
--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static com.github.dockerjava.api.model.Capability.IPC_LOCK;
 
@@ -90,6 +91,17 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
     public SELF withVaultPort(int port) {
         this.port = port;
         return self();
+    }
+
+    /**
+     * Sets the logging level for the Vault server in the container.
+     * Logs can be consumed through {@link #withLogConsumer(Consumer)}.
+     *
+     * @param level the logging level to set for Vault.
+     * @return this
+     */
+    public SELF withLogLevel(VaultLogLevel level) {
+        return withEnv("VAULT_LOG_LEVEL", level.config);
     }
 
     /**

--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultLogLevel.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultLogLevel.java
@@ -1,0 +1,14 @@
+package org.testcontainers.vault;
+
+/**
+ * Vault preset of logging levels.
+ */
+public enum VaultLogLevel {
+    Trace("trace"), Debug("debug"), Info("info"), Warn("warn"), Error("err");
+
+    public final String config;
+
+    VaultLogLevel(String config) {
+        this.config = config;
+    }
+}


### PR DESCRIPTION
Setting the logging level of Vault is useful while debugging Vault Container.
Added a fluent-API to allow easier/safer setting of logging level.