### PR TITLE
Filter mapped ports when port numbers are not specified (replaces #3948)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -12,6 +12,7 @@ import lombok.SneakyThrows;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.utils.IOUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.DockerClientFactory;
@@ -181,7 +182,9 @@ public interface ContainerState {
             .map(PortBinding::getBinding)
             .map(Ports.Binding::getHostPortSpec)
             .filter(Objects::nonNull)
+            .filter(NumberUtils::isNumber)
             .map(Integer::valueOf)
+            .filter(port -> port.compareTo(0) > 0)
             .collect(Collectors.toList());
     }
 

--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -184,7 +184,7 @@ public interface ContainerState {
             .filter(Objects::nonNull)
             .filter(NumberUtils::isNumber)
             .map(Integer::valueOf)
-            .filter(port -> port.compareTo(0) > 0)
+            .filter(port -> port > 0)
             .collect(Collectors.toList());
     }
 

--- a/core/src/test/java/org/testcontainers/containers/ContainerStateTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ContainerStateTest.java
@@ -34,7 +34,7 @@ public class ContainerStateTest {
         testSet("80:8080/tcp");
         List<Integer> res = containerState.getBoundPortNumbers();
         assertEquals(null,1,res.size());
-        assertEquals(null,80, res.stream().findFirst().get());
+        assertEquals("regular mapping works",80, res.stream().findFirst().get());
     }
 
     @Test
@@ -42,20 +42,34 @@ public class ContainerStateTest {
         testSet("127.0.0.1:80:8080/tcp");
         List<Integer> res = containerState.getBoundPortNumbers();
         assertEquals(null,1,res.size());
-        assertEquals(null,80, res.stream().findFirst().get());
+        assertEquals("regular mapping with host works",80, res.stream().findFirst().get());
     }
 
     @Test
     public void testGetBoundPortNumbersFullExplicitZero() {
-        testSet("127.0.0.1:0:8080/tcp");
+        testSet(":0:8080/tcp");
         List<Integer> res = containerState.getBoundPortNumbers();
-        assertEquals(null,0,res.size());
+        assertEquals("zero port with host is ignored",0,res.size());
+    }
+
+    @Test
+    public void testGetBoundPortNumbersFullImplicitZero() {
+        testSet("0.0.0.0::8080/tcp");
+        List<Integer> res = containerState.getBoundPortNumbers();
+        assertEquals("missing port with host is ignored",0,res.size());
+    }
+
+    @Test
+    public void testGetBoundPortNumbersExplicitZero() {
+        testSet("0:8080/tcp");
+        List<Integer> res = containerState.getBoundPortNumbers();
+        assertEquals("zero port (synthetic case) is ignored",0,res.size());
     }
 
     @Test
     public void testGetBoundPortNumbersImplicitZero() {
         testSet(":8080/tcp");
         List<Integer> res = containerState.getBoundPortNumbers();
-        assertEquals(null,0,res.size());
+        assertEquals("missing port is ignored",0,res.size());
     }
 }

--- a/core/src/test/java/org/testcontainers/containers/ContainerStateTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ContainerStateTest.java
@@ -1,0 +1,61 @@
+package org.testcontainers.containers;
+
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.when;
+import static org.rnorth.visibleassertions.VisibleAssertions.*;
+
+public class ContainerStateTest {
+
+    @Mock
+    ContainerState containerState;
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        doCallRealMethod().when(containerState).getBoundPortNumbers();
+    }
+
+    void testSet(String... args) {
+        when(containerState.getPortBindings()).thenReturn(
+            Lists.list(args)
+        );
+    }
+
+    @Test
+    public void testGetBoundPortNumbers() {
+        testSet("80:8080/tcp");
+        List<Integer> res = containerState.getBoundPortNumbers();
+        assertEquals(null,1,res.size());
+        assertEquals(null,80, res.stream().findFirst().get());
+    }
+
+    @Test
+    public void testGetBoundPortNumbersFull() {
+        testSet("127.0.0.1:80:8080/tcp");
+        List<Integer> res = containerState.getBoundPortNumbers();
+        assertEquals(null,1,res.size());
+        assertEquals(null,80, res.stream().findFirst().get());
+    }
+
+    @Test
+    public void testGetBoundPortNumbersFullExplicitZero() {
+        testSet("127.0.0.1:0:8080/tcp");
+        List<Integer> res = containerState.getBoundPortNumbers();
+        assertEquals(null,0,res.size());
+    }
+
+    @Test
+    public void testGetBoundPortNumbersImplicitZero() {
+        testSet(":8080/tcp");
+        List<Integer> res = containerState.getBoundPortNumbers();
+        assertEquals(null,0,res.size());
+    }
+}


### PR DESCRIPTION
From @wrover's description:
> This fixes the issue which happens on some verisons of docker on some platforms (particulalrly, on macOS X) when port mapping comes in form of 0.0.0.0:0:80.

#3923 seems to be a direct occurrence of this problem, and we need to resolve quickly.