### PR TITLE
Ignore reuse with networks

### DIFF
--- a/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
+++ b/core/src/test/java/org/testcontainers/containers/ReusabilityUnitTests.java
@@ -3,6 +3,7 @@ package org.testcontainers.containers;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ConnectToNetworkCmd;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
 import com.github.dockerjava.api.command.InspectContainerCmd;
@@ -48,6 +49,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -456,6 +458,11 @@ public class ReusabilityUnitTests {
             when(client.listContainersCmd()).then(listContainersAnswer());
             when(client.startContainerCmd(containerId)).then(startContainerAnswer());
             when(client.inspectContainerCmd(containerId)).then(inspectContainerAnswer());
+
+            ConnectToNetworkCmd connectToNetwork = mock(ConnectToNetworkCmd.class);
+            when(client.connectToNetworkCmd()).thenReturn(connectToNetwork);
+            when(connectToNetwork.withContainerId(any())).thenReturn(connectToNetwork);
+            when(connectToNetwork.withNetworkId(any())).thenReturn(connectToNetwork);
 
             makeReusable(container);
             container.start();


### PR DESCRIPTION
As mentioned in #3081, containers with Networks are not reusable. Currently, they are still created as if they were reusable. In this PR, we output a warning when a container that uses a network is marked as reusable and consequently ignore the setting.

Alternatively, an exception could have been thrown, but this could break existing builds.