### PR TITLE
Upgrade docker-java to 3.2.4

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -157,14 +157,14 @@ dependencies {
 
     compile "net.java.dev.jna:jna-platform:5.5.0"
 
-    shaded ('com.github.docker-java:docker-java-transport-okhttp:3.2.3') {
+    shaded ('com.github.docker-java:docker-java-transport-okhttp:3.2.4') {
         exclude(group: 'net.java.dev.jna')
         exclude(group: 'com.google.code.findbug')
         exclude(group: 'org.slf4j')
         exclude(group: 'org.apache.commons', module: 'commons-compress')
     }
 
-    shaded ('com.github.docker-java:docker-java-transport-zerodep:3.2.3') {
+    shaded ('com.github.docker-java:docker-java-transport-zerodep:3.2.4') {
         exclude(group: 'net.java.dev.jna')
         exclude(group: 'org.slf4j')
     }


### PR DESCRIPTION
Primarily to incorporate https://github.com/docker-java/docker-java/pull/1420 and improve build stability issues seen recently.