### PR TITLE
Correct Minor Typo in GitLab CI Example

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
@@ -13,7 +13,7 @@ services:
 variables:
   # Instruct Testcontainers to use the daemon of DinD.
   DOCKER_HOST: "tcp://docker:2375"
-  # Improve performance with overlayfs.
+  # Improve performance with overlays.
   DOCKER_DRIVER: overlay2
 
 test:


### PR DESCRIPTION
This corrects a minor typo within the GitLab CI example.