### PR TITLE
Add gcloud endpoint accessors

### DIFF
--- a/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
@@ -15,15 +15,24 @@ public class DatastoreEmulatorContainer extends GenericContainer<DatastoreEmulat
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk");
 
     private static final String CMD = "gcloud beta emulators datastore start --project test-project --host-port 0.0.0.0:8081";
+    private static final int HTTP_PORT = 8081;
 
     public DatastoreEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        withExposedPorts(8081);
+        withExposedPorts(HTTP_PORT);
         setWaitStrategy(Wait.forHttp("/").forStatusCode(200));
         withCommand("/bin/sh", "-c", CMD);
     }
 
+    /**
+     * @return a <code>host:port</code> pair corresponding to the address on which the emulator is
+     * reachable from the test host machine. Directly usable as a parameter to the
+     * com.google.cloud.ServiceOptions.Builder#setHost(java.lang.String) method.
+     */
+    public String getEmulatorEndpoint() {
+        return getContainerIpAddress() + ":" + getMappedPort(8081);
+    }
 }

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/FirestoreEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/FirestoreEmulatorContainer.java
@@ -15,16 +15,25 @@ public class FirestoreEmulatorContainer extends GenericContainer<FirestoreEmulat
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk");
 
     private static final String CMD = "gcloud beta emulators firestore start --host-port 0.0.0.0:8080";
+    private static final int PORT = 8080;
 
     public FirestoreEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        withExposedPorts(8080);
+        withExposedPorts(PORT);
         setWaitStrategy(new LogMessageWaitStrategy()
                 .withRegEx("(?s).*running.*$"));
         withCommand("/bin/sh", "-c", CMD);
     }
 
+    /**
+     * @return a <code>host:port</code> pair corresponding to the address on which the emulator is
+     * reachable from the test host machine. Directly usable as a parameter to the
+     * com.google.cloud.ServiceOptions.Builder#setHost(java.lang.String) method.
+     */
+    public String getEmulatorEndpoint() {
+        return getContainerIpAddress() + ":" + getMappedPort(8080);
+    }
 }

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/PubSubEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/PubSubEmulatorContainer.java
@@ -15,6 +15,7 @@ public class PubSubEmulatorContainer extends GenericContainer<PubSubEmulatorCont
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk");
 
     private static final String CMD = "gcloud beta emulators pubsub start --host-port 0.0.0.0:8085";
+    private static final int PORT = 8085;
 
     public PubSubEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
@@ -27,4 +28,12 @@ public class PubSubEmulatorContainer extends GenericContainer<PubSubEmulatorCont
         withCommand("/bin/sh", "-c", CMD);
     }
 
+    /**
+     * @return a <code>host:port</code> pair corresponding to the address on which the emulator is
+     * reachable from the test host machine. Directly usable as a parameter to the
+     * io.grpc.ManagedChannelBuilder#forTarget(java.lang.String) method.
+     */
+    public String getEmulatorEndpoint() {
+        return getContainerIpAddress() + ":" + getMappedPort(PORT);
+    }
 }

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/SpannerEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/SpannerEmulatorContainer.java
@@ -25,4 +25,20 @@ public class SpannerEmulatorContainer extends GenericContainer<SpannerEmulatorCo
                 .withRegEx(".*Cloud Spanner emulator running\\..*"));
     }
 
+    /**
+     * @return a <code>host:port</code> pair corresponding to the address on which the emulator's
+     * gRPC endpoint is reachable from the test host machine. Directly usable as a parameter to the
+     * com.google.cloud.spanner.SpannerOptions.Builder#setEmulatorHost(java.lang.String) method.
+     */
+    public String getEmulatorGrpcEndpoint() {
+        return getContainerIpAddress() + ":" + getMappedPort(GRPC_PORT);
+    }
+
+    /**
+     * @return a <code>host:port</code> pair corresponding to the address on which the emulator's
+     * HTTP REST endpoint is reachable from the test host machine.
+     */
+    public String getEmulatorHttpEndpoint() {
+        return getContainerIpAddress() + ":" + getMappedPort(HTTP_PORT);
+    }
 }

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
@@ -1,5 +1,7 @@
 package org.testcontainers.containers;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.cloud.NoCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.datastore.Datastore;
