### PR TITLE
Bump Couchbase Server Image Version

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -68,7 +68,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     private static final String DOCKER_IMAGE_NAME = "couchbase/server";
 
-    private static final String VERSION = "6.5.0";
+    private static final String VERSION = "6.5.1";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 


### PR DESCRIPTION
6.5.1 got released in april 2020 and brings bugfixes and
enhancements. Let's make sure users pick that up by default.