### PR TITLE
Add generic update() method to GenericContainer

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1379,6 +1379,18 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         return self();
     }
 
+    /**
+     * Update the container configuration using the provided consumer.
+     *
+     * @param consumer the consumer of the container
+     * @return this
+     */
+    public SELF update(Consumer<SELF> consumer)
+    {
+        consumer.accept(self());
+        return self();
+    }
+
     @Override
     public boolean equals(Object o) {
         return this == o;

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -46,7 +46,7 @@ public class GenericContainerTest {
         try (
             GenericContainer container = new GenericContainer<>()
                 .withStartupCheckStrategy(new NoopStartupCheckStrategy())
-                .waitingFor(new WaitForExitedState(state -> state.getExitCode() > 0))
+                .update(WaitForExitedState::waitForNonZeroExit)
                 .withCommand("sh", "-c", "usleep 100; exit 123")
         ) {
             assertThatThrownBy(container::start)
@@ -84,6 +84,11 @@ public class GenericContainerTest {
             });
 
             throw new IllegalStateException("Nope!");
+        }
+
+        public static void waitForNonZeroExit(GenericContainer container)
+        {
+            container.waitingFor(new WaitForExitedState(state -> state.getExitCode() > 0));
         }
     }
 }


### PR DESCRIPTION
This allows abstracting setup code into utility methods while still building the container using a fluent style. For example, suppose we often bind multiple file systems:
```java
return new GenericContainer<>("ubuntu:18.04")
        .withExposedPorts(1234)
        .withFileSystemBind(getTestPath("/etc"), "/etc")
        .withFileSystemBind(getTestPath("/var"), "/var");
```
We could extract a method for the setup, but then we can't use the fluent style:
```java
GenericContainer<?> container = new GenericContainer<>("ubuntu:18.04")
        .withExposedPorts(1234);
setupFileSystemBinds(container);
return container;
```
The `update()` method fixes that:
```java
return new GenericContainer<>("ubuntu:18.04")
        .withExposedPorts(1234)
        .update(container -> setupFileSystemBinds(container));
```
(the lambda could be a method reference in this case, but that complicates the example)