### PR TITLE
Exclude multi-module `module-info.class` from shaded JAR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -44,6 +44,7 @@ shadowJar {
         'META-INF/DEPENDENCIES',
         'META-INF/maven/',
         'META-INF/proguard/',
+        'META-INF/versions/*/module-info.class',
         'META-INF/services/README.md',
         'META-INF/services/com.fasterxml.jackson.core.*',
         'META-INF/services/com.github.dockerjava.api.command.*',


### PR DESCRIPTION
Similar to 8dede0455827f89c03e753ee75dc70326303de68