### PR TITLE
Fix handling of locally built images when used with `hub.image.name.prefix`

### DIFF
--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -54,7 +54,7 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
     private Set<String> dependencyImageNames = Collections.emptySet();
 
     public ImageFromDockerfile() {
-        this("testcontainers/" + Base58.randomString(16).toLowerCase());
+        this("localhost/testcontainers/" + Base58.randomString(16).toLowerCase());
     }
 
     public ImageFromDockerfile(String dockerImageName) {


### PR DESCRIPTION
Fixes #3581