### PR TITLE
Use testCompileClasspath instead of testCompileOnly

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     compile 'junit:junit:4.12'
     compile 'org.slf4j:slf4j-api:1.7.30'
     compileOnly 'org.jetbrains:annotations:20.0.0'
-    testCompileOnly 'org.jetbrains:annotations:20.0.0'
+    testCompileClasspath 'org.jetbrains:annotations:20.0.0'
     compile 'org.apache.commons:commons-compress:1.20'
     compile ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')

--- a/examples/mongodb-container/build.gradle
+++ b/examples/mongodb-container/build.gradle
@@ -9,5 +9,5 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13'
-    testCompileOnly 'org.jetbrains:annotations:20.0.0'
+    testCompileClasspath 'org.jetbrains:annotations:20.0.0'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     testCompile project(':nginx')
 
     compileOnly 'org.jetbrains:annotations:20.0.0'
-    testCompileOnly 'org.jetbrains:annotations:20.0.0'
+    testCompileClasspath 'org.jetbrains:annotations:20.0.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntime 'org.postgresql:postgresql:42.2.16'
     testRuntime 'mysql:mysql-connector-java:8.0.21'
 
-    testCompileOnly 'org.jetbrains:annotations:20.0.0'
+    testCompileClasspath 'org.jetbrains:annotations:20.0.0'
 }
 
 sourceJar {


### PR DESCRIPTION
This will make the project future-proof for Gradle 7: [Dependencies should no longer be declared using the compile and runtime configurations](https://docs.gradle.org/6.6.1/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations)

Example build script:

```build.gradle
plugins {
    id 'java-library'
}

repositories {
    jcenter()
}

dependencies {
    testImplementation "org.testcontainers:junit-jupiter:1.14.3"
}
```

Current output:

```
The testCompileOnly configuration has been deprecated for resolution. This will fail with an error in Gradle 7.0. Please resolve the testCompileClasspath configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.6.1/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations

FAILURE: Build failed with an exception.

* What went wrong:
Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0
```