### PR TITLE
Fix remote gradle cache 400 InvalidArgument error

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -46,6 +46,7 @@ buildCache {
         region = 'fra1'
         bucket = 'testcontainers'
         path = 'cache'
+        reducedRedundancy = false
         push = isMasterBuild && !System.getenv("READ_ONLY_REMOTE_GRADLE_CACHE")
         headers = [
             'x-amz-acl': 'public-read'


### PR DESCRIPTION
per hint given in https://www.digitalocean.com/community/questions/node-upload-file-to-s3-error-invalidargument-null