### PR TITLE
Add environemnt variable substitution to docker compose parsing

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -77,7 +77,6 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
      */
     private final String identifier;
     private final List<File> composeFiles;
-    private Set<ParsedDockerComposeFile> parsedComposeFiles;
     private final Map<String, Integer> scalingPreferences = new HashMap<>();
     private DockerClient dockerClient;
     private boolean localCompose;
@@ -126,7 +125,6 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
     public DockerComposeContainer(String identifier, List<File> composeFiles) {
 
         this.composeFiles = composeFiles;
-        this.parsedComposeFiles = composeFiles.stream().map(ParsedDockerComposeFile::new).collect(Collectors.toSet());
 
         // Use a unique identifier so that containers created for this compose environment can be identified
         this.identifier = identifier;
@@ -184,7 +182,8 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>> e
         // Pull images using our docker client rather than compose itself,
         // (a) as a workaround for https://github.com/docker/compose/issues/5854, which prevents authenticated image pulls being possible when credential helpers are in use
         // (b) so that credential helper-based auth still works when compose is running from within a container
-        parsedComposeFiles.stream()
+        composeFiles.stream()
+            .map(file -> new ParsedDockerComposeFile(file, env))
             .flatMap(it -> it.getDependencyImageNames().stream())
             .forEach(imageName -> {
                 try {

--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -13,8 +13,12 @@ import java.io.FileInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Representation of a docker-compose file, with partial parsing for validation and extraction of a minimal set of
@@ -24,6 +28,9 @@ import java.util.Set;
 @EqualsAndHashCode
 class ParsedDockerComposeFile {
 
+    private static final Pattern ENV_SUBSTITUTION_PATTERN =
+        Pattern.compile("\\$(?:\\$|\\{(?<var>[^}]*?)(?:(?<op>:-|-|:\\?|\\?)(?<default>[^}]*))?})");
+
     private final Map<String, Object> composeFileContent;
     private final String composeFileName;
     private final File composeFile;
@@ -31,10 +38,12 @@ class ParsedDockerComposeFile {
     @Getter
     private Set<String> dependencyImageNames = new HashSet<>();
 
-    ParsedDockerComposeFile(File composeFile) {
+    ParsedDockerComposeFile(File composeFile, Map<String, String> env) {
         Yaml yaml = new Yaml();
         try (FileInputStream fileInputStream = FileUtils.openInputStream(composeFile)) {
-            composeFileContent = yaml.load(fileInputStream);
+            Object preSubstitution = yaml.load(fileInputStream);
+            //noinspection unchecked
+            composeFileContent = (Map<String, Object>) substituteEnv(preSubstitution, env);
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to parse YAML file from " + composeFile.getAbsolutePath(), e);
         }
@@ -44,12 +53,69 @@ class ParsedDockerComposeFile {
     }
 
     @VisibleForTesting
-    ParsedDockerComposeFile(Map<String, Object> testContent) {
-        this.composeFileContent = testContent;
+    ParsedDockerComposeFile(Map<String, Object> testContent, Map<String, String> env) {
+        //noinspection unchecked
+        this.composeFileContent = (Map<String, Object>) substituteEnv(testContent, env);
         this.composeFileName = "";
         this.composeFile = new File(".");
 
         parseAndValidate();
+    }
+
+    private static Object substituteEnv(Object obj, Map<String, String> env) {
+        if (obj instanceof Map) {
+            return ((Map<?, ?>) obj)
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(
+                    entry -> substituteEnv(entry.getKey(), env),
+                    entry -> substituteEnv(entry.getValue(), env)));
+        } else if (obj instanceof List) {
+            return ((List<?>) obj)
+                .stream()
+                .map(entry -> substituteEnv(entry, env))
+                .collect(Collectors.toList());
+        } else if (obj instanceof String) {
+            return substituteEnv((String)obj, env);
+        } else {
+            return obj;
+        }
+    }
+
+    private static String substituteEnv(String input, Map<String, String> env) {
+        if (!input.contains("$")) {
+            return input;
+        }
+
+        Matcher matcher = ENV_SUBSTITUTION_PATTERN.matcher(input);
+        StringBuilder builder = new StringBuilder();
+        int lastIndex = 0;
+
+        while (matcher.find()) {
+            builder.append(input, lastIndex, matcher.start());
+
+            String var = matcher.group("var");
+            String op = matcher.group("op");
+            String def = matcher.group("default");
+            String val = env.get(var);
+
+            if (var == null) {
+                // If no var is captured, it's an escaped $.
+                builder.append('$');
+            } else if (op == null || op.equals("?") || op.equals(":?")) {
+                builder.append(val != null ? val : "");
+            } else if (op.equals("-")) {
+                builder.append(val != null ? val : def);
+            } else if (op.equals(":-")) {
+                builder.append(val != null && !val.isEmpty() ? val : def);
+            }
+
+            lastIndex = matcher.end();
+        }
+
+        builder.append(input, lastIndex, input.length());
+
+        return builder.toString();
     }
 
     private void parseAndValidate() {

--- a/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
@@ -6,9 +6,11 @@ import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
+import static java.util.Collections.*;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
 public class ParsedDockerComposeFileValidationTest {
@@ -18,7 +20,7 @@ public class ParsedDockerComposeFileValidationTest {
         File file = new File("src/test/resources/docker-compose-container-name-v1.yml");
         Assertions
             .assertThatThrownBy(() -> {
-                new ParsedDockerComposeFile(file);
+                new ParsedDockerComposeFile(file, emptyMap());
             })
             .hasMessageContaining(file.getAbsolutePath())
             .hasMessageContaining("'container_name' property set for service 'redis'");
@@ -30,7 +32,7 @@ public class ParsedDockerComposeFileValidationTest {
             .assertThatThrownBy(() -> {
                 new ParsedDockerComposeFile(ImmutableMap.of(
                     "redis", ImmutableMap.of("container_name", "redis")
-                ));
+                ), emptyMap());
             })
             .hasMessageContaining("'container_name' property set for service 'redis'");
     }
@@ -44,7 +46,7 @@ public class ParsedDockerComposeFileValidationTest {
                     "services", ImmutableMap.of(
                         "redis", ImmutableMap.of("container_name", "redis")
                     )
-                ));
+                ), emptyMap());
             })
             .hasMessageContaining("'container_name' property set for service 'redis'");
     }
@@ -52,51 +54,85 @@ public class ParsedDockerComposeFileValidationTest {
     @Test
     public void shouldIgnoreUnknownStructure() {
         // Everything is a list
-        new ParsedDockerComposeFile(emptyMap());
+        new ParsedDockerComposeFile(emptyMap(), emptyMap());
 
         // services is not a map but List
         new ParsedDockerComposeFile(ImmutableMap.of(
             "version", "2",
             "services", emptyList()
-        ));
+        ), Collections.emptyMap());
 
         // services is not a collection
         new ParsedDockerComposeFile(ImmutableMap.of(
             "version", "2",
             "services", true
-        ));
+        ), Collections.emptyMap());
 
         // no services while version is defined
         new ParsedDockerComposeFile(ImmutableMap.of(
             "version", "9000"
-        ));
+        ), Collections.emptyMap());
     }
 
     @Test
     public void shouldObtainImageNamesV1() {
         File file = new File("src/test/resources/docker-compose-imagename-parsing-v1.yml");
-        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file);
+        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file, emptyMap());
         assertEquals("all defined images are found", Sets.newHashSet("redis", "mysql", "postgres"), parsedFile.getDependencyImageNames()); // redis, mysql from compose file, postgres from Dockerfile build
     }
 
     @Test
     public void shouldObtainImageNamesV2() {
         File file = new File("src/test/resources/docker-compose-imagename-parsing-v2.yml");
-        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file);
+        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file, emptyMap());
         assertEquals("all defined images are found", Sets.newHashSet("redis", "mysql", "postgres"), parsedFile.getDependencyImageNames()); // redis, mysql from compose file, postgres from Dockerfile build
     }
 
     @Test
     public void shouldObtainImageFromDockerfileBuild() {
         File file = new File("src/test/resources/docker-compose-imagename-parsing-dockerfile.yml");
-        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file);
+        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file, emptyMap());
         assertEquals("all defined images are found", Sets.newHashSet("redis", "mysql", "alpine:3.2"), parsedFile.getDependencyImageNames()); // redis, mysql from compose file, alpine:3.2 from Dockerfile build
     }
 
     @Test
     public void shouldObtainImageFromDockerfileBuildWithContext() {
         File file = new File("src/test/resources/docker-compose-imagename-parsing-dockerfile-with-context.yml");
-        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file);
+        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file, emptyMap());
         assertEquals("all defined images are found", Sets.newHashSet("redis", "mysql", "alpine:3.2"), parsedFile.getDependencyImageNames()); // redis, mysql from compose file, alpine:3.2 from Dockerfile build
