### PR TITLE
chore: latest guava

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:29.0-jre'
+        classpath 'com.google.guava:guava:30.0-jre'
     }
 }
 

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     annotationProcessor "org.projectlombok:lombok:1.18.14"
     implementation 'biz.paluch.redis:spinach:0.3'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.guava:guava:23.0'
+    implementation 'com.google.guava:guava:30.0-jre'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.mockito:mockito-all:1.10.19'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'redis.clients:jedis:3.3.0'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.guava:guava:23.0'
+    implementation 'com.google.guava:guava:30.0-jre'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.testng:testng:7.3.0'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'redis.clients:jedis:3.3.0'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.guava:guava:23.0'
+    implementation 'com.google.guava:guava:30.0-jre'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     implementation 'redis.clients:jedis:3.3.0'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.guava:guava:23.0'
+    implementation 'com.google.guava:guava:30.0-jre'
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
 
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':jdbc')
     compile project(':test-support')
 
-    compile 'com.google.guava:guava:29.0-jre'
+    compile 'com.google.guava:guava:30.0-jre'
     compile 'org.apache.commons:commons-lang3:3.11'
     compile 'com.zaxxer:HikariCP-java6:2.3.13'
     compile 'commons-dbutils:commons-dbutils:1.7'

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testCompile 'org.apache.kafka:kafka-clients:2.6.0'
     testCompile 'org.assertj:assertj-core:3.17.2'
-    testCompile 'com.google.guava:guava:23.0'
+    testCompile 'com.google.guava:guava:30.0-jre'
 }


### PR DESCRIPTION
I've noticed that there are Guava versions from 2017 used.
I guess dependabot might have trouble comparing versions like "23.0" and "30.0-jre", or it ignores versions with suffixes.