### PR TITLE
Update the default version of Apache Pulsar

### DIFF
--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -12,7 +12,7 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     public static final int BROKER_HTTP_PORT = 8080;
     public static final String METRICS_ENDPOINT = "/metrics";
 
-    private static final String PULSAR_VERSION = "2.2.0";
+    private static final String PULSAR_VERSION = "2.5.2";
 
     public PulsarContainer() {
         this(PULSAR_VERSION);


### PR DESCRIPTION
The default version of the Apache Pulsar image was updated from 2.2.0 to 2.5.2 (the latest release for now).