### PR TITLE
#1495 Enable parallel tests.

### DIFF
--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelContainerTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelContainerTests.java
@@ -1,0 +1,88 @@
+package org.testcontainers.junit.jupiter;
+
+import static org.junit.Assert.assertEquals;
+import static org.testcontainers.junit.jupiter.JUnitJupiterTestImages.POSTGRES_IMAGE;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+@Testcontainers
+@Execution(ExecutionMode.CONCURRENT)
+public class ParallelContainerTests {
+
+    @Container
+    protected static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(POSTGRES_IMAGE)
+        .withDatabaseName("foo")
+        .withUsername("foo")
+        .withPassword("secret");
+
+    @Test
+    void container_should_be_running_first_test() throws SQLException {
+        assertContainerIsRunning(POSTGRE_SQL_CONTAINER);
+    }
+
+    @Test
+    void container_should_be_running_second_test() throws SQLException {
+        assertContainerIsRunning(POSTGRE_SQL_CONTAINER);
+    }
+
+    @Nested
+    @Execution(ExecutionMode.CONCURRENT)
+    class FirstParallelTest extends BaseContainerTests {
+
+        @Test
+        void container_should_be_running() throws SQLException {
+            assertContainerIsRunning(POSTGRE_SQL_BASE_CONTAINER);
+        }
+
+    }
+
+    @Nested
+    @Execution(ExecutionMode.CONCURRENT)
+    class SecondParallelTest extends BaseContainerTests {
+
+        @Test
+        void container_should_be_running() throws SQLException {
+            assertContainerIsRunning(POSTGRE_SQL_BASE_CONTAINER);
+        }
+
+    }
+
+    @Testcontainers
+    private static class BaseContainerTests {
+
+        @Container
+        protected static final PostgreSQLContainer<?> POSTGRE_SQL_BASE_CONTAINER = new PostgreSQLContainer<>(POSTGRES_IMAGE)
+            .withDatabaseName("foo")
+            .withUsername("foo")
+            .withPassword("secret");
+
+    }
+
+    @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
+    private static void assertContainerIsRunning(PostgreSQLContainer<?> container) throws SQLException {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(container.getJdbcUrl());
+        hikariConfig.setUsername("foo");
+        hikariConfig.setPassword("secret");
+
+        try (HikariDataSource ds = new HikariDataSource(hikariConfig)) {
+            Statement statement = ds.getConnection().createStatement();
+            statement.execute("SELECT 1");
+            ResultSet resultSet = statement.getResultSet();
+            resultSet.next();
+
+            int resultSetInt = resultSet.getInt(1);
+            assertEquals(1, resultSetInt);
+        }
+    }
+
+}

--- a/modules/junit-jupiter/src/test/resources/junit-platform.properties
+++ b/modules/junit-jupiter/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=same_thread
+junit.jupiter.execution.parallel.mode.classes.default=same_thread


### PR DESCRIPTION
A container can be shared among different tests classes via container defined in a base class for parallel tests.
I used synchronized because right now the execution is single threaded, booting up one container after other. In the future I would like to change it to run in threads.

Related Issue:
https://github.com/testcontainers/testcontainers-java/issues/1495