### PR TITLE
Add support for MongoDB 4.4

### DIFF
--- a/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
@@ -43,7 +43,7 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
         withExposedPorts(MONGODB_INTERNAL_PORT);
         withCommand("--replSet", "docker-rs");
         waitingFor(
-            Wait.forLogMessage(".*waiting for connections on port.*", 1)
+            Wait.forLogMessage("(?i).*waiting for connections.*", 1)
         );
     }
 

--- a/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
+++ b/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
@@ -73,4 +73,13 @@ public class MongoDBContainerTest {
             }
         }
     }
+
+    @Test
+    public void supportsMongoDB_4_4() {
+        try (
+            final MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.4"))
+        ) {
+            mongoDBContainer.start();
+        }
+    }
 }


### PR DESCRIPTION
Makes `LogMessageWaitStrategy` in `MongoDBContainer` compatible with MongoDB 4.4 images without breaking backwards compatibility (regex changed to `(?i).*waiting for connections.*`).

It is a bit unfortunate that this uses a full integration test for checking something trivial (working regex), so maybe there is a better approach using a mock/stub? Do we have other tests where we solve this on a unit test level?

Fixes #3077