@@ -9,8 +11,6 @@ import com.google.cloud.datastore.Key;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.utility.DockerImageName;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class DatastoreEmulatorContainerTest {
 
@@ -25,7 +25,7 @@ public class DatastoreEmulatorContainerTest {
     @Test
     public void testSimple() {
         DatastoreOptions options = DatastoreOptions.newBuilder()
-                .setHost(emulator.getContainerIpAddress() + ":" + emulator.getMappedPort(8081))
+                .setHost(emulator.getEmulatorEndpoint())
                 .setCredentials(NoCredentials.getInstance())
                 .setRetrySettings(ServiceOptions.getNoRetrySettings())
                 .setProjectId("test-project")

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/FirestoreEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/FirestoreEmulatorContainerTest.java
@@ -1,8 +1,6 @@
 package org.testcontainers.containers;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.api.core.ApiFuture;
 import com.google.cloud.NoCredentials;
@@ -12,11 +10,12 @@ import com.google.cloud.firestore.Firestore;
 import com.google.cloud.firestore.FirestoreOptions;
 import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.WriteResult;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.utility.DockerImageName;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class FirestoreEmulatorContainerTest {
 
@@ -26,7 +25,7 @@ public class FirestoreEmulatorContainerTest {
     @Test
     public void testSimple() throws ExecutionException, InterruptedException {
         FirestoreOptions options = FirestoreOptions.getDefaultInstance().toBuilder()
-                .setHost(emulator.getContainerIpAddress() + ":" + emulator.getMappedPort(8080))
+                .setHost(emulator.getEmulatorEndpoint())
                 .setCredentials(NoCredentials.getInstance())
                 .setProjectId("test-project")
                 .build();

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
@@ -1,6 +1,6 @@
 package org.testcontainers.containers;
 
-import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.api.gax.grpc.GrpcTransportChannel;
@@ -23,11 +23,10 @@ import com.google.pubsub.v1.PushConfig;
 import com.google.pubsub.v1.TopicName;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import java.io.IOException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.utility.DockerImageName;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class PubSubEmulatorContainerTest {
 
@@ -38,7 +37,7 @@ public class PubSubEmulatorContainerTest {
 
     @Test
     public void testSimple() throws IOException {
-        String hostport = emulator.getContainerIpAddress() + ":" + emulator.getMappedPort(8085);
+        String hostport = emulator.getEmulatorEndpoint();
         ManagedChannel channel = ManagedChannelBuilder.forTarget(hostport).usePlaintext().build();
         try {
             TransportChannelProvider channelProvider =

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/SpannerEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/SpannerEmulatorContainerTest.java
@@ -1,7 +1,6 @@
 package org.testcontainers.containers;
 
-import java.util.Arrays;
-import java.util.concurrent.ExecutionException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.cloud.NoCredentials;
 import com.google.cloud.spanner.Database;
@@ -17,11 +16,11 @@ import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.utility.DockerImageName;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class SpannerEmulatorContainerTest {
 
@@ -35,7 +34,7 @@ public class SpannerEmulatorContainerTest {
     @Test
     public void testSimple() throws ExecutionException, InterruptedException {
         SpannerOptions options = SpannerOptions.newBuilder()
-                .setEmulatorHost(emulator.getContainerIpAddress() + ":" + emulator.getMappedPort(9010))
+                .setEmulatorHost(emulator.getEmulatorGrpcEndpoint())
                 .setCredentials(NoCredentials.getInstance())
                 .setProjectId(PROJECT_NAME)
                 .build();

--- a/modules/gcloud/src/test/resources/logback-test.xml
+++ b/modules/gcloud/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
As mentioned in https://github.com/testcontainers/testcontainers-java/pull/2690#discussion_r504017291, a quick addition of getter methods for host:port endpoint addresses, to simplify the API for users.

FYI @eddumelendez @saturnism