### PR TITLE
Temporarily ignore DB2 test - unrelated CI disk space issues

### DIFF
--- a/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/jdbc/JDBCDriverTest.java
@@ -67,7 +67,7 @@ public class JDBCDriverTest {
                 {"jdbc:tc:clickhouse://hostname/databasename", EnumSet.of(Options.PmdKnownBroken)},
                 {"jdbc:tc:sqlserver:2017-CU12://hostname:hostport;databaseName=databasename", EnumSet.noneOf(Options.class)},
                 {"jdbc:tc:cockroach://hostname/databasename", EnumSet.noneOf(Options.class)},
-                {"jdbc:tc:db2://hostname/databasename", EnumSet.noneOf(Options.class)}
+//                {"jdbc:tc:db2://hostname/databasename", EnumSet.noneOf(Options.class)}
             });
     }
 

--- a/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleDb2Test.java
+++ b/modules/jdbc-test/src/test/java/org/testcontainers/junit/SimpleDb2Test.java
@@ -2,6 +2,7 @@ package org.testcontainers.junit;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.Db2Container;
@@ -13,6 +14,7 @@ import java.sql.Statement;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
 
+@Ignore("Disabled since we had problems with CI disk space filling up from images in jdbc-test module")
 public class SimpleDb2Test {
 
     @Rule


### PR DESCRIPTION
We have some problems with file space running out on CI, so the jdbc-test module, pulling a lot of database images, can potentially break the build.