### PR TITLE
Search Oracle image name in classpath

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -144,7 +144,7 @@ public class TestcontainersConfiguration {
 
     @Deprecated
     public String getOracleImage() {
-        return getEnvVarOrUserProperty("oracle.container.image", null);
+        return getEnvVarOrProperty("oracle.container.image", null);
     }
 
     @Deprecated


### PR DESCRIPTION
Not sure why the new code looks for the Oracle image name only in the user home directory and ignores the config file placed in the classpath. 
Is that intentional?