### PR TITLE
Bump Cucucmber example version to 5.5.0

### DIFF
--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.14.0'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.14.0'
-    implementation 'io.cucumber:cucumber-java:4.8.0'
-    testImplementation 'io.cucumber:cucumber-junit:4.8.0'
+    testImplementation 'io.cucumber:cucumber-junit:5.5.0'
+    testImplementation 'io.cucumber:cucumber-java:5.5.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/cucumber/src/test/java/org/testcontainsers/examples/CucumberTest.java
+++ b/examples/cucumber/src/test/java/org/testcontainsers/examples/CucumberTest.java
@@ -1,7 +1,7 @@
 package org.testcontainsers.examples;
 
-import cucumber.api.CucumberOptions;
-import cucumber.api.junit.Cucumber;
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
 import org.junit.runner.RunWith;
 
 @RunWith(Cucumber.class)

--- a/examples/cucumber/src/test/java/org/testcontainsers/examples/Stepdefs.java
+++ b/examples/cucumber/src/test/java/org/testcontainsers/examples/Stepdefs.java
@@ -1,11 +1,11 @@
 package org.testcontainsers.examples;
 
-import cucumber.api.Scenario;
-import cucumber.api.java.After;
-import cucumber.api.java.Before;
-import cucumber.api.java.en.Given;
-import cucumber.api.java.en.Then;
-import cucumber.api.java.en.When;
+import io.cucumber.java.Scenario;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.junit.After;
+import org.junit.Before;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;

--- a/examples/cucumber/src/test/java/org/testcontainsers/examples/Stepdefs.java
+++ b/examples/cucumber/src/test/java/org/testcontainsers/examples/Stepdefs.java
@@ -1,11 +1,11 @@
 package org.testcontainsers.examples;
 
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-import org.junit.After;
-import org.junit.Before;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;


### PR DESCRIPTION
We removed deprecated API a while ago in cucumber-jvm, so dependabot can't bump version.