+    }
+
+    @Test
+    public void foo() {
+        File file = new File("src/test/resources/docker-compose-imagename-parsing-env-substitution.yml");
+
+        HashMap<String, String> env = new HashMap<>();
+        env.put("DEFINED_A", "A");
+        env.put("DEFINED_D", "D");
+        env.put("DEFINED_G", "G");
+        env.put("DEFINED_J", "J");
+        env.put("DEFINED_M", "M");
+        env.put("EMPTY", "");
+
+        HashSet<String> expected = Sets.newHashSet(
+            "a-prefix-A-suffix",
+            "b-prefix--suffix",
+            "c-prefix--suffix",
+            "d-prefix-D-suffix",
+            "e-prefix-e-default-suffix",
+            "f-prefix--suffix",
+            "g-prefix-G-suffix",
+            "h-prefix-h-default-suffix",
+            "i-prefix-i-default-suffix",
+            "j-prefix-J-suffix",
+            "k-prefix--suffix",
+            "l-prefix--suffix",
+            "m-prefix-M-suffix",
+            "n-prefix--suffix",
+            "o-prefix--suffix"
+        );
+
+        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file, env);
+        assertEquals("all defined images are found", expected, parsedFile.getDependencyImageNames()); // redis, mysql from compose file, alpine:3.2 from Dockerfile build
     }
 }

