### PR TITLE
Upgrade cockroachdb image tag to v20.1.0

### DIFF
--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -7,7 +7,7 @@ import java.time.Duration;
 public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer> {
     public static final String NAME = "cockroach";
     public static final String IMAGE = "cockroachdb/cockroach";
-    public static final String IMAGE_TAG = "v19.1.1";
+    public static final String IMAGE_TAG = "v20.1.0";
     private static final String JDBC_DRIVER_CLASS_NAME = "org.postgresql.Driver";
     private static final String JDBC_URL_PREFIX = "jdbc:postgresql";
     private static final String TEST_QUERY_STRING = "SELECT 1";


### PR DESCRIPTION
Hi folks,

While doing some integration testing + flyway, I found that the image tag for cockroachdb in testcontainers is `19.1.1`  because I faced https://github.com/cockroachdb/cockroach/issues/28751 😅 

I think it would be great if the latest stable release is used here which is `v20.1.0` released on May 12th.