### PR TITLE
docker-machine: get full remote daemon URL, to allow for use of custom daemon port (#2769)

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerMachineClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerMachineClientProviderStrategy.java
@@ -37,12 +37,12 @@ public final class DockerMachineClientProviderStrategy extends DockerClientProvi
 
         DockerMachineClient.instance().ensureMachineRunning(machineName);
 
-        String dockerDaemonIpAddress = DockerMachineClient.instance().getDockerDaemonIpAddress(machineName);
+        String dockerDaemonUrl = DockerMachineClient.instance().getDockerDaemonUrl(machineName);
 
-        log.info("Docker daemon IP address for docker machine {} is {}", machineName, dockerDaemonIpAddress);
+        log.info("Docker daemon URL for docker machine {} is {}", machineName, dockerDaemonUrl);
 
         return TransportConfig.builder()
-            .dockerHost(URI.create("tcp://" + dockerDaemonIpAddress + ":2376"))
+            .dockerHost(URI.create(dockerDaemonUrl))
             .sslConfig(
                 new LocalDirectorySSLConfig(
                     Paths.get(System.getProperty("user.home") + "/.docker/machine/certs/").toString()

--- a/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
@@ -79,6 +79,14 @@ public class DockerMachineClient {
         }
     }
 
+    /**
+     * @deprecated Use getDockerDaemonUrl(@NonNull String machineName) for connection to docker-machine
+     */
+    @Deprecated
+    public String getDockerDaemonIpAddress(@NonNull String machineName) {
+        return runShellCommand(executableName, "ip", machineName);
+    }
+
     public String getDockerDaemonUrl(@NonNull String machineName) {
         return runShellCommand(executableName, "url", machineName);
     }

--- a/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
@@ -79,8 +79,8 @@ public class DockerMachineClient {
         }
     }
 
-    public String getDockerDaemonIpAddress(@NonNull String machineName) {
-        return runShellCommand(executableName, "ip", machineName);
+    public String getDockerDaemonUrl(@NonNull String machineName) {
+        return runShellCommand(executableName, "url", machineName);
     }
 
     public boolean isMachineRunning(String machineName) {


### PR DESCRIPTION
Request url from docker-machine instead of manually constructing it from ip and fixed port.

Fixes https://github.com/testcontainers/testcontainers-java/issues/2769