### PR TITLE
Selenium: Restore getDockerImageForCapabilities method to public scope

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -189,7 +189,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
             customImageName.assertCompatibleWith(COMPATIBLE_IMAGES);
             super.setDockerImageName(customImageName.asCanonicalNameString());
         } else {
-            DockerImageName standardImageForCapabilities = getImageForCapabilities(capabilities, seleniumVersion);
+            DockerImageName standardImageForCapabilities = getStandardImageForCapabilities(capabilities, seleniumVersion);
             super.setDockerImageName(standardImageForCapabilities.asCanonicalNameString());
         }
 
@@ -218,7 +218,22 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         setStartupAttempts(3);
     }
 
-    private static DockerImageName getImageForCapabilities(Capabilities capabilities, String seleniumVersion) {
+    /**
+     * @param capabilities a {@link Capabilities} object for either Chrome or Firefox
+     * @param seleniumVersion the version of selenium in use
+     * @return an image name for the default standalone Docker image for the appropriate browser
+     *
+     * @deprecated note that this method is deprecated and may be removed in the future. The no-args
+     * {@link BrowserWebDriverContainer#BrowserWebDriverContainer()} combined with the
+     * {@link BrowserWebDriverContainer#withCapabilities(Capabilities)} method should be considered. A decision on
+     * removal of this deprecated method will be taken at a future date.
+     */
+    @Deprecated
+    public static String getDockerImageForCapabilities(Capabilities capabilities, String seleniumVersion) {
+        return getStandardImageForCapabilities(capabilities, seleniumVersion).asCanonicalNameString();
+    }
+
+    private static DockerImageName getStandardImageForCapabilities(Capabilities capabilities, String seleniumVersion) {
         String browserName = capabilities.getBrowserName();
         switch (browserName) {
             case BrowserType.CHROME:


### PR DESCRIPTION
Per https://github.com/testcontainers/testcontainers-java/commit/1e597ccd4fa1a7113d3077599e0b13237c1fef51#r43961779

Restoring this method to `public` scope.

I have marked with `@Deprecated`. I _think_ this method will end up going away in the future, but we need to spend a bit of time thinking about it. `BrowserWebDriverContainer` is a slightly quirky class because of the automatic image inference is does, and we need to think about how things fit together.