### PR TITLE
checkMountableFile on Windows

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -242,7 +242,11 @@ public class MountableFile implements Transferable {
         // Mark temporary files/dirs for deletion at JVM shutdown
         deleteOnExit(tmpLocation.toPath());
 
-        return tmpLocation.getAbsolutePath();
+        try {
+            return tmpLocation.getCanonicalPath();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     private File createTempDirectory() {
@@ -371,8 +375,8 @@ public class MountableFile implements Transferable {
         try {
             int unixMode = (int) Files.readAttributes(path, "unix:mode").get("mode");
             // Truncate mode bits for z/OS
-            if ("OS/390".equals(SystemUtils.OS_NAME) || 
-                "z/OS".equals(SystemUtils.OS_NAME) || 
+            if ("OS/390".equals(SystemUtils.OS_NAME) ||
+                "z/OS".equals(SystemUtils.OS_NAME) ||
                 "zOS".equals(SystemUtils.OS_NAME) ) {
                 unixMode &= TarConstants.MAXID;
                 unixMode |= Files.isDirectory(path) ? 040000 : 0100000;


### PR DESCRIPTION
Hi,
after update to newer Docker (i suspect it) I found that `checkMountableFile` check returns incorrect values for `/dummy` volume.
I have created PR to correctly resolve .jar resource mountable file from temp directory.
Problem is that when `org.testcontainers.utility.MountableFile#extractClassPathResourceToTempLocation` is called it calls `java.nio.file.Files#createTempDirectory` which resolves base temp dir from `java.io.tmpdir` system property. My environment is shortened directory containing tilde in name which results in error from docker ... see below.
What do you think about this fix?
Thx,
Ivos

1. use path with tilde
```
docker create -v C:\\Users\\IVO~1.SMI\\AppData\\Local\\Temp\\.testcontainers-tmp-2172312636651222509:/dummy:ro alpine:3.5
697d0bbf323823cb2377920659377dc5efc72eb7eb9cae96593e96b0141489da
```
2. start container
```
docker start 697d0bbf323823cb2377920659377dc5efc72eb7eb9cae96593e96b0141489da
Error response from daemon: error while creating mount source path '/host_mnt/c/Users/IVO~1.SMI/AppData/Local/Temp/.testcontainers-tmp-2172312636651222509': mkdir /host_mnt/c/Users/IVO~1.SMI: file exists
Error: failed to start containers: 697d0bbf323823cb2377920659377dc5efc72eb7eb9cae96593e96b0141489da
```
my environment:
```
echo %TEMP%
C:\Users\IVO~1.SMI\AppData\Local\Temp

20:36:07.302 INFO  org.testcontainers.DockerClientFactory - Connected to docker: 
  Server Version: 19.03.5
  API Version: 1.40
  Operating System: Docker Desktop
  Total Memory: 1989 MB
```

original exception/log
```
20:37:45.303 DEBUG org.testcontainers.DockerClientFactory - Failure while checking for mountable file support
com.github.dockerjava.api.exception.InternalServerErrorException: {"message":"error while creating mount source path '/host_mnt/c/Users/IVO~1.SMI/AppData/Local/Temp/.testcontainers-tmp-15023584109874765': mkdir /host_mnt/c/Users/IVO~1.SMI: file exists"}

	at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.execute(OkHttpInvocationBuilder.java:287)
	at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.execute(OkHttpInvocationBuilder.java:265)
	at org.testcontainers.dockerclient.transport.okhttp.OkHttpInvocationBuilder.post(OkHttpInvocationBuilder.java:126)
	at com.github.dockerjava.core.exec.StartContainerCmdExec.execute(StartContainerCmdExec.java:28)
	at com.github.dockerjava.core.exec.StartContainerCmdExec.execute(StartContainerCmdExec.java:11)
	at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
	at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
	at com.github.dockerjava.core.command.StartContainerCmdImpl.exec(StartContainerCmdImpl.java:46)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testcontainers.dockerclient.AuditLoggingDockerClient.lambda$wrappedCommand$14(AuditLoggingDockerClient.java:99)
	at com.sun.proxy.$Proxy23.exec(Unknown Source)
	at org.testcontainers.DockerClientFactory.runInsideDocker(DockerClientFactory.java:286)
	at org.testcontainers.DockerClientFactory.runInsideDocker(DockerClientFactory.java:275)
	at org.testcontainers.DockerClientFactory.checkMountableFile(DockerClientFactory.java:238)
	at org.testcontainers.DockerClientFactory.isFileMountingSupported(DockerClientFactory.java:74)
	at org.testcontainers.containers.GenericContainer.applyConfiguration(GenericContainer.java:734)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:351)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:317)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:315)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:302)
	at org.testcontainers.containers.GenericContainer.starting(GenericContainer.java:1008)
	at org.testcontainers.containers.FailureDetectingExternalResource$1.evaluate(FailureDetectingExternalResource.java:29)
	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:110)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:38)
	at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:62)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:94)
	at com.sun.proxy.$Proxy2.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:118)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:182)
	at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:164)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:412)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:748)
        ⚠︎ Unable to mount a file from test host into a running container. This may be a misconfiguration or limitation of your Docker environment. Some features might not work.
```
