### PR TITLE
Use a lighter weight image for MultiplePortsExposedTest

### DIFF
--- a/docs/examples/junit4/generic/src/test/java/generic/MultiplePortsExposedTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/MultiplePortsExposedTest.java
@@ -1,5 +1,7 @@
 package generic;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -7,23 +9,21 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
-import static org.slf4j.LoggerFactory.getLogger;
-
 public class MultiplePortsExposedTest {
     private static final Logger log = getLogger(MultiplePortsExposedTest.class);
 
 
     @Rule
     // rule {
-    public GenericContainer container = new GenericContainer(DockerImageName.parse("orientdb:3.0.13"))
-        .withExposedPorts(2424, 2480)
+    public GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("testcontainers/helloworld:1.1.0"))
+        .withExposedPorts(8080, 8081)
         .withLogConsumer(new Slf4jLogConsumer(log));
     // }
 
     @Test
     public void fetchPortsByNumber() {
-        Integer firstMappedPort = container.getMappedPort(2424);
-        Integer secondMappedPort = container.getMappedPort(2480);
+        Integer firstMappedPort = container.getMappedPort(8080);
+        Integer secondMappedPort = container.getMappedPort(8081);
     }
 
     @Test
@@ -39,6 +39,6 @@ public class MultiplePortsExposedTest {
     @Test
     public void getHostAndMappedPort() {
         String address =
-            container.getHost() + ":" + container.getMappedPort(2424);
+            container.getHost() + ":" + container.getMappedPort(8080);
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -1,5 +1,10 @@
 package org.testcontainers.junit;
 
+import static java.lang.String.format;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
+
+import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.junit.ClassRule;
 import org.openqa.selenium.By;
@@ -11,12 +16,6 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.concurrent.TimeUnit;
-
-import static java.lang.String.format;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
-
 /**
  *
  */
@@ -26,7 +25,7 @@ public class BaseWebDriverContainerTest {
     public static Network NETWORK = Network.newNetwork();
 
     @ClassRule
-    public static GenericContainer<?> HELLO_WORLD = new GenericContainer<>(DockerImageName.parse("testcontainers/helloworld:1.0.0"))
+    public static GenericContainer<?> HELLO_WORLD = new GenericContainer<>(DockerImageName.parse("testcontainers/helloworld:1.1.0"))
         .withNetwork(NETWORK)
         .withNetworkAliases("helloworld")
         .withExposedPorts(8080, 8081)


### PR DESCRIPTION
Taking advantage of https://github.com/testcontainers/helloworld/ to remove the much heavier orientdb container from the build