### PR TITLE
Only run update-* and release-drafter on original repository, not on forks

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   update_release_draft:
+    if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4 # v5.15.0

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
     build:
+        if: github.repository == 'testcontainers/testcontainers-java'
         runs-on: ubuntu-18.04
         steps:
             -   uses: actions/checkout@v2

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update-gradle-wrapper:
+    if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I think these jobs don't make much sense to run on forks, so to avoid unnecessary errors (as I received recently due to the Gradle Wrapper update), and save GitHub some money 😉, this change will make them only run on testcontainers/testcontainers-java