### PR TITLE
allow setting the timout for CouchbaseQueryServiceWaitStrategy (#2348)

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/AbstractCouchbaseTest.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/AbstractCouchbaseTest.java
@@ -8,6 +8,7 @@ import com.couchbase.client.java.cluster.DefaultBucketSettings;
 import com.couchbase.client.java.query.N1qlParams;
 import com.couchbase.client.java.query.N1qlQuery;
 import com.couchbase.client.java.query.consistency.ScanConsistency;
+import java.time.Duration;
 import org.junit.After;
 
 import java.util.concurrent.TimeUnit;
@@ -44,6 +45,7 @@ public abstract class AbstractCouchbaseTest {
     protected static CouchbaseContainer initCouchbaseContainer(String imageName) {
         CouchbaseContainer couchbaseContainer = (imageName == null) ? new CouchbaseContainer() : new CouchbaseContainer(imageName);
         couchbaseContainer.withNewBucket(getDefaultBucketSettings());
+        couchbaseContainer.withQueryServiceStartupTimeout(Duration.ofMinutes(3));
         return couchbaseContainer;
     }
 

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseQueryServiceWaitStrategy.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseQueryServiceWaitStrategy.java
@@ -23,9 +23,9 @@ public class CouchbaseQueryServiceWaitStrategy extends AbstractWaitStrategy {
 
     private final Bucket bucket;
 
-    public CouchbaseQueryServiceWaitStrategy(Bucket bucket) {
+    public CouchbaseQueryServiceWaitStrategy(Bucket bucket, Duration timeout) {
         this.bucket = bucket;
-        startupTimeout = Duration.ofSeconds(120);
+        this.startupTimeout = timeout;
     }
 
     @Override


### PR DESCRIPTION
The `CouchbaseContainer` has a special `CouchbaseQueryServiceWaitStrategy` with a hard coded timeout. This makes it configurable through the builder methods.
