### PR TITLE
Make Testcontainers extension annotation public to allow using in ordered ExtendWith

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -93,6 +93,14 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     void addFileSystemBind(String hostPath, String containerPath, BindMode mode, SelinuxContext selinuxContext);
 
     /**
+     * Adds a lazy file system binding. Consider using {@link #withFileSystemBind(LazyFileSystemBind)}
+     * for building a container in a fluent style.
+     *
+     * @param lazyBind      that will be used to construct actual bind
+     */
+    void addFileSystemBind(final LazyFileSystemBind lazyBind);
+
+    /**
      * Add a link to another container.
      *
      * @param otherContainer the other container object to link to
@@ -147,6 +155,13 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @return this
      */
     SELF withFileSystemBind(String hostPath, String containerPath, BindMode mode);
+
+    /**
+     * Adds a lazy file system binding.
+     * @param lazyBind
+     * @return this
+     */
+    SELF withFileSystemBind(LazyFileSystemBind lazyBind);
 
     /**
      * Adds container volumes.

--- a/core/src/main/java/org/testcontainers/containers/LazyFileSystemBind.java
+++ b/core/src/main/java/org/testcontainers/containers/LazyFileSystemBind.java
@@ -1,0 +1,97 @@
+package org.testcontainers.containers;
+
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Lazy variant of FileSystem Bind that defers calculation of values used to create
+ * {@link com.github.dockerjava.api.model.Bind}
+ */
+public interface LazyFileSystemBind {
+    String getHostPath();
+
+    String getContainerPath();
+
+    BindMode getMode();
+
+    default SelinuxContext getSelinuxContext() {
+        return SelinuxContext.NONE;
+    }
+
+    class Builder {
+        private Supplier<String> hostPath;
+        private Supplier<String> containerPath;
+        private Supplier<BindMode> mode;
+        private Supplier<SelinuxContext> selinuxContext = () -> SelinuxContext.NONE;
+
+        public Builder withHostPath(String hostPath) {
+            this.hostPath = () -> requireNonNull(hostPath, "hostPath cannot be null");
+            return this;
+        }
+
+        public Builder withHostPath(Supplier<String> hostPath) {
+            this.hostPath = requireNonNull(hostPath, "hostPath cannot be null");
+            return this;
+        }
+
+        public Builder withContainerPath(String containerPath) {
+            this.containerPath = () -> requireNonNull(containerPath, "containerPath cannot be null");
+            return this;
+        }
+
+        public Builder withContainerPath(Supplier<String> containerPath) {
+            this.containerPath = requireNonNull(containerPath, "containerPath cannot be null");
+            return this;
+        }
+
+        public Builder withMode(BindMode mode) {
+            this.mode = () -> requireNonNull(mode, "mode cannot be null");
+            return this;
+        }
+
+        public Builder withMode(Supplier<BindMode> mode) {
+            this.mode = requireNonNull(mode, "mode cannot be null");
+            return this;
+        }
+
+        public Builder withSelinuxContext(SelinuxContext selinuxContext) {
+            this.selinuxContext = () -> requireNonNull(selinuxContext, "mode cannot be null");
+            return this;
+        }
+
+        public Builder withSelinuxContext(Supplier<SelinuxContext> selinuxContext) {
+            this.selinuxContext = requireNonNull(selinuxContext, "selinuxContext cannot be null");
+            return this;
+        }
+
+        public LazyFileSystemBind build() {
+            requireNonNull(hostPath, "hostPath supplier cannot be null");
+            requireNonNull(containerPath, "containerPath supplier cannot be null");
+            requireNonNull(mode, "mode supplier cannot be null");
+            requireNonNull(selinuxContext, "selinuxContext supplier cannot be null");
+
+            return new LazyFileSystemBind() {
+                @Override
+                public String getHostPath() {
+                    return requireNonNull(hostPath.get(), "hostPath lazy value cannot be null");
+                }
+
+                @Override
+                public String getContainerPath() {
+                    return requireNonNull(containerPath.get(), "containerPath lazy value cannot be null");
+                }
+
+                @Override
+                public BindMode getMode() {
+                    return requireNonNull(mode.get(), "mode lazy value cannot be null");
+                }
+
+                @Override
+                public SelinuxContext getSelinuxContext() {
+                    return requireNonNull(selinuxContext.get(), "selinuxContext lazy value cannot be null");
+                }
+            };
+        }
+    }
+}

--- a/docs/test_framework_integration/junit_5.md
+++ b/docs/test_framework_integration/junit_5.md
@@ -27,6 +27,10 @@ unsupported and may have unintended side effects.
 [Mixed Lifecycle](../../modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/MixedLifecycleTests.java) inside_block:testClass
 <!--/codeinclude-->
 
+You can use `@Testcontainers` annotation with JUnit5's `@ExtendWith` annotation to expression extensions execution order.
+If you want to use `@Testcontainers.disabledWithoutDocker` property, put `@Testcontainers` annotation on class. Configured
+property will be loaded and order of extension will also preserve. 
+
 ## Examples
 
 To use the Testcontainers extension annotate your test class with `@Testcontainers`.

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
@@ -59,9 +59,10 @@ import java.lang.annotation.Target;
 @ExtendWith(TestcontainersExtension.class)
 @Inherited
 public @interface Testcontainers {
+    boolean defaultDisabledWithoutDocker = false;
 
     /**
      * Whether tests should be disabled (rather than failing) when Docker is not available.
      */
-    boolean disabledWithoutDocker() default false;
+    boolean disabledWithoutDocker() default defaultDisabledWithoutDocker;
 }

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/PublicTestcontainersExtensionTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/PublicTestcontainersExtensionTests.java
@@ -1,0 +1,117 @@
+package org.testcontainers.junit.jupiter;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.ClassUtils;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.platform.commons.util.ExceptionUtils;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.LazyFileSystemBind;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotatedMethods;
+
+@ExtendWith({
+    PublicTestcontainersExtensionTests.RunCodeExtension.class,
+    TestcontainersExtension.class
+})
+class PublicTestcontainersExtensionTests {
+    @TempDir
+    static File tempDir;
+
+    @Container
+    private static final GenericContainer<?> nginx = new GenericContainer<>("nginx:1.9.4")
+        .withFileSystemBind(new LazyFileSystemBind.Builder()
+            .withHostPath(() -> myDir(tempDir, "nginx").getAbsolutePath())
+            .withContainerPath("/usr/share/nginx/html")
+            .withMode(BindMode.READ_ONLY)
+            .build())
+        .withExposedPorts(80)
+        .waitingFor(new HttpWaitStrategy());
+
+    @RunCodeExtension.RunBeforeCustomExtensions
+    private static void generateHtmlFiles(ExtensionContext context) throws IOException {
+        final File dirFe = myDir(tempDir, "nginx");
+        dirFe.mkdirs();
+
+        try (final OutputStream out = new BufferedOutputStream(new FileOutputStream(new File(dirFe, "index.html")))) {
+            IOUtils.write("<html><body>Hello from nginx!</body></html>", out, StandardCharsets.UTF_8);
+        }
+    }
+
+    @BeforeAll
+    public static void beforeAll() {
+        assertThat(nginx.isRunning())
+            .describedAs("nginx should be running")
+            .isTrue();
+    }
+
+    @Test
+    void httpGetFromNginxStatic() throws IOException {
+        HttpClient client = HttpClientBuilder.create().build();
+        HttpResponse response = client.execute(new HttpGet("http://" + nginx.getContainerIpAddress() + ":" + nginx.getMappedPort(80)));
+
+        assertThat(response.getStatusLine().getStatusCode())
+            .isEqualTo(200);
+        final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        response.getEntity().writeTo(buffer);
+        final String body = buffer.toString(StandardCharsets.UTF_8.displayName());
+        assertThat(body)
+            .isEqualTo("<html><body>Hello from nginx!</body></html>");
+    }
+
+    private static File myDir(File parent, String dir) {
+        return new File(Objects.requireNonNull(parent, "parent dir cannot be null"), dir);
+    }
+
+    public static class RunCodeExtension implements BeforeAllCallback {
+        @Override
+        public void beforeAll(ExtensionContext context) {
+            context.getTestInstance();
+            findAnnotatedMethods(context.getRequiredTestClass(), RunBeforeCustomExtensions.class, ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+                .stream()
+                .filter(ReflectionUtils::isStatic)
+                .filter(it -> it.getParameterCount() == 1)
+                .filter(it -> ClassUtils.isAssignable(it.getParameterTypes()[0], ExtensionContext.class))
+                .map(ReflectionUtils::makeAccessible)
+                .forEach(method -> {
+                    try {
+                        method.invoke(null, context);
+                    } catch (Throwable t) {
+                        ExceptionUtils.throwAsUncheckedException(t);
+                    }
+                });
+        }
+
+        @Target({ElementType.METHOD})
+        @Retention(RetentionPolicy.RUNTIME)
+        @Documented
+        public @interface RunBeforeCustomExtensions {
+        }
+    }
+}

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/SkipTestcontainersTestWithExtendWithTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/SkipTestcontainersTestWithExtendWithTests.java
@@ -1,0 +1,21 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+@ExtendWith(SkipTestcontainersTestWithExtendWithTests.DockerNotAvailableTestcontainersExtension.class)
+@Testcontainers(disabledWithoutDocker = true)
+class SkipTestcontainersTestWithExtendWithTests {
+    @Test
+    void shouldBeSkipped() {
+        fail("This test has to be skipped");
+    }
+
+    static final class DockerNotAvailableTestcontainersExtension extends TestcontainersExtension {
+        boolean isDockerAvailable() {
+            return false;
+        }
+    }
+}

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExtensionTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExtensionTests.java
@@ -2,7 +2,10 @@ package org.testcontainers.junit.jupiter;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -26,6 +29,20 @@ public class TestcontainersExtensionTests {
     }
 
     @Test
+    void whenDisabledWithoutDockerAndDockerIsAvailableTestsAreEnabledUsingExtendsWith() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(true)
+            .evaluateExecutionCondition(extensionContext(DisabledExtendWithAndAnnotation.class));
+        assertFalse(result.isDisabled());
+    }
+
+    @Test
+    void whenDisabledWithoutDockerAndDockerIsUnavailableTestsAreDisabledUsingExtendsWith() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(false)
+            .evaluateExecutionCondition(extensionContext(DisabledExtendWithAndAnnotation.class));
+        assertTrue(result.isDisabled());
+    }
+
+    @Test
     void whenEnabledWithoutDockerAndDockerIsAvailableTestsAreEnabled() {
         ConditionEvaluationResult result = new TestTestcontainersExtension(true)
             .evaluateExecutionCondition(extensionContext(EnabledWithoutDocker.class));
@@ -39,9 +56,37 @@ public class TestcontainersExtensionTests {
         assertFalse(result.isDisabled());
     }
 
-    private ExtensionContext extensionContext(Class clazz) {
+    @Test
+    void whenEnabledWithoutDockerAndDockerIsAvailableTestsAreEnabledUsingExtendsWith() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(true)
+            .evaluateExecutionCondition(extensionContext(EnabledExtendWith.class));
+        assertFalse(result.isDisabled());
+    }
+
+    @Test
+    void whenEnabledWithoutDockerAndDockerIsUnavailableTestsAreEnabledUsingExtendsWith() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(false)
+            .evaluateExecutionCondition(extensionContext(EnabledExtendWith.class));
+        assertFalse(result.isDisabled());
+    }
+
+    @Test
+    void whenEnabledWithoutDockerAndDockerIsAvailableTestsAreEnabledUsingExtendsWithAndAnnotation() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(true)
+            .evaluateExecutionCondition(extensionContext(EnabledExtendWithAndAnnotation.class));
+        assertFalse(result.isDisabled());
+    }
+
+    @Test
+    void whenEnabledWithoutDockerAndDockerIsUnavailableTestsAreEnabledUsingExtendsWithAndAnnotation() {
+        ConditionEvaluationResult result = new TestTestcontainersExtension(false)
+            .evaluateExecutionCondition(extensionContext(EnabledExtendWithAndAnnotation.class));
+        assertFalse(result.isDisabled());
+    }
+
+    private ExtensionContext extensionContext(Class<?> clazz) {
         ExtensionContext extensionContext = mock(ExtensionContext.class);
-        when(extensionContext.getRequiredTestClass()).thenReturn(clazz);
+        when(extensionContext.getTestClass()).thenReturn(Optional.ofNullable(clazz));
         return extensionContext;
     }
 
@@ -53,6 +98,20 @@ public class TestcontainersExtensionTests {
     @Testcontainers
     static final class EnabledWithoutDocker {
 
+    }
+
+    @ExtendWith(TestcontainersExtension.class)
+    static final class EnabledExtendWith {
+    }
+
+    @ExtendWith(TestcontainersExtension.class)
+    @Testcontainers
+    static final class EnabledExtendWithAndAnnotation {
+    }
+
+    @ExtendWith(TestcontainersExtension.class)
+    @Testcontainers(disabledWithoutDocker = true)
+    static final class DisabledExtendWithAndAnnotation {
     }
 
     static final class TestTestcontainersExtension extends TestcontainersExtension {


### PR DESCRIPTION
Original PR https://github.com/testcontainers/testcontainers-java/pull/2262 was closed due to inactivity on my side, sorry for this.

Hi,
I found fix of https://github.com/testcontainers/testcontainers-java/issues/2045 useful and created PR. My usecase could be found in TestcontainersSharedContainerWithGeneratedResourcesTests. Problem is that I want to have static containers that use some generated resources and without @ExtendWith I am unable to tell order in which extensions are invoked.
What do you think?
Thx
Ivos