### PR TITLE
Improved stack trace (#2253)

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -3,6 +3,7 @@ package org.testcontainers.utility;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.testcontainers.UnstableAPI;
 
 import java.io.*;
@@ -169,9 +170,11 @@ public class TestcontainersConfiguration {
         try (InputStream inputStream = url.openStream()) {
             properties.load(inputStream);
         } catch (FileNotFoundException e) {
-            log.trace("Testcontainers config override was found on {} but the file was not found", url, e);
+            log.warn("Testcontainers config override was found on {} but the file was not found." +
+                " Exception message: {}", url, ExceptionUtils.getRootCauseMessage(e));
         } catch (IOException e) {
-            log.warn("Testcontainers config override was found on {} but could not be loaded", url, e);
+            log.warn("Testcontainers config override was found on {} but could not be loaded. " +
+                "Exception message: {}", url, ExceptionUtils.getRootCauseMessage(e));
         }
         return properties;
     }


### PR DESCRIPTION
Stopped displaying a stack trace in the logs when .testcontainers.properties wasn't found (#2253)