### PR TITLE
Revert "Bump HikariCP from 3.4.3 to 3.4.4 in /modules/junit-jupiter"

### DIFF
--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     testCompile project(':mysql')
     testCompile project(':postgresql')
-    testCompile 'com.zaxxer:HikariCP:3.4.4'
+    testCompile 'com.zaxxer:HikariCP:3.4.3'
     testCompile 'redis.clients:jedis:3.3.0'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.12'
     testCompile ('org.mockito:mockito-core:3.3.3') {


### PR DESCRIPTION
Reverts testcontainers/testcontainers-java#2679

Reverting due to https://github.com/brettwooldridge/HikariCP/issues/1578