### PR TITLE
Docker compose options.

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -78,6 +78,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
     private boolean localCompose;
     private boolean pull = true;
     private boolean build = false;
+    private String options = StringUtils.EMPTY;
     private boolean tailChildContainers;
 
     private String project;
@@ -209,9 +210,9 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
 
         // Run the docker-compose container, which starts up the services
         if(Strings.isNullOrEmpty(servicesWithScalingSettings)) {
-            runWithCompose("up " + flags);
+            runWithCompose(options + "up " + flags);
         } else {
-            runWithCompose("up " + flags + " " + servicesWithScalingSettings);
+            runWithCompose(options + "up " + flags + " " + servicesWithScalingSettings);
         }
     }
 
@@ -497,6 +498,20 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
      */
     public SELF withBuild(boolean build) {
         this.build = build;
+        return self();
+    }
+
+    /**
+     * Adds options to the docker-compose command, e.g. docker-compose --compatibility. Options must be space separated
+     * Options are raw strings to allow future options to be accommodated transparently.
+     *
+     * @return this instance, for chaining
+     */
+    public SELF withOptions(String options) {
+        if (options.length() != 0 && !options.endsWith(" ")) {
+            options+=" ";
+        }
+        this.options = options;
         return self();
     }
 

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeContainerWithOptionsTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeContainerWithOptionsTest.java
@@ -1,0 +1,58 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.testcontainers.containers.DockerComposeContainer;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the options associated with the docker-compose command.
+ */
+@RunWith(Parameterized.class)
+public class DockerComposeContainerWithOptionsTest {
+
+    public DockerComposeContainerWithOptionsTest(final File composeFile, final boolean local, final String options, final boolean expectError) {
+        this.composeFile = composeFile;
+        this.local = local;
+        this.options = options;
+        this.expectError = expectError;
+    }
+
+    private final File composeFile;
+    private final boolean local;
+    public final String options;
+    private final boolean expectError;
+
+    @Parameterized.Parameters(name = "docker-compose test [compose file: {0}, local: {1}, option: {2}, expected result: {3}]")
+    public static Object[][] params() {
+        return new Object[][]{
+            // Test the happy day case. THe compatibility option should be accepted by docker-compose.
+            {new File("src/test/resources/compose-options-test/with-deploy-block.yml"), false, "--compatibility", false},
+            // Test with flags absent. Docker compose will warn but continue, ignoring the deploy block.
+            {new File("src/test/resources/compose-options-test/with-deploy-block.yml"), false, "", false},
+            // Test with a bad option. Compose will complain.
+            {new File("src/test/resources/compose-options-test/with-deploy-block.yml"), false, "--bad-option", true},
+            // Local compose
+            {new File("src/test/resources/compose-options-test/with-deploy-block.yml"), true, "--compatibility", false},
+        };
+    }
+
+    @Test
+    public void performTest() {
+
+        try (DockerComposeContainer<?> environment = new DockerComposeContainer<>(composeFile)
+                .withOptions(options)
+                .withLocalCompose(local)) {
+            environment.start();
+            assertThat(expectError).isEqualTo(false);
+        } catch (Exception e) {
+            assertThat(expectError).isEqualTo(true);
+        }
+
+    }
+
+}

--- a/core/src/test/resources/compose-options-test/with-deploy-block.yml
+++ b/core/src/test/resources/compose-options-test/with-deploy-block.yml
@@ -1,0 +1,8 @@
+version: '3.7'
+services:
+  redis:
+      image: redis:2.6.17
+      deploy:
+        resources:
+          limits:
+            memory: 150M


### PR DESCRIPTION
Adds support for docker compose options using a 'with' fluent style syntax. 

This enables a client to pass for example, the '--compatibility' option to the docker-compose command.

Parameterized Junit Test has been added.