### PR TITLE
Regard specified VNC recording directory for BrowserWebDriverContainer again

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -143,12 +143,15 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         }
 
         if (recordingMode != VncRecordingMode.SKIP) {
-            try {
-                vncRecordingDirectory = Files.createTempDirectory(TC_TEMP_DIR_PREFIX).toFile();
-            } catch (IOException e) {
-                // should never happen as per javadoc, since we use valid prefix
-                logger().error("Exception while trying to create temp directory " + vncRecordingDirectory.getAbsolutePath(), e);
-                throw new ContainerLaunchException("Exception while trying to create temp directory", e);
+
+            if (vncRecordingDirectory == null) {
+                try {
+                    vncRecordingDirectory = Files.createTempDirectory(TC_TEMP_DIR_PREFIX).toFile();
+                } catch (IOException e) {
+                    // should never happen as per javadoc, since we use valid prefix
+                    logger().error("Exception while trying to create temp directory " + vncRecordingDirectory.getAbsolutePath(), e);
+                    throw new ContainerLaunchException("Exception while trying to create temp directory", e);
+                }
             }
 
             if (getNetwork() == null) {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -1,17 +1,19 @@
 package org.testcontainers.junit;
 
+
+import com.google.common.io.PatternFilenameFilter;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.DefaultRecordingFileFactory;
 import org.testcontainers.lifecycle.TestDescription;
 
-import java.io.File;
 import java.util.Optional;
-
+import static org.junit.Assert.assertTrue;
 import static org.testcontainers.containers.BrowserWebDriverContainer.VncRecordingMode.RECORD_ALL;
 
 @RunWith(Enclosed.class)
@@ -20,14 +22,34 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
     public static class ChromeThatRecordsAllTests {
 
         @Rule
-        public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
-                .withCapabilities(new ChromeOptions())
-                .withRecordingMode(RECORD_ALL, new File("./build/"))
-                .withRecordingFileFactory(new DefaultRecordingFileFactory());
+        public TemporaryFolder vncRecordingDirectory = new TemporaryFolder();
 
         @Test
         public void recordingTestThatShouldBeRecordedAndRetained() {
-            doSimpleExplore(chrome);
+            try (
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
+                    .withCapabilities(new ChromeOptions())
+                    .withRecordingMode(RECORD_ALL, vncRecordingDirectory.getRoot())
+                    .withRecordingFileFactory(new DefaultRecordingFileFactory())
+            ) {
+                chrome.start();
+
+                doSimpleExplore(chrome);
+                chrome.afterTest(new TestDescription() {
+                    @Override
+                    public String getTestId() {
+                        return getFilesystemFriendlyName();
+                    }
+
+                    @Override
+                    public String getFilesystemFriendlyName() {
+                        return "ChromeThatRecordsAllTests-recordingTestThatShouldBeRecordedAndRetained";
+                    }
+                }, Optional.empty());
+
+                String[] files = vncRecordingDirectory.getRoot().list(new PatternFilenameFilter("PASSED-.*\\.flv"));
+                assertTrue("Recorded file not found", files.length == 1);
+            }
         }
     }
 


### PR DESCRIPTION
Since the changes of #2562 which were released with 1.14.0 the possibility to specify a target directory for the VNC recordings doesn't work anymore.