### PR TITLE
ec2 added to localstack services enum

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -306,6 +306,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     @FieldDefaults(makeFinal = true)
     public enum Service {
         API_GATEWAY("apigateway", 4567),
+        EC2("ec2", 4597),
         KINESIS("kinesis", 4568),
         DYNAMODB("dynamodb", 4569),
         DYNAMODB_STREAMS("dynamodbstreams", 4570),


### PR DESCRIPTION
Now the EC2 service can be initialized like the other services.

This should close localstack/localstack#3590