### PR TITLE
Add a getter for Toxiproxy exposed port

### DIFF
--- a/docs/modules/toxiproxy.md
+++ b/docs/modules/toxiproxy.md
@@ -32,7 +32,7 @@ We do this as follows:
 To establish a connection from the test code (on the host machine) to the target container via Toxiproxy, we obtain **Toxiproxy's** proxy host IP and port:
 
 <!--codeinclude-->
-[Obtaining proxied host and port for the host mahcine](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForHostMachine
+[Obtaining proxied host and port for connections from the host machine](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForHostMachine
 <!--/codeinclude-->
 
 Code under test should connect to this proxied host IP and port.
@@ -40,7 +40,7 @@ Code under test should connect to this proxied host IP and port.
 To establish a connection from a different container on the same network to the target container via Toxiproxy, we use **Toxiproxy's** network alias and original port:
 
 <!--codeinclude-->
-[Obtaining proxied host and port for a different container](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForDifferentContainer
+[Obtaining proxied host and port for connections from a different container](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForDifferentContainer
 <!--/codeinclude-->
 
 Other containers should connect to this proxied host and port.
@@ -90,4 +90,3 @@ testCompile "org.testcontainers:toxiproxy:{{latest_version}}"
 This module was inspired by a [hotels.com blog post](https://medium.com/hotels-com-technology/i-dont-know-about-resilience-testing-and-so-can-you-b3c59d80012d).
 
 [toxiproxy-java](https://github.com/trekawek/toxiproxy-java) is used to help control failure conditions.
-

--- a/docs/modules/toxiproxy.md
+++ b/docs/modules/toxiproxy.md
@@ -29,13 +29,21 @@ We do this as follows:
 [Starting proxying connections to a target container](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxyObject
 <!--/codeinclude-->
 
-Then, to establish a connection via Toxiproxy, we obtain **Toxiproxy's** proxy host IP and port:
+To establish a connection from the test code (on the host machine) to the target container via Toxiproxy, we obtain **Toxiproxy's** proxy host IP and port:
 
 <!--codeinclude-->
-[Obtaining proxied host and port](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPort
+[Obtaining proxied host and port for the host mahcine](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForHostMachine
 <!--/codeinclude-->
 
-Code under test, or other containers, should connect to this proxied host IP and port.
+Code under test should connect to this proxied host IP and port.
+
+To establish a connection from a different container on the same network to the target container via Toxiproxy, we use **Toxiproxy's** network alias and original port:
+
+<!--codeinclude-->
+[Obtaining proxied host and port for a different container](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForDifferentContainer
+<!--/codeinclude-->
+
+Other containers should connect to this proxied host and port.
 
 Having done this, it is possible to trigger failure conditions ('Toxics') through the `proxy.toxics()` object:
 

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -101,7 +101,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
         private static final String CUT_CONNECTION_UPSTREAM = "CUT_CONNECTION_UPSTREAM";
         private final Proxy toxi;
         /**
-         * The IP address that this proxy container may be reached on.
+         * The IP address that this proxy container may be reached on from the host machine.
          */
         @Getter private final String containerIpAddress;
         /**

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -87,7 +87,8 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
                 }
 
                 final Proxy proxy = client.createProxy(upstream, "0.0.0.0:" + toxiPort, upstream);
-                return new ContainerProxy(proxy, getContainerIpAddress(), getMappedPort(toxiPort));
+                final int mappedPort = getMappedPort(toxiPort);
+                return new ContainerProxy(proxy, getContainerIpAddress(), mappedPort, toxiPort);
             } catch (IOException e) {
                 throw new RuntimeException("Proxy could not be created", e);
             }
@@ -99,8 +100,21 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
         private static final String CUT_CONNECTION_DOWNSTREAM = "CUT_CONNECTION_DOWNSTREAM";
         private static final String CUT_CONNECTION_UPSTREAM = "CUT_CONNECTION_UPSTREAM";
         private final Proxy toxi;
+        /**
+         * The IP address that this proxy container may be reached on.
+         */
         @Getter private final String containerIpAddress;
+        /**
+         * The mapped port of this proxy. This is a port of the host machine. It can be used to
+         * access the Toxiproxy container from the host machine.
+         */
         @Getter private final int proxyPort;
+        /**
+         * The original (exposed) port of this proxy. This is a port of the Toxiproxy Docker
+         * container. It can be used to access this container from a different Docker container
+         * on the same network.
+         */
+        @Getter private final int originalProxyPort;
         private boolean isCurrentlyCut;
 
         public ToxicList toxics() {

--- a/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
+++ b/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
@@ -125,6 +125,17 @@ public class ToxiproxyTest {
         }
     }
 
+    @Test
+    public void testOriginalAndMappedPorts() {
+        final ToxiproxyContainer.ContainerProxy proxy1 = toxiproxy.getProxy("hostname1", 8080);
+        assertEquals("original port is correct", 8666, proxy1.getOriginalProxyPort());
+        assertEquals("mapped port is correct", toxiproxy.getMappedPort(proxy1.getOriginalProxyPort()), proxy1.getProxyPort());
+
+        final ToxiproxyContainer.ContainerProxy proxy2 = toxiproxy.getProxy("hostname2", 9090);
+        assertEquals("original port is correct", 8667, proxy2.getOriginalProxyPort());
+        assertEquals("mapped port is correct", toxiproxy.getMappedPort(proxy2.getOriginalProxyPort()), proxy2.getProxyPort());
+    }
+
     private void checkCallWithLatency(Jedis jedis, final String description, int expectedMinLatency, long expectedMaxLatency) {
         final long start = System.currentTimeMillis();
         String s = jedis.get("somekey");


### PR DESCRIPTION
Hello!
I used Toxiproxy container to simulate a connection cut between two different Docker containers. It was a bit hard to determine what exposed port of the proxy corresponds to the exposed port of the target container. The code I ended up with did `toxiproxy.getExposedPorts().get(1)` which is not very intuitive because `toxiproxy.getExposedPorts().get(0)` is the proxy control port. Thus this PR. Hope it makes sense :)

Before this change, there only existed a getter for the mapped port which is useful for accessing the container from the host. A new getter can be useful when a Toxiproxy is setup between two different Docker containers to simulate network instabilities.