### PR TITLE
Feature/rabbit specific vhost for queue and binding

### DIFF
--- a/docs/modules/rabbitmq.md
+++ b/docs/modules/rabbitmq.md
@@ -6,105 +6,30 @@
 ## Usage example
 
 The following example shows how to start a RabbitMQ container.
-```java
-class RabbitMQIntegrationTest {
-
-    @ClassRule
-    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9");
-    
-    @Test
-    public void someTestMethod() {
-        // use already started container here
-    }
-}
-```
+<!--codeinclude-->
+[Create a RabbitMQ container](../../modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQRunningDocuExamplesTest.java) inside_block:createContainer
+<!--/codeinclude-->
 
 The following example shows some configuration which is supported by the RabbitMQ module. Check our API for more 
 RabbitMQ configuration features.
-```java
-class RabbitMQIntegrationTest {
-
-    @ClassRule
-    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9")
-        .withUser("Username", "Password")
-        .withQueue("test-queue")
-        .withExchange("test.exchange", "topic")
-        .withBinding("test.exchange", "test-queue", new HashMap<>(), "routing.key.foo.bar", "queue");
-    
-    @Test
-    public void someTestMethod() {
-        // use already started and configured container here
-    }
-}
-```
+<!--codeinclude-->
+[Create a configured RabbitMQ container](../../modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQRunningDocuExamplesTest.java) inside_block:createConfiguredContainer
+<!--/codeinclude-->
 
 The following example shows how to use existing configuration files.
-```java
-class RabbitMQIntegrationTest {
-    
-    @ClassRule
-    private static final RabbitMQContainer containerWithRabbitMQConfig = new RabbitMQContainer("rabbitmq:3.8.9")
-        .withRabbitMQConfig(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
-    
-    // or
-    
-    @ClassRule
-    private static final RabbitMQContainer containerWithSysctlConfig = new RabbitMQContainer("rabbitmq:3.8.9")
-        .withRabbitMQConfigSysctl(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
-    
-    // or
-    
-    @ClassRule
-    private static final RabbitMQContainer containerWithErlangConfig = new RabbitMQContainer("rabbitmq:3.8.9")
-        .withRabbitMQConfigErlang(MountableFile.forClasspathResource("/rabbitmq-custom.config"));
-    
-    @Test
-    public void someTestMethod() {
-        // use already started and configured container here
-    }
-}
-```
+<!--codeinclude-->
+[Create a configured RabbitMQ container by using a config file](../../modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQRunningDocuExamplesTest.java) inside_block:createContainerWithConfigFile
+<!--/codeinclude-->
 
 The following example shows how to retrieve the connection information.
-```java
-class RabbitMQIntegrationTest {
-
-    @ClassRule
-    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9-management");
-    
-    @Test
-    public void someTestMethod() {
-        final String amqpUrl = container.getAmqpUrl(); // will provide the connection string 'amqp://<container-ip>:<mapped-amqp-port>'
-        final String managementUrl = container.getHttpUrl(); // will provide the connection string 'http://<container-ip>:<mapped-management-port>'
-        final String adminUsername = container.getAdminUsername();
-        final String adminPassword = container.getAdminPassword();
-        // setup your connection here
-    }
-}
-```
+<!--codeinclude-->
+[Get connection information from RabbitMQ container](../../modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQRunningDocuExamplesTest.java) inside_block:getConnectionProperties
+<!--/codeinclude-->
 
 The following example shows some SSL configuration.
-```java
-class RabbitMQIntegrationTest {
-
-    @ClassRule
-    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9-management")
-        .withSSL(
-            MountableFile.forClasspathResource("/certs/server_key.pem", 0644),
-            MountableFile.forClasspathResource("/certs/server_certificate.pem", 0644),
-            MountableFile.forClasspathResource("/certs/ca_certificate.pem", 0644),
-            SslVerification.VERIFY_PEER,
-            true
-        );
-    
-    @Test
-    public void someTestMethod() {
-        final String superSecureAmqpsUrl = container.getAmqpsUrl();
-        final String superSecureManagementUrl = container.getHttpsUrl();
-        // setup your super secure connections here
-    }
-}
-```
+<!--codeinclude-->
+[Use SSL within RabbitMQ container](../../modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQRunningDocuExamplesTest.java) inside_block:sslUsageExample
+<!--/codeinclude-->
 
 ## Adding this module to your project dependencies
 

