### PR TITLE
Support timestamps with offset from "inspect image"

### DIFF
--- a/core/src/main/java/org/testcontainers/images/ImageData.java
+++ b/core/src/main/java/org/testcontainers/images/ImageData.java
@@ -7,6 +7,7 @@ import lombok.NonNull;
 import lombok.Value;
 
 import java.time.Instant;
+import java.time.ZonedDateTime;
 
 @Value
 @Builder
@@ -17,7 +18,7 @@ public class ImageData {
 
     static ImageData from(InspectImageResponse inspectImageResponse) {
         return ImageData.builder()
-            .createdAt(Instant.parse(inspectImageResponse.getCreated()))
+            .createdAt(ZonedDateTime.parse(inspectImageResponse.getCreated()).toInstant())
             .build();
     }
 

--- a/core/src/test/java/org/testcontainers/images/ImageDataTest.java
+++ b/core/src/test/java/org/testcontainers/images/ImageDataTest.java
@@ -1,0 +1,27 @@
+package org.testcontainers.images;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.junit.Test;
+
+import com.github.dockerjava.api.command.InspectImageResponse;
+
+public class ImageDataTest {
+
+    @Test
+    public void shouldReadTimestampWithoutOffsetFromInspectImageResponse() {
+        final String timestamp = "2020-07-27T18:23:31.365190246Z";
+        final ImageData imageData = ImageData.from(new InspectImageResponse().withCreated(timestamp));
+        assertThat(imageData.getCreatedAt()).isEqualTo(Instant.parse(timestamp));
+    }
+
+    @Test
+    public void shouldReadTimestampWithOffsetFromInspectImageResponse() {
+        final String timestamp = "2020-07-27T18:23:31.365190246+02:00";
+        final ImageData imageData = ImageData.from(new InspectImageResponse().withCreated(timestamp));
+        assertThat(imageData.getCreatedAt()).isEqualTo(Instant.parse("2020-07-27T16:23:31.365190246Z"));
+    }
+
+}


### PR DESCRIPTION
The command "inspect image" can return a "created" timestamp without a
time zone offset (e.g. "2020-07-27T18:23:31.365190246Z") or with a time
zone offset (e.g. "2020-07-27T18:23:31.365190246+02:00"). This change
adds support for timestamps with a time zone offset.

This fixes #3054.