### PR TITLE
Move static config in modules to constructor

### DIFF
--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
@@ -26,10 +26,7 @@ public class ClickHouseContainer extends JdbcDatabaseContainer {
 
     public ClickHouseContainer(String dockerImageName) {
         super(dockerImageName);
-    }
 
-    @Override
-    protected void configure() {
         withExposedPorts(HTTP_PORT, NATIVE_PORT);
         waitingFor(
             new HttpWaitStrategy()

--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -37,6 +37,8 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
         this.waitStrategy = new LogMessageWaitStrategy()
                 .withRegEx(".*Setup has completed\\..*")
                 .withStartupTimeout(Duration.of(10, ChronoUnit.MINUTES));
+
+        addExposedPort(DB2_PORT);
     }
 
     @Override
@@ -51,8 +53,6 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
             LicenseAcceptance.assertLicenseAccepted(this.getDockerImageName());
             acceptLicense();
         }
-
-        addExposedPort(DB2_PORT);
 
         addEnv("DBNAME", databaseName);
         addEnv("DB2INSTANCE", username);

--- a/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
+++ b/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
@@ -36,12 +36,12 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
         waitStrategy = new WaitAllStrategy()
             .withStrategy(Wait.forHttp("/ping").withBasicCredentials(username, password).forStatusCode(204))
             .withStrategy(Wait.forListeningPort());
+
+        addExposedPort(INFLUXDB_PORT);
     }
 
     @Override
     protected void configure() {
-        addExposedPort(INFLUXDB_PORT);
-
         addEnv("INFLUXDB_ADMIN_USER", admin);
         addEnv("INFLUXDB_ADMIN_PASSWORD", adminPassword);
 

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -24,6 +24,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
 
     public MariaDBContainer(String dockerImageName) {
         super(dockerImageName);
+        addExposedPort(MARIADB_PORT);
     }
 
     @Override
@@ -35,7 +36,6 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
     protected void configure() {
         optionallyMapResourceParameterAsVolume(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/conf.d", "mariadb-default-conf");
 
-        addExposedPort(MARIADB_PORT);
         addEnv("MYSQL_DATABASE", databaseName);
         addEnv("MYSQL_USER", username);
         if (password != null && !password.isEmpty()) {
@@ -83,7 +83,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
-    
+
     @Override
     public SELF withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -36,6 +36,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
         super(dockerImageName);
         withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
         withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+        addExposedPort(MS_SQL_SERVER_PORT);
     }
 
     @Override
@@ -45,11 +46,8 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
 
     @Override
     protected void configure() {
-        addExposedPort(MS_SQL_SERVER_PORT);
-
         LicenseAcceptance.assertLicenseAccepted(this.getDockerImageName());
         addEnv("ACCEPT_EULA", "Y");
-
         addEnv("SA_PASSWORD", password);
     }
 

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -27,6 +27,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
     public MySQLContainer(String dockerImageName) {
         super(dockerImageName);
+        addExposedPort(MYSQL_PORT);
     }
 
     @NotNull
@@ -40,7 +41,6 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         optionallyMapResourceParameterAsVolume(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/conf.d",
                 "mysql-default-conf");
 
-        addExposedPort(MYSQL_PORT);
         addEnv("MYSQL_DATABASE", databaseName);
         addEnv("MYSQL_USER", username);
         if (password != null && !password.isEmpty()) {

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -87,6 +87,8 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
             .withStrategy(waitForBolt)
             .withStrategy(waitForHttp)
             .withStartupTimeout(Duration.ofMinutes(2));
+
+        addExposedPorts(DEFAULT_BOLT_PORT, DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT);
     }
 
     @Override
@@ -99,8 +101,6 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
 
     @Override
     protected void configure() {
-
-        addExposedPorts(DEFAULT_BOLT_PORT, DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT);
 
         boolean emptyAdminPassword = this.adminPassword == null || this.adminPassword.isEmpty();
         String neo4jAuth = emptyAdminPassword ? "none" : String.format(AUTH_FORMAT, this.adminPassword);

--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -16,19 +16,20 @@ public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericCo
     private static final int NGINX_DEFAULT_PORT = 80;
 
     public NginxContainer() {
-        super("nginx:1.9.4");
+        this("nginx:1.9.4");
+    }
+
+    public NginxContainer(String dockerImageName) {
+        super(dockerImageName);
+
+        addExposedPort(NGINX_DEFAULT_PORT);
+        setCommand("nginx", "-g", "daemon off;");
     }
 
     @NotNull
     @Override
     protected Set<Integer> getLivenessCheckPorts() {
         return Collections.singleton(getMappedPort(80));
-    }
-
-    @Override
-    protected void configure() {
-        addExposedPort(NGINX_DEFAULT_PORT);
-        setCommand("nginx", "-g", "daemon off;");
     }
 
     public URL getBaseUrl(String scheme, int port) throws MalformedURLException {

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -46,16 +46,12 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
         super(dockerImageName);
         withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
         withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+        addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
     }
 
     @Override
     protected Integer getLivenessCheckPort() {
         return getMappedPort(ORACLE_PORT);
-    }
-
-    @Override
-    protected void configure() {
-        addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
     }
 
     @Override

--- a/modules/orientdb/src/main/java/org/testcontainers/containers/OrientDBContainer.java
+++ b/modules/orientdb/src/main/java/org/testcontainers/containers/OrientDBContainer.java
@@ -66,11 +66,12 @@ public class OrientDBContainer extends GenericContainer<OrientDBContainer> {
             .withStrategy(Wait.forListeningPort())
             .withStrategy(waitForHttp)
             .withStartupTimeout(Duration.ofMinutes(2));
+
+        addExposedPorts(DEFAULT_BINARY_PORT, DEFAULT_HTTP_PORT);
     }
 
     @Override
     protected void configure() {
-        addExposedPorts(DEFAULT_BINARY_PORT, DEFAULT_HTTP_PORT);
         addEnv("ORIENTDB_ROOT_PASSWORD", serverPassword);
     }
 

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -38,6 +38,8 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
                 .withTimes(2)
                 .withStartupTimeout(Duration.of(60, SECONDS));
         this.setCommand("postgres", "-c", FSYNC_OFF_OPTION);
+
+        addExposedPort(POSTGRESQL_PORT);
     }
 
     @NotNull
@@ -48,7 +50,6 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
 
     @Override
     protected void configure() {
-        addExposedPort(POSTGRESQL_PORT);
         addEnv("POSTGRES_DB", databaseName);
         addEnv("POSTGRES_USER", username);
         addEnv("POSTGRES_PASSWORD", password);

--- a/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
+++ b/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
@@ -32,17 +32,14 @@ public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDat
         this.waitStrategy = new LogMessageWaitStrategy()
             .withRegEx(".*io.prestosql.server.PrestoServer\\s+======== SERVER STARTED ========.*")
             .withStartupTimeout(Duration.of(60, SECONDS));
+
+        addExposedPort(PRESTO_PORT);
     }
 
     @NotNull
     @Override
     protected Set<Integer> getLivenessCheckPorts() {
         return new HashSet<>(getMappedPort(PRESTO_PORT));
-    }
-
-    @Override
-    protected void configure() {
-        addExposedPort(PRESTO_PORT);
     }
 
     @Override


### PR DESCRIPTION
As discussed with @bsideup on slack, static config should be applied in the constructor, not in configure()