### PR TITLE
Custom init script separator

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -107,8 +107,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         extends FailureDetectingExternalResource
         implements Container<SELF>, AutoCloseable, WaitStrategyTarget, Startable {
 
-    private static final Charset UTF8 = Charset.forName("UTF-8");
-
     public static final int CONTAINER_RUNNING_TIMEOUT_SEC = 30;
 
     public static final String INTERNAL_HOST_HOSTNAME = "host.testcontainers.internal";

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -75,22 +75,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      */
     private void runInitScriptIfRequired() {
         if (initScriptPath != null) {
-            try {
-                URL resource = Thread.currentThread().getContextClassLoader().getResource(initScriptPath);
-                if (resource == null) {
-                    logger().warn("Could not load classpath init script: {}", initScriptPath);
-                    throw new ScriptLoadException("Could not load classpath init script: " + initScriptPath + ". Resource not found.");
-                }
-                String cql = IOUtils.toString(resource, StandardCharsets.UTF_8);
-                DatabaseDelegate databaseDelegate = getDatabaseDelegate();
-                ScriptUtils.executeDatabaseScript(databaseDelegate, initScriptPath, cql);
-            } catch (IOException e) {
-                logger().warn("Could not load classpath init script: {}", initScriptPath);
-                throw new ScriptLoadException("Could not load classpath init script: " + initScriptPath, e);
-            } catch (ScriptException e) {
-                logger().error("Error while executing init script: {}", initScriptPath, e);
-                throw new ScriptUtils.UncategorizedScriptException("Error while executing init script: " + initScriptPath, e);
-            }
+            ScriptUtils.runInitScript(getDatabaseDelegate(), initScriptPath);
         }
     }
 

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -287,14 +287,26 @@ public abstract class ScriptUtils {
 		return false;
 	}
 
-	/**
-	 * Load script from classpath and apply it to the given database
-	 *
-	 * @param databaseDelegate database delegate for script execution
-	 * @param initScriptPath   the resource to load the init script from
-	 */
-	public static void runInitScript(DatabaseDelegate databaseDelegate, String initScriptPath) {
-		try {
+    /**
+     * Load script from classpath and apply it to the given database
+     *
+     * @param databaseDelegate database delegate for script execution
+     * @param initScriptPath   the resource to load the init script from
+     */
+    public static void runInitScript(DatabaseDelegate databaseDelegate, String initScriptPath) {
+        runInitScript(databaseDelegate, initScriptPath, DEFAULT_STATEMENT_SEPARATOR);
+    }
+
+    /**
+     * Load script from classpath and apply it to the given database
+     *
+     * @param databaseDelegate    database delegate for script execution
+     * @param initScriptPath      the resource to load the init script from
+     * @param initScriptSeparator separator to split script
+     */
+    public static void runInitScript(DatabaseDelegate databaseDelegate, String initScriptPath,
+                                     String initScriptSeparator) {
+        try {
             URL resource;
             if (initScriptPath.startsWith(FILE_PATH_PREFIX)) {
                 //relative workdir path
@@ -309,7 +321,9 @@ public abstract class ScriptUtils {
 				throw new ScriptLoadException("Could not load classpath init script: " + initScriptPath + ". Resource not found.");
 			}
 			String scripts = IOUtils.toString(resource, StandardCharsets.UTF_8);
-			executeDatabaseScript(databaseDelegate, initScriptPath, scripts);
+            executeDatabaseScript(databaseDelegate, initScriptPath, scripts, false, false,
+                DEFAULT_COMMENT_PREFIX, initScriptSeparator,
+                DEFAULT_BLOCK_COMMENT_START_DELIMITER, DEFAULT_BLOCK_COMMENT_END_DELIMITER);
 		} catch (IOException e) {
 			LOGGER.warn("Could not load classpath init script: {}", initScriptPath);
 			throw new ScriptLoadException("Could not load classpath init script: " + initScriptPath, e);

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -31,6 +31,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     private static final Object DRIVER_LOAD_MUTEX = new Object();
     private Driver driver;
     private String initScriptPath;
+    private String initScriptSeparator = ScriptUtils.DEFAULT_STATEMENT_SEPARATOR;
     protected Map<String, String> parameters = new HashMap<>();
     protected Map<String, String> urlParameters = new HashMap<>();
 
@@ -128,6 +129,11 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
 
     public SELF withInitScript(String initScriptPath) {
         this.initScriptPath = initScriptPath;
+        return self();
+    }
+
+    public SELF withInitScriptSeparator(String initScriptSeparator) {
+        this.initScriptSeparator = initScriptSeparator;
         return self();
     }
 
@@ -283,7 +289,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
      */
     protected void runInitScriptIfRequired() {
         if (initScriptPath != null) {
-            ScriptUtils.runInitScript(getDatabaseDelegate(), initScriptPath);
+            ScriptUtils.runInitScript(getDatabaseDelegate(), initScriptPath, initScriptSeparator);
         }
     }
 

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
@@ -28,7 +28,6 @@ import static org.testcontainers.MySQLTestImages.MYSQL_55_IMAGE;
 import static org.testcontainers.MySQLTestImages.MYSQL_56_IMAGE;
 import static org.testcontainers.MySQLTestImages.MYSQL_IMAGE;
 
-
 public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleMySQLTest.class);

--- a/modules/postgresql/src/test/resources/somepath/init_postgresql.sql
+++ b/modules/postgresql/src/test/resources/somepath/init_postgresql.sql
@@ -3,3 +3,17 @@ CREATE TABLE bar (
 );
 
 INSERT INTO bar (foo) VALUES ('hello world');
+
+CREATE FUNCTION hi_lo(
+    a  NUMERIC,
+    b  NUMERIC,
+    c  NUMERIC,
+    OUT hi NUMERIC,
+    OUT lo NUMERIC)
+AS $$
+BEGIN
+    hi := GREATEST(a, b, c);
+    lo := LEAST(a, b, c);
+END; $$
+    LANGUAGE plpgsql;
+


### PR DESCRIPTION
The problem: only ";" (semicolon) character can be used as a statement separator of database init script. At least it makes a problem when you try to create a stored procedure for postgres, the procedure body may have a semicolon character.

Proposed change: add customizable `JdbcDatabaseContainer.initScriptSeparator` (has default value `";"`) and pass it to `ScriptUtils.runInitScript`. Back compatibility is saved.

Also this PR has unification of `ScriptUtils.runInitScript` calls just to reduce the repeated code.