### PR TITLE
Configurable default startup timeout

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/AbstractWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/AbstractWaitStrategy.java
@@ -3,6 +3,7 @@ package org.testcontainers.containers.wait.strategy;
 import lombok.NonNull;
 import org.rnorth.ducttape.ratelimits.RateLimiter;
 import org.rnorth.ducttape.ratelimits.RateLimiterBuilder;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.time.Duration;
 import java.util.Set;
@@ -19,7 +20,7 @@ public abstract class AbstractWaitStrategy implements WaitStrategy {
     protected WaitStrategyTarget waitStrategyTarget;
 
     @NonNull
-    protected Duration startupTimeout = Duration.ofSeconds(60);
+    protected Duration startupTimeout = Duration.ofSeconds(TestcontainersConfiguration.getInstance().getStartupTimeout());
 
     @NonNull
     private RateLimiter rateLimiter = DOCKER_CLIENT_RATE_LIMITER;

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -128,6 +128,10 @@ public class TestcontainersConfiguration {
         return Integer.parseInt((String) properties.getOrDefault("pull.pause.timeout", "30"));
     }
 
+    public Integer getStartupTimeout() {
+        return Integer.parseInt((String) properties.getOrDefault("startup.timeout", "60"));
+    }
+
     @Synchronized
     public boolean updateGlobalConfig(@NonNull String prop, @NonNull String value) {
         try {

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -24,6 +24,11 @@ Before running any containers Testcontainers will perform a set of startup check
 ```
 It takes a couple of seconds, but if you want to speed up your tests, you can disable the checks once you have everything configured. Add `checks.disable=true` to your `$HOME/.testcontainers.properties` to completely disable them.
 
+## Customizing containers startup behaviour
+
+> **startup.timeout = 60**
+> By default Testcontainers will wait for up to this duration (in seconds) for the container's first mapped network port to start listening. 
+
 ## Customizing images
 
 Testcontainers uses public Docker images to perform different actions like startup checks, VNC recording and others. 


### PR DESCRIPTION
Custom configuration let users override some default properties if your environment requires that. Most of the properties are to mitigate various environment constraints users might have (and let them define the workaround globally in the `.testcontainers.properties`). For example, timing out images pulls or disable startup checks. 

One of the local constraints might be tests startup timing out due. While I'd like to keep the more aggressive timeouts for the CI builds (60 seconds), the test performance on the developers' laptop might be limited. Therefore a possibility relax the default startup timeout globally will make the local build more repeatable. 

This is target for a more integration / blackbox testing scenarious, when multiple containers are setup to emulate the deployment environment. 

**Testing evidence**
This is a backwards-compatible change. Existing tests pass. The feature is covered by other tests.