### PR TITLE
Make clear that HostPortWaitStrategy waits for all ports

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
- * Waits until a socket connection can be established on a port exposed or mapped by the container.
+ * Waits until a socket connection can be established on all port exposed or mapped by the container.
  *
  * @author richardnorth
  */

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/Wait.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/Wait.java
@@ -17,12 +17,22 @@ public class Wait {
     }
 
     /**
-     * Convenience method to return a WaitStrategy for an exposed or mapped port.
+     * Convenience method to return a WaitStrategy for all exposed or mapped port.
      *
      * @return the WaitStrategy
      * @see HostPortWaitStrategy
      */
     public static HostPortWaitStrategy forListeningPort() {
+        return forListeningPorts();
+    }
+
+    /**
+     * Convenience method to return a WaitStrategy for all exposed or mapped port.
+     *
+     * @return the WaitStrategy
+     * @see HostPortWaitStrategy
+     */
+    public static HostPortWaitStrategy forListeningPorts() {
         return new HostPortWaitStrategy();
     }
 


### PR DESCRIPTION
As a caller it is unclear what to expect from this wait strategy
when a given container have several ports.

I try to explicit that out by:

 - Javadoc changes
 - Alternative factory method name emphasising the plural