### PR TITLE
When an image version is not specified, use `latest` as the default tag

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/Versioning.java
+++ b/core/src/main/java/org/testcontainers/utility/Versioning.java
@@ -24,12 +24,12 @@ interface Versioning {
 
         @Override
         public String getSeparator() {
-            return "";
+            return ":";
         }
 
         @Override
         public String toString() {
-            return "";
+            return "latest";
         }
 
         @Override

--- a/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
@@ -22,9 +22,11 @@ public class AmbiguousImagePullTest {
             client.removeImageCmd(alpineImage.getId()).exec();
         }
 
-        try (final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine"))
-            .withCommand("/bin/sh", "-c", "sleep 0")
-            .withStartupCheckStrategy(new OneShotStartupCheckStrategy())) {
+        try (
+            final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine"))
+                .withCommand("/bin/sh", "-c", "sleep 0")
+                .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+        ) {
             container.start();
             // do nothing other than start and stop
         }

--- a/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
@@ -1,0 +1,32 @@
+package org.testcontainers.dockerclient;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Image;
+import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.List;
+
+public class AmbiguousImagePullTest {
+
+    @Test(timeout = 30_000)
+    public void testNotUsingParse() {
+        DockerClient client = DockerClientFactory.instance().client();
+        List<Image> alpineImages = client.listImagesCmd()
+            .withImageNameFilter("alpine:latest")
+            .exec();
+        for (Image alpineImage : alpineImages) {
+            client.removeImageCmd(alpineImage.getId()).exec();
+        }
+
+        try (final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine"))
+            .withCommand("/bin/sh", "-c", "sleep 0")
+            .withStartupCheckStrategy(new OneShotStartupCheckStrategy())) {
+            container.start();
+            // do nothing other than start and stop
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
@@ -112,7 +112,7 @@ public class DockerImageNameTest {
                 canonicalName = unversionedPart + versionSeparator + version;
             } else {
                 combined = unversionedPart;
-                canonicalName = unversionedPart;
+                canonicalName = unversionedPart + ":latest";
             }
 
             VisibleAssertions.context("For " + combined);
@@ -124,7 +124,7 @@ public class DockerImageNameTest {
             if (version != null) {
                 assertEquals(combined + " has version part: " + version, version, imageName.getVersionPart());
             } else {
-                assertEquals(combined + " has no version specified", "", imageName.getVersionPart());
+                assertEquals(combined + " has automatic 'latest' version specified", "latest", imageName.getVersionPart());
             }
             assertEquals(combined + " has canonical name: " + canonicalName, canonicalName, imageName.asCanonicalNameString());
 


### PR DESCRIPTION
Fixes #3310 

An alternative approach I was considering was to add a `getVersionPartOrDefault(String)` method to `DockerImageName` which would return the default. This approach would have the advantage of not skewing the `AnyVersioning` so that it always `toString`s to `latest`.

If preferred, we could use this other approach. Keen for thoughts.