### PR TITLE
Pin localstack to 0.12.8

### DIFF
--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
@@ -1,30 +1,31 @@
 package org.testcontainers.containers.localstack;
 
+import com.github.dockerjava.api.DockerClient;
 import lombok.AllArgsConstructor;
-import lombok.SneakyThrows;
-import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.utility.DockerImageName;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Arrays;
-import java.util.function.Consumer;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertNotEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+import static org.testcontainers.containers.localstack.LocalstackTestImages.LOCALSTACK_0_10_IMAGE;
+import static org.testcontainers.containers.localstack.LocalstackTestImages.LOCALSTACK_0_11_IMAGE;
+import static org.testcontainers.containers.localstack.LocalstackTestImages.LOCALSTACK_0_12_IMAGE;
+import static org.testcontainers.containers.localstack.LocalstackTestImages.LOCALSTACK_0_7_IMAGE;
 import static org.testcontainers.containers.localstack.LocalstackTestImages.LOCALSTACK_IMAGE;
 
 @RunWith(Enclosed.class)
 public class LegacyModeTest {
+    private static DockerImageName LOCALSTACK_CUSTOM_TAG = LOCALSTACK_IMAGE.withTag("custom");
 
     @RunWith(Parameterized.class)
     @AllArgsConstructor
@@ -35,10 +36,9 @@ public class LegacyModeTest {
         @Parameterized.Parameters(name = "{0}")
         public static Iterable<Object[]> constructors() {
             return Arrays.asList(new Object[][]{
-                {"default constructor", new LocalStackContainer(LOCALSTACK_IMAGE)},
-                {"0.12.8", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.12.8"))},
-                {"0.11.1", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.11.1"))},
-                {"0.7.0 with legacy = off", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.7.0"), false)}
+                {"0.12", new LocalStackContainer(LOCALSTACK_0_12_IMAGE)},
+                {"0.11", new LocalStackContainer(LOCALSTACK_0_11_IMAGE)},
+                {"0.7 with legacy = off", new LocalStackContainer(LOCALSTACK_0_7_IMAGE, false)}
             });
         }
 
@@ -47,20 +47,19 @@ public class LegacyModeTest {
             localstack.withServices(S3, SQS);
             localstack.start();
 
-            assertTrue("A single port is exposed", localstack.getExposedPorts().size() == 1);
-            assertEquals(
-                "Endpoint overrides are different",
-                localstack.getEndpointOverride(S3).toString(),
-                localstack.getEndpointOverride(SQS).toString());
-            assertEquals(
-                "Endpoint configuration have different endpoints",
-                localstack.getEndpointConfiguration(S3).getServiceEndpoint(),
-                localstack.getEndpointConfiguration(SQS).getServiceEndpoint());
-        }
-
-        @After
-        public void cleanup() {
-            if (localstack != null) localstack.stop();
+            try {
+                assertTrue("A single port is exposed", localstack.getExposedPorts().size() == 1);
+                assertEquals(
+                    "Endpoint overrides are different",
+                    localstack.getEndpointOverride(S3).toString(),
+                    localstack.getEndpointOverride(SQS).toString());
+                assertEquals(
+                    "Endpoint configuration have different endpoints",
+                    localstack.getEndpointConfiguration(S3).getServiceEndpoint(),
+                    localstack.getEndpointConfiguration(SQS).getServiceEndpoint());
+            } finally {
+                localstack.stop();
+            }
         }
     }
 
@@ -72,16 +71,28 @@ public class LegacyModeTest {
 
         @BeforeClass
         public static void createCustomTag() {
-            run("docker pull localstack/localstack:0.12.8");
-            run("docker tag localstack/localstack:0.12.8 localstack/localstack:custom");
+            DockerClient dockerClient = DockerClientFactory.instance().client();
+            DockerClientFactory
+                .instance()
+                .checkAndPullImage(
+                    dockerClient,
+                    LOCALSTACK_0_12_IMAGE.asCanonicalNameString()
+                );
+            dockerClient
+                .tagImageCmd(
+                    LOCALSTACK_0_12_IMAGE.asCanonicalNameString(),
+                    LOCALSTACK_CUSTOM_TAG.getRepository(),
+                    LOCALSTACK_CUSTOM_TAG.getVersionPart()
+                )
+                .exec();
         }
 
         @Parameterized.Parameters(name = "{0}")
         public static Iterable<Object[]> constructors() {
             return Arrays.asList(new Object[][]{
-                {"0.10.7", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.10.7"))},
-                {"custom", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("custom"))},
-                {"0.11.1 with legacy = on", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.11.1"), true)}
+                {"0.10", new LocalStackContainer(LOCALSTACK_0_10_IMAGE)},
+                {"custom", new LocalStackContainer(LOCALSTACK_CUSTOM_TAG)},
+                {"0.11 with legacy = on", new LocalStackContainer(LOCALSTACK_0_11_IMAGE, true)}
             });
         }
 
@@ -90,39 +101,19 @@ public class LegacyModeTest {
             localstack.withServices(S3, SQS);
             localstack.start();
 
-            assertTrue("Multiple ports are exposed", localstack.getExposedPorts().size() > 1);
-            assertNotEquals(
-                "Endpoint overrides are different",
-                localstack.getEndpointOverride(S3).toString(),
-                localstack.getEndpointOverride(SQS).toString());
-            assertNotEquals(
-                "Endpoint configuration have different endpoints",
-                localstack.getEndpointConfiguration(S3).getServiceEndpoint(),
-                localstack.getEndpointConfiguration(SQS).getServiceEndpoint());
-        }
-
-        @After
-        public void cleanup() {
-            if (localstack != null) localstack.stop();
-        }
-    }
-
-    @SneakyThrows
-    private static void run(String command) {
-        Process process = Runtime.getRuntime().exec(command);
-        join(process.getInputStream(), System.out::println);
-        join(process.getErrorStream(), System.err::println);
-        process.waitFor();
-        if (process.exitValue() != 0)
-            throw new RuntimeException("Failed to execute " + command);
-    }
-
-    private static void join(InputStream stream, Consumer<String> logger) throws IOException {
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(stream));
-        String line;
-        while ((line = bufferedReader.readLine()) != null) {
-            logger.accept(line);
+            try {
+                assertTrue("Multiple ports are exposed", localstack.getExposedPorts().size() > 1);
+                assertNotEquals(
+                    "Endpoint overrides are different",
+                    localstack.getEndpointOverride(S3).toString(),
+                    localstack.getEndpointOverride(SQS).toString());
+                assertNotEquals(
+                    "Endpoint configuration have different endpoints",
+                    localstack.getEndpointConfiguration(S3).getServiceEndpoint(),
+                    localstack.getEndpointConfiguration(SQS).getServiceEndpoint());
+            } finally {
+                localstack.stop();
+            }
         }
     }
-
 }

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
@@ -36,7 +36,7 @@ public class LegacyModeTest {
         public static Iterable<Object[]> constructors() {
             return Arrays.asList(new Object[][]{
                 {"default constructor", new LocalStackContainer(LOCALSTACK_IMAGE)},
-                {"latest", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("latest"))},
+                {"0.12.8", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.12.8"))},
                 {"0.11.1", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.11.1"))},
                 {"0.7.0 with legacy = off", new LocalStackContainer(LOCALSTACK_IMAGE.withTag("0.7.0"), false)}
             });
@@ -72,8 +72,8 @@ public class LegacyModeTest {
 
         @BeforeClass
         public static void createCustomTag() {
-            run("docker pull localstack/localstack:latest");
-            run("docker tag localstack/localstack:latest localstack/localstack:custom");
+            run("docker pull localstack/localstack:0.12.8");
+            run("docker tag localstack/localstack:0.12.8 localstack/localstack:custom");
         }
 
         @Parameterized.Parameters(name = "{0}")

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
@@ -3,6 +3,10 @@ package org.testcontainers.containers.localstack;
 import org.testcontainers.utility.DockerImageName;
 
 public interface LocalstackTestImages {
-    DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:0.11.3");
+    DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:0.12.8");
+    DockerImageName LOCALSTACK_0_7_IMAGE = LOCALSTACK_IMAGE.withTag("0.7.0");
+    DockerImageName LOCALSTACK_0_10_IMAGE = LOCALSTACK_IMAGE.withTag("0.10.7");
+    DockerImageName LOCALSTACK_0_11_IMAGE = LOCALSTACK_IMAGE.withTag("0.11.3");
+    DockerImageName LOCALSTACK_0_12_IMAGE = LOCALSTACK_IMAGE.withTag("0.12.8");
     DockerImageName AWS_CLI_IMAGE = DockerImageName.parse("atlassian/pipelines-awscli:1.16.302");
 }


### PR DESCRIPTION
It seems that our build is afflicted by https://github.com/localstack/localstack/issues/3816
Localstack builds >=0.12.9 seem to have this issue, so pinning our test dependency to 0.12.8 for now.