### PR TITLE
Remove GitHub Actions cache restore keys

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-examples-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-home-testmatrix-examples-
       - id: set-matrix
         working-directory: ./examples/
         env:
@@ -51,8 +49,6 @@ jobs:
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-examples-${{matrix.gradle_args}}_check-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-home-examples-${{matrix.gradle_args}}_check-
       - name: Clear existing docker image cache
         run: docker image prune -af
       - name: Build and test Examples with Gradle (${{matrix.gradle_args}})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-home-testmatrix-
       - id: set-matrix
         env:
           # Since we override the tests executor,
@@ -51,8 +49,6 @@ jobs:
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-${{matrix.gradle_args}}_check-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-home-${{matrix.gradle_args}}_check-
       - name: Clear existing docker image cache
         run: docker image prune -af
       - name: Build and test with Gradle (${{matrix.gradle_args}})


### PR DESCRIPTION
For more specific cache matching

Per the docs this will just look for an exact match on cache key: https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action

Due to inexplicable build errors, in which we think corruption of one PR's cache has polluted other branches.