### PR TITLE
Upgrade cassandra driver 4.10.0

### DIFF
--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -1,6 +1,6 @@
 description = "TestContainers :: Cassandra"
 
 dependencies {
-    compile project(":database-commons")
-    compile "com.datastax.cassandra:cassandra-driver-core:3.7.1"
+    implementation project(":database-commons")
+    implementation "com.datastax.oss:java-driver-core:4.10.0"
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -2,5 +2,9 @@ description = "TestContainers :: Cassandra"
 
 dependencies {
     implementation project(":database-commons")
-    implementation "com.datastax.oss:java-driver-core:4.10.0"
+    implementation("com.datastax.oss:java-driver-core:4.10.0") {
+        // fasterxml 2.12 not compatible for com.github.docker-java
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
 }

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -37,6 +37,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
     private static final String CONTAINER_CONFIG_LOCATION = "/etc/cassandra";
     private static final String USERNAME = "cassandra";
     private static final String PASSWORD = "cassandra";
+    protected static final String LOCAL_DC = "datacenter1";
 
     private String configLocation;
     private String initScriptPath;
@@ -172,8 +173,10 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
     }
 
     public String getCqlHostAddress() {
-        return getHost() + ":" + getMappedPort(CQL_PORT);
+        return getHost() + ":" + getMappedPort(CassandraContainer.CQL_PORT);
     }
+
+    public String getLocalDc() { return CassandraContainer.LOCAL_DC; }
 
     /**
      * Get configured Cluster
@@ -188,7 +191,8 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
         InetSocketAddress endpoint = new InetSocketAddress(containerState.getHost(), containerState.getMappedPort(CQL_PORT));
         final CqlSessionBuilder builder = CqlSession.builder()
             .addContactPoint(endpoint)
-            .withLocalDatacenter("datacenter1");
+            .withLocalDatacenter(LOCAL_DC);
+
         if (meterRegistry != null) {
             builder.withMetricRegistry(meterRegistry);
         }

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/delegate/CassandraDatabaseDelegate.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/delegate/CassandraDatabaseDelegate.java
@@ -1,8 +1,9 @@
 package org.testcontainers.containers.delegate;
 
-import com.datastax.driver.core.ResultSet;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.exceptions.DriverException;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.DriverException;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.CassandraContainer;
@@ -18,15 +19,14 @@ import org.testcontainers.ext.ScriptUtils.ScriptStatementFailedException;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class CassandraDatabaseDelegate extends AbstractDatabaseDelegate<Session> {
+public class CassandraDatabaseDelegate extends AbstractDatabaseDelegate<CqlSession> {
 
     private final ContainerState container;
 
     @Override
-    protected Session createNewConnection() {
+    protected CqlSession createNewConnection() {
         try {
-            return CassandraContainer.getCluster(container)
-                    .newSession();
+            return CassandraContainer.getCqlSession(container, false);
         } catch (DriverException e) {
             log.error("Could not obtain cassandra connection");
             throw new ConnectionCreationException("Could not obtain cassandra connection", e);
@@ -48,9 +48,9 @@ public class CassandraDatabaseDelegate extends AbstractDatabaseDelegate<Session>
     }
 
     @Override
-    protected void closeConnectionQuietly(Session session) {
+    protected void closeConnectionQuietly(CqlSession cqlSession) {
         try {
-            session.getCluster().close();
+            cqlSession.close();
         } catch (Exception e) {
             log.error("Could not close cassandra connection", e);
         }

--- a/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
+++ b/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
 @Slf4j
 public class CassandraContainerTest {
 
-    private static final DockerImageName CASSANDRA_IMAGE = DockerImageName.parse("cassandra:3.11.9");
+    private static final DockerImageName CASSANDRA_IMAGE = DockerImageName.parse("cassandra:3.11.2");
 
     private static final String TEST_CLUSTER_NAME_IN_CONF = "Test Cluster Integration Test";
 
@@ -124,9 +124,12 @@ public class CassandraContainerTest {
     }
 
     private ResultSet performQuery(CassandraContainer<?> cassandraContainer, String cql) {
-        InetSocketAddress endpoint = new InetSocketAddress(cassandraContainer.getHost(), CassandraContainer.CQL_PORT);
+        InetSocketAddress endpoint = new InetSocketAddress(
+            cassandraContainer.getHost(),
+            cassandraContainer.getMappedPort(CassandraContainer.CQL_PORT));
         CqlSession cqlSession = CqlSession.builder()
             .addContactPoint(endpoint)
+            .withLocalDatacenter(CassandraContainer.LOCAL_DC)
             .build();
         return cqlSession.execute(cql);
     }


### PR DESCRIPTION
### Motivations

Unit tests with the OSS Cassandra driver version 4.10.0

### Modifications

* Upgrade the Cassandra driver.

### Tests

Exclude the fasterxml (core+databind) from the cassandra driver deps to avoid an issue with docker-java. All unit tests are ok.