### PR TITLE
#2431 Correction for an edge case in local image repos (duplicates tags)

### DIFF
--- a/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
+++ b/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
@@ -79,7 +79,11 @@ enum LocalImagesCache {
             }
 
             cache.putAll(
-                Stream.of(repoTags).collect(Collectors.toMap(
+                Stream.of(repoTags)
+                    // Protection against some edge case where local image repository tags end up with duplicates
+                    // making toMap crash at merge time.
+                   .distinct()
+                    .collect(Collectors.toMap(
                     DockerImageName::new,
                     it -> ImageData.from(image)
                 ))

--- a/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
+++ b/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
@@ -82,7 +82,7 @@ enum LocalImagesCache {
                 Stream.of(repoTags)
                     // Protection against some edge case where local image repository tags end up with duplicates
                     // making toMap crash at merge time.
-                   .distinct()
+                    .distinct()
                     .collect(Collectors.toMap(
                     DockerImageName::new,
                     it -> ImageData.from(image)

--- a/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
+++ b/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
@@ -84,9 +84,9 @@ enum LocalImagesCache {
                     // making toMap crash at merge time.
                     .distinct()
                     .collect(Collectors.toMap(
-                    DockerImageName::new,
-                    it -> ImageData.from(image)
-                ))
+                        DockerImageName::new,
+                        it -> ImageData.from(image)
+                    ))
             );
         }
     }


### PR DESCRIPTION
Duplicate image tags in local docker causing a crash in LocalImagesCache. #2431
