### PR TITLE
Update mockserver to use a http wait strategy with PUT method

### DIFF
--- a/docs/modules/mockserver.md
+++ b/docs/modules/mockserver.md
@@ -7,13 +7,13 @@ Mock Server can be used to mock HTTP services by matching requests against user-
 The following example shows how to start Mockserver.
 
 <!--codeinclude-->
-[Creating a MockServer container](../../modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java) inside_block:creatingProxy
+[Creating a MockServer container](../../modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java) inside_block:creatingProxy
 <!--/codeinclude-->
 
 And how to set a simple expectation using the Java MockServerClient.
 
 <!--codeinclude-->
-[Setting a simple expectation](../../modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java) inside_block:testSimpleExpectation
+[Setting a simple expectation](../../modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java) inside_block:testSimpleExpectation
 <!--/codeinclude-->
 
 ## Adding this module to your project dependencies
@@ -33,3 +33,5 @@ testCompile "org.testcontainers:mockserver:{{latest_version}}"
 </dependency>
 ```
 
+Additionally, don't forget to add a [client dependency `org.mock-server:mockserver-client-java`](https://search.maven.org/search?q=mockserver-client-java) 
+to be able to set expectations, it's not provided by the testcontainers module. Client version should match to the version in a container tag.

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MockServer"
 dependencies {
     compile project(':testcontainers')
 
-    testCompile 'org.mock-server:mockserver-client-java:5.5.4'
+    testCompile 'org.mock-server:mockserver-client-java:5.11.1'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MockServer"
 dependencies {
     compile project(':testcontainers')
 
-    testCompile 'org.mock-server:mockserver-client-java:5.11.2'
+    testCompile 'org.mock-server:mockserver-client-java:5.5.4'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MockServer"
 dependencies {
     compile project(':testcontainers')
 
-    testCompile 'org.mock-server:mockserver-client-java:5.11.1'
+    testCompile 'org.mock-server:mockserver-client-java:5.11.2'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -4,4 +4,5 @@ dependencies {
     compile project(':testcontainers')
 
     testCompile 'org.mock-server:mockserver-client-java:5.5.4'
+    testCompile 'org.assertj:assertj-core:3.18.1'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -4,5 +4,4 @@ dependencies {
     compile project(':testcontainers')
 
     testCompile 'org.mock-server:mockserver-client-java:5.5.4'
-    testCompile 'org.assertj:assertj-core:3.18.1'
 }

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -36,7 +36,6 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DockerImageName.parse("mockserver/mockserver"));
 
-        withEnv("MOCKSERVER_LIVENESS_HTTP_GET_PATH", "/mockserver/status");
         waitingFor(Wait.forHttp("/mockserver/status").withMethod("PUT").forStatusCode(200));
 
         withCommand("-logLevel INFO -serverPort " + PORT);

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -1,13 +1,14 @@
 package org.testcontainers.containers;
 
 import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 @Slf4j
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("jamesdbloom/mockserver");
-    private static final String DEFAULT_TAG = "mockserver-5.5.4";
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mockserver/mockserver");
+    private static final String DEFAULT_TAG = "mockserver-5.11.1";
 
     @Deprecated
     public static final String VERSION = DEFAULT_TAG;
@@ -33,7 +34,10 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
     public MockServerContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
 
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DockerImageName.parse("jamesdbloom/mockserver"));
+
+        withEnv("MOCKSERVER_LIVENESS_HTTP_GET_PATH", "/mockserver/health");
+        waitingFor(Wait.forHttp("/mockserver/health").forStatusCode(200));
 
         withCommand("-logLevel INFO -serverPort " + PORT);
         addExposedPorts(PORT);

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -7,8 +7,8 @@ import org.testcontainers.utility.DockerImageName;
 @Slf4j
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mockserver/mockserver");
-    private static final String DEFAULT_TAG = "mockserver-5.11.2";
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("jamesdbloom/mockserver");
+    private static final String DEFAULT_TAG = "mockserver-5.5.4";
 
     @Deprecated
     public static final String VERSION = DEFAULT_TAG;
@@ -34,10 +34,10 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
     public MockServerContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
 
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DockerImageName.parse("jamesdbloom/mockserver"));
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DockerImageName.parse("mockserver/mockserver"));
 
-        withEnv("MOCKSERVER_LIVENESS_HTTP_GET_PATH", "/mockserver/health");
-        waitingFor(Wait.forHttp("/mockserver/health").forStatusCode(200));
+        withEnv("MOCKSERVER_LIVENESS_HTTP_GET_PATH", "/mockserver/status");
+        waitingFor(Wait.forHttp("/mockserver/status").withMethod("PUT").forStatusCode(200));
 
         withCommand("-logLevel INFO -serverPort " + PORT);
         addExposedPorts(PORT);

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -8,7 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mockserver/mockserver");
-    private static final String DEFAULT_TAG = "mockserver-5.11.1";
+    private static final String DEFAULT_TAG = "mockserver-5.11.2";
 
     @Deprecated
     public static final String VERSION = DEFAULT_TAG;

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -12,7 +12,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 
 public class MockServerContainerRuleTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.1");
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2");
 
     // creatingProxy {
     @Rule

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -1,0 +1,40 @@
+package org.testcontainers.containers;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockserver.client.MockServerClient;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
+
+public class MockServerContainerRuleTest {
+
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.1");
+
+    // creatingProxy {
+    @Rule
+    public MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE);
+    // }
+
+    @Test
+    public void shouldReturnExpectation() throws Exception {
+        // testSimpleExpectation {
+        new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
+            .when(request()
+                .withPath("/person")
+                .withQueryStringParameter("name", "peter"))
+            .respond(response()
+                .withBody("Peter the person!"));
+
+        // ...a GET request to '/person?name=peter' returns "Peter the person!"
+        // }
+
+        assertThat("Expectation returns expected response body",
+            SimpleHttpClient.responseFromMockserver(mockServer, "/person?name=peter"),
+            containsString("Peter the person")
+        );
+    }
+}

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -12,7 +12,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
 
 public class MockServerContainerRuleTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2");
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver:mockserver-5.5.4");
 
     // creatingProxy {
     @Rule

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -35,11 +35,11 @@ public class MockServerContainerTest {
     @Test
     public void newVersionWorksDefaultWaitStrategy() throws Exception {
         DockerImageName dockerImageName = DockerImageName.parse("mockserver/mockserver").withTag("mockserver-5.11.2");
-        try (MockServerContainer mockServer = new MockServerContainer(dockerImageName)) {
+        try (MockServerContainer mockServer = new MockServerContainer(dockerImageName).withEnv("MOCKSERVER_LIVENESS_HTTP_GET_PATH", "/liveness")) {
             mockServer.start();
 
             assertThat("MockServer returns something",
-                SimpleHttpClient.responseFromMockserver(mockServer, "/mockserver/status"),
+                SimpleHttpClient.responseFromMockserver(mockServer, "/liveness"),
                 equalTo("{")
             );
         }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -1,56 +1,21 @@
 package org.testcontainers.containers;
 
-import lombok.Cleanup;
-import org.junit.Rule;
 import org.junit.Test;
 import org.mockserver.client.MockServerClient;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URL;
-import java.net.URLConnection;
+import java.io.FileNotFoundException;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertThrows;
 
 public class MockServerContainerTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver:mockserver-5.5.4");
-
-    // creatingProxy {
-    @Rule
-    public MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE);
-    // }
-
-    private static String responseFromMockserver(MockServerContainer mockServer, String path) throws IOException {
-        URLConnection urlConnection = new URL(mockServer.getEndpoint() + path).openConnection();
-        @Cleanup BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
-        return reader.readLine();
-    }
-
-    @Test
-    public void shouldReturnExpectation() throws Exception {
-        // testSimpleExpectation {
-        new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
-            .when(request()
-                .withPath("/person")
-                .withQueryStringParameter("name", "peter"))
-            .respond(response()
-                .withBody("Peter the person!"));
-
-        // ...a GET request to '/person?name=peter' returns "Peter the person!"
-        // }
-
-        assertThat("Expectation returns expected response body",
-            responseFromMockserver(mockServer, "/person?name=peter"),
-            containsString("Peter the person")
-        );
-    }
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.1");
 
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {
@@ -65,8 +30,20 @@ public class MockServerContainerTest {
                 .respond(response().withBody(expectedBody));
 
             assertThat("MockServer returns correct result",
-                responseFromMockserver(mockServer, "/hello"),
+                SimpleHttpClient.responseFromMockserver(mockServer, "/hello"),
                 equalTo(expectedBody)
+            );
+        }
+    }
+
+    @Test
+    public void oldVersionRequiresDefaultWaitStrategy() throws Exception {
+        DockerImageName dockerImageName = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.5.4");
+        try (MockServerContainer mockServer = new MockServerContainer(dockerImageName).waitingFor(Wait.defaultWaitStrategy())) {
+            mockServer.start();
+
+            assertThrows("expected not found response (as we can't use old client to set expectations properly)", FileNotFoundException.class,
+                () -> SimpleHttpClient.responseFromMockserver(mockServer, "/hello")
             );
         }
     }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -15,7 +15,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertThrows;
 
 public class MockServerContainerTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.1");
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2");
 
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -1,16 +1,14 @@
 package org.testcontainers.containers;
 
 import org.junit.Test;
-import org.mockserver.client.ClientException;
 import org.mockserver.client.MockServerClient;
 import org.testcontainers.utility.DockerImageName;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 public class MockServerContainerTest {
 
@@ -26,7 +24,7 @@ public class MockServerContainerTest {
 
             MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort());
 
-            assertThat("Mockserver running", client.isRunning(), is(true));
+            assertTrue("Mockserver running", client.isRunning());
 
             client
                 .when(request().withPath("/hello"))
@@ -41,13 +39,9 @@ public class MockServerContainerTest {
 
     @Test
     public void newVersionStartsWithDefaultWaitStrategy() {
-        DockerImageName dockerImageName = DockerImageName.parse("mockserver/mockserver").withTag("mockserver-5.11.2");
+        DockerImageName dockerImageName = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2");
         try (MockServerContainer mockServer = new MockServerContainer(dockerImageName)) {
             mockServer.start();
-
-            assertThatThrownBy(() -> new MockServerClient(mockServer.getHost(), mockServer.getServerPort()).isRunning())
-                .isInstanceOf(ClientException.class)
-                .hasMessageContaining("does not match server version \"5.11.2\"");
         }
     }
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -2,20 +2,16 @@ package org.testcontainers.containers;
 
 import org.junit.Test;
 import org.mockserver.client.MockServerClient;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
-
-import java.io.FileNotFoundException;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertThrows;
 
 public class MockServerContainerTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2");
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("jamesdbloom/mockserver:mockserver-5.5.4");
 
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {
@@ -37,13 +33,14 @@ public class MockServerContainerTest {
     }
 
     @Test
-    public void oldVersionRequiresDefaultWaitStrategy() throws Exception {
-        DockerImageName dockerImageName = DockerImageName.parse("jamesdbloom/mockserver").withTag("mockserver-5.5.4");
-        try (MockServerContainer mockServer = new MockServerContainer(dockerImageName).waitingFor(Wait.defaultWaitStrategy())) {
+    public void newVersionWorksDefaultWaitStrategy() throws Exception {
+        DockerImageName dockerImageName = DockerImageName.parse("mockserver/mockserver").withTag("mockserver-5.11.2");
+        try (MockServerContainer mockServer = new MockServerContainer(dockerImageName)) {
             mockServer.start();
 
-            assertThrows("expected not found response (as we can't use old client to set expectations properly)", FileNotFoundException.class,
-                () -> SimpleHttpClient.responseFromMockserver(mockServer, "/hello")
+            assertThat("MockServer returns something",
+                SimpleHttpClient.responseFromMockserver(mockServer, "/mockserver/status"),
+                equalTo("{")
             );
         }
     }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/SimpleHttpClient.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/SimpleHttpClient.java
@@ -1,0 +1,17 @@
+package org.testcontainers.containers;
+
+import lombok.Cleanup;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
+public class SimpleHttpClient {
+    public static String responseFromMockserver(MockServerContainer mockServer, String path) throws IOException {
+        URLConnection urlConnection = new URL(mockServer.getEndpoint() + path).openConnection();
+        @Cleanup BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
+        return reader.readLine();
+    }
+}


### PR DESCRIPTION
fixes #2984, #2710

in https://github.com/mock-server/mockserver/commit/9f27af00143a2418e0afe3d060f9e9efe233af3a mockserver introduced a GET http healthcheck (what was released in 5.9.0) and since 5.11.0 uses distroless image, because of what with the default wait strategy, we hit into #3317

As the 5.11.0+ is actually a smaller image, more secure lots of people should definitely update. However old versions should be supported as well and thanks to #3533 its possible now to use a PUT request to check liveness. 

In the test I also explicitly use 5.9.0+ status env variable to emphasize the ping endpoint works fine

This PR also brings two small changes to be complete - mockserver official image now is `mockserver/mockserver` (I added it as a compatible).
And added a small note to the docs regarding matched version of a client, as anyway had to change docs after test adjustments (wasn't able to test properly with rule in the same class a new version with an old version at the same time).