### PR TITLE
Elasticsearch: Add withPassword(String) method for secure access

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -22,7 +22,7 @@ or set `client.transport.ignore_cluster_name` to `true`.
 ## Secure your Elasticsearch cluster
 
 The default distribution of Elasticsearch comes with the basic license which contains security feature.
-You can turn on security by providing some extra environment settings:
+You can turn on security by providing a password:
 
 <!--codeinclude-->
 [HttpClient](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientSecuredContainer

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -39,6 +39,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
      */
     @Deprecated
     protected static final String DEFAULT_TAG = "7.9.2";
+    private boolean isOss = false;
 
     /**
      * @deprecated use {@link ElasticsearchContainer(DockerImageName)} instead
@@ -65,6 +66,10 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DEFAULT_OSS_IMAGE_NAME);
 
+        if (dockerImageName.isCompatibleWith(DEFAULT_OSS_IMAGE_NAME)) {
+            this.isOss = true;
+        }
+
         logger().info("Starting an elasticsearch container using [{}]", dockerImageName);
         withNetworkAliases("elasticsearch-" + Base58.randomString(6));
         withEnv("discovery.type", "single-node");
@@ -82,7 +87,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
      * @return this
      */
     public ElasticsearchContainer withPassword(String password) {
-        if (getDockerImageName().startsWith(DEFAULT_OSS_IMAGE_NAME.getUnversionedPart())) {
+        if (isOss) {
             throw new IllegalArgumentException("You can not activate security on Elastic OSS Image. " +
                 "Please switch to the default distribution");
         }

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -75,6 +75,22 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
             .withStartupTimeout(Duration.ofMinutes(2)));
     }
 
+    /**
+     * Define the Elasticsearch password to set. It enables security behind the scene.
+     * It's not possible to use security with the oss image.
+     * @param password  Password to set
+     * @return this
+     */
+    public ElasticsearchContainer withPassword(String password) {
+        if (getDockerImageName().startsWith(DEFAULT_OSS_IMAGE_NAME.getUnversionedPart())) {
+            throw new IllegalArgumentException("You can not activate security on Elastic OSS Image. " +
+                "Please switch to the default distribution");
+        }
+        withEnv("ELASTIC_PASSWORD", password);
+        withEnv("xpack.security.enabled", "true");
+        return this;
+    }
+
     public String getHttpHostAddress() {
         return getHost() + ":" + getMappedPort(ELASTICSEARCH_DEFAULT_PORT);
     }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -236,6 +236,19 @@ public class ElasticsearchContainerTest {
         // }
     }
 
+    @Test
+    public void incompatibleSettingsTest() {
+        // The OSS image can not use security feature
+        assertThrows("We should not be able to activate security with an OSS License",
+            IllegalArgumentException.class,
+            () -> new ElasticsearchContainer(
+                DockerImageName
+                    .parse("docker.elastic.co/elasticsearch/elasticsearch-oss")
+                    .withTag(ELASTICSEARCH_VERSION))
+            .withPassword("foo")
+        );
+    }
+
     private RestClient getClient(ElasticsearchContainer container) {
         if (client == null) {
             final CredentialsProvider credentialsProvider = new BasicCredentialsProvider();

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -110,9 +110,7 @@ public class ElasticsearchContainerTest {
     @Test
     public void elasticsearchSecuredTest() throws IOException {
         try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
-            .withEnv("ELASTIC_PASSWORD", ELASTICSEARCH_PASSWORD)
-            .withEnv("xpack.security.enabled", "true")
-        ) {
+            .withPassword(ELASTICSEARCH_PASSWORD)) {
             container.start();
 
             // The cluster should be secured so it must fail when we try to access / without credentials
@@ -191,8 +189,7 @@ public class ElasticsearchContainerTest {
         // Create the elasticsearch container.
         try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
             // With a password
-            .withEnv("ELASTIC_PASSWORD", ELASTICSEARCH_PASSWORD)
-            .withEnv("xpack.security.enabled", "true")) {
+            .withPassword(ELASTICSEARCH_PASSWORD)) {
             // Start the container. This step might take some time...
             container.start();
 


### PR DESCRIPTION
Instead of providing env settings manually, we can simplify the usage of Elasticsearch in the context of TestContainers by just asking a password.
Behind the scene, we do provide the needed env settings. 

This PR comes after #2320 and should be probably rebased on master when 2320 will be merged.