### PR TITLE
Convert Docs for the Spock Testframework

### DIFF
--- a/docs/test_framework_integration/spock.md
+++ b/docs/test_framework_integration/spock.md
@@ -9,37 +9,9 @@
 Specifying the `@Testcontainers` annotation will instruct Spock to start and stop all testcontainers accordingly. This annotation 
 can be mixed with Spock's `@Shared` annotation to indicate, that containers shouldn't be restarted between tests.
 
-```groovy
-@Testcontainers
-class DatabaseTest extends Specification {
-
-    @Shared
-    PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer()
-            .withDatabaseName("foo")
-            .withUsername("foo")
-            .withPassword("secret")
-
-    def "database is accessible"() {
-
-        given: "a jdbc connection"
-        HikariConfig hikariConfig = new HikariConfig()
-        hikariConfig.setJdbcUrl(postgreSQLContainer.jdbcUrl)
-        hikariConfig.setUsername("foo")
-        hikariConfig.setPassword("secret")
-        HikariDataSource ds = new HikariDataSource(hikariConfig)
-
-        when: "querying the database"
-        Statement statement = ds.getConnection().createStatement()
-        statement.execute("SELECT 1")
-        ResultSet resultSet = statement.getResultSet()
-        resultSet.next()
-
-        then: "result is returned"
-        int resultSetInt = resultSet.getInt(1)
-        resultSetInt == 1
-    }
-}
-```
+<!--codeinclude-->
+[PostgresContainerIT](../../modules/spock/src/test/groovy/org/testcontainers/spock/PostgresContainerIT.groovy) inside_block:PostgresContainerIT
+<!--/codeinclude-->
 
 ## Adding Testcontainers Spock support to your project dependencies
 

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/PostgresContainerIT.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/PostgresContainerIT.groovy
@@ -9,6 +9,7 @@ import spock.lang.Specification
 import java.sql.ResultSet
 import java.sql.Statement
 
+// PostgresContainerIT {
 @Testcontainers
 class PostgresContainerIT extends Specification {
 
@@ -42,3 +43,4 @@ class PostgresContainerIT extends Specification {
     }
 
 }
+// }


### PR DESCRIPTION
Convert inline example code to use codeinclude macro for the Spock Testframework documentation.
See #1158 for more details.