### PR TITLE
Improved usage of generics in some modules

### DIFF
--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  *
  * @author Eugeny Karpov
  */
-public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends GenericContainer<SELF> {
+public class CassandraContainer extends GenericContainer<CassandraContainer> {
 
     public static final String IMAGE = "cassandra";
     public static final Integer CQL_PORT = 9042;
@@ -101,7 +101,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      *
      * @param configLocation relative classpath with the directory that contains cassandra.yaml and other configuration files
      */
-    public SELF withConfigurationOverride(String configLocation) {
+    public CassandraContainer withConfigurationOverride(String configLocation) {
         this.configLocation = configLocation;
         return self();
     }
@@ -113,7 +113,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      *
      * @param initScriptPath relative classpath resource
      */
-    public SELF withInitScript(String initScriptPath) {
+    public CassandraContainer withInitScript(String initScriptPath) {
         this.initScriptPath = initScriptPath;
         return self();
     }
@@ -121,7 +121,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
     /**
      * Initialize Cassandra client with JMX reporting enabled or disabled
      */
-    public SELF withJmxReporting(boolean enableJmxReporting) {
+    public CassandraContainer withJmxReporting(boolean enableJmxReporting) {
         this.enableJmxReporting = enableJmxReporting;
         return self();
     }

--- a/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
+++ b/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
@@ -20,7 +20,7 @@ public class CassandraContainerTest {
 
     @Test
     public void testSimple() {
-        try (CassandraContainer cassandraContainer = new CassandraContainer<>()) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer()) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer, "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());
@@ -31,7 +31,7 @@ public class CassandraContainerTest {
     @Test
     public void testSpecificVersion() {
         String cassandraVersion = "3.0.15";
-        try (CassandraContainer cassandraContainer = new CassandraContainer<>("cassandra:" + cassandraVersion)) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer("cassandra:" + cassandraVersion)) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer, "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());
@@ -42,7 +42,7 @@ public class CassandraContainerTest {
     @Test
     public void testConfigurationOverride() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .withConfigurationOverride("cassandra-test-configuration-example")
         ) {
             cassandraContainer.start();
@@ -55,7 +55,7 @@ public class CassandraContainerTest {
     @Test(expected = ContainerLaunchException.class)
     public void testEmptyConfigurationOverride() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .withConfigurationOverride("cassandra-empty-configuration")
         ) {
             cassandraContainer.start();
@@ -65,7 +65,7 @@ public class CassandraContainerTest {
     @Test
     public void testInitScript() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .withInitScript("initial.cql")
         ) {
             cassandraContainer.start();
@@ -76,7 +76,7 @@ public class CassandraContainerTest {
     @Test
     public void testInitScriptWithLegacyCassandra() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>("cassandra:2.2.11")
+            CassandraContainer cassandraContainer = new CassandraContainer("cassandra:2.2.11")
                 .withInitScript("initial.cql")
         ) {
             cassandraContainer.start();
@@ -87,7 +87,7 @@ public class CassandraContainerTest {
     @Test
     public void testCassandraQueryWaitStrategy() {
         try (
-            CassandraContainer cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .waitingFor(new CassandraQueryWaitStrategy())
         ) {
             cassandraContainer.start();
@@ -98,7 +98,7 @@ public class CassandraContainerTest {
 
     @Test
     public void testCassandraGetCluster() {
-        try (CassandraContainer cassandraContainer = new CassandraContainer<>()) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer()) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer.getCluster(), "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());

--- a/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
+++ b/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
@@ -11,7 +11,7 @@ import java.util.Set;
 /**
  * See <a href="https://store.docker.com/images/influxdb">https://store.docker.com/images/influxdb</a>
  */
-public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends GenericContainer<SELF> {
+public class InfluxDBContainer extends GenericContainer<InfluxDBContainer> {
 
     public static final String VERSION = "1.4.3";
     public static final Integer INFLUXDB_PORT = 8086;
@@ -63,7 +63,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      * @param authEnabled Enables authentication.
      * @return a reference to this container instance
      */
-    public SELF withAuthEnabled(final boolean authEnabled) {
+    public InfluxDBContainer withAuthEnabled(final boolean authEnabled) {
         this.authEnabled = authEnabled;
         return self();
     }
@@ -74,7 +74,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      * @param admin The name of the admin user to be created. If this is unset, no admin user is created.
      * @return a reference to this container instance
      */
-    public SELF withAdmin(final String admin) {
+    public InfluxDBContainer withAdmin(final String admin) {
         this.admin = admin;
         return self();
     }
@@ -86,7 +86,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      *                      random password is generated and printed to standard out.
      * @return a reference to this container instance
      */
-    public SELF withAdminPassword(final String adminPassword) {
+    public InfluxDBContainer withAdminPassword(final String adminPassword) {
         this.adminPassword = adminPassword;
         return self();
     }
@@ -97,7 +97,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      * @param database Automatically initializes a database with the name of this environment variable.
      * @return a reference to this container instance
      */
-    public SELF withDatabase(final String database) {
+    public InfluxDBContainer withDatabase(final String database) {
         this.database = database;
         return self();
     }
@@ -109,7 +109,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      *                 be granted read and write permissions for that database.
      * @return a reference to this container instance
      */
-    public SELF withUsername(final String username) {
+    public InfluxDBContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
@@ -121,7 +121,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      *                 is generated and printed to standard out.
      * @return a reference to this container instance
      */
-    public SELF withPassword(final String password) {
+    public InfluxDBContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/MultiVersionMySQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/MultiVersionMySQLTest.java
@@ -26,7 +26,7 @@ public class MultiVersionMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void versionCheckTest() throws SQLException {
-        try (final MySQLContainer container = new MySQLContainer<>("mysql:" + version)) {
+        try (final MySQLContainer container = new MySQLContainer("mysql:" + version)) {
             container.start();
             final ResultSet resultSet = performQuery(container, "SELECT VERSION()");
             final String resultSetString = resultSet.getString(1);

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimplePostgreSQLTest.java
@@ -20,7 +20,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
-        try (PostgreSQLContainer postgres = new PostgreSQLContainer<>()) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer()) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT 1");
@@ -31,7 +31,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testCommandOverride() throws SQLException {
-        try (PostgreSQLContainer postgres = new PostgreSQLContainer<>().withCommand("postgres -c max_connections=42")) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer().withCommand("postgres -c max_connections=42")) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
@@ -42,7 +42,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testUnsetCommand() throws SQLException {
-        try (PostgreSQLContainer postgres = new PostgreSQLContainer<>().withCommand("postgres -c max_connections=42").withCommand()) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer().withCommand("postgres -c max_connections=42").withCommand()) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
@@ -53,7 +53,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testExplicitInitScript() throws SQLException {
-        try (PostgreSQLContainer postgres = new PostgreSQLContainer<>().withInitScript("somepath/init_postgresql.sql")) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer().withInitScript("somepath/init_postgresql.sql")) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT foo FROM bar");

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -5,7 +5,7 @@ package org.testcontainers.containers;
  *
  * @author Miguel Gonzalez Sanchez
  */
-public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MariaDBContainer extends JdbcDatabaseContainer<MariaDBContainer> {
 
     public static final String NAME = "mariadb";
     public static final String IMAGE = "mariadb";
@@ -79,25 +79,25 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         return "SELECT 1";
     }
 
-    public SELF withConfigurationOverride(String s) {
+    public MariaDBContainer withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
     
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public MariaDBContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public MariaDBContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MariaDBContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -8,7 +8,7 @@ import java.util.stream.Stream;
 /**
  * @author Stefan Hufschmidt
  */
-public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MSSQLServerContainer extends JdbcDatabaseContainer<MSSQLServerContainer> {
 
     public static final String NAME = "sqlserver";
     public static final String IMAGE = "mcr.microsoft.com/mssql/server";
@@ -79,7 +79,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MSSQLServerContainer withPassword(final String password) {
         checkPasswordStrength(password);
         this.password = password;
         return self();

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -8,7 +8,7 @@ import java.util.Set;
 /**
  * @author richardnorth
  */
-public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MySQLContainer extends JdbcDatabaseContainer<MySQLContainer> {
 
     public static final String NAME = "mysql";
     public static final String IMAGE = "mysql";
@@ -105,25 +105,25 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         return "SELECT 1";
     }
 
-    public SELF withConfigurationOverride(String s) {
+    public MySQLContainer withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public MySQLContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public MySQLContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MySQLContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -11,7 +11,7 @@ import java.util.Set;
 /**
  * @author richardnorth
  */
-public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer {
+public class NginxContainer extends GenericContainer<NginxContainer> implements LinkableContainer {
 
     private static final int NGINX_DEFAULT_PORT = 80;
 
@@ -39,7 +39,7 @@ public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericCo
         addFileSystemBind(htmlContentPath, "/usr/share/nginx/html", BindMode.READ_ONLY);
     }
 
-    public SELF withCustomContent(String htmlContentPath) {
+    public NginxContainer withCustomContent(String htmlContentPath) {
         this.setCustomContent(htmlContentPath);
         return self();
     }

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -23,7 +23,7 @@ public class SimpleNginxTest {
 
     // creatingContainer {
     @Rule
-    public NginxContainer nginx = new NginxContainer<>()
+    public NginxContainer nginx = new NginxContainer()
         .withCustomContent(tmpDirectory)
         .waitingFor(new HttpWaitStrategy());
     // }

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -12,7 +12,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 /**
  * @author richardnorth
  */
-public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class PostgreSQLContainer extends JdbcDatabaseContainer<PostgreSQLContainer> {
     public static final String NAME = "postgresql";
     public static final String IMAGE = "postgres";
     public static final String DEFAULT_TAG = "9.6.12";
@@ -83,19 +83,19 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public PostgreSQLContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public PostgreSQLContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public PostgreSQLContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
+++ b/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
@@ -13,7 +13,7 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
 import static java.time.temporal.ChronoUnit.SECONDS;
 
-public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class PrestoContainer extends JdbcDatabaseContainer<PrestoContainer> {
     public static final String NAME = "presto";
     public static final String IMAGE = "prestosql/presto";
     public static final String DEFAULT_TAG = "329";
@@ -76,7 +76,7 @@ public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDat
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public PrestoContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
@@ -86,14 +86,14 @@ public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDat
      */
     @Override
     @Deprecated
-    public SELF withPassword(final String password) {
+    public PrestoContainer withPassword(final String password) {
         // ignored, Presto does not support password authentication without TLS
         // TODO: make JDBCDriverTest not pass a password unconditionally and remove this method
         return self();
     }
 
     @Override
-    public SELF withDatabaseName(String dbName) {
+    public PrestoContainer withDatabaseName(String dbName) {
         this.catalog = dbName;
         return self();
     }

--- a/modules/presto/src/test/java/org/testcontainers/containers/PrestoContainerTest.java
+++ b/modules/presto/src/test/java/org/testcontainers/containers/PrestoContainerTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertTrue;
 public class PrestoContainerTest {
     @Test
     public void testSimple() throws Exception {
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>()) {
+        try (PrestoContainer prestoSql = new PrestoContainer()) {
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();
                  Statement statement = connection.createStatement();
@@ -38,7 +38,7 @@ public class PrestoContainerTest {
     @Test
     public void testSpecificVersion() throws Exception {
         String prestoVersion = Integer.toString(parseInt(PrestoContainer.DEFAULT_TAG) - 1);
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>("prestosql/presto:" + prestoVersion)) {
+        try (PrestoContainer prestoSql = new PrestoContainer("prestosql/presto:" + prestoVersion)) {
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();
                  Statement statement = connection.createStatement();
@@ -51,7 +51,7 @@ public class PrestoContainerTest {
 
     @Test
     public void testQueryMemoryAndTpch() throws SQLException {
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>()) {
+        try (PrestoContainer prestoSql = new PrestoContainer()) {
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();
                  Statement statement = connection.createStatement()) {
@@ -77,7 +77,7 @@ public class PrestoContainerTest {
 
     @Test
     public void testInitScript() throws Exception {
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>()) {
+        try (PrestoContainer prestoSql = new PrestoContainer()) {
             prestoSql.withInitScript("initial.sql");
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -42,7 +42,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  * <p>
  * The container should expose Selenium remote control protocol and VNC.
  */
-public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SELF>> extends GenericContainer<SELF> implements VncService, LinkableContainer, TestLifecycleAware {
+public class BrowserWebDriverContainer extends GenericContainer<BrowserWebDriverContainer> implements VncService, LinkableContainer, TestLifecycleAware {
 
     private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:%s";
     private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:%s";
@@ -95,7 +95,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     }
 
 
-    public SELF withCapabilities(Capabilities capabilities) {
+    public BrowserWebDriverContainer withCapabilities(Capabilities capabilities) {
         this.capabilities = capabilities;
         return self();
     }
@@ -108,7 +108,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      * @return SELF
      * */
     @Deprecated
-    public SELF withDesiredCapabilities(DesiredCapabilities capabilities) {
+    public BrowserWebDriverContainer withDesiredCapabilities(DesiredCapabilities capabilities) {
         this.capabilities = capabilities;
         return self();
     }
@@ -299,18 +299,18 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
      */
     @Deprecated
-    public SELF withLinkToContainer(LinkableContainer otherContainer, String alias) {
+    public BrowserWebDriverContainer withLinkToContainer(LinkableContainer otherContainer, String alias) {
         addLink(otherContainer, alias);
         return self();
     }
 
-    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory) {
+    public BrowserWebDriverContainer withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory) {
         this.recordingMode = recordingMode;
         this.vncRecordingDirectory = vncRecordingDirectory;
         return self();
     }
 
-    public SELF withRecordingFileFactory(RecordingFileFactory recordingFileFactory) {
+    public BrowserWebDriverContainer withRecordingFileFactory(RecordingFileFactory recordingFileFactory) {
         this.recordingFileFactory = recordingFileFactory;
         return self();
     }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BrowserWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BrowserWebDriverContainerTest.java
@@ -67,7 +67,7 @@ public class BrowserWebDriverContainerTest {
     @Test
     public void createContainerWithoutShmVolume() {
         try (
-            BrowserWebDriverContainer webDriverContainer = new BrowserWebDriverContainer<>()
+            BrowserWebDriverContainer webDriverContainer = new BrowserWebDriverContainer()
                 .withSharedMemorySize(512 * FileUtils.ONE_MB)
                 .withCapabilities(new FirefoxOptions())
         ) {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
@@ -15,7 +15,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 public class CustomWaitTimeoutWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Rule
-    public BrowserWebDriverContainer chromeWithCustomTimeout = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer chromeWithCustomTimeout = new BrowserWebDriverContainer()
             .withCapabilities(new ChromeOptions())
             .withStartupTimeout(Duration.of(30, SECONDS));
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/LinkedContainerTest.java
@@ -27,13 +27,13 @@ public class LinkedContainerTest {
     public Network network = Network.newNetwork();
 
     @Rule
-    public NginxContainer nginx = new NginxContainer<>()
+    public NginxContainer nginx = new NginxContainer()
             .withNetwork(network)
             .withNetworkAliases("nginx")
             .withCustomContent(contentFolder.toString());
 
     @Rule
-    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
             .withNetwork(network)
             .withCapabilities(new ChromeOptions());
 

--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -20,7 +20,7 @@ import static com.github.dockerjava.api.model.Capability.IPC_LOCK;
  * <p>
  * Other helpful features include the withVaultPort, and withVaultToken methods for convenience.
  */
-public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericContainer<SELF> {
+public class VaultContainer extends GenericContainer<VaultContainer> {
 
     private static final int VAULT_PORT = 8200;
 
@@ -73,7 +73,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param token the root token value to set for Vault.
      * @return this
      */
-    public SELF withVaultToken(String token) {
+    public VaultContainer withVaultToken(String token) {
         withEnv("VAULT_DEV_ROOT_TOKEN_ID", token);
         withEnv("VAULT_TOKEN", token);
         return self();
@@ -87,7 +87,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @deprecated the exposed port will be randomized automatically. As calling this method provides no additional value, you are recommended to remove the call. getFirstMappedPort() may be used to obtain the listening vault port.
      */
     @Deprecated
-    public SELF withVaultPort(int port) {
+    public VaultContainer withVaultPort(int port) {
         this.port = port;
         return self();
     }
@@ -104,7 +104,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param remainingSecrets var args list of secrets to add to specified path
      * @return this
      */
-    public SELF withSecretInVault(String path, String firstSecret, String... remainingSecrets) {
+    public VaultContainer withSecretInVault(String path, String firstSecret, String... remainingSecrets) {
         List<String> list = new ArrayList<>();
         list.add(firstSecret);
         for (String secret : remainingSecrets) {

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultClientTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultClientTest.java
@@ -19,7 +19,7 @@ public class VaultClientTest {
     @Test
     public void writeAndReadMultipleValues() throws VaultException {
         try (
-            VaultContainer vaultContainer = new VaultContainer<>()
+            VaultContainer vaultContainer = new VaultContainer()
                     .withVaultToken(VAULT_TOKEN)
         ) {
 

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
@@ -19,7 +19,7 @@ public class VaultContainerTest {
     private static final String VAULT_TOKEN = "my-root-token";
 
     @ClassRule
-    public static VaultContainer vaultContainer = new VaultContainer<>()
+    public static VaultContainer vaultContainer = new VaultContainer()
         .withVaultToken(VAULT_TOKEN)
         .withSecretInVault("secret/testing1", "top_secret=password123")
         .withSecretInVault("secret/testing2",


### PR DESCRIPTION
The following code does not compile because `withStartupAttempts` (and other methods inherited from `GenericContainer` which return `SELF` type) returns `GenericContainer` instead of concrete implementation (eg `CassandraContainer`):

```
    private static final CassandraContainer cassandra = new CassandraContainer()
            .withStartupAttempts(MAX_STARTUP_ATTEMPTS);
```

Similar issue was found in the next modules:
- cassandra
- influxdb
- mariadb
- mssqlserver
- mysql
- nginx
- postgresql
- presto
- selenium
- vault