### PR TITLE
Fix NPE bug with docker-compose files in working directory

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -120,6 +120,7 @@ class ParsedDockerComposeFile {
             final Object contextRelativePath = buildElement.get("context");
             if (dockerfileRelativePath instanceof String && contextRelativePath instanceof String) {
                 dockerfilePath = composeFile
+                    .getAbsoluteFile()
                     .getParentFile()
                     .toPath()
                     .resolve((String) contextRelativePath)
@@ -128,6 +129,7 @@ class ParsedDockerComposeFile {
             }
         } else if (buildNode instanceof String) {
             dockerfilePath = composeFile
+                .getAbsoluteFile()
                 .getParentFile()
                 .toPath()
                 .resolve((String) buildNode)

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeContainerTest.java
@@ -6,6 +6,9 @@ import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.DockerComposeContainer;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Optional;
 
 import static java.lang.String.format;
@@ -52,5 +55,24 @@ public class DockerComposeContainerTest extends BaseDockerComposeTest {
         String notExistingServiceName = "db_256";
         Optional<ContainerState> result = environment.getContainerByServiceName(notExistingServiceName);
         assertFalse(format("No container should be found under service name %s", notExistingServiceName), result.isPresent());
+    }
+
+    @Test
+    public void shouldCreateContainerWhenFileNotPrefixedWithPath() throws IOException {
+        String validYaml =
+            "version: '2.2'\n" +
+                "services:\n" +
+                "  http:\n" +
+                "    image: python:latest\n" +
+                "    ports:\n" +
+                "    - 8080:8080";
+
+        File filePathNotStartWithDotSlash = new File("docker-compose-test.yml");
+        filePathNotStartWithDotSlash.createNewFile();
+        filePathNotStartWithDotSlash.deleteOnExit();
+        Files.write(filePathNotStartWithDotSlash.toPath(), validYaml.getBytes(StandardCharsets.UTF_8));
+
+        final DockerComposeContainer<?> dockerComposeContainer = new DockerComposeContainer<>(filePathNotStartWithDotSlash);
+        assertNotNull("Container could not be created using docker compose file", dockerComposeContainer);
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeContainerTest.java
@@ -63,6 +63,7 @@ public class DockerComposeContainerTest extends BaseDockerComposeTest {
             "version: '2.2'\n" +
                 "services:\n" +
                 "  http:\n" +
+                "    build: .\n" +
                 "    image: python:latest\n" +
                 "    ports:\n" +
                 "    - 8080:8080";


### PR DESCRIPTION
```java
new File("file-in-working-directory.txt").getParentFile();
```
throws a NullPointerException

### Solutions
1. Prefix the path with `./` → `new File("./file-in-working-directory.txt").getParentFile();`
2. call `getAbsoluteFile()` before `getParentFile()`

More details: https://bugs.openjdk.java.net/browse/JDK-8202972