### PR TITLE
Make Testcontainers extension annotation public to allow using in ordered ExtendWith

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -98,6 +98,9 @@ task japicmp(type: me.champeau.gradle.japicmp.JapicmpTask) {
 
         // 'METHOD_RETURN_TYPE_CHANGED', exposed `com.github.dockerjava.core.command.PullImageResultCallback` to the public API
         "org.testcontainers.images.TimeLimitedLoggedPullImageResultCallback",
+
+        // 'METHOD_NEW_DEFAULT', added withFileSystemBind and withFileSystemBind methods with Supplier<String> for hostPath
+        "org.testcontainers.containers.Container",
     ]
 
     onlyBinaryIncompatibleModified = true

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public interface Container<SELF extends Container<SELF>> extends LinkableContainer, ContainerState {
 
@@ -96,6 +97,18 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     }
 
     /**
+     * Adds a file system binding. Consider using {@link #withFileSystemBind(Supplier, String, BindMode)}
+     * for building a container in a fluent style.
+     *
+     * @param hostPath      the file system path on the host supplier
+     * @param containerPath the file system path inside the container
+     * @param mode          the bind mode
+     */
+    default void addFileSystemBind(final Supplier<String> hostPath, final String containerPath, final BindMode mode) {
+        addFileSystemBind(hostPath, containerPath, mode, SelinuxContext.NONE);
+    }
+
+    /**
      * Adds a file system binding. Consider using {@link #withFileSystemBind(String, String, BindMode)}
      * for building a container in a fluent style.
      *
@@ -105,6 +118,17 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @param selinuxContext selinux context argument to use for this file
      */
     void addFileSystemBind(String hostPath, String containerPath, BindMode mode, SelinuxContext selinuxContext);
+
+    /**
+     * Adds a file system binding. Consider using {@link #withFileSystemBind(Supplier, String, BindMode)}
+     * for building a container in a fluent style.
+     *
+     * @param hostPath      the file system path on the host supplier
+     * @param containerPath the file system path inside the container
+     * @param mode          the bind mode
+     * @param selinuxContext selinux context argument to use for this file
+     */
+    void addFileSystemBind(Supplier<String> hostPath, String containerPath, BindMode mode, SelinuxContext selinuxContext);
 
     /**
      * Add a link to another container.
@@ -153,6 +177,17 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     }
 
     /**
+     * Adds a file system binding. Host-path will be evaluated when processing binds.
+     *
+     * @param hostPath the file system path on the host supplier
+     * @param containerPath the file system path inside the container
+     * @return this
+     */
+    default SELF withFileSystemBind(Supplier<String> hostPath, String containerPath) {
+        return withFileSystemBind(hostPath, containerPath, BindMode.READ_WRITE);
+    }
+
+    /**
      * Adds a file system binding.
      *
      * @param hostPath the file system path on the host
@@ -161,6 +196,16 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @return this
      */
     SELF withFileSystemBind(String hostPath, String containerPath, BindMode mode);
