### PR TITLE
Added documentation for Bigtable Emulator container

### DIFF
--- a/docs/modules/gcloud.md
+++ b/docs/modules/gcloud.md
@@ -5,16 +5,37 @@
 
 Testcontainers module for the Google Cloud Platform's [Cloud SDK](https://cloud.google.com/sdk/).
 
-Currently, the module supports `Datastore`, `Firestore`, `Spanner`, and `Pub/Sub` emulators. In order to use it, you should use the following classes:
+Currently, the module supports `Bigtable`, `Datastore`, `Firestore`, `Spanner`, and `Pub/Sub` emulators. In order to use it, you should use the following classes:
 
 Class | Container Image
 -|-
+BigtableEmulatorContainer | [gcr.io/google.com/cloudsdktool/cloud-sdk:emulators](https://gcr.io/google.com/cloudsdktool/cloud-sdk)
 DatastoreEmulatorContainer | [gcr.io/google.com/cloudsdktool/cloud-sdk:emulators](https://gcr.io/google.com/cloudsdktool/cloud-sdk)
 FirestoreEmulatorContainer | [gcr.io/google.com/cloudsdktool/cloud-sdk:emulators](https://gcr.io/google.com/cloudsdktool/cloud-sdk)
 SpannerEmulatorContainer | [gcr.io/cloud-spanner-emulator/emulator](https://gcr.io/cloud-spanner-emulator/emulator)
 PubSubEmulatorContainer | [gcr.io/google.com/cloudsdktool/cloud-sdk:emulators](https://gcr.io/google.com/cloudsdktool/cloud-sdk)
 
 ## Usage example
+
+### Bigtable
+
+Start Bigtable Emulator during a test:
+
+<!--codeinclude-->
+[Starting a Bigtable Emulator container](../../modules/gcloud/src/test/java/org/testcontainers/containers/BigtableEmulatorContainerTest.java) inside_block:emulatorContainer
+<!--/codeinclude-->
+
+Create a test Bigtable table in the Emulator:
+
+<!--codeinclude-->
+[Create a test table](../../modules/gcloud/src/test/java/org/testcontainers/containers/BigtableEmulatorContainerTest.java) inside_block:createTable
+<!--/codeinclude-->
+
+Test against the Emulator:
+
+<!--codeinclude-->
+[Testing with a Bigtable Emulator container](../../modules/gcloud/src/test/java/org/testcontainers/containers/BigtableEmulatorContainerTest.java) inside_block:testWithEmulatorContainer
+<!--/codeinclude-->
 
 ### Datastore
 
@@ -93,7 +114,7 @@ Start Pub/Sub Emulator during a test:
 [Starting a Pub/Sub Emulator container](../../modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java) inside_block:emulatorContainer
 <!--/codeinclude-->
 
-Create a test Pub/Sub topic the Emulator:
+Create a test Pub/Sub topic in the Emulator:
 
 <!--codeinclude-->
 [Create a test topic](../../modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java) inside_block:createTopic


### PR DESCRIPTION
Currently Testcontainers  have support for Google Cloud Bigtable Emulator, but have no documentation for it, so basically nobody does know about it.