### PR TITLE
Fix PrestoContainer WaitStrategy regex

### DIFF
--- a/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
+++ b/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
@@ -30,7 +30,7 @@ public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDat
     public PrestoContainer(final String dockerImageName) {
         super(dockerImageName);
         this.waitStrategy = new LogMessageWaitStrategy()
-            .withRegEx(".*io.prestosql.server.PrestoServer\\s+======== SERVER STARTED ========.*")
+            .withRegEx(".*======== SERVER STARTED ========.*")
             .withStartupTimeout(Duration.of(60, SECONDS));
 
         addExposedPort(PRESTO_PORT);


### PR DESCRIPTION
The Presto readyness check is currently broken, as the regex doesn't match anymore (class name has changed). This small fix corrects this, and should be more robust in the future.

The container used: `prestosql/presto:latest`.