### PR TITLE
Update docs to clarify shading approach

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -86,8 +86,9 @@ testImplementation('org.testcontainers:mysql') //no version specified
 [JitPack](jitpack_dependencies.md) builds are available for pre-release versions.
 
 !!! warning "Shaded dependencies"
-    Testcontainers uses the docker-java client library, which in turn depends on JAX-RS, Jersey and Jackson libraries. 
-    These libraries in particular seem to be especially prone to conflicts with test code/application under test code. 
+    Testcontainers depends on other libraries (like docker-java) for it to work.  
+    Some of them (JUnit, docker-java-{api,transport} and its transitive dependencies, JNA, visible-assertions and others) are part of our public API.  
+    But there are also "private", implementation detail dependencies (e.g. docker-java-core, Guava, OkHttp, etc etc) that are not exposed to public API but prone to conflicts with test code/application under test code. 
     As such, **these libraries are 'shaded' into the core testcontainers JAR** and relocated under `org.testcontainers.shaded` to prevent class conflicts.
 
 ## Sponsors


### PR DESCRIPTION
Make the docs section about our shading approach and motivation more up-to-date and less confusing (no JAX-RS/Jersey anymore, mention docker-java-api, etc)