### PR TITLE
Fix mp4 recording to be compatible with Firefox

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/VncRecordingContainer.java
@@ -132,7 +132,7 @@ public class VncRecordingContainer extends GenericContainer<VncRecordingContaine
             @Override
             String reencodeRecording(@NonNull VncRecordingContainer container, @NonNull String source) throws IOException, InterruptedException {
                 String newFileOutput = "/newScreen.mp4";
-                container.execInContainer("ffmpeg", "-i", source, "-vcodec", "libx264", "-movflags", "faststart", newFileOutput);
+                container.execInContainer("ffmpeg", "-i", source, "-vcodec", "libx264", "-movflags", "faststart", "-pix_fmt", "yuv420p", newFileOutput);
                 return newFileOutput;
             }
         };


### PR DESCRIPTION
Firefox still doesn't support yuv444 so use yuv420p
https://shallowsky.com/blog/linux/videos-from-images.html

Related #3180, #512  