### PR TITLE
Remove unused JEE deps

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -116,7 +116,6 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.30'
     compile 'org.jetbrains:annotations:17.0.0'
     compile 'org.apache.commons:commons-compress:1.20'
-    // Added for JDK9 compatibility since it's missing this package
     compile ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -115,10 +115,8 @@ dependencies {
     compile 'junit:junit:4.12'
     compile 'org.slf4j:slf4j-api:1.7.30'
     compile 'org.jetbrains:annotations:17.0.0'
-    compile 'javax.annotation:javax.annotation-api:1.3.2'
     compile 'org.apache.commons:commons-compress:1.20'
     // Added for JDK9 compatibility since it's missing this package
-    compile 'javax.xml.bind:jaxb-api:2.3.1'
     compile ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
Two compile dependencies referencing JEE artifacts don't seem to be required for compilation. This PR removes them from the build.

Closes #2091