### PR TITLE
Fix problem of starting up mysql 5.7.33 version when user is root

### DIFF
--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -49,7 +49,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        addExposedPort(MYSQL_PORT);
+        addExposedP ort(MYSQL_PORT);
     }
 
 
@@ -62,10 +62,12 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     @Override
     protected void configure() {
         optionallyMapResourceParameterAsVolume(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, "/etc/mysql/conf.d",
-                "mysql-default-conf");
+            "mysql-default-conf");
 
         addEnv("MYSQL_DATABASE", databaseName);
-        addEnv("MYSQL_USER", username);
+        if (!MYSQL_ROOT_USER.equalsIgnoreCase(username)) {
+            addEnv("MYSQL_USER", username);
+        }
         if (password != null && !password.isEmpty()) {
             addEnv("MYSQL_PASSWORD", password);
             addEnv("MYSQL_ROOT_PASSWORD", password);
@@ -98,12 +100,12 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     protected String constructUrlForConnection(String queryString) {
         String url = super.constructUrlForConnection(queryString);
 
-        if (! url.contains("useSSL=")) {
+        if (!url.contains("useSSL=")) {
             String separator = url.contains("?") ? "&" : "?";
             url = url + separator + "useSSL=false";
         }
 
-        if (! url.contains("allowPublicKeyRetrieval=")) {
+        if (!url.contains("allowPublicKeyRetrieval=")) {
             url = url + "&allowPublicKeyRetrieval=true";
         }
 

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -49,7 +49,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        addExposedP ort(MYSQL_PORT);
+        addExposedPort(MYSQL_PORT);
     }
 
 

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
@@ -45,6 +45,7 @@ public class MySQLRootAccountTest {
             db.withLogConsumer(new Slf4jLogConsumer(log)).start();
             Connection connection = DriverManager.getConnection(db.getJdbcUrl(), db.getUsername(), db.getPassword());
             connection.createStatement().execute("SELECT 1");
+            connection.createStatement().execute("set sql_log_bin=0"); // requires root
         } finally {
             db.close();
         }

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
@@ -32,7 +32,7 @@ public class MySQLRootAccountTest {
 
     @Test
     public void testRootAccountUsageWithEmptyPassword() throws SQLException {
-        testWithDB(new MySQLContainer<>(image).withUsername("root").withPassword(null));
+        testWithDB(new MySQLContainer<>(image).withUsername("root").withPassword(""));
     }
 
     @Test

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
@@ -1,0 +1,52 @@
+package org.testcontainers.containers;
+
+import lombok.extern.slf4j.Slf4j;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+@Slf4j
+@RunWith(Parameterized.class)
+public class MySQLRootAccountTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static String[] params() {
+        return new String[]{
+            "mysql:8",
+            "mysql:5"
+        };
+    }
+
+    @Parameterized.Parameter()
+    public String image;
+
+    @Test
+    public void testRootAccountUsageWithDefaultPassword() throws SQLException {
+        testWithDB(new MySQLContainer<>(image).withUsername("root"));
+    }
+
+    @Test
+    public void testRootAccountUsageWithEmptyPassword() throws SQLException {
+        testWithDB(new MySQLContainer<>(image).withUsername("root").withPassword(null));
+    }
+
+    @Test
+    public void testRootAccountUsageWithCustomPassword() throws SQLException {
+        testWithDB(new MySQLContainer<>(image).withUsername("root").withPassword("not-default"));
+    }
+
+    private void testWithDB(MySQLContainer<?> db) throws SQLException {
+        try {
+            db.withLogConsumer(new Slf4jLogConsumer(log)).start();
+            Connection connection = DriverManager.getConnection(db.getJdbcUrl(), db.getUsername(), db.getPassword());
+            connection.createStatement().execute("SELECT 1");
+        } finally {
+            db.close();
+        }
+    }
+}


### PR DESCRIPTION
Fixes following problem in console of mysql container


```
java.lang.IllegalStateException: Container did not start correctly.
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:435)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:325)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:323)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:311)
```

```
[ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
    Remove MYSQL_USER="root" and use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD
```

Fixes issue https://github.com/testcontainers/testcontainers-java/issues/3893