### PR TITLE
Add information for TLS disabled mode

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
@@ -1,7 +1,7 @@
 # GitLab CI
 
 In order to use Testcontainers in a Gitlab CI pipeline, you need to run the job as a Docker container (see [Patterns for running inside Docker](dind_patterns.md)).
-So edit your `.gitlab-ci.yml` to include the [Docker-In-Docker service](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker-executor) (`docker:dind`) and set the `DOCKER_HOST` variable to `tcp://docker:2375`.
+So edit your `.gitlab-ci.yml` to include the [Docker-In-Docker service](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker-workflow-with-docker-executor) (`docker:dind`) and set the `DOCKER_HOST` variable to `tcp://docker:2375` and `DOCKER_TLS_CERTDIR` to empty string.
 
 Here is a sample `.gitlab-ci.yml` that executes test with gradle:
 
@@ -13,6 +13,8 @@ services:
 variables:
   # Instruct Testcontainers to use the daemon of DinD.
   DOCKER_HOST: "tcp://docker:2375"
+  # Instruct Docker not to start over TLS.
+  DOCKER_TLS_CERTDIR: ""
   # Improve performance with overlayfs.
   DOCKER_DRIVER: overlay2
 


### PR DESCRIPTION
The Docker daemon supports connection over TLS and it’s done by default for Docker 19.03.1 or higher.
We need to instruct docker to not start over TLS with DOCKER_TLS_CERTDIR variable