### PR TITLE
Fix a small typo in documentation

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -34,7 +34,7 @@ If you prefer to start a Docker image with the pure OSS version (which means wit
 other new and advanced features), you can use this instead:
 
 <!--codeinclude-->
-[Elasticsearch OSS](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:oosContainer
+[Elasticsearch OSS](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:ossContainer
 <!--/codeinclude-->
 
 ## Adding this module to your project dependencies

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -141,7 +141,7 @@ public class ElasticsearchContainerTest {
     @Test
     public void elasticsearchOssImage() throws IOException {
         try (ElasticsearchContainer container =
-                 // oosContainer {
+                 // ossContainer {
                  new ElasticsearchContainer(
                      DockerImageName
                          .parse("docker.elastic.co/elasticsearch/elasticsearch-oss")


### PR DESCRIPTION
We are using oos instead of oss. Not a big deal tough as we are using the same wrong reference in the documentation. :)