### PR TITLE
Prevent ContainerDatabaseDriver from throwing NPEs when on classpath but not initialized

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -230,27 +230,30 @@ public class ContainerDatabaseDriver implements Driver {
 
     @Override
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) throws SQLException {
-        return delegate.getPropertyInfo(url, info);
+        return delegate != null ? delegate.getPropertyInfo(url, info) : new DriverPropertyInfo[0];
     }
 
     @Override
     public int getMajorVersion() {
-        return delegate.getMajorVersion();
+        return delegate != null ? delegate.getMajorVersion() : 1;
     }
 
     @Override
     public int getMinorVersion() {
-        return delegate.getMinorVersion();
+        return delegate != null ? delegate.getMinorVersion() : 0;
     }
 
     @Override
     public boolean jdbcCompliant() {
-        return delegate.jdbcCompliant();
+        return delegate != null && delegate.jdbcCompliant();
     }
 
     @Override
     public Logger getParentLogger() throws SQLFeatureNotSupportedException {
-        return delegate.getParentLogger();
+        if (delegate != null) {
+            return delegate.getParentLogger();
+        }
+        throw new SQLFeatureNotSupportedException("getParentLogger not supported");
     }
 
     /**


### PR DESCRIPTION
When `ContainerDatabaseDriver` hasn't been used yet to connect, the `delegate` is `null`. This causes various JDBC metadata methods of the driver to fail with a `NullPointerException`. The change prevents this by providing reasonable defaults.

As an example, when org.testcontainers:jdbc is on the classpath, but hasn't been used yet, the following produces a `NullPointerException`:

```java
DriverManager.drivers()
    .forEach(driver -> System.out.printf("Driver: '%s', version: %d.%d%n", 
        driver.getClass().getName(), driver.getMajorVersion(), driver.getMinorVersion()));
```

```none
Exception in thread "main" java.lang.NullPointerException
	at org.testcontainers.jdbc.ContainerDatabaseDriver.getMajorVersion(ContainerDatabaseDriver.java:237)
	at nl.lawinegevaar.pg.DriverVersion.lambda$main$1(DriverVersion.java:39)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at nl.lawinegevaar.pg.DriverVersion.main(DriverVersion.java:39)
```

The interrogation of the `java.sql.Driver` metadata shouldn't produce a NPE.