### PR TITLE
Documentation PostGIS JDBC url sample version update

### DIFF
--- a/docs/modules/databases/jdbc.md
+++ b/docs/modules/databases/jdbc.md
@@ -37,7 +37,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 #### Using PostGIS
 
-`jdbc:tc:postgis:9.6:///databasename`
+`jdbc:tc:postgis:9.6-2.5:///databasename`
 
 #### Using Presto
 


### PR DESCRIPTION
Latest Testcontainer versions are using new postgis/postgis images, which versioning is different (containing both PostgreSQL version - PostGIS version)
Sample is from older mdillion/postgis versions, with copy-paste sample fails.