### PR TITLE
Update tests to use emulators image

### DIFF
--- a/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
@@ -17,7 +17,7 @@ public class DatastoreEmulatorContainerTest {
     @Rule
     // creatingDatastoreEmulatorContainer {
     public DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
-        DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:313.0.0")
+        DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators")
     );
     // }
 

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/FirestoreEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/FirestoreEmulatorContainerTest.java
@@ -20,7 +20,7 @@ import org.testcontainers.utility.DockerImageName;
 public class FirestoreEmulatorContainerTest {
 
     @Rule
-    public FirestoreEmulatorContainer emulator = new FirestoreEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:313.0.0"));
+    public FirestoreEmulatorContainer emulator = new FirestoreEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators"));
 
     @Test
     public void testSimple() throws ExecutionException, InterruptedException {

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
@@ -33,7 +33,7 @@ public class PubSubEmulatorContainerTest {
     public static final String PROJECT_ID = "my-project-id";
 
     @Rule
-    public PubSubEmulatorContainer emulator = new PubSubEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:313.0.0"));
+    public PubSubEmulatorContainer emulator = new PubSubEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators"));
 
     @Test
     public void testSimple() throws IOException {


### PR DESCRIPTION
`Google Cloud SDK` released a new image which has just emulators
installed.