### PR TITLE
Startables#deepStart with varargs

### DIFF
--- a/core/src/main/java/org/testcontainers/lifecycle/Startables.java
+++ b/core/src/main/java/org/testcontainers/lifecycle/Startables.java
@@ -1,5 +1,6 @@
 package org.testcontainers.lifecycle;
 
+import java.util.Arrays;
 import lombok.experimental.UtilityClass;
 
 import java.util.Collection;
@@ -40,6 +41,13 @@ public class Startables {
      */
     public CompletableFuture<Void> deepStart(Iterable<? extends Startable> startables) {
         return deepStart(StreamSupport.stream(startables.spliterator(), false));
+    }
+
+    /**
+     * @see #deepStart(Stream)
+     */
+    public CompletableFuture<Void> deepStart(Startable... startables) {
+        return deepStart(Arrays.stream(startables));
     }
 
     /**


### PR DESCRIPTION
Support varargs in Startables to start multiple containers in parallel, esp. for singleton pattern.

```java
// instead of     
List<Startable> startables = List.of(mongoDBContainer, kafkaContainer, mockServerContainer);
Startables.deepStart(startables).get();

// this more readable
Startables.deepStart(mongoDBContainer, kafkaContainer, mockServerContainer).get();
```