### PR TITLE
preserve containers on jvm exist/tests failure

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -46,12 +46,14 @@ public class DockerClientFactory {
 
     public static final ThreadGroup TESTCONTAINERS_THREAD_GROUP = new ThreadGroup("testcontainers");
     public static final String TESTCONTAINERS_LABEL = DockerClientFactory.class.getPackage().getName();
+    public static final String TESTCONTAINERS_LABEL_RYUK_REMOVABLE = TESTCONTAINERS_LABEL + ".ryukRemovable";
     public static final String TESTCONTAINERS_SESSION_ID_LABEL = TESTCONTAINERS_LABEL + ".sessionId";
 
     public static final String SESSION_ID = UUID.randomUUID().toString();
 
     public static final Map<String, String> DEFAULT_LABELS = ImmutableMap.of(
             TESTCONTAINERS_LABEL, "true",
+            TESTCONTAINERS_LABEL_RYUK_REMOVABLE, "true",
             TESTCONTAINERS_SESSION_ID_LABEL, SESSION_ID
     );
 

--- a/core/src/main/java/org/testcontainers/containers/ContainerPreserveOptions.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerPreserveOptions.java
@@ -1,0 +1,8 @@
+package org.testcontainers.containers;
+
+/**
+ * Enum specifying conditions on which container instance will not be deleted from docker daemon.
+ */
+public enum ContainerPreserveOptions {
+    ON_JVM_SHUTDOWN, ON_TESTS_FAILURE
+}


### PR DESCRIPTION
This closes https://github.com/testcontainers/testcontainers-java/issues/971

My use-case is that sometimes I want to preserve containers when tests fail or when JVM crashes/closes.

Implementation:
* for ON_JVM_EXIT: I used ryuk tags to exclude my container from being deleted.
* for ON_TEST_FAIL: Since I didn't see an option to add label to already running container, ryuk deletion is disabled for this option. Method ```GenericContainer#failed``` holds logic responsible for deleting/preserving container after test run.

I am open to any kind of feedback - I didn't include tests yet. 