### PR TITLE
Force JVM file encoding for Gradle to UTF-8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ subprojects {
             inputs.dir(srcDir)
             args(srcDir, "-d", outputDir)
         }
+        encoding = "UTF-8"
     }
     delombok.onlyIf {
         project.sourceSets.main.java.srcDirs.find { it.exists() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.parallel=false
 org.gradle.caching=true
+org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
To prevent system encoding settings affecting build, e.g. `delombok` failure:
```
> Task :testcontainers:delombok
C:\Users\bsideup\Downloads\agent\_work\6\s\core\src\main\java\org\testcontainers\DockerClientFactory.java:226: error: unmappable character (0x9D) for encoding windows-1252
```