### PR TITLE
Use relative path for temp dirs in test

### DIFF
--- a/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.model.AuthConfig;
 import org.intellij.lang.annotations.Language;
-import org.jetbrains.annotations.NotNull;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -111,8 +110,7 @@ public class AuthenticatedImagePullTest {
     @Test
     public void testThatAuthLocatorIsUsedForDockerfileBuild() throws IOException {
         // Prepare a simple temporary Dockerfile which requires our custom private image
-        Path tempContext = getLocalTempDir();
-        Path tempFile = Files.createTempFile(tempContext, "test", ".Dockerfile");
+        Path tempFile = getLocalTempFile(".Dockerfile");
         String dockerFileContent = "FROM " + testImageNameWithTag;
         Files.write(tempFile, dockerFileContent.getBytes());
 
@@ -131,8 +129,7 @@ public class AuthenticatedImagePullTest {
     @Test
     public void testThatAuthLocatorIsUsedForDockerComposePull() throws IOException {
         // Prepare a simple temporary Docker Compose manifest which requires our custom private image
-        Path tempContext = getLocalTempDir();
-        Path tempFile = Files.createTempFile(tempContext, "test", ".docker-compose.yml");
+        Path tempFile = getLocalTempFile(".docker-compose.yml");
         @Language("yaml") String composeFileContent =
             "version: '2.0'\n" +
                 "services:\n" +
@@ -154,11 +151,16 @@ public class AuthenticatedImagePullTest {
         }
     }
 
-    @NotNull
-    private Path getLocalTempDir() throws IOException {
+    private Path getLocalTempFile(String s) throws IOException {
         Path projectRoot = Paths.get(".");
         Path tempDirectory = Files.createTempDirectory(projectRoot, this.getClass().getSimpleName() + "-test-");
-        return projectRoot.relativize(tempDirectory);
+        Path relativeTempDirectory = projectRoot.relativize(tempDirectory);
+        Path tempFile = Files.createTempFile(relativeTempDirectory, "test", s);
+
+        tempDirectory.toFile().deleteOnExit();
+        tempFile.toFile().deleteOnExit();
+
+        return tempFile;
     }
 
     private static void putImageInRegistry() throws InterruptedException {

--- a/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
@@ -5,6 +5,7 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.PullImageResultCallback;
 import com.github.dockerjava.api.model.AuthConfig;
 import org.intellij.lang.annotations.Language;
+import org.jetbrains.annotations.NotNull;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -110,7 +111,7 @@ public class AuthenticatedImagePullTest {
     @Test
     public void testThatAuthLocatorIsUsedForDockerfileBuild() throws IOException {
         // Prepare a simple temporary Dockerfile which requires our custom private image
-        Path tempContext = Files.createTempDirectory(Paths.get("."), this.getClass().getSimpleName() + "-test-");
+        Path tempContext = getLocalTempDir();
         Path tempFile = Files.createTempFile(tempContext, "test", ".Dockerfile");
         String dockerFileContent = "FROM " + testImageNameWithTag;
         Files.write(tempFile, dockerFileContent.getBytes());
@@ -130,7 +131,7 @@ public class AuthenticatedImagePullTest {
     @Test
     public void testThatAuthLocatorIsUsedForDockerComposePull() throws IOException {
         // Prepare a simple temporary Docker Compose manifest which requires our custom private image
-        Path tempContext = Files.createTempDirectory(Paths.get("."), this.getClass().getSimpleName() + "-test-");
+        Path tempContext = getLocalTempDir();
         Path tempFile = Files.createTempFile(tempContext, "test", ".docker-compose.yml");
         @Language("yaml") String composeFileContent =
             "version: '2.0'\n" +
@@ -151,6 +152,13 @@ public class AuthenticatedImagePullTest {
                     .orElse(false)
             );
         }
+    }
+
+    @NotNull
+    private Path getLocalTempDir() throws IOException {
+        Path projectRoot = Paths.get(".");
+        Path tempDirectory = Files.createTempDirectory(projectRoot, this.getClass().getSimpleName() + "-test-");
+        return projectRoot.relativize(tempDirectory);
     }
 
     private static void putImageInRegistry() throws InterruptedException {


### PR DESCRIPTION
For reasons I don't fully understand, `DockerComposeContainer` is failing to mount a directory when passed the _absolute path form_ of temporary files created in `AuthenticatedImagePullTest`.

This only seems to happen on our Windows CI box, and I cannot reproduce locally on a Windows machine.

Converting the temp file path to relative form fixes the CI failure. 

We should work out how this issue was occurring as it seems like there's a small bug lurking somewhere. But as this is the first known occurrence, I think it's safe to assume it's a pretty rare problem.