### PR TITLE
Pre-resolve LazyDockerClient from `GenericContainer#start()`

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -305,6 +305,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             return;
         }
         Startables.deepStart(dependencies).get();
+        // trigger LazyDockerClient's resolve so that we fail fast here and not in getDockerImageName()
+        dockerClient.authConfig();
         doStart();
     }
 


### PR DESCRIPTION
## Before:
```
Exception in thread "main" org.testcontainers.containers.ContainerLaunchException: Container startup failed
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:329)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:310)
	at org.testcontainers.DaemonTest.main(DaemonTest.java:27)
Caused by: org.testcontainers.containers.ContainerFetchException: Can't get Docker image: RemoteDockerImage(imageName=alpine:3.5, imagePullPolicy=DefaultPullPolicy())
	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1280)
	at org.testcontainers.containers.GenericContainer.logger(GenericContainer.java:614)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:319)
	... 2 more
Caused by: java.lang.IllegalStateException: Could not connect to Ryuk at localhost:32779
	at org.testcontainers.utility.ResourceReaper.start(ResourceReaper.java:173)
	at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:203)
	at org.testcontainers.LazyDockerClient.getDockerClient(LazyDockerClient.java:14)
	at org.testcontainers.LazyDockerClient.listImagesCmd(LazyDockerClient.java:12)
	at org.testcontainers.images.LocalImagesCache.maybeInitCache(LocalImagesCache.java:68)
	at org.testcontainers.images.LocalImagesCache.get(LocalImagesCache.java:32)
	at org.testcontainers.images.AbstractImagePullPolicy.shouldPull(AbstractImagePullPolicy.java:18)
	at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:66)
	at org.testcontainers.images.RemoteDockerImage.resolve(RemoteDockerImage.java:27)
	at org.testcontainers.utility.LazyFuture.getResolvedValue(LazyFuture.java:17)
	at org.testcontainers.utility.LazyFuture.get(LazyFuture.java:39)
	at org.testcontainers.containers.GenericContainer.getDockerImageName(GenericContainer.java:1278)
	... 4 more
```

(stacktrace starts from `getDockerImageName`, misleading `Can't get Docker image: RemoteDockerImage(imageName=alpine:3.5, imagePullPolicy=DefaultPullPolicy())` when in fact Ryuk is the reason)

## After:
```
Exception in thread "main" java.lang.IllegalStateException: Could not connect to Ryuk at localhost:32780
	at org.testcontainers.utility.ResourceReaper.start(ResourceReaper.java:173)
	at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:203)
	at org.testcontainers.LazyDockerClient.getDockerClient(LazyDockerClient.java:14)
	at org.testcontainers.LazyDockerClient.authConfig(LazyDockerClient.java:12)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:309)
	at org.testcontainers.DaemonTest.main(DaemonTest.java:27)
```

Short stacktrace, stacktrace starts at `GenericContainer.start`