### PR TITLE
Replace testCompile with testImplementation

### DIFF
--- a/docs/quickstart/spock_quickstart.md
+++ b/docs/quickstart/spock_quickstart.md
@@ -22,7 +22,7 @@ Let's start from here, and see how to improve the test with Testcontainers:
 First, add Testcontainers as a dependency as follows:
 
 ```groovy tab='Gradle'
-testCompile "org.testcontainers:spock:{{latest_version}}"
+testImplementation "org.testcontainers:spock:{{latest_version}}"
 ```
 
 ```xml tab='Maven'


### PR DESCRIPTION
The testCompile configuration is deprecated and should be replaced in this case with testImplementation.

See https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation