### PR TITLE
Add NATS support module

### DIFF
--- a/docs/modules/nats.md
+++ b/docs/modules/nats.md
@@ -1,0 +1,26 @@
+# NATS Module
+
+## Usage example
+
+This example connects to the NATS server and asserts the connection status of the client.
+
+<!--codeinclude-->
+[Using a NATS container](../../modules/nats/src/test/java/org/testcontainers/containers/NATSContainerTest.java) inside_block:natsContainerUsage
+<!--/codeinclude-->
+
+## Adding this module to your project dependencies
+
+Add the following dependency to your `pom.xml`/`build.gradle` file:
+
+```groovy tab='Gradle'
+testCompile "org.testcontainers:nats:{{latest_version}}"
+```
+
+```xml tab='Maven'
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>nats</artifactId>
+    <version>{{latest_version}}</version>
+    <scope>test</scope>
+</dependency>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
           - modules/kafka.md
           - modules/localstack.md
           - modules/mockserver.md
+          - modules/nats.md
           - modules/nginx.md
           - modules/pulsar.md
           - modules/rabbitmq.md

--- a/modules/nats/build.gradle
+++ b/modules/nats/build.gradle
@@ -1,0 +1,12 @@
+description = "TestContainers :: NATS"
+
+dependencies {
+    compile project(":database-commons")
+
+    testImplementation(platform('org.junit:junit-bom:5.7.0'))
+    testImplementation "io.nats:jnats:2.8.0"
+}
+
+test {
+    useJUnit()
+}

--- a/modules/nats/src/main/java/org/testcontainers/containers/NATSContainer.java
+++ b/modules/nats/src/main/java/org/testcontainers/containers/NATSContainer.java
@@ -1,0 +1,29 @@
+package org.testcontainers.containers;
+
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+public class NATSContainer extends GenericContainer<NATSContainer> {
+
+    public static final DockerImageName DEFAULT_NATS_IMAGE = DockerImageName.parse("nats:2.1.9-alpine3.12");
+
+    public static final Integer NATS_PORT = 4222;
+    public static final Integer NATS_MGMT_PORT = 8222;
+
+    public NATSContainer() {
+        this(DEFAULT_NATS_IMAGE);
+    }
+
+    public NATSContainer(String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public NATSContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+
+        addExposedPort(NATS_PORT);
+        addExposedPort(NATS_MGMT_PORT);
+
+        this.waitStrategy = new LogMessageWaitStrategy().withRegEx(".*Server is ready.*");
+    }
+}

--- a/modules/nats/src/test/java/org/testcontainers/containers/NATSContainerTest.java
+++ b/modules/nats/src/test/java/org/testcontainers/containers/NATSContainerTest.java
@@ -1,0 +1,85 @@
+package org.testcontainers.containers;
+
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.classic.methods.HttpGet;
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.classic.methods.HttpUriRequest;
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpResponse;
+import com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.HttpStatus;
+import io.nats.client.Connection;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+import lombok.SneakyThrows;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class NATSContainerTest {
+    public static final String NATS_PROTOCOL = "nats://";
+    private static final String NATS_NON_DEFAULT_IMAGE = "nats:2.1-alpine3.10";
+
+    @Test
+    public void testNATSServerNonDefaultImage() {
+        try (NATSContainer container = new NATSContainer(NATS_NON_DEFAULT_IMAGE)) {
+            container.start();
+
+            assertConnectionStatus(container);
+        }
+    }
+
+    @Test
+    @SneakyThrows({IOException.class, InterruptedException.class})
+    public void testNATSClientConnectionTest() {
+        // natsContainerUsage {
+        // Create a NATS container.
+        NATSContainer container = new NATSContainer();
+
+        // Start the container. This step might take some time...
+        container.start();
+
+        // Connect to NATS
+        Connection connection = Nats.connect(
+            new io.nats.client.Options.Builder().server(
+                "nats://" + container.getHost() + ":" + container.getFirstMappedPort()
+            ).build());
+
+        // Do whatever you want with the NATS connection ...
+        assertThat(connection.getStatus(), equalTo(Connection.Status.CONNECTED));
+
+        // Stop the container.
+        container.close();
+        // }
+    }
+
+    @Test
+    public void testNATSServerStatus() throws IOException {
+        try (NATSContainer container = new NATSContainer()) {
+            container.start();
+
+            HttpUriRequest request = new HttpGet(getUri(container));
+            HttpResponse httpResponse = HttpClientBuilder.create().build().execute(request);
+            assertThat(httpResponse.getCode(), equalTo(HttpStatus.SC_OK));
+        }
+    }
+
+    private String getUri(NATSContainer container) {
+        return "http://" + container.getHost() + ":" + container.getMappedPort(NATSContainer.NATS_MGMT_PORT) + "/varz";
+    }
+
+    private void assertConnectionStatus(NATSContainer container) {
+        Connection c = getConnection(container);
+        assertThat(c.getStatus(), equalTo(Connection.Status.CONNECTED));
+    }
+
+    @SneakyThrows({IOException.class, InterruptedException.class})
+    public static Connection getConnection(ContainerState containerState) {
+
+        Options options = new io.nats.client.Options.Builder().
+            server(NATS_PROTOCOL + containerState.getHost() + ":" + containerState.getFirstMappedPort()).
+            build();
+
+        return Nats.connect(options);
+    }
+}


### PR DESCRIPTION
### Default docker image

- [X] Should be a Docker Hub official image, or published by a reputable source (ideally the company or organisation that officially supports the technology)
- [X] Should have a verifiable open source Dockerfile and a way to view the history of changes
- [X] MUST show general good practices regarding container image tagging - e.g. we do not use latest tags, and we do not use tags that may be mutated in the future
- [X] MUST be legal for Testcontainers developers and Testcontainers users to pull and use. Mechanisms exist to allow EULA acceptance to be signalled, but images that can be used without a licence are greatly preferred.

### Module dependencies

- [X] The module should use as few dependencies as possible,
- [X] Regarding libraries, either:
  - they should be compileOnly if they are likely to already be on the classpath for users' tests (e.g. client libraries or drivers)
  - they can be implementation (and thus transitive dependencies) if they are very unlikely to conflict with users' dependencies.
- [X] If client libraries are used to test or use the module, these MUST be legal for Testcontainers developers and Testcontainers users to download and use.

### API (e.g. MyModuleContainer class)

- [X] Favour doing the right thing, and least surprising thing, by default
- [X] Ensure that method and parameter names are easy to understand. Many users will ignore documentation, so IDE-based substitutes (autocompletion and Javadocs) should be intuitive.
- [X] The module's public API should only handle standard JDK data types and MUST not expose data types that come from compileOnly dependencies. This is to reduce the risk of compatibility problems with future versions of third party libraries.

### Documentation

- [X] Every module MUST have a dedicated documentation page containing:
- [X] A high level overview
- [X] A usage example
- [X] If appropriate, basic API documentation or further usage guidelines
- [X] Dependency information
- [X] Acknowledgements, if appropriate
- [X] Consider that many users will not read the documentation pages - even if the first person to add it to a project does, people reading/updating the code in the future may not. Try and avoid the need for critical knowledge that is only present in documentation.