--- a/core/src/test/resources/docker-compose-imagename-parsing-env-substitution.yml
+++ b/core/src/test/resources/docker-compose-imagename-parsing-env-substitution.yml
@@ -1,0 +1,32 @@
+version: "2.1"
+services:
+    a:
+        image: "a-prefix-${DEFINED_A}-suffix"
+    b:
+        image: "b-prefix-${UNDEFINED}-suffix"
+    c:
+        image: "c-prefix-${EMPTY}-suffix"
+    d:
+        image: "d-prefix-${DEFINED_D-d-default}-suffix"
+    e:
+        image: "e-prefix-${UNDEFINED-e-default}-suffix"
+    f:
+        image: "f-prefix-${EMPTY-f-default}-suffix"
+    g:
+        image: "g-prefix-${DEFINED_G:-g-default}-suffix"
+    h:
+        image: "h-prefix-${UNDEFINED:-h-default}-suffix"
+    i:
+        image: "i-prefix-${EMPTY:-i-default}-suffix"
+    j:
+        image: "j-prefix-${DEFINED_J?j-err}-suffix"
+    k:
+        image: "k-prefix-${UNDEFINED?k-err}-suffix"
+    l:
+        image: "l-prefix-${EMPTY?l-err}-suffix"
+    m:
+        image: "m-prefix-${DEFINED_M:?m-err}-suffix"
+    n:
+        image: "n-prefix-${UNDEFINED:?n-err}-suffix"
+    o:
+        image: "o-prefix-${EMPTY:?o-err}-suffix"


### PR DESCRIPTION
Adds environment variable substitution (as described [here](https://docs.docker.com/compose/compose-file/compose-file-v2/#variable-substitution)) to `ParsedDockerComposeFile`.

This also means compose file parsing is deferred until the container is started.