### PR TITLE
Spike creating a container from Image ID

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ImageId.java
+++ b/core/src/main/java/org/testcontainers/utility/ImageId.java
@@ -1,0 +1,21 @@
+package org.testcontainers.utility;
+
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+public final class ImageId {
+
+    private final String imageId;
+
+    private ImageId(String imageId) {
+        this.imageId = imageId;
+    }
+
+    public static ImageId fromString(String imageId) {
+        return new ImageId(imageId);
+    }
+
+    public String getValue() {
+        return imageId;
+    }
+}


### PR DESCRIPTION
Triaging fixing #1406 together with @kiview and asking for feedback whether this is
the right direction.

Added a new constructor to GenericContainer that allows for passing an Image ID thereby
bypassing docker pull because that does not work with Image IDs.
 