### PR TITLE
Fallback to `getDefaultGateway()` if "bridge" is unavailable.

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -218,7 +218,9 @@ public abstract class DockerClientProviderStrategy {
                         .filter(it -> it.getGateway() != null)
                         .findAny()
                         .map(Network.Ipam.Config::getGateway)
-                        .orElse("localhost");
+                        .orElseGet(() -> {
+                            return DockerClientConfigUtils.getDefaultGateway().orElse("localhost");
+                        });
                 }
                 return "localhost";
             default:


### PR DESCRIPTION
Fixes #2239