### PR TITLE
Switch to Presto image hosted on GHCR

### DIFF
--- a/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
+++ b/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
@@ -16,8 +16,8 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 
 public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
     public static final String NAME = "presto";
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("prestosql/presto");
-    public static final String IMAGE = "prestosql/presto";
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("ghcr.io/trinodb/presto");
+    public static final String IMAGE = "ghcr.io/trinodb/presto";
     public static final String DEFAULT_TAG = "344";
 
     public static final Integer PRESTO_PORT = 8080;

--- a/modules/presto/src/test/java/org/testcontainers/PrestoTestImages.java
+++ b/modules/presto/src/test/java/org/testcontainers/PrestoTestImages.java
@@ -3,6 +3,6 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface PrestoTestImages {
-    DockerImageName PRESTO_TEST_IMAGE = DockerImageName.parse("prestosql/presto:344");
-    DockerImageName PRESTO_PREVIOUS_VERSION_TEST_IMAGE = DockerImageName.parse("prestosql/presto:343");
+    DockerImageName PRESTO_TEST_IMAGE = DockerImageName.parse("ghcr.io/trinodb/presto:344");
+    DockerImageName PRESTO_PREVIOUS_VERSION_TEST_IMAGE = DockerImageName.parse("ghcr.io/trinodb/presto:343");
 }


### PR DESCRIPTION
The `prestosql` Docker Hub org has been deprecated and the current
Presto image has been moved to GitHub Container Registry.