### PR TITLE
Use volatile referneces to prevent double creation of Ryuk containers

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -56,14 +56,14 @@ public class DockerClientFactory {
     );
 
     private static final String TINY_IMAGE = TestcontainersConfiguration.getInstance().getTinyImage();
-    private static DockerClientFactory instance;
+    private static volatile DockerClientFactory instance;
 
     // Cached client configuration
     @VisibleForTesting
-    DockerClientProviderStrategy strategy;
+    volatile DockerClientProviderStrategy strategy;
 
     @VisibleForTesting
-    DockerClient dockerClient;
+    volatile DockerClient dockerClient;
 
     @VisibleForTesting
     RuntimeException cachedChecksFailure;
@@ -115,7 +115,7 @@ public class DockerClientFactory {
     }
 
     @Synchronized
-    private DockerClientProviderStrategy getOrInitializeStrategy() {
+    private synchronized DockerClientProviderStrategy getOrInitializeStrategy() {
         if (strategy != null) {
             return strategy;
         }
@@ -133,7 +133,6 @@ public class DockerClientFactory {
      */
     @Synchronized
     public DockerClient client() {
-
         if (dockerClient != null) {
             return dockerClient;
         }


### PR DESCRIPTION
I believe this fixes #2395 

According to my logs for single-container usage, the docker client is being obtained twice:
```
[06/21/2020 19:07:33:948 UTC] 001 DockerClientFactory            client                         I Docker host IP address is <remote machine>
[06/21/2020 19:07:33:989 UTC] 001 DockerClientFactory            client                         I Connected to docker: 
  Server Version: 19.03.8
  API Version: 1.40
  Operating System: Ubuntu 18.04.1 LTS
  Total Memory: 16039 MB
[06/21/2020 19:07:34:022 UTC] 001 RegistryAuthLocator            lookupUncachedAuthConfig       W Failure when attempting to lookup auth config (dockerImageName: quay.io/testcontainers/ryuk:0.2.3, configFile: /home/jazz_build/.docker/config.json. Falling back to docker-java default behaviour. Exception message: /home/jazz_build/.docker/config.json (No such file or directory)
[06/21/2020 19:07:34:164 UTC] 001 DockerClientFactory            client                         I Docker host IP address is <remote machine>
[06/21/2020 19:07:34:186 UTC] 001 DockerClientFactory            client                         I Connected to docker: 
  Server Version: 19.03.8
  API Version: 1.40
  Operating System: Ubuntu 18.04.1 LTS
  Total Memory: 16039 MB
```