### PR TITLE
Remove use of implicit network for multi-container Kafka

### DIFF
--- a/docs/modules/kafka.md
+++ b/docs/modules/kafka.md
@@ -53,6 +53,8 @@ If your test needs to run some other Docker container which needs access to the 
 * Use `kafka.getNetworkAliases().get(0)+":9092"` as bootstrap server location. 
 Or just give your Kafka container a network alias of your liking.
 
+You will need to explicitly create a network and set it on the Kafka container as well as on your other containers that need to communicate with Kafka.
+
 ## Adding this module to your project dependencies
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -75,7 +75,7 @@ public class KafkaContainerTest {
                 .withEnv("ZOOKEEPER_CLIENT_PORT", "2181");
 
             // withKafkaNetwork {
-            GenericContainer application = new GenericContainer("alpine").withNetwork(kafka.getNetwork())
+            GenericContainer application = new GenericContainer("alpine").withNetwork(network)
             // }
                 .withNetworkAliases("dummy")
                 .withCommand("sleep 10000")


### PR DESCRIPTION
The use of implicit networks in the Kafka container (like other
containers) is no longer correct. In order for multiple containers to be
able to communicate with one another via an internal Docker network, it
is necessary for all of them to be given an explicit reference to a
Network object.