### PR TITLE
Fix localstack cloudwatchlogs service

### DIFF
--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,4 +6,5 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.11.683'
     testCompile 'com.amazonaws:aws-java-sdk-s3:1.11.683'
     testCompile 'com.amazonaws:aws-java-sdk-sqs:1.11.636'
+    testCompile 'com.amazonaws:aws-java-sdk-logs:1.11.636'
 }

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -154,7 +154,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         SSM("ssm", 4583),
         SECRETSMANAGER("secretsmanager", 4584),
         STEPFUNCTIONS("stepfunctions", 4585),
-        CLOUDWATCHLOGS("cloudwatchlogs", 4586),
+        CLOUDWATCHLOGS("logs", 4586),
         STS("sts", 4592),
         IAM("iam", 4593);
 

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -31,6 +31,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.CLOUDWATCHLOGS;
 
 /**
  * Tests for Localstack Container, used both in bridge network (exposed to host) and docker network modes.
@@ -105,7 +106,7 @@ public class LocalstackContainerTest {
         public static LocalStackContainer localstackInDockerNetwork = new LocalStackContainer()
             .withNetwork(network)
             .withNetworkAliases("notthis", "localstack")    // the last alias is used for HOSTNAME_EXTERNAL
-            .withServices(S3, SQS);
+            .withServices(S3, SQS, CLOUDWATCHLOGS);
         // }
 
         @ClassRule
@@ -137,6 +138,11 @@ public class LocalstackContainerTest {
                 String.format("sqs receive-message --endpoint http://localstack:%d --queue-url http://localstack:%d/queue/baz", SQS.getPort(), SQS.getPort()), SQS.getPort());
 
             assertTrue("the sent message can be received", message.contains("\"Body\": \"test\""));
+        }
+
+        @Test
+        public void cloudWatchLogsTestOverDockerNetwork() throws Exception {
+        	runAwsCliAgainstDockerNetworkContainer("logs create-log-group --log-group-name foo", CLOUDWATCHLOGS.getPort());
         }
 
         private String runAwsCliAgainstDockerNetworkContainer(String command, final int port) throws Exception {

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -163,7 +163,7 @@ public class LocalstackContainerTest {
 
         @Test
         public void cloudWatchLogsTestOverDockerNetwork() throws Exception {
-        	runAwsCliAgainstDockerNetworkContainer("logs create-log-group --log-group-name foo", CLOUDWATCHLOGS.getPort());
+            runAwsCliAgainstDockerNetworkContainer("logs create-log-group --log-group-name foo", CLOUDWATCHLOGS.getPort());
         }
 
         private String runAwsCliAgainstDockerNetworkContainer(String command, final int port) throws Exception {


### PR DESCRIPTION
Hello,
this pull request fixes cloudwatch logs with localstack.

According to https://hub.docker.com/r/localstack/localstack/ (search for "service names of the AWS CLI")
service name for cloudwatch logs should be "logs", not "cloudwatchlogs".


Please note: I've implemented two tests. One of them is `@Ignored` due to localstack/localstack#1434 (`createLogGroup` works fine, but fails in `describeLogGroups`)
