### PR TITLE
Maintain deterministic order in withCopyFileToContainer

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -78,6 +78,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -179,7 +180,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Nullable
     private Long shmSize;
 
-    private Map<MountableFile, String> copyToFileContainerPathMap = new HashMap<>();
+    // Maintain order in which entries are added, as earlier target location may be a prefix of a later location.
+    private Map<MountableFile, String> copyToFileContainerPathMap = new LinkedHashMap<>();
 
     protected final Set<Startable> dependencies = new HashSet<>();
 


### PR DESCRIPTION
`withCopyFileToContainer` can be invoked multiple times, including with
one `containerPath` being prefix of another `containerPath`.

This change makes the end result deterministic.

Extracted from https://github.com/testcontainers/testcontainers-java/pull/2861