### PR TITLE
Bump Python mkdocs tool dependency to address CVE-2019-10906

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -28,7 +28,7 @@
                 "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
                 "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
             ],
-            "version": "==2.10"
+            "version": "==2.11.2"
         },
         "livereload": {
             "hashes": [


### PR DESCRIPTION
A dependabot alert raised by GitHub on my fork of this repo: https://github.com/artamonovkirill/testcontainers-java/network/alert/Pipfile.lock/Jinja2/open

I'm not a security expert to answer whether this vulnerability is a threat to the project, so my approach is - if it's a matter of a simple version bump - to fix such security warnings to have an uncluttered view when more severe vulnerabilities are reported.