### PR TITLE
add more information for using registry mirror

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -48,6 +48,11 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 Another possibility is to set up a registry mirror in your environment so that all images are pulled from there and not directly from Docker Hub.
 For more information, see the [official Docker documentation about "Registry as a pull through cache"](https://docs.docker.com/registry/recipes/mirror/).
 
+!!!tip
+    Registry mirror currently only works for Docker images with image name that has no registry specified (for example, for Docker image `mariadb:10.3.6`, it works, for Docker image `quay.io/testcontainers/ryuk:0.2.3`, not).
+    Workaround is to to configure the affected Docker image in `.testcontainers.properties`.
+    For example: `ryuk.container.image = testcontainers/ryuk:0.2.3` or `ryuk.container.image = <your.docker.registry>/testcontainers/ryuk:0.2.3`
+
 ## Customizing Ryuk resource reaper
 
 > **ryuk.container.image = quay.io/testcontainers/ryuk:0.2.3**


### PR DESCRIPTION
Describe workaround for docker images with image name that has a registry specified