### PR TITLE
added support for custom resources in solr container configuration

### DIFF
--- a/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
+++ b/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
@@ -57,12 +57,17 @@ public class SolrContainer extends GenericContainer<SolrContainer> {
             throw new IllegalArgumentException();
         }
         configuration.setConfigurationName(name);
-        configuration.setSolrConfiguration(solrConfig);
+        configuration.addResource(name, solrConfig);
         return self();
     }
 
     public SolrContainer withSchema(URL schema) {
-        configuration.setSolrSchema(schema);
+        configuration.addResource("schema.xml", schema);
+        return self();
+    }
+
+    public SolrContainer withResource(String name, URL resource) {
+        configuration.addResource(name, resource);
         return self();
     }
 
@@ -118,18 +123,16 @@ public class SolrContainer extends GenericContainer<SolrContainer> {
 
         if (StringUtils.isNotEmpty(configuration.getConfigurationName())) {
             SolrClientUtils.uploadConfiguration(
-                getContainerIpAddress(),
-                getSolrPort(),
-                configuration.getConfigurationName(),
-                configuration.getSolrConfiguration(),
-                configuration.getSolrSchema());
+                    getContainerIpAddress(),
+                    getSolrPort(),
+                    configuration);
         }
 
         SolrClientUtils.createCollection(
-            getContainerIpAddress(),
-            getSolrPort(),
-            configuration.getCollectionName(),
-            configuration.getConfigurationName());
+                getContainerIpAddress(),
+                getSolrPort(),
+                configuration.getCollectionName(),
+                configuration.getConfigurationName());
     }
 }
 

--- a/modules/solr/src/main/java/org/testcontainers/containers/SolrContainerConfiguration.java
+++ b/modules/solr/src/main/java/org/testcontainers/containers/SolrContainerConfiguration.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
 import java.net.URL;
+import java.util.HashMap;
 
 import lombok.Data;
 
@@ -13,6 +14,19 @@ public class SolrContainerConfiguration {
     private boolean zookeeper = true;
     private String collectionName = "dummy";
     private String configurationName;
-    private URL solrConfiguration;
-    private URL solrSchema;
+    private String schemaName;
+    private HashMap<String, URL> resources = new HashMap<>();
+
+    public SolrContainerConfiguration addResource(String name, URL resource) {
+        resources.put(name, resource);
+        return this;
+    }
+
+    public URL getSolrSchema() {
+        return resources.get(schemaName);
+    }
+
+    public URL getSolrConfiguration() {
+        return resources.get(configurationName);
+    }
 }

--- a/modules/solr/src/test/resources/solr/schema.xml
+++ b/modules/solr/src/test/resources/solr/schema.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<schema name="minimal" version="1.1">
+    <fieldType name="string" class="solr.StrField"/>
+    <dynamicField name="*" type="string" indexed="true" stored="true"/>
+    <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms/synonyms.txt" ignoreCase="true" expand="true" tokenizerFactory="solr.WhitespaceTokenizerFactory" />
+</schema>

--- a/modules/solr/src/test/resources/solr/solrconfig.xml
+++ b/modules/solr/src/test/resources/solr/solrconfig.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" ?>
+
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!-- Minimal solrconfig.xml with /select, /admin and /update only -->
+
+<config>
+
+    <dataDir>${solr.data.dir:}</dataDir>
+
+    <directoryFactory name="DirectoryFactory"
+                      class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
+    <schemaFactory class="ClassicIndexSchemaFactory"/>
+
+    <luceneMatchVersion>${tests.luceneMatchVersion:LATEST}</luceneMatchVersion>
+
+    <updateHandler class="solr.DirectUpdateHandler2">
+        <commitWithin>
+            <softCommit>${solr.commitwithin.softcommit:true}</softCommit>
+        </commitWithin>
+
+    </updateHandler>
+    <requestHandler name="/select" class="solr.SearchHandler">
+        <lst name="defaults">
+            <str name="echoParams">explicit</str>
+            <str name="indent">true</str>
+            <str name="df">text</str>
+        </lst>
+
+    </requestHandler>
+</config>

--- a/modules/solr/src/test/resources/solr/synonyms/synonyms.txt
+++ b/modules/solr/src/test/resources/solr/synonyms/synonyms.txt
@@ -1,0 +1,1 @@
+synonym,equivalent


### PR DESCRIPTION
Advanced configuration of your solr container is cumbersome and requires you to manually upload your configuration after a first dummy or incomplete configuration has been uploaded in the `containerIsStarted` method. The `withResource` method should solve this issue by allowing clients to define arbitrary files they also want to package and upload to the solr container during the initial process without having to care about the actual packaging and uploading logic.