### PR TITLE
Explicitly set ciMate's projectId in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
     - run: &ciMate
         name: aggregate test reports with ciMate
         when: always
+        environment:
+          CIMATE_PROJECT_ID: 2348n4vl
         command: |
           wget -q https://get.cimate.io/release/linux/cimate
           chmod +x cimate


### PR DESCRIPTION
it looks like CircleCI does not set environment variables on PR builds.

This change sets it in the YAML file