### PR TITLE
CircleCI docs: fix invalid executor key

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -9,7 +9,7 @@ Here is a sample CircleCI configuration that does a checkout of a project and ru
 # Check https://circleci.com/docs/2.0/language-java/ for more details
 #
 version: 2
-executorType: machine
+machine: true
 jobs:
   build:
     steps:


### PR DESCRIPTION
executorType is no longer a valid executor definition in CircleCI. The simplest form to designate using machine executor is `machine: true`. Here is an [example usage](https://circleci.com/docs/2.0/configuration-reference/#example-1) in the current docs.

