### PR TITLE
Prevent duplicate attempts to start Ryuk container

### DIFF
--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -66,9 +66,10 @@ public class DockerClientFactoryTest {
     public void failedChecksFailFast() {
         Mockito.doReturn(false).when(TestcontainersConfiguration.getInstance()).isDisableChecks();
 
-        DockerClientFactory instance = new DockerClientFactory();
-        assertThat(instance.client()).isNotNull();
+        // Make sure that Ryuk is started
+        assertThat(DockerClientFactory.instance().client()).isNotNull();
 
+        DockerClientFactory instance = new DockerClientFactory();
         DockerClient dockerClient = instance.dockerClient;
         assertThat(instance.cachedChecksFailure).isNull();
         try {

--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -1,7 +1,7 @@
 package org.testcontainers;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.exception.ConflictException;
+import com.github.dockerjava.api.exception.DockerException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,7 +77,7 @@ public class DockerClientFactoryTest {
             instance.dockerClient = null;
 
             // Ryuk should fail to start twice due to the name conflict (equal to the session id)
-            assertThatThrownBy(instance::client).isInstanceOf(ConflictException.class);
+            assertThatThrownBy(instance::client).isInstanceOf(DockerException.class);
 
             RuntimeException failure = new IllegalStateException("Boom!");
             instance.cachedChecksFailure = failure;

--- a/core/src/test/java/org/testcontainers/utility/MockTestcontainersConfigurationRule.java
+++ b/core/src/test/java/org/testcontainers/utility/MockTestcontainersConfigurationRule.java
@@ -23,6 +23,9 @@ public class MockTestcontainersConfigurationRule implements TestRule {
             @Override
             public void evaluate() throws Throwable {
                 TestcontainersConfiguration previous = REF.get();
+                if (previous == null) {
+                    previous = TestcontainersConfiguration.getInstance();
+                }
                 REF.set(Mockito.spy(previous));
 
                 try {


### PR DESCRIPTION
If for example, checks fail once but the Docker client is otherwise initialized, an error would occur due to an attempt to start a Ryuk container twice with the same name.
This changed is aimed at avoiding that situation.

Additionally, if checks fail once they should fail on every subsequent attempt to start a client. Therefore, we cache the failure and rethrow it.