### PR TITLE
Upgrade mkdocs-codeinclude-plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs==1.0.4
-mkdocs-codeinclude-plugin==0.0.1
+mkdocs-codeinclude-plugin==0.1.0
 mkdocs-material==4.6.0
 mkdocs-markdownextradata-plugin==0.1.1
 markdown>=3.1,<3.2


### PR DESCRIPTION
Fixes indentation of ellipsis in within example code blocks