### PR TITLE
couchbase: include error response from couchbase in checkSuccessfulResponse()

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -168,7 +168,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
                             .map("healthy"::equals)
                             .orElse(false);
                     } catch (IOException e) {
-                        logger().error("Unable to parse response {}", response);
+                        logger().error("Unable to parse response {}", response, e);
                         return false;
                     }
                 })
@@ -337,10 +337,10 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
      * Based on the user-configured bucket definitions, creating buckets and corresponding indexes if needed.
      */
     private void createBuckets() {
-        logger().debug("Creating " + buckets.size() + " buckets (and corresponding indexes).");
+        logger().debug("Creating {} buckets (and corresponding indexes).", buckets.size());
 
         for (BucketDefinition bucket : buckets) {
-            logger().debug("Creating bucket \"" + bucket.getName() + "\"");
+            logger().debug("Creating bucket \"{}\"", bucket.getName());
 
             @Cleanup Response response = doHttpRequest(MGMT_PORT, "/pools/default/buckets", "POST", new FormBody.Builder()
                 .add("name", bucket.getName())
@@ -382,7 +382,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
                     checkSuccessfulResponse(queryResponse, "Could not create primary index for bucket " + bucket.getName());
                 } else {
-                    logger().info("Primary index creation for bucket " + bucket.getName() + " ignored, since QUERY service is not present.");
+                    logger().info("Primary index creation for bucket {} ignored, since QUERY service is not present.", bucket.getName());
                 }
             }
         }
@@ -406,7 +406,16 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
      */
     private void checkSuccessfulResponse(final Response response, final String message) {
         if (!response.isSuccessful()) {
-            throw new IllegalStateException(message + ": " + response.toString());
+            String body = null;
+            if (response.body() != null) {
+                try {
+                    body = response.body().string();
+                } catch (IOException e) {
+                    logger().debug("Unable to read body of response: {}", response, e);
+                }
+            }
+
+            throw new IllegalStateException(message + ": " + response.toString() + ", body=" + (body == null ? "<null>" : body));
         }
     }
 


### PR DESCRIPTION
checkSuccessfulResponse() now passes the body of the response to the thrown exception, if present.

Also minor logging cleanup, and prevented an exception from being swallowed.

fixes #2799