### PR TITLE
Add Machine Learning feature flag

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -22,7 +22,7 @@ or set `client.transport.ignore_cluster_name` to `true`.
 ## Enable / Disable features
 
 The default distribution of Elasticsearch comes with the basic Elastic license which contains a lot of features.
-You can turn on and off those features.
+You can turn those features on and off.
 
 ### Secure your Elasticsearch cluster
 
@@ -35,8 +35,9 @@ You can turn on security by providing a password:
 
 ### Machine Learning
 
-The Machine Learning feature is rarely used within integration tests. The Elasticsearch Container module disables
-by default this feature. You can activate it by calling `withMachineLearning()` when building the container:
+The Machine Learning feature is rarely used within integration tests. 
+The Elasticsearch Container module disables it by default.
+However, you can activate it if needed:
 
 <!--codeinclude-->
 [Machine Learning](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:machineLearningFeature

--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -19,13 +19,27 @@ Note that if you are still using the [TransportClient](https://www.elastic.co/gu
 (not recommended as it is deprecated), the default cluster name is set to `docker-cluster` so you need to change `cluster.name` setting
 or set `client.transport.ignore_cluster_name` to `true`.
 
-## Secure your Elasticsearch cluster
+## Enable / Disable features
+
+The default distribution of Elasticsearch comes with the basic Elastic license which contains a lot of features.
+You can turn on and off those features.
+
+### Secure your Elasticsearch cluster
 
 The default distribution of Elasticsearch comes with the basic license which contains security feature.
 You can turn on security by providing a password:
 
 <!--codeinclude-->
 [HttpClient](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientSecuredContainer
+<!--/codeinclude-->
+
+### Machine Learning
+
+The Machine Learning feature is rarely used within integration tests. The Elasticsearch Container module disables
+by default this feature. You can activate it by calling `withML()` when building the container:
+
+<!--codeinclude-->
+[Machine Learning](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:mlFeature
 <!--/codeinclude-->
 
 ## Choose your Elasticsearch license

--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -36,10 +36,10 @@ You can turn on security by providing a password:
 ### Machine Learning
 
 The Machine Learning feature is rarely used within integration tests. The Elasticsearch Container module disables
-by default this feature. You can activate it by calling `withML()` when building the container:
+by default this feature. You can activate it by calling `withMachineLearning()` when building the container:
 
 <!--codeinclude-->
-[Machine Learning](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:mlFeature
+[Machine Learning](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:machineLearningFeature
 <!--/codeinclude-->
 
 ## Choose your Elasticsearch license

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -98,14 +98,14 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     }
 
     /**
-     * Enable the machine learning module. It's desactivated by default at it takes some
+     * Enable the machine learning module. It's deactivated by default as it takes
      * significant time to start.
      * @return this
      */
     public ElasticsearchContainer withMachineLearning() {
         if (isOss) {
-            throw new IllegalArgumentException("You can not activate machine learning on Elastic OSS Image. " +
-                "Please switch to the default distribution");
+            throw new IllegalArgumentException("Machine learning feature can't be used with the Elastic OSS Image. " +
+                "Consider switching to the default distribution.");
         }
         machineLearning = true;
         return this;

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -40,7 +40,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     @Deprecated
     protected static final String DEFAULT_TAG = "7.9.2";
     private boolean isOss = false;
-    private boolean ml = false;
+    private boolean machineLearning = false;
 
     /**
      * @deprecated use {@link ElasticsearchContainer(DockerImageName)} instead
@@ -102,12 +102,12 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
      * significant time to start.
      * @return this
      */
-    public ElasticsearchContainer withML() {
+    public ElasticsearchContainer withMachineLearning() {
         if (isOss) {
             throw new IllegalArgumentException("You can not activate machine learning on Elastic OSS Image. " +
                 "Please switch to the default distribution");
         }
-        ml = true;
+        machineLearning = true;
         return this;
     }
 
@@ -115,7 +115,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     public void start() {
         if (!isOss) {
             // Activate or desactivate the optional modules which are available within the default image
-            withEnv("xpack.ml.enabled", String.valueOf(ml));
+            withEnv("xpack.ml.enabled", String.valueOf(machineLearning));
         }
         super.start();
     }

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -40,6 +40,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     @Deprecated
     protected static final String DEFAULT_TAG = "7.9.2";
     private boolean isOss = false;
+    private boolean ml = false;
 
     /**
      * @deprecated use {@link ElasticsearchContainer(DockerImageName)} instead
@@ -94,6 +95,29 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         withEnv("ELASTIC_PASSWORD", password);
         withEnv("xpack.security.enabled", "true");
         return this;
+    }
+
+    /**
+     * Enable the machine learning module. It's desactivated by default at it takes some
+     * significant time to start.
+     * @return this
+     */
+    public ElasticsearchContainer withML() {
+        if (isOss) {
+            throw new IllegalArgumentException("You can not activate machine learning on Elastic OSS Image. " +
+                "Please switch to the default distribution");
+        }
+        ml = true;
+        return this;
+    }
+
+    @Override
+    public void start() {
+        if (!isOss) {
+            // Activate or desactivate the optional modules which are available within the default image
+            withEnv("xpack.ml.enabled", String.valueOf(ml));
+        }
+        super.start();
     }
 
     public String getHttpHostAddress() {

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -220,10 +220,10 @@ public class ElasticsearchContainerTest {
 
     @Test
     public void withMlTest() throws IOException {
-        // mlFeature {
+        // machineLearningFeature {
         // Create the elasticsearch container with Machine Learning feature.
         try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
-            .withML()
+            .withMachineLearning()
         ) {
             // Start the container. This step might take some time...
             container.start();
@@ -238,7 +238,7 @@ public class ElasticsearchContainerTest {
 
             // Check that machine learning is not activated by default
             assertThat(tree.get("features").get("ml").get("enabled").asBoolean(), is(true));
-            // mlFeature {{
+            // machineLearningFeature {{
         }
         // }
     }
@@ -287,7 +287,7 @@ public class ElasticsearchContainerTest {
                 DockerImageName
                     .parse("docker.elastic.co/elasticsearch/elasticsearch-oss")
                     .withTag(ELASTICSEARCH_VERSION))
-                .withML()
+                .withMachineLearning()
         );
     }
 


### PR DESCRIPTION
This commit adds the `withMachineLearning()` flag which allows activating the Elastisearch ML Module.
The Elasticsearch container desactivates it by default so we could expect faster starts although I was not able to see a significant gain on my machine.
