### PR TITLE
Fix CI Docker Compose test failure

### DIFF
--- a/core/src/test/resources/compose-build-test/Dockerfile
+++ b/core/src/test/resources/compose-build-test/Dockerfile
@@ -1,3 +1,3 @@
-FROM redis
+FROM redis:2.6.17
 
 CMD ["redis-server"]

--- a/core/src/test/resources/compose-build-test/docker-compose.yml
+++ b/core/src/test/resources/compose-build-test/docker-compose.yml
@@ -3,4 +3,4 @@ services:
   customredis:
       build: .
   normalredis:
-      image: redis:latest
+      image: redis:2.6.17


### PR DESCRIPTION
Seeing this failure in CI:

```
org.testcontainers.junit.DockerComposeContainerWithBuildTest > performTest[removeMode = ALL] FAILED
    java.lang.RuntimeException: java.lang.AssertionError: the pulled image is present after running: 'true' does not equal expected 'false'
        at org.rnorth.ducttape.timeouts.Timeouts.callFuture(Timeouts.java:68)
        at org.rnorth.ducttape.timeouts.Timeouts.getWithTimeout(Timeouts.java:43)
        at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:40)
        at org.testcontainers.junit.DockerComposeContainerWithBuildTest.performTest(DockerComposeContainerWithBuildTest.java:72)

        Caused by:
        java.lang.AssertionError: the pulled image is present after running: 'true' does not equal expected 'false'
            at org.rnorth.visibleassertions.VisibleAssertions.fail(VisibleAssertions.java:440)
            at org.rnorth.visibleassertions.VisibleAssertions.assertEquals(VisibleAssertions.java:174)
            at org.testcontainers.junit.DockerComposeContainerWithBuildTest.lambda$performTest$1(DockerComposeContainerWithBuildTest.java:74)
```

Hypothesis: docker-compose cannot remove the `redis` (latest) image because there is some other running container that relies on that image. This may be a CI-specific problem depending on the Azure Pipelines Docker setup.

To work around (without publishing our own single-use image): use an old version of the Redis image that is unlikely to be in use by concurrent builds.