### PR TITLE
Use up-to-date MySQL docker images

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -240,7 +240,7 @@ public abstract class DockerClientProviderStrategy {
         DefaultDockerClientConfig.Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder();
 
         if (configBuilder.build().getApiVersion() == RemoteApiVersion.UNKNOWN_VERSION) {
-            configBuilder.withApiVersion(RemoteApiVersion.VERSION_1_30);
+            configBuilder.withApiVersion(RemoteApiVersion.VERSION_1_40);
         }
         return DockerClientImpl.getInstance(
             new AuthDelegatingDockerClientConfig(

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -240,7 +240,7 @@ public abstract class DockerClientProviderStrategy {
         DefaultDockerClientConfig.Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder();
 
         if (configBuilder.build().getApiVersion() == RemoteApiVersion.UNKNOWN_VERSION) {
-            configBuilder.withApiVersion(RemoteApiVersion.VERSION_1_40);
+            configBuilder.withApiVersion(RemoteApiVersion.VERSION_1_30);
         }
         return DockerClientImpl.getInstance(
             new AuthDelegatingDockerClientConfig(

--- a/core/src/test/resources/compose-test.yml
+++ b/core/src/test/resources/compose-test.yml
@@ -1,6 +1,6 @@
 redis:
   image: redis
 db:
-  image: mysql:5.7.22
+  image: mysql:5.7.34
   environment:
     MYSQL_RANDOM_ROOT_PASSWORD: "true"

--- a/docs/examples/junit4/generic/src/test/java/generic/ImageNameSubstitutionTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ImageNameSubstitutionTest.java
@@ -12,9 +12,9 @@ public class ImageNameSubstitutionTest {
     public void simpleExample() {
         try (
             // directDockerHubReference {
-            // Referring directly to an image on Docker Hub (mysql:8.0.22)
+            // Referring directly to an image on Docker Hub (mysql:8.0.24)
             final MySQLContainer<?> mysql = new MySQLContainer<>(
-                DockerImageName.parse("mysql:8.0.22")
+                DockerImageName.parse("mysql:8.0.24")
             )
 
             // start the container and use it for testing
@@ -35,7 +35,7 @@ public class ImageNameSubstitutionTest {
             // hardcodedMirror {
             // Referring directly to an image on a private registry - image name will vary
             final MySQLContainer<?> mysql = new MySQLContainer<>(
-                DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.22")
+                DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.24")
                                .asCompatibleSubstituteFor("mysql")
             )
 

--- a/docs/examples/junit4/generic/src/test/java/generic/support/TestSpecificImageNameSubstitutor.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/support/TestSpecificImageNameSubstitutor.java
@@ -12,7 +12,7 @@ public class TestSpecificImageNameSubstitutor extends ImageNameSubstitutor {
 
     @Override
     public DockerImageName apply(final DockerImageName original) {
-        if (original.equals(DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.22"))) {
+        if (original.equals(DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.24"))) {
             return DockerImageName.parse("mysql");
         } else {
             return original;

--- a/docs/features/image_name_substitution.md
+++ b/docs/features/image_name_substitution.md
@@ -53,7 +53,7 @@ Consider this if:
 
 * Developers and CI machines need to use different image names. For example, developers are able to pull images from Docker Hub, but CI machines need to pull from a private registry
 * Your private registry has copies of images from Docker Hub where the names are predictable, and just adding a prefix is enough. 
-  For example, `registry.mycompany.com/mirror/mysql:8.0.22` can be derived from the original Docker Hub image name (`mysql:8.0.22`) with a consistent prefix string: `registry.mycompany.com/mirror/`
+  For example, `registry.mycompany.com/mirror/mysql:8.0.24` can be derived from the original Docker Hub image name (`mysql:8.0.22`) with a consistent prefix string: `registry.mycompany.com/mirror/`
 
 In this case, image name references in code are **unchanged**.
 i.e. you would leave as-is:

--- a/docs/features/image_name_substitution.md
+++ b/docs/features/image_name_substitution.md
@@ -53,7 +53,7 @@ Consider this if:
 
 * Developers and CI machines need to use different image names. For example, developers are able to pull images from Docker Hub, but CI machines need to pull from a private registry
 * Your private registry has copies of images from Docker Hub where the names are predictable, and just adding a prefix is enough. 
-  For example, `registry.mycompany.com/mirror/mysql:8.0.24` can be derived from the original Docker Hub image name (`mysql:8.0.22`) with a consistent prefix string: `registry.mycompany.com/mirror/`
+  For example, `registry.mycompany.com/mirror/mysql:8.0.24` can be derived from the original Docker Hub image name (`mysql:8.0.24`) with a consistent prefix string: `registry.mycompany.com/mirror/`
 
 In this case, image name references in code are **unchanged**.
 i.e. you would leave as-is:

--- a/docs/modules/databases/jdbc.md
+++ b/docs/modules/databases/jdbc.md
@@ -20,7 +20,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 !!! note
     We will use `///` (host-less URIs) from now on to emphasis the unimportance of the `host:port` pair.  
-    From Testcontainers' perspective, `jdbc:mysql:5.7.22://localhost:3306/databasename` and `jdbc:mysql:5.7.22:///databasename` is the same URI.
+    From Testcontainers' perspective, `jdbc:mysql:5.7.34://localhost:3306/databasename` and `jdbc:mysql:5.7.34:///databasename` is the same URI.
 
 !!! warning
     If you're using the JDBC URL support, there is no need to instantiate an instance of the container - Testcontainers will do it automagically.
@@ -29,7 +29,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 #### Using Testcontainers with a fixed version
 
-`jdbc:tc:mysql:5.6.23:///databasename`
+`jdbc:tc:mysql:5.7.34:///databasename`
 
 #### Using PostgreSQL
 
@@ -47,7 +47,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 Testcontainers can run an init script after the database container is started, but before your code is given a connection to it. The script must be on the classpath, and is referenced as follows:
 
-`jdbc:tc:mysql:5.7.22:///databasename?TC_INITSCRIPT=somepath/init_mysql.sql`
+`jdbc:tc:mysql:5.7.34:///databasename?TC_INITSCRIPT=somepath/init_mysql.sql`
 
 This is useful if you have a fixed script for setting up database schema, etc.
 
@@ -55,13 +55,13 @@ This is useful if you have a fixed script for setting up database schema, etc.
 
 If the init script path is prefixed `file:`, it will be loaded from a file (relative to the working directory, which will usually be the project root).
 
-`jdbc:tc:mysql:5.7.22:///databasename?TC_INITSCRIPT=file:src/main/resources/init_mysql.sql`
+`jdbc:tc:mysql:5.7.34:///databasename?TC_INITSCRIPT=file:src/main/resources/init_mysql.sql`
 
 ### Using an init function
 
 Instead of running a fixed script for DB setup, it may be useful to call a Java function that you define. This is intended to allow you to trigger database schema migration tools. To do this, add TC_INITFUNCTION to the URL as follows, passing a full path to the class name and method:
 
- `jdbc:tc:mysql:5.7.22:///databasename?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction`
+ `jdbc:tc:mysql:5.7.34:///databasename?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction`
 
 The init function must be a public static method which takes a `java.sql.Connection` as its only parameter, e.g.
 ```java
@@ -76,7 +76,7 @@ public class JDBCDriverTest {
 
 By default database container is being stopped as soon as last connection is closed. There are cases when you might need to start container and keep it running till you stop it explicitly or JVM is shutdown. To do this, add `TC_DAEMON` parameter to the URL as follows:
 
- `jdbc:tc:mysql:5.7.22:///databasename?TC_DAEMON=true`
+ `jdbc:tc:mysql:5.7.34:///databasename?TC_DAEMON=true`
 
 With this parameter database container will keep running even when there're no open connections.
 

--- a/docs/modules/databases/mysql.md
+++ b/docs/modules/databases/mysql.md
@@ -7,7 +7,7 @@ See [Database containers](./index.md) for documentation and usage that is common
 For MySQL databases, it is possible to override configuration settings using resources on the classpath. Assuming `somepath/mysql_conf_override`
 is a directory on the classpath containing .cnf files, the following URL can be used:
 
-  `jdbc:tc:mysql:5.6://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override`
+  `jdbc:tc:mysql:5.7.34://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override`
 
 Any .cnf files in this classpath directory will be mapped into the database container's /etc/mysql/conf.d directory,
 and will be able to override server settings when the container starts.

--- a/docs/modules/databases/r2dbc.md
+++ b/docs/modules/databases/r2dbc.md
@@ -22,7 +22,7 @@ The started container will be terminated when the `ConnectionFactory` is closed.
 **Note that, unlike Testcontainers' JDBC URL support, it is not possible to specify an image tag in the 'scheme' part of the URL, and it is always necessary to specify a tag using `TC_IMAGE_TAG`.**
 
 So that the URL becomes:  
-`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=5.7.22`
+`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=5.7.34`
 
 !!! note
     We will use `///` (host-less URIs) from now on to emphasis the unimportance of the `host:port` pair.  
@@ -35,7 +35,7 @@ So that the URL becomes:
 
 #### Using MySQL
 
-`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=5.6.23`
+`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=5.7.34`
 
 #### Using MariaDB
 

--- a/modules/jdbc-test/src/main/java/org/testcontainers/db/AbstractContainerDatabaseTest.java
+++ b/modules/jdbc-test/src/main/java/org/testcontainers/db/AbstractContainerDatabaseTest.java
@@ -27,7 +27,6 @@ public abstract class AbstractContainerDatabaseTest {
         hikariConfig.setUsername(container.getUsername());
         hikariConfig.setPassword(container.getPassword());
         hikariConfig.setDriverClassName(container.getDriverClassName());
-        hikariConfig.addDataSourceProperty("enabledTLSProtocols", "TLSv1,TLSv1.1,TLSv1.2");
         return new HikariDataSource(hikariConfig);
     }
 }

--- a/modules/jdbc-test/src/main/java/org/testcontainers/db/AbstractContainerDatabaseTest.java
+++ b/modules/jdbc-test/src/main/java/org/testcontainers/db/AbstractContainerDatabaseTest.java
@@ -27,7 +27,7 @@ public abstract class AbstractContainerDatabaseTest {
         hikariConfig.setUsername(container.getUsername());
         hikariConfig.setPassword(container.getPassword());
         hikariConfig.setDriverClassName(container.getDriverClassName());
-
+        hikariConfig.addDataSourceProperty("enabledTLSProtocols", "TLSv1,TLSv1.1,TLSv1.2");
         return new HikariDataSource(hikariConfig);
     }
 }

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -33,7 +33,7 @@ public class ConnectionUrlDriversTests {
     public static Iterable<Object[]> data() {
         return asList(
             new Object[][]{
-                {"jdbc:tc:mysql:5.5.43://hostname/test", "mysql", Optional.of("5.5.43"), "hostname/test", "test"},
+                {"jdbc:tc:mysql:5.7.34://hostname/test", "mysql", Optional.of("5.7.34"), "hostname/test", "test"},
                 {"jdbc:tc:mysql://hostname/test", "mysql", Optional.empty(), "hostname/test", "test"},
                 {"jdbc:tc:postgresql:1.2.3://hostname/test", "postgresql", Optional.of("1.2.3"), "hostname/test", "test"},
                 {"jdbc:tc:postgresql://hostname/test", "postgresql", Optional.empty(), "hostname/test", "test"},

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
@@ -16,11 +16,11 @@ public class ConnectionUrlTest {
 
     @Test
     public void testConnectionUrl1() {
-        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d";
+        String urlString = "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertEquals("Database Type value is as expected", "mysql", url.getDatabaseType());
-        assertEquals("Database Image tag value is as expected", "5.6.23", url.getImageTag().get());
+        assertEquals("Database Image tag value is as expected", "5.7.34", url.getImageTag().get());
         assertEquals("Database Host String is as expected", "somehostname:3306/databasename", url.getDbHostString());
         assertEquals("Query String value is as expected", "?a=b&c=d", url.getQueryString().get());
         assertEquals("Database Host value is as expected", "somehostname", url.getDatabaseHost().get());
@@ -72,7 +72,7 @@ public class ConnectionUrlTest {
 
     @Test
     public void testInitScriptPathCapture() {
-        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
+        String urlString = "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertEquals("Database Type value is as expected", "somepath/init_mysql.sql", url.getInitScriptPath().get());
@@ -88,7 +88,7 @@ public class ConnectionUrlTest {
 
     @Test
     public void testInitFunctionCapture() {
-        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
+        String urlString = "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertTrue("Init Function parameter exists", url.getInitFunction().isPresent());
@@ -100,7 +100,7 @@ public class ConnectionUrlTest {
 
     @Test
     public void testDaemonCapture() {
-        String urlString = "jdbc:tc:mysql:5.6.23://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
+        String urlString = "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertTrue("Daemon flag is set to true.", url.isInDaemonMode());

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/MissingJdbcDriverTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/MissingJdbcDriverTest.java
@@ -40,7 +40,7 @@ public class MissingJdbcDriverTest {
         private final AtomicInteger connectionAttempts = new AtomicInteger();
 
         MissingDriverContainer() {
-            super(DockerImageName.parse("mysql:5.7.22"));
+            super(DockerImageName.parse("mysql:5.7.34"));
             withEnv("MYSQL_ROOT_PASSWORD", "test");
             withExposedPorts(3306);
         }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testCompile 'mysql:mysql-connector-java:8.0.22'
 
     testCompile testFixtures(project(':r2dbc'))
-    testCompile 'dev.miku:r2dbc-mysql:0.8.1.RELEASE'
+    testCompile 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     compileOnly 'org.jetbrains:annotations:20.1.0'
 }

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -16,7 +16,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mysql");
 
     @Deprecated
-    public static final String DEFAULT_TAG = "5.7.22";
+    public static final String DEFAULT_TAG = "5.7.34";
 
     @Deprecated
     public static final String IMAGE = DEFAULT_IMAGE_NAME.getUnversionedPart();

--- a/modules/mysql/src/test/java/org/testcontainers/MySQLTestImages.java
+++ b/modules/mysql/src/test/java/org/testcontainers/MySQLTestImages.java
@@ -3,7 +3,7 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public class MySQLTestImages {
-    public static final DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:5.7.22");
-    public static final DockerImageName MYSQL_55_IMAGE = DockerImageName.parse("mysql:5.5");
-    public static final DockerImageName MYSQL_56_IMAGE = DockerImageName.parse("mysql:5.6");
+    public static final DockerImageName MYSQL_56_IMAGE = DockerImageName.parse("mysql:5.6.51");
+    public static final DockerImageName MYSQL_57_IMAGE = DockerImageName.parse("mysql:5.7.34");
+    public static final DockerImageName MYSQL_80_IMAGE = DockerImageName.parse("mysql:8.0.24");
 }

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerTest.java
@@ -13,12 +13,12 @@ public class MySQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContai
 
     @Override
     protected String createR2DBCUrl() {
-        return "r2dbc:tc:mysql:///db?TC_IMAGE_TAG=" + MySQLTestImages.MYSQL_57_IMAGE.getVersionPart();
+        return "r2dbc:tc:mysql:///db?TC_IMAGE_TAG=" + MySQLTestImages.MYSQL_80_IMAGE.getVersionPart();
     }
 
     @Override
     protected MySQLContainer<?> createContainer() {
-        return new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE);
+        return new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE);
     }
 
 }

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerTest.java
@@ -13,12 +13,12 @@ public class MySQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContai
 
     @Override
     protected String createR2DBCUrl() {
-        return "r2dbc:tc:mysql:///db?TC_IMAGE_TAG=5.7.22";
+        return "r2dbc:tc:mysql:///db?TC_IMAGE_TAG=" + MySQLTestImages.MYSQL_57_IMAGE.getVersionPart();
     }
 
     @Override
     protected MySQLContainer<?> createContainer() {
-        return new MySQLContainer<>(MySQLTestImages.MYSQL_IMAGE);
+        return new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE);
     }
 
 }

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
@@ -4,7 +4,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.testcontainers.MySQLTestImages;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -15,15 +17,15 @@ import java.sql.SQLException;
 public class MySQLRootAccountTest {
 
     @Parameterized.Parameters(name = "{0}")
-    public static String[] params() {
-        return new String[]{
-            "mysql:8",
-            "mysql:5"
+    public static DockerImageName[] params() {
+        return new DockerImageName[]{
+            MySQLTestImages.MYSQL_80_IMAGE,
+            MySQLTestImages.MYSQL_57_IMAGE
         };
     }
 
     @Parameterized.Parameter()
-    public String image;
+    public DockerImageName image;
 
     @Test
     public void testRootAccountUsageWithDefaultPassword() throws SQLException {

--- a/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/JDBCDriverWithPoolTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/JDBCDriverWithPoolTest.java
@@ -31,7 +31,7 @@ import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 @RunWith(Parameterized.class)
 public class JDBCDriverWithPoolTest {
 
-    public static final String URL = "jdbc:tc:mysql:5://hostname/databasename?TC_INITFUNCTION=org.testcontainers.jdbc.mysql.JDBCDriverWithPoolTest::sampleInitFunction";
+    public static final String URL = "jdbc:tc:mysql:5.7.34://hostname/databasename?TC_INITFUNCTION=org.testcontainers.jdbc.mysql.JDBCDriverWithPoolTest::sampleInitFunction";
     private final DataSource dataSource;
 
     @Parameterized.Parameters

--- a/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/MySQLJDBCDriverTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/MySQLJDBCDriverTest.java
@@ -17,14 +17,14 @@ public class MySQLJDBCDriverTest extends AbstractJDBCDriverTest {
             new Object[][]{
                 {"jdbc:tc:mysql://hostname/databasename", EnumSet.noneOf(Options.class)},
                 {"jdbc:tc:mysql://hostname/databasename?user=someuser&TC_INITSCRIPT=somepath/init_mysql.sql", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
-                {"jdbc:tc:mysql:5.5.43://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
-                {"jdbc:tc:mysql:5.5.43://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mysql.sql", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
-                {"jdbc:tc:mysql:5.5.43://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=file:sql/init_mysql.sql", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
-                {"jdbc:tc:mysql:5.5.43://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
-                {"jdbc:tc:mysql:5.5.43://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mysql.sql&useUnicode=yes&characterEncoding=utf8", EnumSet.of(Options.CharacterSet)},
-                {"jdbc:tc:mysql:5.5.43://hostname/databasename", EnumSet.noneOf(Options.class)},
-                {"jdbc:tc:mysql:5.5.43://hostname/databasename?useSSL=false", EnumSet.noneOf(Options.class)},
-                {"jdbc:tc:mysql:5.6://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override", EnumSet.of(Options.CustomIniFile)},
+                {"jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
+                {"jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mysql.sql", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
+                {"jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=file:sql/init_mysql.sql", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
+                {"jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction", EnumSet.of(Options.ScriptedSchema, Options.JDBCParams)},
+                {"jdbc:tc:mysql:5.7.34://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mysql.sql&useUnicode=yes&characterEncoding=utf8", EnumSet.of(Options.CharacterSet)},
+                {"jdbc:tc:mysql:5.7.34://hostname/databasename", EnumSet.noneOf(Options.class)},
+                {"jdbc:tc:mysql:5.7.34://hostname/databasename?useSSL=false", EnumSet.noneOf(Options.class)},
+                {"jdbc:tc:mysql:5.6.51://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override", EnumSet.of(Options.CustomIniFile)},
             });
     }
 }

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
@@ -18,7 +18,7 @@ public class CustomizableMysqlTest extends AbstractContainerDatabaseTest {
     @Test
     public void testSimple() throws SQLException {
         // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
-        try (MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_IMAGE)
+        try (MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
             .withDatabaseName(DB_NAME)
             .withUsername(USER)
             .withPassword(PWD)

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
@@ -3,7 +3,6 @@ package org.testcontainers.junit.mysql;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.testcontainers.MySQLTestImages;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 import org.testcontainers.utility.DockerImageName;
@@ -12,32 +11,33 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
+import static org.testcontainers.MySQLTestImages.MYSQL_56_IMAGE;
+import static org.testcontainers.MySQLTestImages.MYSQL_57_IMAGE;
+import static org.testcontainers.MySQLTestImages.MYSQL_80_IMAGE;
 
 @RunWith(Parameterized.class)
 public class MultiVersionMySQLTest extends AbstractContainerDatabaseTest {
 
     @Parameterized.Parameters(name = "{0}")
-    public static String[] params() {
-        return new String[]{"5.5.62", "5.6.42", "5.7.26", "8.0.16"};
+    public static DockerImageName[] params() {
+        return new DockerImageName[]{
+            MYSQL_56_IMAGE,
+            MYSQL_57_IMAGE,
+            MYSQL_80_IMAGE
+        };
     }
 
-    private final String version;
-
-    public MultiVersionMySQLTest(String version) {
-        this.version = version;
-    }
+    @Parameterized.Parameter()
+    public DockerImageName dockerImageName;
 
     @Test
     public void versionCheckTest() throws SQLException {
-
-        final DockerImageName dockerImageName = MySQLTestImages.MYSQL_IMAGE.withTag(version);
-
         try (MySQLContainer<?> mysql = new MySQLContainer<>(dockerImageName)) {
             mysql.start();
             final ResultSet resultSet = performQuery(mysql, "SELECT VERSION()");
             final String resultSetString = resultSet.getString(1);
 
-            assertEquals("The database version can be set using a container rule parameter", version, resultSetString);
+            assertEquals("The database version can be set using a container rule parameter", dockerImageName.getVersionPart(), resultSetString);
         }
     }
 }

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
@@ -24,9 +24,8 @@ import static org.junit.Assume.assumeFalse;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 import static org.rnorth.visibleassertions.VisibleAssertions.fail;
-import static org.testcontainers.MySQLTestImages.MYSQL_55_IMAGE;
 import static org.testcontainers.MySQLTestImages.MYSQL_56_IMAGE;
-import static org.testcontainers.MySQLTestImages.MYSQL_IMAGE;
+import static org.testcontainers.MySQLTestImages.MYSQL_57_IMAGE;
 
 
 public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
@@ -52,7 +51,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
-        try (MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_IMAGE)
+        try (MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
             .withConfigurationOverride("somepath/mysql_conf_override")
             .withLogConsumer(new Slf4jLogConsumer(logger))) {
 
@@ -67,7 +66,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSpecificVersion() throws SQLException {
-        try (MySQLContainer<?> mysqlOldVersion = new MySQLContainer<>(MYSQL_55_IMAGE)
+        try (MySQLContainer<?> mysqlOldVersion = new MySQLContainer<>(MYSQL_56_IMAGE)
             .withConfigurationOverride("somepath/mysql_conf_override")
             .withLogConsumer(new Slf4jLogConsumer(logger))) {
 
@@ -76,7 +75,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
             ResultSet resultSet = performQuery(mysqlOldVersion, "SELECT VERSION()");
             String resultSetString = resultSet.getString(1);
 
-            assertTrue("The database version can be set using a container rule parameter", resultSetString.startsWith("5.5"));
+            assertTrue("The database version can be set using a container rule parameter", resultSetString.startsWith("5.6"));
         }
     }
 
@@ -98,7 +97,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testCommandOverride() throws SQLException {
-        try (MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MYSQL_IMAGE)
+        try (MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MYSQL_57_IMAGE)
             .withCommand("mysqld --auto_increment_increment=42")) {
 
             mysqlCustomConfig.start();
@@ -112,7 +111,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testExplicitInitScript() throws SQLException {
-        try (MySQLContainer<?> container = new MySQLContainer<>(MYSQL_IMAGE)
+        try (MySQLContainer<?> container = new MySQLContainer<>(MYSQL_57_IMAGE)
             .withInitScript("somepath/init_mysql.sql")
             .withLogConsumer(new Slf4jLogConsumer(logger))) {
             container.start();
@@ -126,7 +125,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test(expected = ContainerLaunchException.class)
     public void testEmptyPasswordWithNonRootUser() {
-        try (MySQLContainer<?> container = new MySQLContainer<>(MYSQL_55_IMAGE)
+        try (MySQLContainer<?> container = new MySQLContainer<>(MYSQL_56_IMAGE)
                     .withDatabaseName("TEST")
                     .withUsername("test")
                     .withPassword("")
@@ -139,7 +138,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     @Test
     public void testEmptyPasswordWithRootUser() throws SQLException {
         // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
-        try (MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_55_IMAGE)
+        try (MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_56_IMAGE)
             .withDatabaseName("foo")
             .withUsername("root")
             .withPassword("")
@@ -156,7 +155,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamTimeZone() throws SQLException {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_IMAGE)
+        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
             .withUrlParam("serverTimezone", "Europe/Zurich")
             .withEnv("TZ", "Europe/Zurich")
             .withLogConsumer(new Slf4jLogConsumer(logger));
@@ -186,7 +185,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamMultiQueries() throws SQLException {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_IMAGE)
+        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
             .withUrlParam("allowMultiQueries", "true")
             .withLogConsumer(new Slf4jLogConsumer(logger));
         mysql.start();
@@ -210,7 +209,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamInJdbcUrl() {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_IMAGE)
+        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
             .withUrlParam("allowMultiQueries", "true")
             .withUrlParam("rewriteBatchedStatements", "true")
             .withLogConsumer(new Slf4jLogConsumer(logger));

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
@@ -3,7 +3,7 @@ package org.testcontainers.spock
 import org.testcontainers.utility.DockerImageName
 
 interface SpockTestImages {
-    DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:5.7.22")
+    DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:5.7.34")
     DockerImageName POSTGRES_TEST_IMAGE = DockerImageName.parse("postgres:9.6.12")
     DockerImageName HTTPD_IMAGE = DockerImageName.parse("httpd:2.4-alpine")
     DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.5")


### PR DESCRIPTION
Fixes #4058

Latest versions of JDKs (including `adopt@1.11.0-11`) have disabled TLS1.0 and 1.1, which means that these JDKs can no longer use particularly old versions of the MySQL docker images. This PR makes Testcontainers' own tests use the most up-to-date images available (for each version of MySQL in use).

The PR also updates the 'default' MySQL tag, since the previous version can no longer be used reliably.