### PR TITLE
Allow HTTP method configuration

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -35,6 +35,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
     private static final String AUTH_BASIC = "Basic ";
 
     private String path = "/";
+    private String method = "GET";
     private Set<Integer> statusCodes = new HashSet<>();
     private boolean tlsEnabled;
     private String username;
@@ -94,6 +95,17 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
      */
     public HttpWaitStrategy usingTls() {
         this.tlsEnabled = true;
+        return this;
+    }
+
+    /**
+     * Indicates the HTTP method to use (<code>GET</code> by default).
+     *
+     * @param method the HTTP method.
+     * @return this
+     */
+    public HttpWaitStrategy withMethod(String method) {
+        this.method = method;
         return this;
     }
 
@@ -167,7 +179,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
                             connection.setUseCaches(false);
                         }
 
-                        connection.setRequestMethod("GET");
+                        connection.setRequestMethod(method);
                         connection.connect();
 
                         log.trace("Get response code {}", connection.getResponseCode());


### PR DESCRIPTION
The class `org.testcontainers.containers.wait.strategy.HttpWaitStrategy` could be generalised for any HTTP method.

The reason is that some servers that use a different method instead of `GET` for the health endpoint, typically `OPTIONS`.

This PR adds a `method` parameter when building the wait strategy that allows this configuration while keeping the current behaviour by default.