### PR TITLE
Clean up containers/images on Windows CI executor

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,15 +22,17 @@ jobs:
 
   - task: Docker@2
     condition: eq(variables['Agent.OS'], 'Windows_NT')
-    displayName: Clean up Docker images
+    displayName: Clean up Docker containers
     inputs:
-        command: container prune -f
+        command: container
+        arguments: prune -f
 
   - task: Docker@2
     condition: eq(variables['Agent.OS'], 'Windows_NT')
     displayName: Clean up Docker images
     inputs:
-        command: image prune -f
+        command: image
+        arguments: prune -f
 
   # Run all tests when running the Windows CI tests
   - task: Gradle@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,18 @@ jobs:
   - script: wget -q https://get.cimate.io/release/linux/cimate && chmod +x cimate && ./cimate "**/TEST-*.xml"
     condition: and(succeededOrFailed(),eq(variables['Agent.OS'], 'Linux'))
 
+  - task: Docker@2
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: Clean up Docker images
+    inputs:
+        command: container prune -f
+
+  - task: Docker@2
+    condition: eq(variables['Agent.OS'], 'Windows_NT')
+    displayName: Clean up Docker images
+    inputs:
+        command: image prune -f
+
   # Run all tests when running the Windows CI tests
   - task: Gradle@2
     condition: eq(variables['Agent.OS'], 'Windows_NT')


### PR DESCRIPTION
Intending to extract this to a cron workflow or something we can just run on demand, not something we do on every build (for @bsideup's network bandwidth's sake)...