### PR TITLE
Upgrade localstack to 0.10.8

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -29,7 +29,7 @@ import java.util.stream.Collectors;
  */
 public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
-    public static final String VERSION = "0.9.4";
+    public static final String VERSION = "0.10.8";
     private static final String HOSTNAME_EXTERNAL_ENV_VAR = "HOSTNAME_EXTERNAL";
 
     private final List<Service> services = new ArrayList<>();

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -105,7 +105,6 @@ public class LocalstackContainerTest {
         }
 
         @Test
-        @Ignore("Fails due to https://github.com/localstack/localstack/issues/1434")
         public void cloudWatchLogsTestOverBridgeNetwork() {
             AWSLogs logs = AWSLogsClientBuilder.standard()
                     .withEndpointConfiguration(localstack.getEndpointConfiguration(CLOUDWATCHLOGS))


### PR DESCRIPTION
Just found out that localstack/localstack#1434 has been fixed.
This PR unignores test created in #2316; it requires localstack to be upgraded.