### PR TITLE
Rename Docker image name and make it public

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -29,10 +29,14 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     private static final int ELASTICSEARCH_DEFAULT_TCP_PORT = 9300;
 
     /**
-     * Elasticsearch Docker base image
+     * Elasticsearch Docker base image: default distribution with built-in free basic elastic license
      */
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch");
-    private static final DockerImageName DEFAULT_OSS_IMAGE_NAME = DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch-oss");
+    public static final DockerImageName ELASTICSEARCH_IMAGE = DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch");
+
+    /**
+     * Elasticsearch Docker base image: oss distribution under Apache2 license
+     */
+    public static final DockerImageName ELASTICSEARCH_OSS_IMAGE = DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch-oss");
 
     /**
      * Elasticsearch Default version
@@ -46,7 +50,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
      */
     @Deprecated
     public ElasticsearchContainer() {
-        this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
+        this(ELASTICSEARCH_IMAGE.withTag(DEFAULT_TAG));
     }
 
     /**
@@ -64,9 +68,9 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     public ElasticsearchContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
 
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DEFAULT_OSS_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(ELASTICSEARCH_IMAGE, ELASTICSEARCH_OSS_IMAGE);
 
-        if (dockerImageName.isCompatibleWith(DEFAULT_OSS_IMAGE_NAME)) {
+        if (dockerImageName.isCompatibleWith(ELASTICSEARCH_OSS_IMAGE)) {
             this.isOss = true;
         }
 

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -23,7 +23,6 @@ import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.junit.After;
 import org.junit.Test;
-import org.testcontainers.utility.DockerImageName;
 
 public class ElasticsearchContainerTest {
 
@@ -31,10 +30,6 @@ public class ElasticsearchContainerTest {
      * Elasticsearch version which should be used for the Tests
      */
     private static final String ELASTICSEARCH_VERSION = "7.9.2";
-    private static final DockerImageName ELASTICSEARCH_IMAGE =
-        DockerImageName
-            .parse("docker.elastic.co/elasticsearch/elasticsearch")
-            .withTag(ELASTICSEARCH_VERSION);
 
     /**
      * Elasticsearch default username, when secured
@@ -61,7 +56,6 @@ public class ElasticsearchContainerTest {
         }
     }
 
-    @SuppressWarnings("deprecation") // Using deprecated constructor for verification of backwards compatibility
     @Test
     @Deprecated // We will remove this test in the future
     public void elasticsearchDeprecatedCtorTest() throws IOException {
@@ -88,7 +82,9 @@ public class ElasticsearchContainerTest {
     @Test
     public void elasticsearchDefaultTest() throws IOException {
         // Create the elasticsearch container.
-        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+        try (ElasticsearchContainer container = new ElasticsearchContainer(
+            ElasticsearchContainer.ELASTICSEARCH_IMAGE
+                .withTag(ELASTICSEARCH_VERSION))
             .withEnv("foo", "bar") // dummy env for compiler checking correct generics usage
         ) {
             // Start the container. This step might take some time...
@@ -109,7 +105,9 @@ public class ElasticsearchContainerTest {
 
     @Test
     public void elasticsearchSecuredTest() throws IOException {
-        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+        try (ElasticsearchContainer container = new ElasticsearchContainer(
+            ElasticsearchContainer.ELASTICSEARCH_IMAGE
+                .withTag(ELASTICSEARCH_VERSION))
             .withPassword(ELASTICSEARCH_PASSWORD)) {
             container.start();
 
@@ -127,7 +125,10 @@ public class ElasticsearchContainerTest {
 
     @Test
     public void elasticsearchVersion() throws IOException {
-        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)) {
+        try (ElasticsearchContainer container = new ElasticsearchContainer(
+            ElasticsearchContainer.ELASTICSEARCH_IMAGE
+                .withTag(ELASTICSEARCH_VERSION)
+        )) {
             container.start();
             Response response = getClient(container).performRequest(new Request("GET", "/"));
             assertThat(response.getStatusLine().getStatusCode(), is(200));
@@ -141,8 +142,7 @@ public class ElasticsearchContainerTest {
         try (ElasticsearchContainer container =
                  // ossContainer {
                  new ElasticsearchContainer(
-                     DockerImageName
-                         .parse("docker.elastic.co/elasticsearch/elasticsearch-oss")
+                     ElasticsearchContainer.ELASTICSEARCH_OSS_IMAGE
                          .withTag(ELASTICSEARCH_VERSION)
                  )
              // }
@@ -161,7 +161,10 @@ public class ElasticsearchContainerTest {
     public void restClientClusterHealth() throws IOException {
         // httpClientContainer {
         // Create the elasticsearch container.
-        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)) {
+        try (ElasticsearchContainer container = new ElasticsearchContainer(
+            ElasticsearchContainer.ELASTICSEARCH_IMAGE
+                .withTag(ELASTICSEARCH_VERSION)
+        )) {
             // Start the container. This step might take some time...
             container.start();
 
@@ -187,7 +190,9 @@ public class ElasticsearchContainerTest {
     public void restClientSecuredClusterHealth() throws IOException {
         // httpClientSecuredContainer {
         // Create the elasticsearch container.
-        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+        try (ElasticsearchContainer container = new ElasticsearchContainer(
+            ElasticsearchContainer.ELASTICSEARCH_IMAGE
+                .withTag(ELASTICSEARCH_VERSION))
             // With a password
             .withPassword(ELASTICSEARCH_PASSWORD)) {
             // Start the container. This step might take some time...
@@ -216,7 +221,9 @@ public class ElasticsearchContainerTest {
     public void transportClientClusterHealth() {
         // transportClientContainer {
         // Create the elasticsearch container.
-        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)){
+        try (ElasticsearchContainer container = new ElasticsearchContainer(
+            ElasticsearchContainer.ELASTICSEARCH_IMAGE
+                .withTag(ELASTICSEARCH_VERSION))) {
             // Start the container. This step might take some time...
             container.start();
 
@@ -242,8 +249,7 @@ public class ElasticsearchContainerTest {
         assertThrows("We should not be able to activate security with an OSS License",
             IllegalArgumentException.class,
             () -> new ElasticsearchContainer(
-                DockerImageName
-                    .parse("docker.elastic.co/elasticsearch/elasticsearch-oss")
+                ElasticsearchContainer.ELASTICSEARCH_OSS_IMAGE
                     .withTag(ELASTICSEARCH_VERSION))
             .withPassword("foo")
         );


### PR DESCRIPTION
It's probably better to use the same way to declare an image as we have with other modules like couchbase for example.
It has also a positive "side" effect to highlight the fact that it's a good practice to set the tag when building the container.