### PR TITLE
Make testMatrix task emit all check tasks, rather than filtering out up-to-date tasks

### DIFF
--- a/gradle/ci-support.gradle
+++ b/gradle/ci-support.gradle
@@ -9,10 +9,7 @@ task testMatrix {
 
         dependsOn(checkTasks)
         doLast {
-            // Obtain a list of check tasks that are not up-to-date, i.e.
-            //  the ones which Gradle cannot find a cached output for.
             def checkTaskPaths = checkTasks
-                .findAll { !it.state.upToDate }
                 .collect { it.path }
 
             println(JsonOutput.toJson(checkTaskPaths))


### PR DESCRIPTION
It seems that this is causing problems when a random build failure occurs: if you re-run, and all the modules have a build cache hit, the taskMatrix is empty and GHA never overwrites the failed job.