### PR TITLE
Fix bind mounts for ResourceReaper/ryuk and ContainerisedDockerCompose on macOS

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -19,6 +19,7 @@ import lombok.SneakyThrows;
 import lombok.Synchronized;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.testcontainers.dockerclient.DockerClientProviderStrategy;
 import org.testcontainers.dockerclient.DockerMachineClientProviderStrategy;
 import org.testcontainers.dockerclient.TransportConfig;
@@ -145,9 +146,12 @@ public class DockerClientFactory {
         }
 
         URI dockerHost = getTransportConfig().getDockerHost();
-        return "unix".equals(dockerHost.getScheme())
+        String path = "unix".equals(dockerHost.getScheme())
             ? dockerHost.getRawPath()
             : "/var/run/docker.sock";
+        return SystemUtils.IS_OS_WINDOWS
+               ? "/" + path
+               : path;
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -608,7 +608,7 @@ class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCom
         //  as the docker daemon, just mapping the docker control socket is OK.
         // As there seems to be a problem with mapping to the /var/run directory in certain environments (e.g. CircleCI)
         //  we map the socket file outside of /var/run, as just /docker.sock
-        addFileSystemBind("/" + DockerClientFactory.instance().getRemoteDockerUnixSocketPath(), "/docker.sock", READ_WRITE);
+        addFileSystemBind(DockerClientFactory.instance().getRemoteDockerUnixSocketPath(), "/docker.sock", READ_WRITE);
         addEnv("DOCKER_HOST", "unix:///docker.sock");
         setStartupCheckStrategy(new IndefiniteWaitOneShotStartupCheckStrategy());
         setWorkingDirectory(containerPwd);

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -76,7 +76,7 @@ public final class ResourceReaper {
         DockerClientFactory.instance().checkAndPullImage(client, ryukImage);
 
         List<Bind> binds = new ArrayList<>();
-        binds.add(new Bind("/" + DockerClientFactory.instance().getRemoteDockerUnixSocketPath(), new Volume("/var/run/docker.sock")));
+        binds.add(new Bind(DockerClientFactory.instance().getRemoteDockerUnixSocketPath(), new Volume("/var/run/docker.sock")));
 
         String ryukContainerId = client.createContainerCmd(ryukImage)
                 .withHostConfig(new HostConfig().withAutoRemove(true))

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
 import org.rnorth.ducttape.Preconditions;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.ComparableVersion;
@@ -84,7 +85,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         super(dockerImageName);
         this.legacyMode = useLegacyMode;
 
-        withFileSystemBind("//var/run/docker.sock", "/var/run/docker.sock");
+        withFileSystemBind(DockerClientFactory.instance().getRemoteDockerUnixSocketPath(), "/var/run/docker.sock");
         waitingFor(Wait.forLogMessage(".*Ready\\.\n", 1));
     }
 


### PR DESCRIPTION
Ryuk fails with "can't connect to Ryuk" on Docker Desktop for macOS, while everything's fine on Linux. I didn't check Windows, yet.

Removing the leading slash `/` on non-Windows like proposed with this pull request helps. Due to refactorings the leading slash has been there for a while and I don't understand, why there aren't more open issues regarding Ryuk. So, this fix is more a best guess :)

I assume that something has changed in recent releases of Docker Desktop for macOS. The diff of Ryuk's container mounts shows the effect with and without leading slash:

```diff
        "Mounts": [
            {
                "Type": "bind",
<                "Source": "/host_mnt/Users/gesellix/Library/Containers/com.docker.docker/Data/docker.sock",
>                "Source": "/run/host-services/docker.proxy.sock",
                "Destination": "/var/run/docker.sock",
                "Mode": "rw",
                "RW": true,
                "Propagation": "rprivate"
            }
        ],
```

Mount source `/run/host-services/docker.proxy.sock` is the same when manually creating a container via `docker run -v /var/run/docker.sock:...`.

My setup:
Docker Desktop for Mac 2.3.5.0 (47376) (edge Channel)
Docker Engine 19.03.13-beta2

Relates to #545
Relates to #2998
