### PR TITLE
Revert "Bump transport from 6.7.1 to 7.7.0 in /modules/elasticsearch"

### DIFF
--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,5 +3,5 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     compile project(':testcontainers')
     testCompile "org.elasticsearch.client:elasticsearch-rest-client:7.6.2"
-    testCompile "org.elasticsearch.client:transport:7.7.0"
+    testCompile "org.elasticsearch.client:transport:6.7.1"
 }


### PR DESCRIPTION
Reverts testcontainers/testcontainers-java#2737

Failing build on Windows CI - will investigate.