### PR TITLE
Code review suggestions for #2599

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/LicenseAcceptance.java
+++ b/core/src/main/java/org/testcontainers/utility/LicenseAcceptance.java
@@ -15,11 +15,11 @@ import java.util.Set;
 @UtilityClass
 public class LicenseAcceptance {
 
-    private static final String ACCEPTANCE_FILE_NAME = "container-license-acceptance.txt";
+    private final String ACCEPTANCE_FILE_NAME = "container-license-acceptance.txt";
 
-    static final Set<String> ACCEPTED_IMAGE_NAMES = new HashSet<>();
+    final Set<String> ACCEPTED_IMAGE_NAMES = new HashSet<>();
 
-    public static void assertLicenseAccepted(final String imageName) {
+    public void assertLicenseAccepted(final String imageName) {
         if (ACCEPTED_IMAGE_NAMES.contains(imageName)) {
             return;
         }

--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mockito;
 import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.DockerClientFactory.DiskSpaceUsage;
 import org.testcontainers.dockerclient.LogToStringContainerCallback;
-import org.testcontainers.utility.TestcontainersConfigurationRollbackRule;
+import org.testcontainers.utility.TestcontainersConfigurationSpyAndRollbackRule;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class DockerClientFactoryTest {
 
     @Rule
-    public TestcontainersConfigurationRollbackRule configurationMock = new TestcontainersConfigurationRollbackRule();
+    public TestcontainersConfigurationSpyAndRollbackRule configurationMock = new TestcontainersConfigurationSpyAndRollbackRule();
 
     @Test
     public void runCommandInsideDockerShouldNotFailIfImageDoesNotExistsLocally() {

--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -9,7 +9,7 @@ import org.mockito.Mockito;
 import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.DockerClientFactory.DiskSpaceUsage;
 import org.testcontainers.dockerclient.LogToStringContainerCallback;
-import org.testcontainers.utility.MockTestcontainersConfigurationRule;
+import org.testcontainers.utility.TestcontainersConfigurationRollbackRule;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class DockerClientFactoryTest {
 
     @Rule
-    public MockTestcontainersConfigurationRule configurationMock = new MockTestcontainersConfigurationRule();
+    public TestcontainersConfigurationRollbackRule configurationMock = new TestcontainersConfigurationRollbackRule();
 
     @Test
     public void runCommandInsideDockerShouldNotFailIfImageDoesNotExistsLocally() {

--- a/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
+++ b/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
@@ -23,7 +23,7 @@ import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.startupcheck.StartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
-import org.testcontainers.utility.MockTestcontainersConfigurationRule;
+import org.testcontainers.utility.TestcontainersConfigurationRollbackRule;
 import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
@@ -443,7 +443,7 @@ public class ReusabilityUnitTests {
     public static abstract class AbstractReusabilityTest {
 
         @Rule
-        public MockTestcontainersConfigurationRule configurationMock = new MockTestcontainersConfigurationRule();
+        public TestcontainersConfigurationRollbackRule configurationMock = new TestcontainersConfigurationRollbackRule();
 
         protected DockerClient client = Mockito.mock(DockerClient.class);
 

--- a/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
+++ b/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
@@ -23,7 +23,7 @@ import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.startupcheck.StartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
-import org.testcontainers.utility.TestcontainersConfigurationRollbackRule;
+import org.testcontainers.utility.TestcontainersConfigurationSpyAndRollbackRule;
 import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
@@ -443,7 +443,7 @@ public class ReusabilityUnitTests {
     public static abstract class AbstractReusabilityTest {
 
         @Rule
-        public TestcontainersConfigurationRollbackRule configurationMock = new TestcontainersConfigurationRollbackRule();
+        public TestcontainersConfigurationSpyAndRollbackRule configurationMock = new TestcontainersConfigurationSpyAndRollbackRule();
 
         protected DockerClient client = Mockito.mock(DockerClient.class);
 

--- a/core/src/testFixtures/java/org/testcontainers/utility/LicenseAcceptanceRule.java
+++ b/core/src/testFixtures/java/org/testcontainers/utility/LicenseAcceptanceRule.java
@@ -5,7 +5,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-public class MockLicenseAcceptanceRule implements TestRule {
+public class LicenseAcceptanceRule implements TestRule {
 
     @NotNull
     @Override

--- a/core/src/testFixtures/java/org/testcontainers/utility/TestcontainersConfigurationRollbackRule.java
+++ b/core/src/testFixtures/java/org/testcontainers/utility/TestcontainersConfigurationRollbackRule.java
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * This {@link TestRule} applies a spy on {@link TestcontainersConfiguration}
  * for testing features that depend on the global configuration.
  */
-public class MockTestcontainersConfigurationRule implements TestRule {
+public class TestcontainersConfigurationRollbackRule implements TestRule {
 
     static AtomicReference<TestcontainersConfiguration> REF = TestcontainersConfiguration.getInstanceField();
 

--- a/core/src/testFixtures/java/org/testcontainers/utility/TestcontainersConfigurationSpyAndRollbackRule.java
+++ b/core/src/testFixtures/java/org/testcontainers/utility/TestcontainersConfigurationSpyAndRollbackRule.java
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * This {@link TestRule} applies a spy on {@link TestcontainersConfiguration}
  * for testing features that depend on the global configuration.
  */
-public class TestcontainersConfigurationRollbackRule implements TestRule {
+public class TestcontainersConfigurationSpyAndRollbackRule implements TestRule {
 
     static AtomicReference<TestcontainersConfiguration> REF = TestcontainersConfiguration.getInstanceField();
 

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerProvider.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerProvider.java
@@ -16,18 +16,12 @@ public class MariaDBR2DBCDatabaseContainerProvider extends AbstractR2DBCDatabase
     static final String DRIVER = MariadbConnectionFactoryProvider.MARIADB_DRIVER;
 
     public MariaDBR2DBCDatabaseContainerProvider() {
-        super(DRIVER);
+        super(DRIVER, MariaDBContainer.IMAGE);
     }
 
     @Override
     public R2DBCDatabaseContainer doCreateContainer(ConnectionFactoryOptions options) {
-        String image = String.format(
-            "%s:%s",
-            options.hasOption(IMAGE_OPTION)
-                ? options.getValue(IMAGE_OPTION)
-                : MariaDBContainer.IMAGE,
-            options.getRequiredValue(IMAGE_TAG_OPTION)
-        );
+        String image = getImageString(options);
         MariaDBContainer<?> container = new MariaDBContainer<>(image)
             .withDatabaseName(options.getRequiredValue(ConnectionFactoryOptions.DATABASE));
 

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerProvider.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerProvider.java
@@ -4,7 +4,6 @@ import com.google.auto.service.AutoService;
 import io.r2dbc.mssql.MssqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.NonNull;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerProvider;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
@@ -17,18 +16,12 @@ public class MSSQLR2DBCDatabaseContainerProvider extends AbstractR2DBCDatabaseCo
     static final String DRIVER = MssqlConnectionFactoryProvider.MSSQL_DRIVER;
 
     public MSSQLR2DBCDatabaseContainerProvider() {
-        super(DRIVER);
+        super(DRIVER, MSSQLServerContainer.IMAGE);
     }
 
     @Override
     public R2DBCDatabaseContainer doCreateContainer(ConnectionFactoryOptions options) {
-        String image = String.format(
-            "%s:%s",
-            options.hasOption(IMAGE_OPTION)
-                ? options.getValue(IMAGE_OPTION)
-                : MSSQLServerContainer.IMAGE,
-            options.getRequiredValue(IMAGE_TAG_OPTION)
-        );
+        String image = getImageString(options);
         MSSQLServerContainer<?> container = new MSSQLServerContainer<>(image);
 
         if (Boolean.TRUE.equals(options.getValue(REUSABLE_OPTION))) {

--- a/modules/mssqlserver/src/test/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerTest.java
@@ -3,12 +3,12 @@ package org.testcontainers.containers;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.junit.Rule;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
-import org.testcontainers.utility.MockLicenseAcceptanceRule;
+import org.testcontainers.utility.LicenseAcceptanceRule;
 
 public class MSSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MSSQLServerContainer<?>> {
 
     @Rule
-    public final MockLicenseAcceptanceRule licenseAcceptanceRule = new MockLicenseAcceptanceRule();
+    public final LicenseAcceptanceRule licenseAcceptanceRule = new LicenseAcceptanceRule();
 
     @Override
     protected ConnectionFactoryOptions getOptions(MSSQLServerContainer<?> container) {

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerProvider.java
@@ -16,18 +16,12 @@ public class MySQLR2DBCDatabaseContainerProvider extends AbstractR2DBCDatabaseCo
     static final String DRIVER = MySqlConnectionFactoryProvider.MYSQL_DRIVER;
 
     public MySQLR2DBCDatabaseContainerProvider() {
-        super(DRIVER);
+        super(DRIVER, MySQLContainer.IMAGE);
     }
 
     @Override
     public R2DBCDatabaseContainer doCreateContainer(ConnectionFactoryOptions options) {
-        String image = String.format(
-            "%s:%s",
-            options.hasOption(IMAGE_OPTION)
-                ? options.getValue(IMAGE_OPTION)
-                : MySQLContainer.IMAGE,
-            options.getRequiredValue(IMAGE_TAG_OPTION)
-        );
+        String image = getImageString(options);
         MySQLContainer<?> container = new MySQLContainer<>(image)
             .withDatabaseName(options.getRequiredValue(ConnectionFactoryOptions.DATABASE));
 

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
@@ -10,9 +10,6 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
 
 import javax.annotation.Nullable;
 
-import static org.testcontainers.containers.PostgreSQLContainer.DEFAULT_PASSWORD;
-import static org.testcontainers.containers.PostgreSQLContainer.DEFAULT_USER;
-
 @AutoService(R2DBCDatabaseContainerProvider.class)
 public final class PostgreSQLR2DBCDatabaseContainerProvider extends AbstractR2DBCDatabaseContainerProvider {
 
@@ -40,10 +37,10 @@ public final class PostgreSQLR2DBCDatabaseContainerProvider extends AbstractR2DB
     public ConnectionFactoryMetadata getMetadata(ConnectionFactoryOptions options) {
         ConnectionFactoryOptions.Builder builder = options.mutate();
         if (!options.hasOption(ConnectionFactoryOptions.USER)) {
-            builder.option(ConnectionFactoryOptions.USER, DEFAULT_USER);
+            builder.option(ConnectionFactoryOptions.USER, PostgreSQLContainer.DEFAULT_USER);
         }
         if (!options.hasOption(ConnectionFactoryOptions.PASSWORD)) {
-            builder.option(ConnectionFactoryOptions.PASSWORD, DEFAULT_PASSWORD);
+            builder.option(ConnectionFactoryOptions.PASSWORD, PostgreSQLContainer.DEFAULT_PASSWORD);
         }
         return super.getMetadata(builder.build());
     }

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
@@ -4,12 +4,14 @@ import com.google.auto.service.AutoService;
 import io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.NonNull;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerProvider;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
 
 import javax.annotation.Nullable;
+
+import static org.testcontainers.containers.PostgreSQLContainer.DEFAULT_PASSWORD;
+import static org.testcontainers.containers.PostgreSQLContainer.DEFAULT_USER;
 
 @AutoService(R2DBCDatabaseContainerProvider.class)
 public final class PostgreSQLR2DBCDatabaseContainerProvider extends AbstractR2DBCDatabaseContainerProvider {
@@ -17,18 +19,13 @@ public final class PostgreSQLR2DBCDatabaseContainerProvider extends AbstractR2DB
     static final String DRIVER = PostgresqlConnectionFactoryProvider.POSTGRESQL_DRIVER;
 
     public PostgreSQLR2DBCDatabaseContainerProvider() {
-        super(DRIVER);
+        super(DRIVER, PostgreSQLContainer.IMAGE);
     }
 
     @Override
     public R2DBCDatabaseContainer doCreateContainer(ConnectionFactoryOptions options) {
-        String image = String.format(
-            "%s:%s",
-            options.hasOption(IMAGE_OPTION)
-                ? options.getValue(IMAGE_OPTION)
-                : PostgreSQLContainer.IMAGE,
-            options.getRequiredValue(IMAGE_TAG_OPTION)
-        );
+        String image = getImageString(options);
+
         PostgreSQLContainer<?> container = new PostgreSQLContainer<>(image)
             .withDatabaseName(options.getRequiredValue(ConnectionFactoryOptions.DATABASE));
 
@@ -43,10 +40,10 @@ public final class PostgreSQLR2DBCDatabaseContainerProvider extends AbstractR2DB
     public ConnectionFactoryMetadata getMetadata(ConnectionFactoryOptions options) {
         ConnectionFactoryOptions.Builder builder = options.mutate();
         if (!options.hasOption(ConnectionFactoryOptions.USER)) {
-            builder.option(ConnectionFactoryOptions.USER, PostgreSQLContainer.DEFAULT_USER);
+            builder.option(ConnectionFactoryOptions.USER, DEFAULT_USER);
         }
         if (!options.hasOption(ConnectionFactoryOptions.PASSWORD)) {
-            builder.option(ConnectionFactoryOptions.PASSWORD, PostgreSQLContainer.DEFAULT_PASSWORD);
+            builder.option(ConnectionFactoryOptions.PASSWORD, DEFAULT_PASSWORD);
         }
         return super.getMetadata(builder.build());
     }

--- a/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerProvider.java
+++ b/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerProvider.java
@@ -36,7 +36,7 @@ public abstract class AbstractR2DBCDatabaseContainerProvider implements R2DBCDat
         Properties properties = TestcontainersConfiguration.getInstance().getProperties();
         return properties.getProperty(
             driverPropertyName(options.getRequiredValue(ConnectionFactoryOptions.DRIVER)),
-            originalDriver
+            options.getRequiredValue(ConnectionFactoryOptions.DRIVER)
         );
     }
 

--- a/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerProvider.java
+++ b/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerProvider.java
@@ -9,14 +9,26 @@ import java.util.Properties;
 public abstract class AbstractR2DBCDatabaseContainerProvider implements R2DBCDatabaseContainerProvider {
 
     final String originalDriver;
+    final String defaultImage;
 
-    protected AbstractR2DBCDatabaseContainerProvider(@NonNull String originalDriver) {
+    protected AbstractR2DBCDatabaseContainerProvider(@NonNull String originalDriver, @NonNull String defaultImage) {
         this.originalDriver = originalDriver;
+        this.defaultImage = defaultImage;
     }
 
     @Override
     public boolean supports(ConnectionFactoryOptions options) {
         return originalDriver.equals(getDriver(options));
+    }
+
+    protected String getImageString(ConnectionFactoryOptions options) {
+        return String.format(
+            "%s:%s",
+            options.hasOption(IMAGE_OPTION)
+                ? options.getValue(IMAGE_OPTION)
+                : defaultImage,
+            options.getRequiredValue(IMAGE_TAG_OPTION)
+        );
     }
 
     private String getDriver(ConnectionFactoryOptions options) {

--- a/modules/r2dbc/src/testFixtures/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerTest.java
+++ b/modules/r2dbc/src/testFixtures/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerTest.java
@@ -13,7 +13,7 @@ import org.mockito.Mockito;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.r2dbc.Hidden.TestcontainersR2DBCConnectionFactoryProvider;
-import org.testcontainers.utility.MockTestcontainersConfigurationRule;
+import org.testcontainers.utility.TestcontainersConfigurationRollbackRule;
 import org.testcontainers.utility.TestcontainersConfiguration;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class AbstractR2DBCDatabaseContainerTest<T extends GenericContainer<?>> {
 
     @Rule
-    public final MockTestcontainersConfigurationRule configurationMock = new MockTestcontainersConfigurationRule();
+    public final TestcontainersConfigurationRollbackRule configurationMock = new TestcontainersConfigurationRollbackRule();
 
     protected abstract ConnectionFactoryOptions getOptions(T container);
 

--- a/modules/r2dbc/src/testFixtures/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerTest.java
+++ b/modules/r2dbc/src/testFixtures/java/org/testcontainers/r2dbc/AbstractR2DBCDatabaseContainerTest.java
@@ -13,7 +13,7 @@ import org.mockito.Mockito;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.r2dbc.Hidden.TestcontainersR2DBCConnectionFactoryProvider;
-import org.testcontainers.utility.TestcontainersConfigurationRollbackRule;
+import org.testcontainers.utility.TestcontainersConfigurationSpyAndRollbackRule;
 import org.testcontainers.utility.TestcontainersConfiguration;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public abstract class AbstractR2DBCDatabaseContainerTest<T extends GenericContainer<?>> {
 
     @Rule
-    public final TestcontainersConfigurationRollbackRule configurationMock = new TestcontainersConfigurationRollbackRule();
+    public final TestcontainersConfigurationSpyAndRollbackRule configurationRollback = new TestcontainersConfigurationSpyAndRollbackRule();
 
     protected abstract ConnectionFactoryOptions getOptions(T container);
 


### PR DESCRIPTION
Extracts the duplicated code for default image fallback into `AbstractR2DBCDatabaseContainerProvider`.