### PR TITLE
Make recorder .flv videos scrollable (#512)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
@@ -97,7 +97,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
 
     @SneakyThrows
     public InputStream streamRecording() {
-        fixRecordDuration();
+        reencodeRecording();
 
         TarArchiveInputStream archiveInputStream = new TarArchiveInputStream(
                 dockerClient.copyArchiveFromContainerCmd(getContainerId(), RECORDING_FILE_NAME).exec()
@@ -106,7 +106,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
         return archiveInputStream;
     }
 
-    private void fixRecordDuration() throws IOException, InterruptedException {
+    private void reencodeRecording() throws IOException, InterruptedException {
         String newFlvOutput = "/newScreen.flv";
         execInContainer("ffmpeg" , "-i", RECORDING_FILE_NAME, "-vcodec", "libx264", newFlvOutput);
         execInContainer("mv" , "-f", newFlvOutput, RECORDING_FILE_NAME);

--- a/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
@@ -74,7 +74,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
         return this;
     }
 
-    public VncRecordingContainer withVideoExtension(VncRecordingFormat recordingFormat) {
+    public VncRecordingContainer withVideoFormat(VncRecordingFormat recordingFormat) {
         if (recordingFormat != null) {
             this.recordingFormat = recordingFormat;
         }
@@ -99,7 +99,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
 
     @SneakyThrows
     public void saveRecordingToFile(@NonNull File file) {
-        try(InputStream inputStream = streamRecording()) {
+        try (InputStream inputStream = streamRecording()) {
             Files.copy(inputStream, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
     }
@@ -121,7 +121,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
             @Override
             String reencodeRecording(@NonNull VncRecordingContainer container, @NonNull String source) throws IOException, InterruptedException {
                 String newFileOutput = "/newScreen.flv";
-                container.execInContainer("ffmpeg" , "-i", source, "-vcodec", "libx264", newFileOutput);
+                container.execInContainer("ffmpeg", "-i", source, "-vcodec", "libx264", newFileOutput);
                 return newFileOutput;
             }
         },
@@ -129,7 +129,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
             @Override
             String reencodeRecording(@NonNull VncRecordingContainer container, @NonNull String source) throws IOException, InterruptedException {
                 String newFileOutput = "/newScreen.mp4";
-                container.execInContainer("ffmpeg" , "-i", source, "-vcodec", "libx264", "-movflags", "faststart", newFileOutput);
+                container.execInContainer("ffmpeg", "-i", source, "-vcodec", "libx264", "-movflags", "faststart", newFileOutput);
                 return newFileOutput;
             }
         };
@@ -147,14 +147,8 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
             return filenameExtension;
         }
 
-        /**
-         * @return {@code vncRecordingFormat} value if not null, otherwise, {@link VncRecordingFormat#FLV} will be returned as a default format.
-         */
-        public static VncRecordingFormat of(VncRecordingFormat vncRecordingFormat) {
-            if (vncRecordingFormat == null) {
-                return DEFAULT_FORMAT;
-            }
-            return vncRecordingFormat;
+        public static VncRecordingFormat getDefaultFormat() {
+            return DEFAULT_FORMAT;
         }
     }
 

--- a/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
@@ -36,7 +36,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
 
     private String vncPassword = DEFAULT_VNC_PASSWORD;
 
-    private VncRecordingFormat recordingFormat = VncRecordingFormat.FLV;
+    private VncRecordingFormat recordingFormat = VncRecordingFormat.DEFAULT_FORMAT;
 
     private int vncPort = 5900;
 
@@ -98,7 +98,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
     }
 
     @SneakyThrows
-    public void saveRecordingToFile(File file) {
+    public void saveRecordingToFile(@NonNull File file) {
         try(InputStream inputStream = streamRecording()) {
             Files.copy(inputStream, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
@@ -119,7 +119,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
     public enum VncRecordingFormat {
         FLV("flv") {
             @Override
-            String reencodeRecording(VncRecordingContainer container, String source) throws IOException, InterruptedException {
+            String reencodeRecording(@NonNull VncRecordingContainer container, @NonNull String source) throws IOException, InterruptedException {
                 String newFileOutput = "/newScreen.flv";
                 container.execInContainer("ffmpeg" , "-i", source, "-vcodec", "libx264", newFileOutput);
                 return newFileOutput;
@@ -127,7 +127,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
         },
         MP4("mp4") {
             @Override
-            String reencodeRecording(VncRecordingContainer container, String source) throws IOException, InterruptedException {
+            String reencodeRecording(@NonNull VncRecordingContainer container, @NonNull String source) throws IOException, InterruptedException {
                 String newFileOutput = "/newScreen.mp4";
                 container.execInContainer("ffmpeg" , "-i", source, "-vcodec", "libx264", "-movflags", "faststart", newFileOutput);
                 return newFileOutput;
@@ -136,6 +136,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
 
         abstract String reencodeRecording(VncRecordingContainer container, String source) throws IOException, InterruptedException;
 
+        private static final VncRecordingFormat DEFAULT_FORMAT = FLV;
         private final String filenameExtension;
 
         VncRecordingFormat(String filenameExtension) {
@@ -145,5 +146,16 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
         public String getExtension() {
             return filenameExtension;
         }
+
+        /**
+         * @return {@code vncRecordingFormat} value if not null, otherwise, {@link VncRecordingFormat#FLV} will be returned as a default format.
+         */
+        public static VncRecordingFormat of(VncRecordingFormat vncRecordingFormat) {
+            if (vncRecordingFormat == null) {
+                return DEFAULT_FORMAT;
+            }
+            return vncRecordingFormat;
+        }
     }
+
 }

--- a/docs/modules/webdriver_containers.md
+++ b/docs/modules/webdriver_containers.md
@@ -68,8 +68,8 @@ Note that the second parameter of `withRecordingMode` should be a directory wher
 By default, the video will be recorded in [FLV](https://en.wikipedia.org/wiki/Flash_Video) format, but you can specify it explicitly or change it to [MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14) using `withRecordingMode` method with `VncRecordingFormat` option:
 
 <!--codeinclude-->
-[Video Format in MP4](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java) inside_block:recordAllMp4
-[Video Format in FLV](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java) inside_block:recordAllFlv
+[Video Format in MP4](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java) inside_block:recordMp4
+[Video Format in FLV](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java) inside_block:recordFlv
 <!--/codeinclude-->
 
 If you would like to customise the file name of the recording, or provide a different directory at runtime based on the description of the test and/or its success or failure, you may provide a custom recording file factory as follows:

--- a/docs/modules/webdriver_containers.md
+++ b/docs/modules/webdriver_containers.md
@@ -63,7 +63,14 @@ just for failing tests.
 [Record failing Tests](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java) inside_block:recordFailing
 <!--/codeinclude-->
 
-Note that the seconds parameter to `withRecordingMode` should be a directory where recordings can be saved.
+Note that the second parameter of `withRecordingMode` should be a directory where recordings can be saved.
+
+By default, the video will be recorded in [FLV](https://en.wikipedia.org/wiki/Flash_Video) format, but you can specify it explicitly or change it to [MP4](https://en.wikipedia.org/wiki/MPEG-4_Part_14) using `withRecordingMode` method with `VncRecordingFormat` option:
+
+<!--codeinclude-->
+[Video Format in MP4](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java) inside_block:recordAllMp4
+[Video Format in FLV](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java) inside_block:recordAllFlv
+<!--/codeinclude-->
 
 If you would like to customise the file name of the recording, or provide a different directory at runtime based on the description of the test and/or its success or failure, you may provide a custom recording file factory as follows:
 <!--codeinclude-->

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -27,6 +27,7 @@ import org.rnorth.ducttape.timeouts.Timeouts;
 import org.rnorth.ducttape.unreliables.Unreliables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.VncRecordingContainer.VncRecordingFormat;
 import org.testcontainers.containers.traits.LinkableContainer;
 import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -66,6 +67,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     @Nullable
     private RemoteWebDriver driver;
     private VncRecordingMode recordingMode = VncRecordingMode.RECORD_FAILING;
+    private VncRecordingFormat recordingFormat;
     private RecordingFileFactory recordingFileFactory;
     private File vncRecordingDirectory;
 
@@ -182,7 +184,8 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
             vncRecordingContainer = new VncRecordingContainer(this)
                     .withVncPassword(DEFAULT_PASSWORD)
-                    .withVncPort(VNC_PORT);
+                    .withVncPort(VNC_PORT)
+                    .withVideoExtension(recordingFormat);
         }
 
         if (customImageName != null) {
@@ -334,7 +337,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         }
 
         if (shouldRecord) {
-            File recordingFile = recordingFileFactory.recordingFileForTest(vncRecordingDirectory, prefix, succeeded);
+            File recordingFile = recordingFileFactory.recordingFileForTest(vncRecordingDirectory, prefix, succeeded, vncRecordingContainer.getRecordingFormat());
             LOGGER.info("Screen recordings for test {} will be stored at: {}", prefix, recordingFile);
 
             vncRecordingContainer.saveRecordingToFile(recordingFile);
@@ -358,8 +361,13 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     }
 
     public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory) {
+        return withRecordingMode(recordingMode, vncRecordingDirectory, null);
+    }
+
+    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory, VncRecordingFormat recordingFormat) {
         this.recordingMode = recordingMode;
         this.vncRecordingDirectory = vncRecordingDirectory;
+        this.recordingFormat = recordingFormat;
         return self();
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -337,7 +337,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         }
 
         if (shouldRecord) {
-            File recordingFile = recordingFileFactory.recordingFileForTest(vncRecordingDirectory, prefix, succeeded, vncRecordingContainer.getRecordingFormat());
+            File recordingFile = recordingFileFactory.recordingFileForTest(vncRecordingDirectory, prefix, succeeded, vncRecordingContainer.getVideoFormat());
             LOGGER.info("Screen recordings for test {} will be stored at: {}", prefix, recordingFile);
 
             vncRecordingContainer.saveRecordingToFile(recordingFile);

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -364,7 +364,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         return withRecordingMode(recordingMode, vncRecordingDirectory, null);
     }
 
-    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory, VncRecordingFormat recordingFormat) {
+    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory, @Nullable VncRecordingFormat recordingFormat) {
         this.recordingMode = recordingMode;
         this.vncRecordingDirectory = vncRecordingDirectory;
         this.recordingFormat = recordingFormat;

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -185,7 +185,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
             vncRecordingContainer = new VncRecordingContainer(this)
                     .withVncPassword(DEFAULT_PASSWORD)
                     .withVncPort(VNC_PORT)
-                    .withVideoExtension(recordingFormat);
+                    .withVideoFormat(recordingFormat);
         }
 
         if (customImageName != null) {
@@ -364,7 +364,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         return withRecordingMode(recordingMode, vncRecordingDirectory, null);
     }
 
-    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory, @Nullable VncRecordingFormat recordingFormat) {
+    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory, VncRecordingFormat recordingFormat) {
         this.recordingMode = recordingMode;
         this.vncRecordingDirectory = vncRecordingDirectory;
         this.recordingFormat = recordingFormat;

--- a/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
@@ -16,7 +16,7 @@ public class DefaultRecordingFileFactory implements RecordingFileFactory {
 
     @Override
     public File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded) {
-        return recordingFileForTest(vncRecordingDirectory, prefix, succeeded, VncRecordingFormat.getDefaultFormat());
+        return recordingFileForTest(vncRecordingDirectory, prefix, succeeded, VncRecordingContainer.DEFAULT_RECORDING_FORMAT);
     }
 
     @Override
@@ -26,7 +26,7 @@ public class DefaultRecordingFileFactory implements RecordingFileFactory {
             resultMarker,
             prefix,
             filenameDateFormat.format(new Date()),
-            recordingFormat.getExtension()
+            recordingFormat.getFilenameExtension()
         );
         return new File(vncRecordingDirectory, fileName);
     }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
@@ -16,7 +16,7 @@ public class DefaultRecordingFileFactory implements RecordingFileFactory {
 
     @Override
     public File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded) {
-        return recordingFileForTest(vncRecordingDirectory, prefix, succeeded, null);
+        return recordingFileForTest(vncRecordingDirectory, prefix, succeeded, VncRecordingFormat.getDefaultFormat());
     }
 
     @Override
@@ -26,7 +26,7 @@ public class DefaultRecordingFileFactory implements RecordingFileFactory {
             resultMarker,
             prefix,
             filenameDateFormat.format(new Date()),
-            VncRecordingFormat.of(recordingFormat).getExtension()
+            recordingFormat.getExtension()
         );
         return new File(vncRecordingDirectory, fileName);
     }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
@@ -4,20 +4,23 @@ import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import static org.testcontainers.containers.VncRecordingContainer.VncRecordingFormat;
+
 public class DefaultRecordingFileFactory implements RecordingFileFactory {
 
     private static final SimpleDateFormat filenameDateFormat = new SimpleDateFormat("YYYYMMdd-HHmmss");
     private static final String PASSED = "PASSED";
     private static final String FAILED = "FAILED";
-    private static final String FILENAME_FORMAT = "%s-%s-%s.flv";
+    private static final String FILENAME_FORMAT = "%s-%s-%s.%s";
 
     @Override
-    public File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded) {
+    public File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded, VncRecordingFormat recordingFormat) {
         final String resultMarker = succeeded ? PASSED : FAILED;
         final String fileName = String.format(FILENAME_FORMAT,
             resultMarker,
             prefix,
-            filenameDateFormat.format(new Date())
+            filenameDateFormat.format(new Date()),
+            recordingFormat.getExtension()
         );
         return new File(vncRecordingDirectory, fileName);
     }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/DefaultRecordingFileFactory.java
@@ -13,6 +13,12 @@ public class DefaultRecordingFileFactory implements RecordingFileFactory {
     private static final String FAILED = "FAILED";
     private static final String FILENAME_FORMAT = "%s-%s-%s.%s";
 
+
+    @Override
+    public File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded) {
+        return recordingFileForTest(vncRecordingDirectory, prefix, succeeded, null);
+    }
+
     @Override
     public File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded, VncRecordingFormat recordingFormat) {
         final String resultMarker = succeeded ? PASSED : FAILED;
@@ -20,7 +26,7 @@ public class DefaultRecordingFileFactory implements RecordingFileFactory {
             resultMarker,
             prefix,
             filenameDateFormat.format(new Date()),
-            recordingFormat.getExtension()
+            VncRecordingFormat.of(recordingFormat).getExtension()
         );
         return new File(vncRecordingDirectory, fileName);
     }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
@@ -1,15 +1,16 @@
 package org.testcontainers.containers;
 
 import org.junit.runner.Description;
+import org.testcontainers.containers.VncRecordingContainer.VncRecordingFormat;
 
 import java.io.File;
 
 public interface RecordingFileFactory {
 
     @Deprecated
-    default File recordingFileForTest(File vncRecordingDirectory, Description description, boolean succeeded) {
-        return recordingFileForTest(vncRecordingDirectory, description.getTestClass().getSimpleName() + "-" + description.getMethodName(), succeeded);
+    default File recordingFileForTest(File vncRecordingDirectory, Description description, boolean succeeded, VncRecordingFormat recordingFormat) {
+        return recordingFileForTest(vncRecordingDirectory, description.getTestClass().getSimpleName() + "-" + description.getMethodName(), succeeded, recordingFormat);
     }
 
-    File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded);
+    File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded, VncRecordingFormat recordingFormat);
 }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
@@ -12,10 +12,10 @@ public interface RecordingFileFactory {
         return recordingFileForTest(vncRecordingDirectory, description.getTestClass().getSimpleName() + "-" + description.getMethodName(), succeeded);
     }
 
-    File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded);
-
     default File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded, VncRecordingFormat recordingFormat) {
         return recordingFileForTest(vncRecordingDirectory, prefix, succeeded);
     }
+
+    File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded);
 
 }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/RecordingFileFactory.java
@@ -8,9 +8,14 @@ import java.io.File;
 public interface RecordingFileFactory {
 
     @Deprecated
-    default File recordingFileForTest(File vncRecordingDirectory, Description description, boolean succeeded, VncRecordingFormat recordingFormat) {
-        return recordingFileForTest(vncRecordingDirectory, description.getTestClass().getSimpleName() + "-" + description.getMethodName(), succeeded, recordingFormat);
+    default File recordingFileForTest(File vncRecordingDirectory, Description description, boolean succeeded) {
+        return recordingFileForTest(vncRecordingDirectory, description.getTestClass().getSimpleName() + "-" + description.getMethodName(), succeeded);
     }
 
-    File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded, VncRecordingFormat recordingFormat);
+    File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded);
+
+    default File recordingFileForTest(File vncRecordingDirectory, String prefix, boolean succeeded, VncRecordingFormat recordingFormat) {
+        return recordingFileForTest(vncRecordingDirectory, prefix, succeeded);
+    }
+
 }

--- a/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.testcontainers.containers.VncRecordingContainer.VncRecordingFormat;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -47,7 +46,7 @@ public class DefaultRecordingFileFactoryTest {
         File vncRecordingDirectory = Files.createTempDirectory("recording").toFile();
         Description description = createTestDescription(getClass().getCanonicalName(), methodName, Test.class);
 
-        File recordingFile = factory.recordingFileForTest(vncRecordingDirectory, description, success, VncRecordingFormat.FLV);
+        File recordingFile = factory.recordingFileForTest(vncRecordingDirectory, description, success);
 
         String expectedFilePrefix = format("%s-%s-%s", prefix, getClass().getSimpleName(), methodName);
 

--- a/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/DefaultRecordingFileFactoryTest.java
@@ -5,6 +5,7 @@ import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.testcontainers.containers.VncRecordingContainer.VncRecordingFormat;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -46,7 +47,7 @@ public class DefaultRecordingFileFactoryTest {
         File vncRecordingDirectory = Files.createTempDirectory("recording").toFile();
         Description description = createTestDescription(getClass().getCanonicalName(), methodName, Test.class);
 
-        File recordingFile = factory.recordingFileForTest(vncRecordingDirectory, description, success);
+        File recordingFile = factory.recordingFileForTest(vncRecordingDirectory, description, success, VncRecordingFormat.FLV);
 
         String expectedFilePrefix = format("%s-%s-%s", prefix, getClass().getSimpleName(), methodName);
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -8,14 +8,20 @@ import org.junit.experimental.runners.Enclosed;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.chrome.ChromeOptions;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.DefaultRecordingFileFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.ToStringConsumer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.lifecycle.TestDescription;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.testcontainers.containers.BrowserWebDriverContainer.VncRecordingMode.RECORD_ALL;
 import static org.testcontainers.containers.BrowserWebDriverContainer.VncRecordingMode.RECORD_FAILING;
 
@@ -57,6 +63,52 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
 
                 String[] files = vncRecordingDirectory.getRoot().list(new PatternFilenameFilter("PASSED-.*\\.flv"));
                 assertEquals("Recorded file not found", 1, files.length);
+            }
+        }
+
+        @Test
+        public void recordingTestThatShouldHaveCorrectDuration() throws IOException {
+            final String flvFileTitle = "ChromeThatRecordsAllTests-recordingTestThatShouldBeRecordedAndRetained";
+            final String flvFileNameRegEx = "PASSED-" + flvFileTitle + ".*\\.flv";
+
+            try (
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
+                    .withCapabilities(new ChromeOptions())
+                    .withRecordingMode(RECORD_ALL, vncRecordingDirectory.getRoot())
+                    .withRecordingFileFactory(new DefaultRecordingFileFactory())
+            ) {
+                chrome.start();
+
+                doSimpleExplore(chrome);
+                chrome.afterTest(new TestDescription() {
+                    @Override
+                    public String getTestId() {
+                        return getFilesystemFriendlyName();
+                    }
+
+                    @Override
+                    public String getFilesystemFriendlyName() {
+                        return flvFileTitle;
+                    }
+                }, Optional.empty());
+
+                String recordedFile = vncRecordingDirectory.getRoot().listFiles(new PatternFilenameFilter(flvFileNameRegEx))[0].getCanonicalPath();
+
+                ToStringConsumer dockerLogConsumer = new ToStringConsumer();
+
+                try( GenericContainer container = new GenericContainer<>("jrottenberg/ffmpeg:3.2-alpine38") ) {
+                    container.withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+                            .withFileSystemBind(recordedFile, "/tmp/chromeTestRecord.flv", BindMode.READ_WRITE )
+                            .withCommand("-i" ,"/tmp/chromeTestRecord.flv")
+                            .withLogConsumer(dockerLogConsumer)
+                            .start();
+                } catch (RuntimeException ex) {
+                    // Container has started successfully but an exception is thrown as we used OneShotStartupCheckStrategy
+                    // But (for now) OneShotStartupCheckStrategy is useful to get Duration from container output
+                }
+
+                String dockerOutput = dockerLogConsumer.toUtf8String();
+                assertTrue("Duration is incorrect: ", dockerOutput.matches("[\\S\\s]*Duration: (?!00:00:00.00)[\\S\\s]*"));
             }
         }
     }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -83,7 +83,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
             ) {
                 chrome.start();
 
-                TimeUnit.MILLISECONDS.sleep(500);
+                TimeUnit.MILLISECONDS.sleep(500); // to make sure video will have a duration
                 doSimpleExplore(chrome);
                 chrome.afterTest(new TestDescription() {
                     @Override

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -132,14 +132,14 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
                 mountableFile = MountableFile.forHostPath(recordedFiles[0].getCanonicalPath());
             }
 
-            try( GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("testcontainers/vnc-recorder:1.2.0")) ) {
+            try (GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("testcontainers/vnc-recorder:1.2.0"))) {
                 String recordFileContainerPath = "/tmp/chromeTestRecord.flv";
                 container.withCopyFileToContainer(mountableFile, recordFileContainerPath)
-                        .withCreateContainerCmdModifier( createContainerCmd -> createContainerCmd.withEntrypoint("ffmpeg") )
-                        .withCommand("-i" , recordFileContainerPath, "-f" ,"null" ,"-" )
-                        .waitingFor( new LogMessageWaitStrategy()
+                        .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withEntrypoint("ffmpeg"))
+                        .withCommand("-i", recordFileContainerPath, "-f", "null", "-")
+                        .waitingFor(new LogMessageWaitStrategy()
                                                 .withRegEx(".*Duration.*")
-                                                .withStartupTimeout(Duration.of(60, SECONDS)) )
+                                                .withStartupTimeout(Duration.of(60, SECONDS)))
                         .start();
                 String ffmpegOutput = container.getLogs();
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -37,7 +37,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
      * Guaranty a minimum video length for FFmpeg re-encoding.
      * @see VncRecordingFormat#reencodeRecording(VncRecordingContainer, String)
      */
-    private static final int MINIMUM_VIDEO_DURATION_MILLISECONDS = 100;
+    private static final int MINIMUM_VIDEO_DURATION_MILLISECONDS = 200;
 
     public static class ChromeThatRecordsAllTests {
 
@@ -86,8 +86,8 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
         public void recordingTestShouldHaveFlvExtension() throws InterruptedException {
             File target = vncRecordingDirectory.getRoot();
             try (
-                // recordAllFlv {
-                // Define explicitly FLV format for recorded video:
+                // recordFlv {
+                // Set (explicitly) FLV format for recorded video:
                 BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
                     .withCapabilities(new ChromeOptions())
                     .withRecordingMode(RECORD_ALL, target, VncRecordingFormat.FLV)
@@ -104,8 +104,8 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
         public void recordingTestShouldHaveMp4Extension() throws InterruptedException {
             File target = vncRecordingDirectory.getRoot();
             try (
-                // recordAllMp4 {
-                // Define MP4 format for recorded video:
+                // recordMp4 {
+                // Set MP4 format for recorded video:
                 BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
                     .withCapabilities(new ChromeOptions())
                     .withRecordingMode(RECORD_ALL, target, VncRecordingFormat.MP4)


### PR DESCRIPTION
I have written an implementation to fix the scrollable video using ffmpeg command, which will also reduce the video size as mentioned by @leonard84

I have also opened a related pull Request testcontainers/vnc-recorder#4 by adding **ffmpeg** to the docker image, which (I saw) necessary to avoid using another container and also simplify the fix.
Just to mention that some test won't pass untill the new **vnc-recorder** docker image is available with tag 1.2.0. 

(Thank to @kiview for his assitance during **hack-commit-push** (last june) which make contributing to **testcontainers** more clear for me.)

Fixes #512.