### PR TITLE
Add continue-on-error for cache step, and upgrade GH cache action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,8 @@ jobs:
         with:
           java-version: '1.8'
       - name: Cache Gradle Home files
-        uses: actions/cache@v1
+        uses: actions/cache@v2
+        continue-on-error: true
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-${{matrix.gradle_args}}_check-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
... to work around apparent problems with GitHub caching of the (post-build) cache push step.
e.g.
```
Post job cleanup.
/bin/tar -cz -f /home/runner/work/_temp/daec269c-22ea-41a1-a4eb-ede3c9cf30f1/cache.tgz -C /home/runner/.gradle/caches .
[warning]Cache service responded with 503 during chunk upload.
events.js:187
      throw er; // Unhandled 'error' event
      ^

Error: ESPIPE: invalid seek, read
Emitted 'error' event on ReadStream instance at:
    at internal/fs/streams.js:167:12
    at FSReqCallback.wrapper [as oncomplete] (fs.js:470:5) {
  errno: -29,
  code: 'ESPIPE',
  syscall: 'read'
}
```

This failure is obviously a problem with the caching system, and should not fail our build.