### PR TITLE
Extend docs with registry mirror as workaround for custom images

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -46,7 +46,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > Used by LocalStack
 
 Another possibility is to set up a registry mirror in your environment so that all images are pulled from there and not directly from Docker Hub.
-For more information, see [Docker documentation about "Registry as a pull through cache"](https://docs.docker.com/registry/recipes/mirror/).
+For more information, see the [official Docker documentation about "Registry as a pull through cache"](https://docs.docker.com/registry/recipes/mirror/).
 
 ## Customizing Ryuk resource reaper
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -45,6 +45,9 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **localstack.container.image = localstack/localstack**  
 > Used by LocalStack
 
+Other possibility is to set up a registry mirror in your environment, so that all images are pulled from there and not directly from Docker Hub.
+For more information, see [Docker documentation about "Registry as a pull through cache"](https://docs.docker.com/registry/recipes/mirror/).
+
 ## Customizing Ryuk resource reaper
 
 > **ryuk.container.image = quay.io/testcontainers/ryuk:0.2.3**

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -45,7 +45,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **localstack.container.image = localstack/localstack**  
 > Used by LocalStack
 
-Other possibility is to set up a registry mirror in your environment, so that all images are pulled from there and not directly from Docker Hub.
+Another possibility is to set up a registry mirror in your environment so that all images are pulled from there and not directly from Docker Hub.
 For more information, see [Docker documentation about "Registry as a pull through cache"](https://docs.docker.com/registry/recipes/mirror/).
 
 ## Customizing Ryuk resource reaper


### PR DESCRIPTION
add link to registry mirror documentation in docker 

see also my question in slack channel