+
+    /**
+     * Adds a file system binding. Host-path will be evaluated when processing binds.
+     *
+     * @param hostPath the file system path on the host supplier
+     * @param containerPath the file system path inside the container
+     * @param mode the bind mode
+     * @return this
+     */
+    SELF withFileSystemBind(Supplier<String> hostPath, String containerPath, BindMode mode);
 
     /**
      * Adds container volumes.

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -1,11 +1,22 @@
 package org.testcontainers.utility;
 
 import com.google.common.annotations.VisibleForTesting;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.UnstableAPI;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Objects;
@@ -119,6 +130,11 @@ public class TestcontainersConfiguration {
 
     public Integer getImagePullPauseTimeout() {
         return Integer.parseInt((String) properties.getOrDefault("pull.pause.timeout", "30"));
+    }
+
+    public Boolean disabledWithoutDocker() {
+        final String value = properties.getProperty("testcontainers.without-docker-disable");
+        return value == null ? null : Boolean.parseBoolean(value);
     }
 
     @Synchronized

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -3,6 +3,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 dependencies {
     compile project(':testcontainers')
     compile 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+    compile 'org.junit.jupiter:junit-jupiter-params:5.6.0'
 
     testCompile project(':mysql')
     testCompile project(':postgresql')

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExtensionTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExtensionTests.java
@@ -2,15 +2,27 @@ package org.testcontainers.junit.jupiter;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.utility.MockTestcontainersConfigurationExtension;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockTestcontainersConfigurationExtension.class)
 public class TestcontainersExtensionTests {
-
     @Test
     void whenDisabledWithoutDockerAndDockerIsAvailableTestsAreEnabled() {
         ConditionEvaluationResult result = new TestTestcontainersExtension(true)
@@ -39,10 +51,60 @@ public class TestcontainersExtensionTests {
         assertFalse(result.isDisabled());
     }
 
-    private ExtensionContext extensionContext(Class clazz) {
+    @ParameterizedTest
+    @MethodSource("disabledWithoutDockerAllProvider")
+    void whenInvokedByExtendWith(Boolean config, boolean dockerAvailable, boolean expectedDisabled, String expectedReason) {
+        testDisabledEvaluation(config, dockerAvailable, expectedDisabled, expectedReason, WithoutAnnotation.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource("disabledWithoutDockerConfigurationSpecifiedProvider")
+    void whenInvokedByExtendWithTestcontainersAnnotationIgnored(Boolean config,
+                                                                boolean dockerAvailable,
+                                                                boolean expectedDisabled,
+                                                                String expectedReason) {
+        testDisabledEvaluation(config, dockerAvailable, expectedDisabled, expectedReason, DisabledWithoutDocker.class);
+        testDisabledEvaluation(config, dockerAvailable, expectedDisabled, expectedReason, EnabledWithoutDocker.class);
+    }
+
+    private void testDisabledEvaluation(Boolean config,
+                                        boolean dockerAvailable,
+                                        boolean expectedDisabled,
+                                        String expectedReason,
+                                        Class<?> annotationClass) {
+        doReturn(config).when(TestcontainersConfiguration.getInstance()).disabledWithoutDocker();
+        ConditionEvaluationResult result = new TestTestcontainersExtension(dockerAvailable)
+            .evaluateExecutionCondition(extensionContext(annotationClass));
+        assertEquals(expectedDisabled, result.isDisabled());
+        assertEquals(expectedReason, result.getReason().get());
+    }
+
+    private ExtensionContext extensionContext(Class<?> clazz) {
         ExtensionContext extensionContext = mock(ExtensionContext.class);
-        when(extensionContext.getRequiredTestClass()).thenReturn(clazz);
+        when(extensionContext.getTestClass()).thenReturn(Optional.ofNullable(clazz));
         return extensionContext;
+    }
+
+    static Stream<Arguments> disabledWithoutDockerAllProvider() {
+        return Stream.concat(
+            disabledWithoutDockerConfigurationNotSpecifiedProvider(),
+            disabledWithoutDockerConfigurationSpecifiedProvider());
+    }
+
+    static Stream<Arguments> disabledWithoutDockerConfigurationNotSpecifiedProvider() {
+        return Stream.of(
+            arguments(null, true, false, "disabledWithoutDocker is not set, assume enabled"),
+            arguments(null, false, false, "disabledWithoutDocker is not set, assume enabled")
+        );
+    }
+
+    static Stream<Arguments> disabledWithoutDockerConfigurationSpecifiedProvider() {
+        return Stream.of(
+            arguments(true, true, false, "Docker is available"),
+            arguments(true, false, true, "disabledWithoutDocker is true and Docker is not available"),
+            arguments(false, true, false, "disabledWithoutDocker config is false"),
+            arguments(false, false, false, "disabledWithoutDocker config is false")
+        );
     }
 
     @Testcontainers(disabledWithoutDocker = true)
@@ -52,7 +114,9 @@ public class TestcontainersExtensionTests {
 
     @Testcontainers
     static final class EnabledWithoutDocker {
+    }
 
+    static final class WithoutAnnotation {
     }
 
     static final class TestTestcontainersExtension extends TestcontainersExtension {
@@ -66,7 +130,5 @@ public class TestcontainersExtensionTests {
         boolean isDockerAvailable() {
             return dockerAvailable;
         }
-
     }
-
 }

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersSharedContainerWithGeneratedResourcesTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersSharedContainerWithGeneratedResourcesTests.java
@@ -1,0 +1,128 @@
+package org.testcontainers.junit.jupiter;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.ClassUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedMethods;
+
+@ExtendWith({
+    TestcontainersSharedContainerWithGeneratedResourcesTests.RunCodeExtension.class,
+    TestcontainersExtension.class,
+})
+class TestcontainersSharedContainerWithGeneratedResourcesTests {
+    @TempDir
+    static File tempDir;
+
+    @Container
+    private static GenericContainer<?> NGINX = new GenericContainer<>("nginx:1.9.4")
+        .withFileSystemBind(() -> dirFe(tempDir, "fe").getAbsolutePath(), "/usr/share/nginx/html", BindMode.READ_ONLY)
+        .withExposedPorts(80)
+        .waitingFor(new HttpWaitStrategy());
+
+    private static String lastContainerId;
+
+    @RunCodeExtension.RunBeforeCustomExtensions
+    private static void runBeforeAll(ExtensionContext context) throws IOException {
+        final File dirFe = dirFe(tempDir, "fe");
+        dirFe.mkdirs();
+
+        try (final OutputStream out = new BufferedOutputStream(new FileOutputStream(new File(dirFe, "index.html")))) {
+            IOUtils.write("<html><body>Hello from FE!</body></html>", out, StandardCharsets.UTF_8);
+        }
+    }
+
+    @BeforeAll
+    public static void setupAll() {
+        assertTrue(NGINX.isRunning(), "");
+    }
+
+    @Test
+    void httpGetOfCorrectBindOfGeneratedFile() throws IOException {
+        HttpClient client = HttpClientBuilder.create().build();
+        HttpResponse response = client.execute(new HttpGet("http://" + NGINX.getContainerIpAddress() + ":" + NGINX.getMappedPort(80)));
+
+        assertEquals(200, response.getStatusLine().getStatusCode());
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        response.getEntity().writeTo(buffer);
+        final String body = buffer.toString(StandardCharsets.UTF_8.displayName());
+        assertEquals("<html><body>Hello from FE!</body></html>", body);
+    }
+
+    @Test
+    void firstTestThatOneContainerCreated() {
+        if (lastContainerId == null) {
+            lastContainerId = NGINX.getContainerId();
+        } else {
+            assertEquals(lastContainerId, NGINX.getContainerId());
+        }
+    }
+
+    @Test
+    void secondTestThatOneContainerCreated() {
+        if (lastContainerId == null) {
+            lastContainerId = NGINX.getContainerId();
+        } else {
+            assertEquals(lastContainerId, NGINX.getContainerId());
+        }
+    }
+
+    private static File dirFe(File parent, String dir) {
+        return new File(parent, dir);
+    }
+
+    public static class RunCodeExtension implements BeforeAllCallback {
+        @Override
+        public void beforeAll(ExtensionContext context) throws Exception {
+            context.getTestInstance();
+            findAnnotatedMethods(context.getRequiredTestClass(), RunBeforeCustomExtensions.class, ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+                .stream()
+                .filter(ReflectionUtils::isStatic)
+                .filter(it -> it.getParameterCount() == 1)
+                .filter(it -> ClassUtils.isAssignable(it.getParameterTypes()[0], ExtensionContext.class))
+                .map(ReflectionUtils::makeAccessible)
+                .forEach(method -> {
+                    try {
+                        method.invoke(null, context);
+                    } catch (Throwable t) {
+                        ExceptionUtils.throwAsUncheckedException(t);
+                    }
+                });
+        }
+
+        @Target({ElementType.METHOD})
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        public @interface RunBeforeCustomExtensions {
+        }
+    }
+}

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/utility/MockTestcontainersConfigurationExtension.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/utility/MockTestcontainersConfigurationExtension.java
@@ -1,0 +1,34 @@
+package org.testcontainers.utility;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.mockito.Mockito;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+public class MockTestcontainersConfigurationExtension implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+    private static final ExtensionContext.Namespace NAMESPACE = ExtensionContext.Namespace.create(MockTestcontainersConfigurationExtension.class);
+    private static final AtomicReference<TestcontainersConfiguration> REF = TestcontainersConfiguration.getInstanceField();
+    private static final String KEY = MockTestcontainersConfigurationExtension.class.getName() + ".PREV";
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        // Invoke configuration load
+        TestcontainersConfiguration.getInstance();
+    }
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        TestcontainersConfiguration previous = REF.get();
+        REF.set(Mockito.spy(previous));
+        context.getStore(NAMESPACE).put(KEY, previous);
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) {
+        TestcontainersConfiguration previous = context.getStore(NAMESPACE).get(KEY, TestcontainersConfiguration.class);
+        REF.set(previous);
+    }
+}


### PR DESCRIPTION
Hi,
I found fix of https://github.com/testcontainers/testcontainers-java/issues/2045 useful and created PR. My usecase could be found in TestcontainersSharedContainerWithGeneratedResourcesTests. Problem is that I want to have static containers that use some generated resources and without `@ExtendWith` I am unable to tell order in which extensions are invoked.
What do you think?
Thx
Ivos