### PR TITLE
Replace legacy javax.annotation-api with Jakarta one

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -115,7 +115,7 @@ dependencies {
     compile 'junit:junit:4.12'
     compile 'org.slf4j:slf4j-api:1.7.30'
     compile 'org.jetbrains:annotations:17.0.0'
-    compile 'javax.annotation:javax.annotation-api:1.3.2'
+    compile 'jakarta.annotation:jakarta.annotation-api:1.3.5'
     compile 'org.apache.commons:commons-compress:1.20'
     // Added for JDK9 compatibility since it's missing this package
     compile 'javax.xml.bind:jaxb-api:2.3.1'


### PR DESCRIPTION
During the transition from JEE to the Jakarta project the Maven coordinates of the annotations-api have changed.

This results in warnings with quarkus builds:
```
These dependencies are not recommended:
        - javax.annotation:javax.annotation-api should be replaced by jakarta.annotation:jakarta.annotation-api
You might end up with two different versions of the same classes or with an artifact you shouldn't have in your classpath.
```

This patch replaces the legacy JEE dependency with the Jakarta one.