### PR TITLE
Add breaking change and deprecation sections to release notes

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,10 +5,14 @@ template: |
 
     $CHANGES
 categories:
+  - title: ⚠️ Breaking API changes
+    label: type/breaking-api-change
   - title: 🚀 Features & Enhancements
     labels:
       - type/feature
       - type/enhancement
+  - title: ☠️ Deprecations
+    label: type/deprecation
   - title: 🐛 Bug Fixes
     label: type/bug
   - title: 📖 Documentation


### PR DESCRIPTION
So that we don't forget to add adequate documentation when we deprecate or remove items from public APIs.