### PR TITLE
Fixes issue 2982. ElasticsearchContainer to wait for HTTP_OK response as a signal of being ready.

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -51,6 +51,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         addExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT);
         setWaitStrategy(new HttpWaitStrategy()
             .forPort(ELASTICSEARCH_DEFAULT_PORT)
+            .forPath("/_cluster/health")
             .forStatusCode(HTTP_OK)
             .withStartupTimeout(Duration.ofMinutes(2)));
     }

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -8,7 +8,6 @@ import java.net.InetSocketAddress;
 import java.time.Duration;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 
 /**
  * Represents an elasticsearch docker instance which exposes by default port 9200 and 9300 (transport.tcp.port)
@@ -52,7 +51,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         addExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT);
         setWaitStrategy(new HttpWaitStrategy()
             .forPort(ELASTICSEARCH_DEFAULT_PORT)
-            .forStatusCodeMatching(response -> response == HTTP_OK || response == HTTP_UNAUTHORIZED)
+            .forStatusCode(HTTP_OK)
             .withStartupTimeout(Duration.ofMinutes(2)));
     }
 


### PR DESCRIPTION
Changes the default wait strategy on the ElasticsearchContainer to not require users of the class to amend the strategy for the simple unit tests.