### PR TITLE
Bump docs environment to python 3.7

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3.7"
 
 services:
   docs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
-version: "3.7"
+version: "3.8"
 
 services:
   docs:
-    image: python:3.6
+    image: python:3.7
     command: sh -c "pip install -r requirements.txt && mkdocs serve -a 0.0.0.0:8000"
     working_dir: /docs
     volumes:

--- a/docs/contributing_docs.md
+++ b/docs/contributing_docs.md
@@ -15,7 +15,7 @@ The root of the project contains a `docker-compose.yml` file. Simply run `docker
 
 ### Using Python locally
 
-* Ensure that you have Python 3.6.0 or higher.
+* Ensure that you have Python 3.7.0 or higher.
 * Set up a virtualenv and run `pip install -r requirements.txt` in the `testcontainers-java` root directory.
 * Once Python dependencies have been installed, run `mkdocs serve` to start a local auto-updating MkDocs server.
 


### PR DESCRIPTION
This PR bumps docker-compose used for docs and contributing-docs document to Python 3.7.

Reason:

Used 'mkdocs-codeinclude-plugin' requires: Python >=3.7 (https://pypi.org/project/mkdocs-codeinclude-plugin/0.1.0/) and it's not possible to build docs currently with python 3.6.