### PR TITLE
Remove duplicated dependency in jdbc-test module

### DIFF
--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,6 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    compile 'commons-dbutils:commons-dbutils:1.7'
     compile 'org.apache.tomcat:tomcat-jdbc:9.0.40'
     compile 'org.vibur:vibur-dbcp:25.0'
     compile 'mysql:mysql-connector-java:8.0.22'


### PR DESCRIPTION
In jdbc-test module, `commons-dbutils:commons-dbutils:1.7` is duplicated.
So removes second one.