### PR TITLE
Allow using LocalStackContainer with AWS SDK v2 #1442

### DIFF
--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -13,6 +13,7 @@ public LocalStackContainer localstack = new LocalStackContainer()
 
 @Test
 public void someTestMethod() {
+    // AWS SDK v1
     AmazonS3 s3 = AmazonS3ClientBuilder
                     .standard()
                     .withEndpointConfiguration(localstack.getEndpointConfiguration(S3))
@@ -21,6 +22,19 @@ public void someTestMethod() {
     
             s3.createBucket("foo");
             s3.putObject("foo", "bar", "baz");
+
+    // AWS SDK v2
+    S3Client s3 = S3Client
+                .builder()
+                .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                    localstack.getAccessKey(), localstack.getSecretKey()
+                )))
+                .region(Region.of(localstack.getRegion()))
+                .build();
+
+            s3.createBucket(b -> b.bucket("foo"));
+            s3.putObject(b -> b.bucket("foo").key("bar"), RequestBody.fromBytes("baz".getBytes()));
 ```
 
 Environment variables listed in [Localstack's README](https://github.com/localstack/localstack#configurations) may be used to customize Localstack's configuration. 

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     testCompile 'com.amazonaws:aws-java-sdk-s3:1.11.683'
     testCompile 'com.amazonaws:aws-java-sdk-sqs:1.11.636'
     testCompile 'com.amazonaws:aws-java-sdk-logs:1.11.762'
+    testCompile 'software.amazon.awssdk:s3:2.11.10'
 }

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -13,6 +13,8 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.net.InetAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,7 +92,16 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
             .withCredentials(localstack.getDefaultCredentialsProvider())
             .build();
      </code></pre>
-     *
+     * or for AWS SDK v2
+     * <pre><code>S3Client s3 = S3Client
+             .builder()
+             .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
+             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+                localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             )))
+             .region(Region.of(localstack.getDefaultRegion()))
+             .build()
+     </code></pre>
      * <p><strong>Please note that this method is only intended to be used for configuring AWS SDK clients
      * that are running on the test host. If other containers need to call this one, they should be configured
      * specifically to do so using a Docker network and appropriate addressing.</strong></p>
@@ -99,20 +110,41 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * @return an {@link AwsClientBuilder.EndpointConfiguration}
      */
     public AwsClientBuilder.EndpointConfiguration getEndpointConfiguration(Service service) {
-        final String address = getContainerIpAddress();
-        String ipAddress = address;
+        return new AwsClientBuilder.EndpointConfiguration(getEndpointOverride(service).toString(), getDefaultRegion());
+    }
+
+    /**
+     * Provides an endpoint override that is preconfigured to communicate with a given simulated service.
+     * The provided endpoint override should be set in the AWS Java SDK v2 when building a client, e.g.:
+     * <pre><code>S3Client s3 = S3Client
+             .builder()
+             .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
+             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             )))
+             .region(Region.of(localstack.getDefaultRegion()))
+             .build()
+             </code></pre>
+     * <p><strong>Please note that this method is only intended to be used for configuring AWS SDK clients
+     * that are running on the test host. If other containers need to call this one, they should be configured
+     * specifically to do so using a Docker network and appropriate addressing.</strong></p>
+     *
+     * @param service the service that is to be accessed
+     * @return an {@link URI} endpoint override
+     */
+    public URI getEndpointOverride(Service service) {
         try {
+            final String address = getContainerIpAddress();
+            String ipAddress = address;
             // resolve IP address and use that as the endpoint so that path-style access is automatically used for S3
             ipAddress = InetAddress.getByName(address).getHostAddress();
-        } catch (UnknownHostException ignored) {
-
-        }
-
-        return new AwsClientBuilder.EndpointConfiguration(
-                "http://" +
+            return new URI("http://" +
                 ipAddress +
                 ":" +
-                getMappedPort(service.getPort()), "us-east-1");
+                getMappedPort(service.getPort()));
+        } catch (UnknownHostException | URISyntaxException e) {
+            throw new IllegalStateException("Cannot obtain endpoint URL", e);
+        }
     }
 
     /**
@@ -124,10 +156,74 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
             .withCredentials(localstack.getDefaultCredentialsProvider())
             .build();
      </code></pre>
+     * or for AWS SDK v2 you can use {@link #getDefaultAccessKey()}, {@link #getDefaultSecretKey()} directly:
+     * <pre><code>S3Client s3 = S3Client
+             .builder()
+             .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
+             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             )))
+             .region(Region.of(localstack.getDefaultRegion()))
+             .build()
+     </code></pre>
      * @return an {@link AWSCredentialsProvider}
      */
     public AWSCredentialsProvider getDefaultCredentialsProvider() {
-        return new AWSStaticCredentialsProvider(new BasicAWSCredentials("accesskey", "secretkey"));
+        return new AWSStaticCredentialsProvider(new BasicAWSCredentials(getDefaultAccessKey(), getDefaultSecretKey()));
+    }
+
+    /**
+     * Provides a default access key that is preconfigured to communicate with a given simulated service.
+     * The access key can be used to construct AWS SDK v2 clients:
+     * <pre><code>S3Client s3 = S3Client
+             .builder()
+             .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
+             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             )))
+             .region(Region.of(localstack.getDefaultRegion()))
+             .build()
+     </code></pre>
+     * @return a default access key
+     */
+    public String getDefaultAccessKey() {
+        return "accesskey";
+    }
+
+    /**
+     * Provides a default secret key that is preconfigured to communicate with a given simulated service.
+     * The secret key can be used to construct AWS SDK v2 clients:
+     * <pre><code>S3Client s3 = S3Client
+             .builder()
+             .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
+             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             )))
+             .region(Region.of(localstack.getDefaultRegion()))
+             .build()
+     </code></pre>
+     * @return a default secret key
+     */
+    public String getDefaultSecretKey() {
+        return "secretkey";
+    }
+
+    /**
+     * Provides a default region that is preconfigured to communicate with a given simulated service.
+     * The region can be used to construct AWS SDK v2 clients:
+     * <pre><code>S3Client s3 = S3Client
+             .builder()
+             .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
+             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
+             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             )))
+             .region(Region.of(localstack.getDefaultRegion()))
+             .build()
+     </code></pre>
+     * @return a default region
+     */
+    public String getDefaultRegion() {
+        return "us-east-1";
     }
 
     @RequiredArgsConstructor

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -97,9 +97,9 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
              .builder()
              .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
              .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
-                localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+                localstack.getAccessKey(), localstack.getSecretKey()
              )))
-             .region(Region.of(localstack.getDefaultRegion()))
+             .region(Region.of(localstack.getRegion()))
              .build()
      </code></pre>
      * <p><strong>Please note that this method is only intended to be used for configuring AWS SDK clients
@@ -110,7 +110,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * @return an {@link AwsClientBuilder.EndpointConfiguration}
      */
     public AwsClientBuilder.EndpointConfiguration getEndpointConfiguration(Service service) {
-        return new AwsClientBuilder.EndpointConfiguration(getEndpointOverride(service).toString(), getDefaultRegion());
+        return new AwsClientBuilder.EndpointConfiguration(getEndpointOverride(service).toString(), getRegion());
     }
 
     /**
@@ -120,9 +120,9 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
              .builder()
              .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
              .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
-             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             localstack.getAccessKey(), localstack.getSecretKey()
              )))
-             .region(Region.of(localstack.getDefaultRegion()))
+             .region(Region.of(localstack.getRegion()))
              .build()
              </code></pre>
      * <p><strong>Please note that this method is only intended to be used for configuring AWS SDK clients
@@ -156,20 +156,20 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
             .withCredentials(localstack.getDefaultCredentialsProvider())
             .build();
      </code></pre>
-     * or for AWS SDK v2 you can use {@link #getDefaultAccessKey()}, {@link #getDefaultSecretKey()} directly:
+     * or for AWS SDK v2 you can use {@link #getAccessKey()}, {@link #getSecretKey()} directly:
      * <pre><code>S3Client s3 = S3Client
              .builder()
              .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
              .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
-             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             localstack.getAccessKey(), localstack.getSecretKey()
              )))
-             .region(Region.of(localstack.getDefaultRegion()))
+             .region(Region.of(localstack.getRegion()))
              .build()
      </code></pre>
      * @return an {@link AWSCredentialsProvider}
      */
     public AWSCredentialsProvider getDefaultCredentialsProvider() {
-        return new AWSStaticCredentialsProvider(new BasicAWSCredentials(getDefaultAccessKey(), getDefaultSecretKey()));
+        return new AWSStaticCredentialsProvider(new BasicAWSCredentials(getAccessKey(), getSecretKey()));
     }
 
     /**
@@ -179,14 +179,14 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
              .builder()
              .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
              .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
-             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             localstack.getAccessKey(), localstack.getSecretKey()
              )))
-             .region(Region.of(localstack.getDefaultRegion()))
+             .region(Region.of(localstack.getRegion()))
              .build()
      </code></pre>
      * @return a default access key
      */
-    public String getDefaultAccessKey() {
+    public String getAccessKey() {
         return "accesskey";
     }
 
@@ -197,14 +197,14 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
              .builder()
              .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
              .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
-             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             localstack.getAccessKey(), localstack.getSecretKey()
              )))
-             .region(Region.of(localstack.getDefaultRegion()))
+             .region(Region.of(localstack.getRegion()))
              .build()
      </code></pre>
      * @return a default secret key
      */
-    public String getDefaultSecretKey() {
+    public String getSecretKey() {
         return "secretkey";
     }
 
@@ -215,14 +215,14 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
              .builder()
              .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
              .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
-             localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
+             localstack.getAccessKey(), localstack.getSecretKey()
              )))
-             .region(Region.of(localstack.getDefaultRegion()))
+             .region(Region.of(localstack.getRegion()))
              .build()
      </code></pre>
      * @return a default region
      */
-    public String getDefaultRegion() {
+    public String getRegion() {
         return "us-east-1";
     }
 

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -93,7 +93,7 @@ public class LocalstackContainerTest {
         }
 
         @Test
-        public void s3TestOverBridgeNetworkV2() throws IOException {
+        public void s3TestOverBridgeNetworkV2() {
             S3Client s3 = S3Client
                 .builder()
                 .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))


### PR DESCRIPTION
This PR exposes the generated `URI` from the `getEndpointConfiguration(Service)` method
so it can be used by AWS SDK v2 methods. 

It also exposes the default access key, secret key and region which is also required by the clients.

AWS SDK v2 users will be able to use the container without additional changes as follows:

```
S3Client s3 = S3Client
             .builder()
             .endpointOverride(localstack.getEndpointOverride(LocalStackContainer.Service.S3))
             .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(
                localstack.getDefaultAccessKey(), localstack.getDefaultSecretKey()
             )))
             .region(Region.of(localstack.getDefaultRegion()))
             .build()
```

