### PR TITLE
Set sourceJar.from=allSource for modules/spock

### DIFF
--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,3 +16,9 @@ dependencies {
     testRuntime 'org.postgresql:postgresql:42.2.9'
     testRuntime 'mysql:mysql-connector-java:8.0.19'
 }
+
+sourceJar {
+    /* allJava is default (see gradle/publishing.gradle:sourceJar)
+       allSource contains both .java and .groovy files */
+    from sourceSets.main.allSource
+}


### PR DESCRIPTION
Fixes issue #2280
By default, sourceJar.from = allJava (see gradle/publishing.gradle)
But Spock module is in Groovy
  => sourceJar.from should be allGroovy/allSource