### PR TITLE
Public ImageData class for custom image pull policies

### DIFF
--- a/core/src/main/java/org/testcontainers/images/ImageData.java
+++ b/core/src/main/java/org/testcontainers/images/ImageData.java
@@ -10,7 +10,7 @@ import java.time.Instant;
 
 @Value
 @Builder
-class ImageData {
+public class ImageData {
 
     @NonNull
     Instant createdAt;

--- a/core/src/test/java/alt/testcontainers/README.md
+++ b/core/src/test/java/alt/testcontainers/README.md
@@ -1,0 +1,1 @@
+Useful place for running tests that need to be outside of the `org.testcontainers` package.

--- a/core/src/test/java/alt/testcontainers/images/OutOfPackageImagePullPolicyTest.java
+++ b/core/src/test/java/alt/testcontainers/images/OutOfPackageImagePullPolicyTest.java
@@ -11,11 +11,11 @@ public class OutOfPackageImagePullPolicyTest {
     @Test
     public void shouldSupportCustomPoliciesOutOfTestContainersPackage() {
         try (
-            GenericContainer<?> container = new GenericContainer<>("hello-world:latest")
+            GenericContainer<?> container = new GenericContainer<>()
                 .withImagePullPolicy(new AbstractImagePullPolicy() {
                     @Override
                     protected boolean shouldPullCached(DockerImageName imageName, ImageData localImageData) {
-                        return true;
+                        return false;
                     }
                 })
         ) {

--- a/core/src/test/java/alt/testcontainers/images/OutOfPackageImagePullPolicyTest.java
+++ b/core/src/test/java/alt/testcontainers/images/OutOfPackageImagePullPolicyTest.java
@@ -1,0 +1,27 @@
+package alt.testcontainers.images;
+
+import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.images.AbstractImagePullPolicy;
+import org.testcontainers.images.ImageData;
+import org.testcontainers.utility.DockerImageName;
+
+public class OutOfPackageImagePullPolicyTest {
+    @Test
+    public void shouldSupportCustomPoliciesOutOfTestContainersPackage() {
+        try (
+            GenericContainer<?> container = new GenericContainer<>("hello-world:latest")
+                .withImagePullPolicy(new AbstractImagePullPolicy() {
+                    @Override
+                    protected boolean shouldPullCached(DockerImageName imageName, ImageData localImageData) {
+                        return true;
+                    }
+                })
+        ) {
+            container.withStartupCheckStrategy(new OneShotStartupCheckStrategy());
+            container.start();
+        }
+    }
+
+}


### PR DESCRIPTION
I was following the docs here: https://www.testcontainers.org/features/advanced_options/#image-pull-policy for creating a custom pull policy. It wouldn't let me compile since the `ImageData` class was not public. This PR makes that class public and provides a test to ensure `ImageData` can be accessed outside the `org.testcontainers.images` package.