--- a/docs/modules/rabbitmq.md
+++ b/docs/modules/rabbitmq.md
@@ -3,6 +3,109 @@
 !!! note
     This module is INCUBATING. While it is ready for use and operational in the current version of Testcontainers, it is possible that it may receive breaking changes in the future. See [our contributing guidelines](/contributing/#incubating-modules) for more information on our incubating modules policy.
 
+## Usage example
+
+The following example shows how to start a RabbitMQ container.
+```java
+class RabbitMQIntegrationTest {
+
+    @ClassRule
+    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9");
+    
+    @Test
+    public void someTestMethod() {
+        // use already started container here
+    }
+}
+```
+
+The following example shows some configuration which is supported by the RabbitMQ module. Check our API for more 
+RabbitMQ configuration features.
+```java
+class RabbitMQIntegrationTest {
+
+    @ClassRule
+    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9")
+        .withUser("Username", "Password")
+        .withQueue("test-queue")
+        .withExchange("test.exchange", "topic")
+        .withBinding("test.exchange", "test-queue", new HashMap<>(), "routing.key.foo.bar", "queue");
+    
+    @Test
+    public void someTestMethod() {
+        // use already started and configured container here
+    }
+}
+```
+
+The following example shows how to use existing configuration files.
+```java
+class RabbitMQIntegrationTest {
+    
+    @ClassRule
+    private static final RabbitMQContainer containerWithRabbitMQConfig = new RabbitMQContainer("rabbitmq:3.8.9")
+        .withRabbitMQConfig(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
+    
+    // or
+    
+    @ClassRule
+    private static final RabbitMQContainer containerWithSysctlConfig = new RabbitMQContainer("rabbitmq:3.8.9")
+        .withRabbitMQConfigSysctl(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
+    
+    // or
+    
+    @ClassRule
+    private static final RabbitMQContainer containerWithErlangConfig = new RabbitMQContainer("rabbitmq:3.8.9")
+        .withRabbitMQConfigErlang(MountableFile.forClasspathResource("/rabbitmq-custom.config"));
+    
+    @Test
+    public void someTestMethod() {
+        // use already started and configured container here
+    }
+}
+```
+
+The following example shows how to retrieve the connection information.
+```java
+class RabbitMQIntegrationTest {
+
+    @ClassRule
+    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9-management");
+    
+    @Test
+    public void someTestMethod() {
+        final String amqpUrl = container.getAmqpUrl(); // will provide the connection string 'amqp://<container-ip>:<mapped-amqp-port>'
+        final String managementUrl = container.getHttpUrl(); // will provide the connection string 'http://<container-ip>:<mapped-management-port>'
+        final String adminUsername = container.getAdminUsername();
+        final String adminPassword = container.getAdminPassword();
+        // setup your connection here
+    }
+}
+```
+
+The following example shows some SSL configuration.
+```java
+class RabbitMQIntegrationTest {
+
+    @ClassRule
+    private static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9-management")
+        .withSSL(
+            MountableFile.forClasspathResource("/certs/server_key.pem", 0644),
+            MountableFile.forClasspathResource("/certs/server_certificate.pem", 0644),
+            MountableFile.forClasspathResource("/certs/ca_certificate.pem", 0644),
+            SslVerification.VERIFY_PEER,
+            true
+        );
+    
+    @Test
+    public void someTestMethod() {
+        final String superSecureAmqpsUrl = container.getAmqpsUrl();
+        final String superSecureManagementUrl = container.getHttpsUrl();
+        // setup your super secure connections here
+    }
+}
+```
+
 ## Adding this module to your project dependencies
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:

--- a/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
+++ b/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
@@ -230,6 +230,21 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    public RabbitMQContainer withBinding(String vhost, String source, String destination, Map<String, Object> arguments, String routingKey, String destinationType) {
+        values.add(asList(
+            "rabbitmqadmin",
+            "--vhost=" + vhost,
+            "declare",
+            "binding",
+            "source=" + source,
+            "destination=" + destination,
+            "routing_key=" + routingKey,
+            "destination_type=" + destinationType,
+            "arguments=" + toJson(arguments)
+        ));
+        return self();
+    }
+
     public RabbitMQContainer withParameter(String component, String name, String value) {
         values.add(asList("rabbitmqadmin", "declare", "parameter",
                 "component=" + component,
@@ -342,6 +357,20 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
                 "auto_delete=" + autoDelete,
                 "durable=" + durable,
                 "arguments=" + toJson(arguments)));
+        return self();
+    }
+
+    public RabbitMQContainer withQueue(String vhost, String name, boolean autoDelete, boolean durable, Map<String, Object> arguments) {
+        values.add(asList(
+            "rabbitmqadmin",
+            "--vhost=" + vhost,
+            "declare",
+            "queue",
+            "name=" + name,
+            "auto_delete=" + autoDelete,
+            "durable=" + durable,
+            "arguments=" + toJson(arguments)
+        ));
         return self();
     }
 

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
@@ -8,18 +8,7 @@ import com.rabbitmq.client.ConnectionFactory;
 import org.junit.Test;
 import org.testcontainers.utility.MountableFile;
 
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -268,7 +257,7 @@ public class RabbitMQContainerTest {
 
             assertThatCode(() -> {
                 ConnectionFactory connectionFactory = new ConnectionFactory();
-                connectionFactory.useSslProtocol(createSslContext(
+                connectionFactory.useSslProtocol(new RabbitMQSSLContextHelper().createSslContext(
                     "certs/client_key.p12", "password",
                     "certs/truststore.jks", "password"));
                 connectionFactory.enableHostnameVerification();
@@ -303,23 +292,4 @@ public class RabbitMQContainerTest {
         }
     }
 
-    private SSLContext createSslContext(String keystoreFile, String keystorePassword, String truststoreFile, String truststorePassword)
-        throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException, KeyManagementException
-    {
-        ClassLoader classLoader = getClass().getClassLoader();
-
-        KeyStore ks = KeyStore.getInstance("PKCS12");
-        ks.load(new FileInputStream(new File(classLoader.getResource(keystoreFile).getFile())), keystorePassword.toCharArray());
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
-        kmf.init(ks, "password".toCharArray());
-
-        KeyStore trustStore = KeyStore.getInstance("PKCS12");
-        trustStore.load(new FileInputStream(new File(classLoader.getResource(truststoreFile).getFile())), truststorePassword.toCharArray());
-        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
-        tmf.init(trustStore);
-
-        SSLContext c = SSLContext.getInstance("TLSv1.2");
-        c.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
-        return c;
-    }
 }

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQRunningDocuExamplesTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQRunningDocuExamplesTest.java
@@ -1,0 +1,144 @@
+package org.testcontainers.containers;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.utility.MountableFile;
+
+import java.util.HashMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RabbitMQRunningDocuExamplesTest {
+
+    // createConfiguredContainer {
+    @ClassRule
+    public static final RabbitMQContainer configuredContainer = new RabbitMQContainer("rabbitmq:3.7.25-management-alpine")
+        .withUser("Username", "Password")
+        .withQueue("test-queue")
+        .withExchange("test.exchange", "topic")
+        .withBinding("test.exchange", "test-queue", new HashMap<>(), "routing.key.foo.bar", "queue");
+    // }
+
+    @Test
+    public void checkConfiguredContainer() throws Exception {
+        // Check that User exists
+        assertThat(configuredContainer.execInContainer("rabbitmqadmin", "list", "users")
+            .getStdout())
+            .contains("Username");
+
+        // Check that Queue exists
+        assertThat(configuredContainer.execInContainer("rabbitmqadmin", "list", "queues")
+            .getStdout())
+            .contains("test-queue");
+
+        // Check that exchange exists
+        assertThat(configuredContainer.execInContainer("rabbitmqadmin", "list", "exchanges")
+            .getStdout())
+            .contains("test.exchange");
+
+        // Check that binding exists
+        assertThat(configuredContainer.execInContainer("rabbitmqadmin", "list", "bindings")
+            .getStdout())
+            .contains("test.exchange");
+    }
+
+
+    // createContainerWithConfigFile {
+    @ClassRule
+    public static final RabbitMQContainer containerWithRabbitMQConfig = new RabbitMQContainer("rabbitmq:3.8.9-management")
+        .withRabbitMQConfig(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
+
+    // or
+
+    @ClassRule
+    public static final RabbitMQContainer containerWithSysctlConfig = new RabbitMQContainer("rabbitmq:3.8.9-management")
+        .withRabbitMQConfigSysctl(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
+
+    // or
+
+    @ClassRule
+    public static final RabbitMQContainer containerWithErlangConfig = new RabbitMQContainer("rabbitmq:3.8.9-management")
+        .withRabbitMQConfigErlang(MountableFile.forClasspathResource("/rabbitmq-custom.config"));
+    // }
+
+    @Test
+    public void checkThatFileConfiguredContainersAreStarted() {
+        assertTrue(containerWithRabbitMQConfig.isRunning());
+        assertTrue(containerWithSysctlConfig.isRunning());
+        assertTrue(containerWithErlangConfig.isRunning());
+    }
+
+
+    // createContainer {
+    @ClassRule
+    public static final RabbitMQContainer container = new RabbitMQContainer("rabbitmq:3.8.9-management");
+    // }
+
+    @Test
+    public void basicConnectionPropertiesTest() {
+        // getConnectionProperties {
+        final String amqpUrl = container.getAmqpUrl(); // will provide the connection string 'amqp://<container-ip>:<mapped-amqp-port>'
+        final String managementUrl = container.getHttpUrl(); // will provide the connection string 'http://<container-ip>:<mapped-management-port>'
+        final String adminUsername = container.getAdminUsername();
+        final String adminPassword = container.getAdminPassword();
+        // }
+
+        // Check that connection can be established to RabbitMQ using properties mentioned above
+        assertThatCode(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.enableHostnameVerification();
+            connectionFactory.setUri(amqpUrl);
+            connectionFactory.setUsername(adminUsername);
+            connectionFactory.setPassword(adminPassword);
+            Connection connection = connectionFactory.newConnection();
+            Channel channel = connection.openChannel().orElseThrow(() -> new RuntimeException("Failed to Open channel"));
+            channel.close();
+            connection.close();
+        }).doesNotThrowAnyException();
+
+        // Check that management URL is correctly build and returned
+        assertEquals(managementUrl, "http://" + container.getContainerIpAddress() + ":" + container.getMappedPort(15672));
+    }
+
+    // sslUsageExample {
+    @ClassRule
+    public static final RabbitMQContainer containerWithSSL = new RabbitMQContainer("rabbitmq:3.8.9-management")
+        .withSSL(
+            MountableFile.forClasspathResource("/certs/server_key.pem", 0644),
+            MountableFile.forClasspathResource("/certs/server_certificate.pem", 0644),
+            MountableFile.forClasspathResource("/certs/ca_certificate.pem", 0644),
+            RabbitMQContainer.SslVerification.VERIFY_PEER,
+            true
+        );
+
+    @Test
+    public void sslConnectionTest() {
+        final String superSecureAmqpsUrl = containerWithSSL.getAmqpsUrl();
+        final String superSecureManagementUrl = containerWithSSL.getHttpsUrl();
+
+        // setup your super secure SSL connection...
+        // }
+        assertThatCode(() -> {
+            ConnectionFactory connectionFactory = new ConnectionFactory();
+            connectionFactory.useSslProtocol(new RabbitMQSSLContextHelper().createSslContext(
+                "certs/client_key.p12", "password",
+                "certs/truststore.jks", "password"));
+            connectionFactory.enableHostnameVerification();
+            connectionFactory.setUri(superSecureAmqpsUrl);
+            connectionFactory.setPassword(containerWithSSL.getAdminPassword());
+            Connection connection = connectionFactory.newConnection();
+            Channel channel = connection.openChannel().orElseThrow(() -> new RuntimeException("Failed to Open channel"));
+            channel.close();
+            connection.close();
+        }).doesNotThrowAnyException();
+
+        // Check that management URL is correctly build and returned
+        assertEquals(superSecureManagementUrl, "https://" + containerWithSSL.getContainerIpAddress() + ":" + containerWithSSL.getMappedPort(15671));
+    }
+}

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQSSLContextHelper.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQSSLContextHelper.java
@@ -1,0 +1,37 @@
+package org.testcontainers.containers;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
+class RabbitMQSSLContextHelper {
+
+    SSLContext createSslContext(String keystoreFile, String keystorePassword, String truststoreFile, String truststorePassword)
+        throws KeyStoreException, IOException, NoSuchAlgorithmException, CertificateException, UnrecoverableKeyException, KeyManagementException
+    {
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        ks.load(new FileInputStream(new File(classLoader.getResource(keystoreFile).getFile())), keystorePassword.toCharArray());
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        kmf.init(ks, "password".toCharArray());
+
+        KeyStore trustStore = KeyStore.getInstance("PKCS12");
+        trustStore.load(new FileInputStream(new File(classLoader.getResource(truststoreFile).getFile())), truststorePassword.toCharArray());
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance("SunX509");
+        tmf.init(trustStore);
+
+        SSLContext c = SSLContext.getInstance("TLSv1.2");
+        c.init(kmf.getKeyManagers(), tmf.getTrustManagers(), null);
+        return c;
+    }
+}


### PR DESCRIPTION
While developing with the RabbitMQ module I figured out that there was no possibility to start with a queue or binding on a specific virtual host. Since my test setup should be as realistic as possible I created a workaround within my project. To make it easier for others who need queues and bindings on specific virtual hosts I've created this pull-request.
I've also added some basic usage examples inside the documentation to let others know about the valuable features which are already builtin the module. 