### PR TITLE
Add junit-jupiter dependency in junit 5 quickstart docs

### DIFF
--- a/docs/quickstart/junit_5_quickstart.md
+++ b/docs/quickstart/junit_5_quickstart.md
@@ -27,6 +27,7 @@ testCompile "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
 testCompile "org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion"
 testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
 testCompile "org.testcontainers:testcontainers:{{latest_version}}"
+testCompile "org.testcontainers:junit-jupiter:{{latest_version}}"
 ```
 
 ```xml tab='Maven'


### PR DESCRIPTION
While following the tutorial, I realized that junit-jupiter dependency is missing from junit 5 documentation.