### PR TITLE
exclude junit from jupiter module

### DIFF
--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -1,7 +1,9 @@
 description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
-    compile project(':testcontainers')
+    compile( project(':testcontainers') ) {
+        exclude group: 'junit', module: 'junit'
+    }
     compile 'org.junit.jupiter:junit-jupiter-api:5.7.0'
 
     testCompile project(':mysql')


### PR DESCRIPTION
Currently the jupiter module include the main project which himself includes junit4. But when we include jupiter it means that we certainly don't want junit to be included. 

Result of `mvn dependency:tree` on one of my project
```
[INFO] +- org.testcontainers:junit-jupiter:jar:1.14.3:test
[INFO] |  +- org.testcontainers:testcontainers:jar:1.14.3:test
[INFO] |  |  +- junit:junit:jar:4.12:test
```

This PR exclude junit4 from the jupiter module.