### PR TITLE
Presto: Bump default Presto version (used in deprecated constructor and unversioned JDBC URL) from 329 to 344

### DIFF
--- a/docs/modules/databases/jdbc.md
+++ b/docs/modules/databases/jdbc.md
@@ -41,7 +41,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 #### Using Presto
 
-`jdbc:tc:presto:329://localhost/memory/default`
+`jdbc:tc:presto:344://localhost/memory/default`
 
 ### Using a classpath init script
 

--- a/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
+++ b/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
@@ -18,7 +18,7 @@ public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDat
     public static final String NAME = "presto";
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("prestosql/presto");
     public static final String IMAGE = "prestosql/presto";
-    public static final String DEFAULT_TAG = "329";
+    public static final String DEFAULT_TAG = "344";
 
     public static final Integer PRESTO_PORT = 8080;
 

--- a/modules/presto/src/test/java/org/testcontainers/PrestoTestImages.java
+++ b/modules/presto/src/test/java/org/testcontainers/PrestoTestImages.java
@@ -3,6 +3,6 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface PrestoTestImages {
-    DockerImageName PRESTO_TEST_IMAGE = DockerImageName.parse("prestosql/presto:329");
-    DockerImageName PRESTO_PREVIOUS_VERSION_TEST_IMAGE = DockerImageName.parse("prestosql/presto:328");
+    DockerImageName PRESTO_TEST_IMAGE = DockerImageName.parse("prestosql/presto:344");
+    DockerImageName PRESTO_PREVIOUS_VERSION_TEST_IMAGE = DockerImageName.parse("prestosql/presto:343");
 }

--- a/modules/presto/src/test/java/org/testcontainers/jdbc/presto/PrestoJDBCDriverTest.java
+++ b/modules/presto/src/test/java/org/testcontainers/jdbc/presto/PrestoJDBCDriverTest.java
@@ -15,7 +15,7 @@ public class PrestoJDBCDriverTest extends AbstractJDBCDriverTest {
     public static Iterable<Object[]> data() {
         return asList(
             new Object[][]{
-                {"jdbc:tc:presto:329://hostname/", EnumSet.of(Options.PmdKnownBroken)},
+                {"jdbc:tc:presto:344://hostname/", EnumSet.of(Options.PmdKnownBroken)},
             });
     }
 }


### PR DESCRIPTION
Supersedes https://github.com/testcontainers/testcontainers-java/pull/2862
As https://github.com/testcontainers/testcontainers-java/pull/2992 showed, there is a value in updating the default (and tested) version.
