### PR TITLE
Migrate postgis image to the postgis/postgis docker hub repo.

### DIFF
--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
@@ -10,8 +10,8 @@ import java.util.Objects;
 public class PostgisContainerProvider extends JdbcDatabaseContainerProvider {
 
     private static final String NAME = "postgis";
-    private static final String DEFAULT_TAG = "10";
-    private static final String DEFAULT_IMAGE = "mdillon/postgis";
+    private static final String DEFAULT_TAG = "12-3.0";
+    private static final String DEFAULT_IMAGE = "postgis/postgis";
     public static final String USER_PARAM = "user";
     public static final String PASSWORD_PARAM = "password";
 

--- a/modules/postgresql/src/test/java/org/testcontainers/jdbc/postgis/PostgisJDBCDriverTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/jdbc/postgis/PostgisJDBCDriverTest.java
@@ -16,7 +16,7 @@ public class PostgisJDBCDriverTest extends AbstractJDBCDriverTest {
         return asList(
             new Object[][]{
                 {"jdbc:tc:postgis://hostname/databasename?user=someuser&password=somepwd", EnumSet.of(Options.JDBCParams)},
-                {"jdbc:tc:postgis:9.6://hostname/databasename?user=someuser&password=somepwd", EnumSet.of(Options.JDBCParams)},
+                {"jdbc:tc:postgis:9.6-2.5://hostname/databasename?user=someuser&password=somepwd", EnumSet.of(Options.JDBCParams)},
             });
     }
 }


### PR DESCRIPTION
Hello all. [mdillon/postigs](https://hub.docker.com/r/mdillon/postgis) image was renamed to [postgis/postgis](https://hub.docker.com/r/postgis/postgis) few months ago. [the discussion](https://github.com/postgis/docker-postgis/issues/143). Since that time the image has been updated with new postgres and postgis versions.

I've updated the image name and default version but there is a concern with the tags. Migration to the new image broke tag names backward compatibility with the old one. 
Since the new postgis version was added to the repo the image tags were changes. I.e mdillon/postgis:10 became postgis/postgis:10-2.5.