### PR TITLE
Implement getDatabaseName() in CockroachContainer

### DIFF
--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -65,7 +65,12 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
     public String getJdbcUrl() {
         String additionalUrlParams = constructUrlParameters("?", "&");
         return JDBC_URL_PREFIX + "://" + getHost() + ":" + getMappedPort(DB_PORT) +
-            "/" + databaseName + additionalUrlParams;
+            "/" + getDatabaseName() + additionalUrlParams;
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return databaseName;
     }
 
     @Override

--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -65,11 +65,11 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
     public String getJdbcUrl() {
         String additionalUrlParams = constructUrlParameters("?", "&");
         return JDBC_URL_PREFIX + "://" + getHost() + ":" + getMappedPort(DB_PORT) +
-            "/" + getDatabaseName() + additionalUrlParams;
+            "/" + databaseName + additionalUrlParams;
     }
 
     @Override
-    public String getDatabaseName() {
+    public final String getDatabaseName() {
         return databaseName;
     }
 


### PR DESCRIPTION
Override the JdbcDatabaseContainer.getDatabaseName method in CockroachContainer to avoid needing to use the hardcoded `postgres` database name in application code.

```kotlin
every { UserEnv.cockroachdb_host } returns container.host
every { UserEnv.cockroachdb_db } returns "postgres"
```

turns in to:

```kotlin
every { UserEnv.cockroachdb_host } returns container.host
every { UserEnv.cockroachdb_db } returns container.databaseName
```