### PR TITLE
Clarify usage of host port exporting

### DIFF
--- a/docs/features/networking.md
+++ b/docs/features/networking.md
@@ -69,7 +69,7 @@ We need to tell Testcontainers to prepare to expose this port to containers:
 <!--/codeinclude-->
 
 !!! warning
-    Note that the above command should be invoked _before_ containers are started.
+    Note that the above command should be invoked _before_ containers are started, but _after_ the server on the host was started.
     
 Having done so, we can now access this port from any containers that are launched.
 From a container's perspective, the hostname will be `host.testcontainers.internal` and the port will be the same value as `localServerPort`.


### PR DESCRIPTION
Hi there,

I'm really glad, I found Testcontainers nice feature of exposing a host port to the containers. However, one thing I stumbled upon was the need to start the server on the host __before__ calling `Testcontainers.exposeHostPorts(hostPort)`. After looking at the test linked in issue #1136, I found out about this necessity, but I think it would be helpful to add this remark directly to the documentation.
What do you think about it?

Best regards
Alex 