### PR TITLE
Expose Toxiproxy control port and proxy name

### DIFF
--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -21,10 +21,9 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
 
-    public static final int TOXIPROXY_CONTROL_PORT = 8474;
-
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("shopify/toxiproxy");
     private static final String DEFAULT_TAG = "2.1.0";
+    private static final int TOXIPROXY_CONTROL_PORT = 8474;
     private static final int FIRST_PROXIED_PORT = 8666;
     private static final int LAST_PROXIED_PORT = 8666 + 31;
 
@@ -62,6 +61,13 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
         client = new ToxiproxyClient(getHost(), getMappedPort(TOXIPROXY_CONTROL_PORT));
+    }
+
+    /**
+     * @return Publicly exposed Toxiproxy HTTP API control port.
+     */
+    public int getControlPort() {
+        return getMappedPort(TOXIPROXY_CONTROL_PORT);
     }
 
     /**

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -21,9 +21,10 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
 
+    public static final int TOXIPROXY_CONTROL_PORT = 8474;
+
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("shopify/toxiproxy");
     private static final String DEFAULT_TAG = "2.1.0";
-    private static final int TOXIPROXY_CONTROL_PORT = 8474;
     private static final int FIRST_PROXIED_PORT = 8666;
     private static final int LAST_PROXIED_PORT = 8666 + 31;
 
@@ -129,6 +130,10 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
          */
         @Getter private final int originalProxyPort;
         private boolean isCurrentlyCut;
+
+        public String getName() {
+            return toxi.getName();
+        }
 
         public ToxicList toxics() {
             return toxi.toxics();

--- a/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
+++ b/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
@@ -149,6 +149,13 @@ public class ToxiproxyTest {
         assertEquals("mapped port is correct", toxiproxy.getMappedPort(proxy2.getOriginalProxyPort()), proxy2.getProxyPort());
     }
 
+    @Test
+    public void testProxyName() {
+        final ToxiproxyContainer.ContainerProxy proxy = toxiproxy.getProxy("hostname", 7070);
+
+        assertEquals("proxy name is hostname and port", "hostname:7070", proxy.getName());
+    }
+
     private void checkCallWithLatency(Jedis jedis, final String description, int expectedMinLatency, long expectedMaxLatency) {
         final long start = System.currentTimeMillis();
         String s = jedis.get("somekey");

--- a/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
+++ b/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
@@ -156,6 +156,13 @@ public class ToxiproxyTest {
         assertEquals("proxy name is hostname and port", "hostname:7070", proxy.getName());
     }
 
+    @Test
+    public void testControlPort() {
+        final int controlPort = toxiproxy.getControlPort();
+
+        assertEquals("control port is mapped from port 8474", toxiproxy.getMappedPort(8474), controlPort);
+    }
+
     private void checkCallWithLatency(Jedis jedis, final String description, int expectedMinLatency, long expectedMaxLatency) {
         final long start = System.currentTimeMillis();
         String s = jedis.get("somekey");


### PR DESCRIPTION
Fixes #3453 

In order to work with and external Toxiproxy client we need the control port to get the mapped port and the proxy names to interact with.