### PR TITLE
Revert "Bump HikariCP from 3.4.3 to 3.4.4 in /modules/spock"

### DIFF
--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testCompile project(':mysql')
     testCompile project(':postgresql')
 
-    testCompile 'com.zaxxer:HikariCP:3.4.4'
+    testCompile 'com.zaxxer:HikariCP:3.4.3'
     testCompile 'org.apache.httpcomponents:httpclient:4.5.12'
 
     testRuntime 'org.postgresql:postgresql:42.2.12'


### PR DESCRIPTION
Reverts testcontainers/testcontainers-java#2678

Reverting due to https://github.com/brettwooldridge/HikariCP/issues/1578