### PR TITLE
Update Gradle Shadow Plugin to 5.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'io.franzbecker.gradle-lombok' version '3.1.0'
     id 'nebula.provided-base' version '3.0.3'
-    id 'com.github.johnrengelman.shadow' version '5.1.0'
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
     id "com.jfrog.bintray" version "1.8.4" apply false
 }
 


### PR DESCRIPTION
Gradle Shadow Plugin supports Gradle Caching from 5.2.0 and should
help avoiding this heavyweight task when not necessarily.