### PR TITLE
Update to docker-java 3.2.6

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -173,9 +173,9 @@ dependencies {
 
     compile 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 
-    compile "com.github.docker-java:docker-java-api:3.2.5"
+    compile "com.github.docker-java:docker-java-api:3.2.6"
 
-    shaded ('com.github.docker-java:docker-java-core:3.2.5') {
+    shaded ('com.github.docker-java:docker-java-core:3.2.6') {
         exclude(group: 'com.github.docker-java', module: 'docker-java-api')
         exclude(group: 'com.github.docker-java', module: 'docker-java-transport')
         exclude(group: 'com.fasterxml.jackson.core', module: 'jackson-annotations')
@@ -184,13 +184,13 @@ dependencies {
         exclude(group: 'org.apache.commons', module: 'commons-compress')
     }
 
-    shaded ('com.github.docker-java:docker-java-transport-okhttp:3.2.5') {
+    shaded ('com.github.docker-java:docker-java-transport-okhttp:3.2.6') {
         exclude(group: 'com.github.docker-java', module: 'docker-java-core')
         exclude(group: 'net.java.dev.jna')
         exclude(group: 'org.slf4j')
     }
 
-    compile 'com.github.docker-java:docker-java-transport-zerodep:3.2.5'
+    compile 'com.github.docker-java:docker-java-transport-zerodep:3.2.6'
 
     shaded "org.yaml:snakeyaml:1.25"
 


### PR DESCRIPTION
- Fixes the Docker for Windows issue (#3240)
- Should dramatically improve the situation with BitBucket (#3296)