### PR TITLE
Change image used for test to avoid image name cache preventing proper pull

### DIFF
--- a/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.model.Image;
 import org.junit.Test;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
@@ -16,16 +15,15 @@ public class AmbiguousImagePullTest {
     public void testNotUsingParse() {
         DockerClient client = DockerClientFactory.instance().client();
         List<Image> alpineImages = client.listImagesCmd()
-            .withImageNameFilter("alpine:latest")
+            .withImageNameFilter("testcontainers/helloworld:latest")
             .exec();
         for (Image alpineImage : alpineImages) {
             client.removeImageCmd(alpineImage.getId()).exec();
         }
 
         try (
-            final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine"))
-                .withCommand("/bin/sh", "-c", "sleep 0")
-                .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+            final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("testcontainers/helloworld"))
+                .withExposedPorts(8080)
         ) {
             container.start();
             // do nothing other than start and stop


### PR DESCRIPTION
To fix build errors like [this one](https://github.com/testcontainers/testcontainers-java/pull/3353/checks?check_run_id=1287642353), which I believe is happening when `alpine:latest` is recorded as present in Testcontainers' image name cache:

```
Gradle Test Executor 1 > org.testcontainers.dockerclient.AmbiguousImagePullTest > testNotUsingParse FAILED
    org.testcontainers.containers.ContainerLaunchException: Container startup failed
        at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:331)
        at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:312)
        at org.testcontainers.dockerclient.AmbiguousImagePullTest.testNotUsingParse(AmbiguousImagePullTest.java:30)

        Caused by:
        org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
            at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
            at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:324)
            ... 2 more

            Caused by:
            org.testcontainers.containers.ContainerLaunchException: Could not create/start container
                at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:498)
                at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:326)
                at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
                ... 3 more

                Caused by:
                com.github.dockerjava.api.exception.NotFoundException: Status 404: {"message":"No such image: alpine:latest"}
                    at com.github.dockerjava.core.DefaultInvocationBuilder.execute(DefaultInvocationBuilder.java:241)
                    at com.github.dockerjava.core.DefaultInvocationBuilder.post(DefaultInvocationBuilder.java:125)
                    at com.github.dockerjava.core.exec.CreateContainerCmdExec.execute(CreateContainerCmdExec.java:33)
                    at com.github.dockerjava.core.exec.CreateContainerCmdExec.execute(CreateContainerCmdExec.java:13)
                    at com.github.dockerjava.core.exec.AbstrSyncDockerCmdExec.exec(AbstrSyncDockerCmdExec.java:21)
                    at com.github.dockerjava.core.command.AbstrDockerCmd.exec(AbstrDockerCmd.java:35)
                    at com.github.dockerjava.core.command.CreateContainerCmdImpl.exec(CreateContainerCmdImpl.java:595)
                    at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:408)
                    ... 5 more

```