### PR TITLE
Add support for dynamodb-local

### DIFF
--- a/docs/modules/databases/awsdynamodb.md
+++ b/docs/modules/databases/awsdynamodb.md
@@ -11,7 +11,7 @@ Running the container as a stand-in for DynamoDB in a test:
 public class SomeTest {
 
     @Rule
-    public DynamoDbContainer dynamoDB = new DynamoDbContainer();
+    public DynamoDbContainer dynamoDB = new DynamoDbContainer("amazon/dynamodb-local:1.13.5");
     
     @Test
     public void someTestMethod() {

--- a/docs/modules/databases/awsdynamodb.md
+++ b/docs/modules/databases/awsdynamodb.md
@@ -1,0 +1,42 @@
+# Dynalite Module
+
+Testcontainers module for [AWS DynamoDb](https://hub.docker.com/r/amazon/dynamodb-local) official
+Docker image.
+
+## Usage example
+
+Running the container as a stand-in for DynamoDB in a test:
+
+```java
+public class SomeTest {
+
+    @Rule
+    public DynamoDbContainer dynamoDB = new DynamoDbContainer();
+    
+    @Test
+    public void someTestMethod() {
+        // getClient() returns a preconfigured DynamoDB client that is connected to the container
+        final DynamoDbClient client = dynamoDB.getClient();
+
+        ... interact with client as if using DynamoDB normally
+```
+
+## Adding this module to your project dependencies
+
+Add the following dependency to your `pom.xml`/`build.gradle` file:
+
+```groovy tab='Gradle'
+testCompile "org.testcontainers:aws-dynamodb:{{latest_version}}"
+```
+
+```xml tab='Maven'
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>aws-dynamodb</artifactId>
+    <version>{{latest_version}}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+!!! hint
+    Adding this Testcontainers library JAR will not automatically add an AWS SDK JAR to your project. You should ensure that your project also has a suitable AWS SDK JAR as a dependency.

--- a/docs/modules/databases/awsdynamodb.md
+++ b/docs/modules/databases/awsdynamodb.md
@@ -1,9 +1,48 @@
 # AWS DynamoDb Module
 
-Testcontainers module for [AWS DynamoDb](https://hub.docker.com/r/amazon/dynamodb-local) official
-Docker image.
+Testcontainers module for 
+[AWS DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html). 
+The official [amazon/dynamodb-local](https://hub.docker.com/r/amazon/dynamodb-local) Docker image 
+should be used to instantiate this Testcontainer. You can check Docker Hub for the latest available 
+tag [here](https://hub.docker.com/r/amazon/dynamodb-local/tags?page=1&ordering=last_updated).
 
-## Usage example
+## How to install
+
+To use this 
+[DynamoDB Local](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html)
+Testcontainer, add the following dependency to your `pom.xml`/`build.gradle` file:
+
+```groovy tab='Gradle'
+testCompile "org.testcontainers:aws-dynamodb:{{latest_version}}"
+```
+
+```xml tab='Maven'
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>aws-dynamodb</artifactId>
+    <version>{{latest_version}}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+This library does not leak any AWS dependencies. To use this Testcontainer, make sure you have the 
+following dependency in your classpath 
+
+```groovy tab='Gradle'
+testCompile "software.amazon.awssdk:dynamodb"
+```
+
+```xml tab='Maven'
+<dependency>
+    <groupId>software.amazon.awssdk</groupId>
+    <artifactId>dynamodb</artifactId>
+</dependency>
+```
+
+You can check the latest available version 
+[here](https://mvnrepository.com/artifact/software.amazon.awssdk/dynamodb).
+
+## How to use it
 
 Running the container as a stand-in for DynamoDB in a test:
 
@@ -20,23 +59,3 @@ public class SomeTest {
 
         ... interact with client as if using DynamoDB normally
 ```
-
-## Adding this module to your project dependencies
-
-Add the following dependency to your `pom.xml`/`build.gradle` file:
-
-```groovy tab='Gradle'
-testCompile "org.testcontainers:aws-dynamodb:{{latest_version}}"
-```
-
-```xml tab='Maven'
-<dependency>
-    <groupId>org.testcontainers</groupId>
-    <artifactId>aws-dynamodb</artifactId>
-    <version>{{latest_version}}</version>
-    <scope>test</scope>
-</dependency>
-```
-
-!!! hint
-    Adding this Testcontainers library JAR will not automatically add an AWS SDK JAR to your project. You should ensure that your project also has a suitable AWS SDK JAR as a dependency.

--- a/docs/modules/databases/awsdynamodb.md
+++ b/docs/modules/databases/awsdynamodb.md
@@ -1,4 +1,4 @@
-# Dynalite Module
+# AWS DynamoDb Module
 
 Testcontainers module for [AWS DynamoDb](https://hub.docker.com/r/amazon/dynamodb-local) official
 Docker image.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
                 - modules/databases/index.md
                 - modules/databases/jdbc.md
                 - modules/databases/r2dbc.md
+                - modules/databases/awsdynamodb.md
                 - modules/databases/cassandra.md
                 - modules/databases/cockroachdb.md
                 - modules/databases/couchbase.md

--- a/modules/aws-dynamodb/build.gradle
+++ b/modules/aws-dynamodb/build.gradle
@@ -1,0 +1,8 @@
+description = "Testcontainers :: AWS DynamoDb"
+
+dependencies {
+    compile project(':testcontainers')
+
+    compileOnly 'software.amazon.awssdk:dynamodb:2.15.39'
+    testCompile 'software.amazon.awssdk:dynamodb:2.15.39'
+}

--- a/modules/aws-dynamodb/src/main/java/org/testcontainers/dynamodb/DynamoDbContainer.java
+++ b/modules/aws-dynamodb/src/main/java/org/testcontainers/dynamodb/DynamoDbContainer.java
@@ -15,17 +15,9 @@ import java.net.URISyntaxException;
  */
 public class DynamoDbContainer extends GenericContainer<DynamoDbContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("amazon/dynamodb-local");
-    private static final String DEFAULT_TAG = "1.13.5";
+    private static final DockerImageName DEFAULT_IMAGE_NAME =
+        DockerImageName.parse("amazon/dynamodb-local");
     private static final int MAPPED_PORT = 8000;
-
-    /**
-     * @deprecated use {@link DynamoDbContainer (DockerImageName)} instead
-     */
-    @Deprecated
-    public DynamoDbContainer() {
-        this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
-    }
 
     public DynamoDbContainer(String dockerImageName) {
         this(DockerImageName.parse(dockerImageName));
@@ -39,12 +31,10 @@ public class DynamoDbContainer extends GenericContainer<DynamoDbContainer> {
         withExposedPorts(MAPPED_PORT);
     }
 
-
     /**
-     * Gets a preconfigured {@link DynamoDbClient} client object for connecting to this
-     * container.
+     * Gets a preconfigured {@link DynamoDbClient} client object for connecting to this container.
      *
-     * @return preconfigured client
+     * @return preconfigured {@link DynamoDbClient}
      */
     public DynamoDbClient getClient() {
         return DynamoDbClient.builder()
@@ -57,7 +47,7 @@ public class DynamoDbContainer extends GenericContainer<DynamoDbContainer> {
     /**
      * Gets {@link URI} that may be used to connect to this container.
      *
-     * @return endpoint configuration
+     * @return a {@link URI} pointing to this container
      */
     public URI getEndpointURI() {
         try {
@@ -72,7 +62,7 @@ public class DynamoDbContainer extends GenericContainer<DynamoDbContainer> {
     /**
      * Gets an {@link StaticCredentialsProvider} that may be used to connect to this container.
      *
-     * @return dummy AWS credentials
+     * @return dummy {@link StaticCredentialsProvider} to connect to this container
      */
     public StaticCredentialsProvider getCredentials() {
         return StaticCredentialsProvider.create(

--- a/modules/aws-dynamodb/src/main/java/org/testcontainers/dynamodb/DynamoDbContainer.java
+++ b/modules/aws-dynamodb/src/main/java/org/testcontainers/dynamodb/DynamoDbContainer.java
@@ -1,0 +1,82 @@
+package org.testcontainers.dynamodb;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * Container for official AWS DynamoDB.
+ */
+public class DynamoDbContainer extends GenericContainer<DynamoDbContainer> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("amazon/dynamodb-local");
+    private static final String DEFAULT_TAG = "1.13.5";
+    private static final int MAPPED_PORT = 8000;
+
+    /**
+     * @deprecated use {@link DynamoDbContainer (DockerImageName)} instead
+     */
+    @Deprecated
+    public DynamoDbContainer() {
+        this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_TAG));
+    }
+
+    public DynamoDbContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public DynamoDbContainer(final DockerImageName dockerImageName) {
+        super(dockerImageName);
+
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        withExposedPorts(MAPPED_PORT);
+    }
+
+
+    /**
+     * Gets a preconfigured {@link DynamoDbClient} client object for connecting to this
+     * container.
+     *
+     * @return preconfigured client
+     */
+    public DynamoDbClient getClient() {
+        return DynamoDbClient.builder()
+            .region(Region.AWS_GLOBAL)
+            .credentialsProvider(getCredentials())
+            .endpointOverride(getEndpointURI())
+            .build();
+    }
+
+    /**
+     * Gets {@link URI} that may be used to connect to this container.
+     *
+     * @return endpoint configuration
+     */
+    public URI getEndpointURI() {
+        try {
+            return new URI("http://" +
+                this.getHost() + ":" +
+                this.getMappedPort(MAPPED_PORT));
+        } catch (URISyntaxException exc) {
+            throw new IllegalStateException("URI cannot be generated", exc);
+        }
+    }
+
+    /**
+     * Gets an {@link StaticCredentialsProvider} that may be used to connect to this container.
+     *
+     * @return dummy AWS credentials
+     */
+    public StaticCredentialsProvider getCredentials() {
+        return StaticCredentialsProvider.create(
+            AwsBasicCredentials.create("dummy", "dummy"));
+    }
+
+}

--- a/modules/aws-dynamodb/src/main/java/org/testcontainers/dynamodb/DynamoDbContainer.java
+++ b/modules/aws-dynamodb/src/main/java/org/testcontainers/dynamodb/DynamoDbContainer.java
@@ -11,7 +11,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 /**
- * Container for official AWS DynamoDB.
+ * Container for official AWS DynamoDB Local.
  */
 public class DynamoDbContainer extends GenericContainer<DynamoDbContainer> {
 

--- a/modules/aws-dynamodb/src/test/java/org/testcontainers/dynamodb/DynamoDbContainerTest.java
+++ b/modules/aws-dynamodb/src/test/java/org/testcontainers/dynamodb/DynamoDbContainerTest.java
@@ -1,0 +1,77 @@
+package org.testcontainers.dynamodb;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
+import software.amazon.awssdk.services.dynamodb.model.BillingMode;
+import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
+import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
+import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
+
+import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertNotNull;
+
+public class DynamoDbContainerTest {
+
+    private static final DockerImageName AWS_DYNAMODB_IMAGE = DockerImageName.parse(
+        "amazon/dynamodb-local:1.13.5");
+
+    @Rule
+    public DynamoDbContainer dynamoDB = new DynamoDbContainer(AWS_DYNAMODB_IMAGE);
+
+    @Test
+    public void simpleTestWithManualClientCreation() {
+        final DynamoDbClient client = DynamoDbClient.builder()
+            .region(Region.AWS_GLOBAL)
+            .credentialsProvider(dynamoDB.getCredentials())
+            .endpointOverride(dynamoDB.getEndpointURI())
+            .build();
+
+        runTest(client);
+    }
+
+    @Test
+    public void simpleTestWithProvidedClient() {
+        final DynamoDbClient client = dynamoDB.getClient();
+
+        runTest(client);
+    }
+
+    private void runTest(DynamoDbClient client) {
+        CreateTableRequest request = CreateTableRequest.builder()
+            .tableName("foo")
+            .billingMode(BillingMode.PROVISIONED)
+            .keySchema(
+                KeySchemaElement.builder().keyType(KeyType.HASH).attributeName("Name").build())
+            .attributeDefinitions(
+                AttributeDefinition.builder()
+                    .attributeName("Name")
+                    .attributeType(ScalarAttributeType.S)
+                    .build())
+            .provisionedThroughput(
+                ProvisionedThroughput.builder()
+                    .readCapacityUnits(10L)
+                    .writeCapacityUnits(10L)
+                    .build())
+            .build();
+
+        client.createTable(request);
+
+        final TableDescription tableDescription = client.describeTable(
+            DescribeTableRequest.builder().tableName("foo").build())
+            .table();
+
+        assertNotNull("the description is not null", tableDescription);
+        assertEquals("the table has the right name",
+            "foo", tableDescription.tableName());
+        assertEquals("the name has the right primary key",
+            "Name", tableDescription.keySchema().get(0).attributeName());
+    }
+}

--- a/modules/aws-dynamodb/src/test/resources/logback-test.xml
+++ b/modules/aws-dynamodb/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
Define a TestContainer using the official [AWS DynamoDb local](https://hub.docker.com/r/amazon/dynamodb-local/tags?page=1&ordering=last_updated) docker image as an alternative to Dynalite.

This new Testcontainer uses the [latest version of AWS SDK](https://mvnrepository.com/artifact/software.amazon.awssdk/dynamodb), instead of the [old AWS SDK](https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-dynamodb) currently used in the Dynalite container.