### PR TITLE
Improve usability of reusable containers

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -379,7 +379,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                     }
                     reusable = true;
                 } else {
-                    logger().info("Reuse was requested but the environment does not support the reuse of containers");
+                    logger().warn("Reuse was requested but the environment does not support the reuse of containers");
+                    logger().warn("To enable reuse of containers, you must set 'testcontainers.reuse.enable=true' in a file located at ~/.testcontainers.properties");
                     reusable = false;
                 }
             } else {

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -101,9 +101,22 @@ public class TestcontainersConfiguration {
 
     @UnstableAPI
     public boolean environmentSupportsReuse() {
-        return Boolean.parseBoolean((String) environmentProperties.getOrDefault("testcontainers.reuse.enable", "false"));
+        return Boolean.parseBoolean((String) environmentProperties.getOrDefault("testcontainers.reuse.enable", "false"))
+                || !isCI();
     }
-
+    
+    private boolean isCI() {
+        // Inspired by https://github.com/watson/ci-info/blob/master/index.js
+        return notFalse("CI") // Travis CI, CircleCI, Cirrus CI, Gitlab CI, Appveyor, CodeShip, dsari
+                || notFalse("CONTINUOUS_INTEGRATION") // Travis CI, Cirrus CI
+                || System.getenv("BUILD_NUMBER") != null // Jenkins, TeamCity
+                || System.getenv("RUN_ID") != null; // TaskCluster, dsari
+    }
+    
+    private static boolean notFalse(String key) {
+        return System.getenv(key) != null && !"false".equalsIgnoreCase(System.getenv(key));
+    }
+    
     public String getDockerClientStrategyClassName() {
         return (String) environmentProperties.get("docker.client.strategy");
     }


### PR DESCRIPTION
Currently in order to take advantage of the reusable containers feature, two things must happen:
1. The container must explicitly declare `withReuse(true)`
2. The runtime environment must have `testcontainers.reuse.enable=true` set in `~/.testcontainers.properties`

Item (1) is pretty obvious and straightforward, but (2) is a pain point, or something that a lot of people don't know about or don't notice (especially if they weren't the ones that initially added `withReuse(true)` to the codebase. It basically depends on per-project setup documentation (which many devs never read if they've already been working on the codebase for a while), or word-of-mouth among devs collaborating on a project.

The reason why (2) is needed is to prevent reusable containers from hanging around in CI environments -- we only want reusable containers to really be active for developer workstations.

I propose that we use logic found in the NodeJS `ci-info` library to automatically detect the presence of CI. If the presence of CI is not detected, we can enable reusable containers purely based on (1) which eliminates the manual step of each dev working on a project doing (2).

This approach works for the following CI servers:
 - Travis CI
 - Circle CI
 - Jenkins
 - Cirrus CI
 - Gitlab CI
 - Appveyor
 - Codeship
 - TeamCity
 - TaskCluster
 - dsari

which is just as many (if not more) CI environments than Testcontainers itself is supported in. If we find more in the future, we can always add them later.