### PR TITLE
Stop looking for whitespace character after init message

### DIFF
--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -38,7 +38,7 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     public PostgreSQLContainer(final String dockerImageName) {
         super(dockerImageName);
         this.waitStrategy = new LogMessageWaitStrategy()
-                .withRegEx(".*database system is ready to accept connections.*\\s")
+                .withRegEx(".*database system is ready to accept connections.*")
                 .withTimes(2)
                 .withStartupTimeout(Duration.of(60, SECONDS));
         this.setCommand("postgres", "-c", FSYNC_OFF_OPTION);


### PR DESCRIPTION
Why is there a whitespace character at the end of the regex? It's causing issues for me when I start a postgres container that already contains a database and `2020-07-02 13:09:37.148 UTC [1] LOG:  database system is ready to accept connections` is the final message logged by the container. I have no problems when starting the container when there is no existing database and I'm guessing that's bacause this message is logged two times during such a init.

**Here's the log from the spring boot service**
```
2020-07-02 15:09:35.214  INFO 17800 --- [  restartedMain] 🐳 [vohantering:v1.06]                   : Creating container for image: vohantering:v1.06
2020-07-02 15:09:35.297  INFO 17800 --- [  restartedMain] 🐳 [vohantering:v1.06]                   : Starting container with ID: 1511b5d03630a4444a5f91269c95a966af541dc32ffa119da6986fa2d5684324
2020-07-02 15:09:35.585  INFO 17800 --- [  restartedMain] 🐳 [vohantering:v1.06]                   : Container vohantering:v1.06 is starting: 1511b5d03630a4444a5f91269c95a966af541dc32ffa119da6986fa2d5684324
2020-07-02 15:10:35.695 ERROR 17800 --- [  restartedMain] 🐳 [vohantering:v1.06]                   : Could not start container

org.testcontainers.containers.ContainerLaunchException: Timed out waiting for log output matching '.*database system is ready to accept connections.*\s'
	at org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy.waitUntilReady(LogMessageWaitStrategy.java:31)
	at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:35)
	at org.testcontainers.containers.wait.LogMessageWaitStrategy.waitUntilReady(LogMessageWaitStrategy.java:17)
	at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:35)
	at org.testcontainers.containers.PostgreSQLContainer.waitUntilContainerStarted(PostgreSQLContainer.java:117)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:441)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:325)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:323)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:311)
	at com.playtika.test.postgresql.EmbeddedPostgreSQLBootstrapConfiguration.postgresql(EmbeddedPostgreSQLBootstrapConfiguration.java:65)
	at com.playtika.test.postgresql.EmbeddedPostgreSQLBootstrapConfiguration$$EnhancerBySpringCGLIB$$8c8d6aca.CGLIB$postgresql$0(<generated>)
	at com.playtika.test.postgresql.EmbeddedPostgreSQLBootstrapConfiguration$$EnhancerBySpringCGLIB$$8c8d6aca$$FastClassBySpringCGLIB$$d1eed33.invoke(<generated>)
	at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:244)
	at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:331)
	at com.playtika.test.postgresql.EmbeddedPostgreSQLBootstrapConfiguration$$EnhancerBySpringCGLIB$$8c8d6aca.postgresql(<generated>)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:154)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:651)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:636)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.instantiateUsingFactoryMethod(AbstractAutowireCapableBeanFactory.java:1338)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1177)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:557)
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:517)
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:323)
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:226)
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:321)
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:202)
	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:895)
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:878)
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:550)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:758)
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:750)
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:315)
	at org.springframework.boot.builder.SpringApplicationBuilder.run(SpringApplicationBuilder.java:140)
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.bootstrapServiceContext(BootstrapApplicationListener.java:212)
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.onApplicationEvent(BootstrapApplicationListener.java:117)
	at org.springframework.cloud.bootstrap.BootstrapApplicationListener.onApplicationEvent(BootstrapApplicationListener.java:74)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139)
	at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:127)
	at org.springframework.boot.context.event.EventPublishingRunListener.environmentPrepared(EventPublishingRunListener.java:80)
	at org.springframework.boot.SpringApplicationRunListeners.environmentPrepared(SpringApplicationRunListeners.java:53)
	at org.springframework.boot.SpringApplication.prepareEnvironment(SpringApplication.java:345)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:308)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1237)
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226)
	at se.lantmateriet.vardering.octopus.vohanteringservice.OctopusVoHanteringServiceApplication.main(OctopusVoHanteringServiceApplication.java:10)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.springframework.boot.devtools.restart.RestartLauncher.run(RestartLauncher.java:49)

2020-07-02 15:10:35.727 ERROR 17800 --- [  restartedMain] 🐳 [vohantering:v1.06]                   : Log output from the failed container:


PostgreSQL Database directory appears to contain a database; Skipping initialization



2020-07-02 13:09:35.635 UTC [1] LOG:  starting PostgreSQL 12.3 on x86_64-pc-linux-musl, compiled by gcc (Alpine 9.3.0) 9.3.0, 64-bit

2020-07-02 13:09:35.636 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432

2020-07-02 13:09:35.636 UTC [1] LOG:  listening on IPv6 address "::", port 5432

2020-07-02 13:09:35.636 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"

2020-07-02 13:09:35.649 UTC [20] LOG:  database system was interrupted; last known up at 2020-07-02 13:07:54 UTC

2020-07-02 13:09:35.649 UTC [20] LOG:  database system was not properly shut down; automatic recovery in progress

2020-07-02 13:09:35.651 UTC [20] LOG:  redo starts at 0/30B5D68

2020-07-02 13:09:36.818 UTC [20] LOG:  invalid record length at 0/55FE9E8: wanted 24, got 0

2020-07-02 13:09:36.818 UTC [20] LOG:  redo done at 0/55FE9A0

2020-07-02 13:09:37.148 UTC [1] LOG:  database system is ready to accept connections
```

**This is the container log when running without existing data by using `embedded.postgresql.dockerImage: "postgis/postgis:latest` (notice the double log entrys for `database system is ready to accept connections`)**
```

The files belonging to this database system will be owned by user "postgres".
This user must also own the server process.

The database cluster will be initialized with locale "en_US.utf8".
The default database encoding has accordingly been set to "UTF8".
The default text search configuration will be set to "english".

Data page checksums are disabled.

fixing permissions on existing directory /var/lib/postgresql/data ... ok
creating subdirectories ... ok
selecting dynamic shared memory implementation ... posix
selecting default max_connections ... 100
selecting default shared_buffers ... 128MB
selecting default time zone ... Etc/UTC
creating configuration files ... ok
running bootstrap script ... ok
performing post-bootstrap initialization ... ok
syncing data to disk ... ok


Success. You can now start the database server using:

    pg_ctl -D /var/lib/postgresql/data -l logfile start

initdb: warning: enabling "trust" authentication for local connections
You can change this by editing pg_hba.conf or using the option -A, or
--auth-local and --auth-host, the next time you run initdb.
waiting for server to start....2020-07-02 13:24:02.086 UTC [47] LOG:  starting PostgreSQL 12.3 (Debian 12.3-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
2020-07-02 13:24:02.086 UTC [47] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2020-07-02 13:24:02.096 UTC [48] LOG:  database system was shut down at 2020-07-02 13:24:01 UTC
2020-07-02 13:24:02.100 UTC [47] LOG:  database system is ready to accept connections
 done
server started
CREATE DATABASE


/usr/local/bin/docker-entrypoint.sh: sourcing /docker-entrypoint-initdb.d/10_postgis.sh
CREATE DATABASE
Loading PostGIS extensions into template_postgis
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
Loading PostGIS extensions into test_db
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION
CREATE EXTENSION

waiting for server to shut down...2020-07-02 13:24:04.885 UTC [47] LOG:  received fast shutdown request
.2020-07-02 13:24:04.885 UTC [47] LOG:  aborting any active transactions
2020-07-02 13:24:04.887 UTC [47] LOG:  background worker "logical replication launcher" (PID 54) exited with exit code 1
2020-07-02 13:24:04.914 UTC [49] LOG:  shutting down
2020-07-02 13:24:04.943 UTC [47] LOG:  database system is shut down
 done
server stopped

PostgreSQL init process complete; ready for start up.

2020-07-02 13:24:04.999 UTC [1] LOG:  starting PostgreSQL 12.3 (Debian 12.3-1.pgdg100+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 8.3.0-6) 8.3.0, 64-bit
2020-07-02 13:24:04.999 UTC [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2020-07-02 13:24:04.999 UTC [1] LOG:  listening on IPv6 address "::", port 5432
2020-07-02 13:24:04.999 UTC [1] LOG:  listening on Unix socket "/var/run/postgresql/.s.PGSQL.5432"
2020-07-02 13:24:05.011 UTC [93] LOG:  database system was shut down at 2020-07-02 13:24:04 UTC
2020-07-02 13:24:05.015 UTC [1] LOG:  database system is ready to accept connections

```