### PR TITLE
Add support for java-driver-core

### DIFF
--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -2,5 +2,5 @@ description = "TestContainers :: Cassandra"
 
 dependencies {
     compile project(":database-commons")
-    compile "com.datastax.cassandra:cassandra-driver-core:3.7.1"
+    compile "com.datastax.oss:java-driver-core:4.9.0"
 }

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
-import com.datastax.driver.core.Cluster;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.session.Session;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.apache.commons.io.IOUtils;
 import org.testcontainers.containers.delegate.CassandraDatabaseDelegate;
@@ -12,6 +13,7 @@ import org.testcontainers.utility.MountableFile;
 
 import javax.script.ScriptException;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
@@ -165,28 +167,21 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
         return PASSWORD;
     }
 
-    /**
-     * Get configured Cluster
-     *
-     * Can be used to obtain connections to Cassandra in the container
-     */
-    public Cluster getCluster() {
-        return getCluster(this, enableJmxReporting);
+    public CqlSession getSession() {
+        return getSession(this, enableJmxReporting);
     }
 
-    public static Cluster getCluster(ContainerState containerState, boolean enableJmxReporting) {
-        final Cluster.Builder builder = Cluster.builder()
-            .addContactPoint(containerState.getHost())
-            .withPort(containerState.getMappedPort(CQL_PORT));
-        if (!enableJmxReporting) {
-            builder.withoutJMXReporting();
-        }
-        return builder.build();
+    public static CqlSession getSession(ContainerState containerState, boolean enableJmxReporting) {
+	CqlSession session = CqlSession.builder()
+                .addContactPoint(new InetSocketAddress(containerState.getHost(), containerState.getMappedPort(CQL_PORT)))
+                .withLocalDatacenter("datacenter1").build();
+        return session;
     }
 
-    public static Cluster getCluster(ContainerState containerState) {
-        return getCluster(containerState, false);
+    public static CqlSession getSession(ContainerState containerState) {
+        return getSession(containerState, false);
     }
+
 
     private DatabaseDelegate getDatabaseDelegate() {
         return new CassandraDatabaseDelegate(this);

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/delegate/CassandraDatabaseDelegate.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/delegate/CassandraDatabaseDelegate.java
@@ -1,8 +1,9 @@
 package org.testcontainers.containers.delegate;
 
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.DriverException;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DriverException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.CassandraContainer;
@@ -25,8 +26,7 @@ public class CassandraDatabaseDelegate extends AbstractDatabaseDelegate<Session>
     @Override
     protected Session createNewConnection() {
         try {
-            return CassandraContainer.getCluster(container)
-                    .newSession();
+	      return CassandraContainer.getSession(container);
         } catch (DriverException e) {
             log.error("Could not obtain cassandra connection");
             throw new ConnectionCreationException("Could not obtain cassandra connection", e);
@@ -36,7 +36,7 @@ public class CassandraDatabaseDelegate extends AbstractDatabaseDelegate<Session>
     @Override
     public void execute(String statement, String scriptPath, int lineNumber, boolean continueOnError, boolean ignoreFailedDrops) {
         try {
-            ResultSet result = getConnection().execute(statement);
+            ResultSet result = CassandraContainer.getSession(container).execute(statement);
             if (result.wasApplied()) {
                 log.debug("Statement {} was applied", statement);
             } else {
@@ -50,7 +50,7 @@ public class CassandraDatabaseDelegate extends AbstractDatabaseDelegate<Session>
     @Override
     protected void closeConnectionQuietly(Session session) {
         try {
-            session.getCluster().close();
+            session.close();
         } catch (Exception e) {
             log.error("Could not close cassandra connection", e);
         }

--- a/modules/cassandra/src/test/resources/initial.cql
+++ b/modules/cassandra/src/test/resources/initial.cql
@@ -1,7 +1,5 @@
 CREATE KEYSPACE keySpaceTest WITH replication = {'class': 'SimpleStrategy', 'replication_factor' : 1};
 
-USE keySpaceTest;
+CREATE TABLE keySpaceTest.catalog_category (id bigint primary key, name text);
 
-CREATE TABLE catalog_category (id bigint primary key, name text);
-
-INSERT INTO catalog_category (id, name) VALUES (1, 'test_category');
+INSERT INTO keySpaceTest.catalog_category (id, name) VALUES (1, 'test_category');


### PR DESCRIPTION
- Upgrade cassandra-driver-core(3.7.1) to java-driver-core(4.9.0) as cassandra-driver-core is moved to java-driver-core
- java-driver-core is using netty(4.1.51.Final) which includes both security fixes and AArch64 performance improvements
- Refer release notes for detail:
  - https://netty.io/news/2020/05/13/4-1-50-Final.html
  - https://netty.io/news/2020/07/09/4-1-51-Final.html