### PR TITLE
Add support for adding and dropping linux capabilities to/from containers.

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -2,6 +2,7 @@ package org.testcontainers.containers;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Capability;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
@@ -317,6 +318,20 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @return this
      */
     SELF withPrivilegedMode(boolean mode);
+
+    /**
+     * Add linux capabilities to the container.
+     * @param capabilities an array of capabilities
+     * @return this
+     */
+    SELF withCapabilitiesAdded(Capability... capabilities);
+
+    /**
+     * Drop linux capabilities from the container.
+     * @param capabilities an array of capabilities
+     * @return this
+     */
+    SELF withCapabilitiesDropped(Capability... capabilities);
 
     /**
      * Only consider a container to have successfully started if it has been running for this duration. The default

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -11,6 +11,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
@@ -155,6 +156,12 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     private List<Bind> binds = new ArrayList<>();
 
     private boolean privilegedMode;
+
+    @NonNull
+    private Set<Capability> capabilitiesAdded = new LinkedHashSet<>();
+
+    @NonNull
+    private Set<Capability> capabilitiesDropped = new LinkedHashSet<>();
 
     @NonNull
     private List<VolumesFrom> volumesFroms = new ArrayList<>();
@@ -824,6 +831,14 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             createCommand.withPrivileged(privilegedMode);
         }
 
+        Capability[] capabilitiesAddedArray = capabilitiesAdded.stream()
+                .toArray(Capability[]::new);
+        hostConfig.withCapAdd(capabilitiesAddedArray);
+
+        Capability[] capabilitiesDroppedArray = capabilitiesDropped.stream()
+                .toArray(Capability[]::new);
+        hostConfig.withCapDrop(capabilitiesDroppedArray);
+
         createContainerCmdModifiers.forEach(hook -> hook.accept(createCommand));
 
         Map<String, String> combinedLabels = new HashMap<>();
@@ -1216,6 +1231,24 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withPrivilegedMode(boolean mode) {
         this.privilegedMode = mode;
+        return self();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SELF withCapabilitiesAdded(Capability... capabilities) {
+        Collections.addAll(capabilitiesAdded, capabilities);
+        return self();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SELF withCapabilitiesDropped(Capability... capabilities) {
+        Collections.addAll(capabilitiesDropped, capabilities);
         return self();
     }
 

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -1,5 +1,6 @@
 package org.testcontainers.junit;
 
+import com.github.dockerjava.api.model.Capability;
 import com.github.dockerjava.api.model.HostConfig;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -45,6 +46,7 @@ import java.util.regex.Pattern;
 
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertFalse;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertThat;
@@ -243,6 +245,34 @@ public class GenericContainerRuleTest {
         String line = getReaderForContainerPort80(alpineEnvVarFromMap).readLine();
 
         assertEquals("Environment variables can be passed into a command from a map", "42 and 50", line);
+    }
+
+    @Test
+    public void capabilitiesAddedTest() {
+        try (final GenericContainer alpineCapabilitiesAdded = new GenericContainer<>(ALPINE_IMAGE)
+            .withCapabilitiesAdded(Capability.SYSLOG)
+            .withCommand("top")) {
+
+            alpineCapabilitiesAdded.start();
+
+            Capability[] capabilitiesAdded = alpineCapabilitiesAdded.getCurrentContainerInfo()
+                    .getHostConfig().getCapAdd();
+            assertArrayEquals(new Capability[]{Capability.SYSLOG}, capabilitiesAdded);
+        }
+    }
+
+    @Test
+    public void capabilitiesDroppedTest() {
+        try (final GenericContainer alpineCapabilitiesDropped = new GenericContainer<>(ALPINE_IMAGE)
+            .withCapabilitiesDropped(Capability.SYSLOG)
+            .withCommand("top")) {
+
+            alpineCapabilitiesDropped.start();
+
+            Capability[] capabilitiesDropped = alpineCapabilitiesDropped.getCurrentContainerInfo()
+                    .getHostConfig().getCapDrop();
+            assertArrayEquals(new Capability[]{Capability.SYSLOG}, capabilitiesDropped);
+        }
     }
 
     @Test


### PR DESCRIPTION
Creating containers with adjusted capabilities is a more secure alternative to using privileged mode.
I have a use case that forces me to use privileged mode instead of just adding one missing capability.
I feel testcontainers should support capabilities.

I placed the new code below the privileged mode pieces because they are functionally related.
In implementig, I followed #725, which added support for container labels.