### PR TITLE
Maintain deterministic order in withCopyFileToContainer and allow file reuse

### DIFF
--- a/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
+++ b/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
@@ -323,7 +323,7 @@ public class ReusabilityUnitTests {
 
             long hash1 = container.hashCopiedFiles().getValue();
 
-            container.getCopyToFileContainerPathMap().clear();
+            container.getCopyToFileContainerPathList().clear();
 
             container.withCopyFileToContainer(mountableFile, "/foo/baz");
 

--- a/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
@@ -8,7 +8,10 @@ import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toMap;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertFalse;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 import static org.testcontainers.TestImages.TINY_IMAGE;
@@ -53,7 +56,8 @@ public class CopyFileToContainerTest {
             .withClasspathResourceMapping(resource, "/readOnlyShared", BindMode.READ_ONLY, SelinuxContext.SHARED)
             .withClasspathResourceMapping(resource, "/readWrite", BindMode.READ_WRITE);
 
-        Map<MountableFile, String> copyMap = container.getCopyToFileContainerPathMap();
+        Map<MountableFile, String> copyMap = container.getCopyToFileContainerPathList().stream()
+            .collect(toMap(Entry::getKey, Entry::getValue));
         assertTrue("uses copy for read-only", copyMap.containsValue("/readOnly"));
         assertTrue("uses copy for read-only and no Selinux", copyMap.containsValue("/readOnlyNoSelinux"));
 


### PR DESCRIPTION
`withCopyFileToContainer` can be invoked multiple times, including with
one `containerPath` being prefix of another `containerPath`.

This change makes the end result deterministic.

This also allows copying a single source file (e.g. `/dev/null`) to
multiple destinations.

Fixes https://github.com/testcontainers/testcontainers-java/issues/2956