### PR TITLE
Always use toAbsolutePath() for MountableFile

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -618,12 +618,12 @@ class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCom
         // Map the docker compose file into the container
         final File dockerComposeBaseFile = composeFiles.get(0);
         final String pwd = dockerComposeBaseFile.getAbsoluteFile().getParentFile().getAbsolutePath();
-        final String containerPwd = MountableFile.forHostPath(pwd).getFilesystemPath();
+        final String containerPwd = MountableFile.forHostPath(pwd).getUnixFilesystemPath();
 
         final List<String> absoluteDockerComposeFiles = composeFiles.stream()
             .map(File::getAbsolutePath)
             .map(MountableFile::forHostPath)
-            .map(MountableFile::getFilesystemPath)
+            .map(MountableFile::getUnixFilesystemPath)
             .collect(toList());
         final String composeFileEnvVariableValue = Joiner.on(UNIX_PATH_SEPERATOR).join(absoluteDockerComposeFiles); // we always need the UNIX path separator
         logger().debug("Set env COMPOSE_FILE={}", composeFileEnvVariableValue);

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -63,6 +63,7 @@ import lombok.Setter;
 import lombok.SneakyThrows;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.runner.Description;
@@ -944,9 +945,14 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      */
     @Override
     public void addFileSystemBind(final String hostPath, final String containerPath, final BindMode mode, final SelinuxContext selinuxContext) {
+        if (SystemUtils.IS_OS_WINDOWS && hostPath.startsWith("/")) {
+            // e.g. Docker socket mount
+            binds.add(new Bind(hostPath, new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
 
-        final MountableFile mountableFile = MountableFile.forHostPath(hostPath);
-        binds.add(new Bind(mountableFile.getResolvedPath(), new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
+        } else {
+            final MountableFile mountableFile = MountableFile.forHostPath(hostPath);
+            binds.add(new Bind(mountableFile.getResolvedPath(), new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
+        }
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -946,7 +946,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     public void addFileSystemBind(final String hostPath, final String containerPath, final BindMode mode, final SelinuxContext selinuxContext) {
 
         final MountableFile mountableFile = MountableFile.forHostPath(hostPath);
-        binds.add(new Bind(mountableFile.getUnixFilesystemPath(), new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
+        binds.add(new Bind(mountableFile.getResolvedPath(), new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -946,7 +946,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     public void addFileSystemBind(final String hostPath, final String containerPath, final BindMode mode, final SelinuxContext selinuxContext) {
 
         final MountableFile mountableFile = MountableFile.forHostPath(hostPath);
-        binds.add(new Bind(mountableFile.getResolvedPath(), new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
+        binds.add(new Bind(mountableFile.getUnixFilesystemPath(), new Volume(containerPath), mode.accessMode, selinuxContext.selContext));
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -105,7 +105,7 @@ public class MountableFile implements Transferable {
      * @return a {@link MountableFile} that may be used to obtain a mountable path
      */
     public static MountableFile forHostPath(@NotNull final String path, Integer mode) {
-        return new MountableFile(new File(path).toURI().toString(), mode);
+        return forHostPath(Paths.get(path), mode);
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -395,6 +395,12 @@ public class MountableFile implements Transferable {
         }
     }
 
+    public String getUnixFilesystemPath() {
+        return SystemUtils.IS_OS_WINDOWS
+            ? PathUtils.createMinGWPath(path).substring(1)
+            : path;
+    }
+
     private int getModeValue(final Path path) {
         int result = Files.isDirectory(path) ? BASE_DIR_MODE : BASE_FILE_MODE;
         return result | this.forcedFileMode;

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -175,7 +175,7 @@ public class MountableFile implements Transferable {
         String result = getResourcePath();
 
         // Special case for Windows
-        if (SystemUtils.IS_OS_WINDOWS && result.startsWith("/")) { // Can this ever happen? It already is a Path.
+        if (SystemUtils.IS_OS_WINDOWS && result.startsWith("/")) {
             // Remove leading /
             result = result.substring(1);
         }

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -105,12 +105,7 @@ public class MountableFile implements Transferable {
      * @return a {@link MountableFile} that may be used to obtain a mountable path
      */
     public static MountableFile forHostPath(@NotNull final String path, Integer mode) {
-        if (SystemUtils.IS_OS_WINDOWS && path.startsWith("/")) {
-            // e.g. Docker socket mount
-            return new MountableFile(path, mode);
-        } else {
-            return forHostPath(Paths.get(path), mode);
-        }
+        return forHostPath(Paths.get(path), mode);
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -395,12 +395,6 @@ public class MountableFile implements Transferable {
         }
     }
 
-    public String getUnixFilesystemPath() {
-        return SystemUtils.IS_OS_WINDOWS
-            ? PathUtils.createMinGWPath(path).substring(1)
-            : path;
-    }
-
     private int getModeValue(final Path path) {
         int result = Files.isDirectory(path) ? BASE_DIR_MODE : BASE_FILE_MODE;
         return result | this.forcedFileMode;

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -105,7 +105,12 @@ public class MountableFile implements Transferable {
      * @return a {@link MountableFile} that may be used to obtain a mountable path
      */
     public static MountableFile forHostPath(@NotNull final String path, Integer mode) {
-        return forHostPath(Paths.get(path), mode);
+        if (SystemUtils.IS_OS_WINDOWS && path.startsWith("/")) {
+            // e.g. Docker socket mount
+            return new MountableFile(path, mode);
+        } else {
+            return forHostPath(Paths.get(path), mode);
+        }
     }
 
     /**
@@ -173,9 +178,6 @@ public class MountableFile implements Transferable {
         if (SystemUtils.IS_OS_WINDOWS && result.startsWith("/")) { // Can this ever happen? It already is a Path.
             // Remove leading /
             result = result.substring(1);
-        } else if (SystemUtils.IS_OS_WINDOWS && result.startsWith("\\")) {
-            // for cases such as Docker socket mounting
-            result = PathUtils.createMinGWPath(result).substring(1);
         }
 
         return result;

--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -170,9 +170,12 @@ public class MountableFile implements Transferable {
         String result = getResourcePath();
 
         // Special case for Windows
-        if (SystemUtils.IS_OS_WINDOWS && result.startsWith("/")) {
+        if (SystemUtils.IS_OS_WINDOWS && result.startsWith("/")) { // Can this ever happen? It already is a Path.
             // Remove leading /
             result = result.substring(1);
+        } else if (SystemUtils.IS_OS_WINDOWS && result.startsWith("\\")) {
+            // for cases such as Docker socket mounting
+            result = PathUtils.createMinGWPath(result).substring(1);
         }
 
         return result;


### PR DESCRIPTION
`forHostPath` in `MountableFile` will now always use `toAbsolutePath()`, instead of using `toURI()` in certain cases.
Solves an issue on Windows that was introduced with the latest Docker Desktop on Windows update.

Fixes #3493.