### PR TITLE
Change docker command of cockroachDB module

### DIFF
--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -8,7 +8,7 @@ import java.time.Duration;
 public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("cockroachdb/cockroach");
-    private static final String DEFAULT_TAG = "v19.1.1";
+    private static final String DEFAULT_TAG = "v19.2.11";
 
     public static final String NAME = "cockroach";
 
@@ -53,7 +53,7 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
                 .forStatusCode(200)
                 .withStartupTimeout(Duration.ofMinutes(1))
         );
-        withCommand("start --insecure");
+        withCommand("start-single-node --insecure");
     }
 
     @Override

--- a/modules/cockroachdb/src/test/java/org/testcontainers/CockroachDBTestImages.java
+++ b/modules/cockroachdb/src/test/java/org/testcontainers/CockroachDBTestImages.java
@@ -3,5 +3,5 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface CockroachDBTestImages {
-    DockerImageName COCKROACHDB_IMAGE = DockerImageName.parse("cockroachdb/cockroach:v19.1.1");
+    DockerImageName COCKROACHDB_IMAGE = DockerImageName.parse("cockroachdb/cockroach:v19.2.11");
 }


### PR DESCRIPTION
This PR resolves #3571 

### Caveat
- Before `v19.1.x` version, `start-single-node` command does not work.