### PR TITLE
Added publishAllPorts option

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -319,6 +319,13 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     SELF withPrivilegedMode(boolean mode);
 
     /**
+     * Set publishAllPorts for the container
+     * @param publishAllPorts boolean
+     * @return this
+     */
+    SELF withPublishAllPorts(boolean publishAllPorts);
+
+    /**
      * Only consider a container to have successfully started if it has been running for this duration. The default
      * value is null; if that's the value, ignore this check.
      *

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -153,6 +153,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @NonNull
     private List<Bind> binds = new ArrayList<>();
 
+    private boolean publishAllPorts = true;
+
     private boolean privilegedMode;
 
     @NonNull
@@ -798,7 +800,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             createCommand.withNetworkMode(networkForLinks.get());
         }
 
-        createCommand.withPublishAllPorts(true);
+        createCommand.withPublishAllPorts(publishAllPorts);
 
         PortForwardingContainer.INSTANCE.getNetwork().ifPresent(it -> {
             withExtraHost(INTERNAL_HOST_HOSTNAME, it.getIpAddress());
@@ -1215,6 +1217,12 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withPrivilegedMode(boolean mode) {
         this.privilegedMode = mode;
+        return self();
+    }
+
+    @Override
+    public SELF withPublishAllPorts(boolean publishAllPorts) {
+        this.publishAllPorts = publishAllPorts;
         return self();
     }
 


### PR DESCRIPTION
This PR adds a `withPublishAllPorts` method. In testcontainers-java 1.15.3, `publishAllPorts` is hard-coded to true which is an issue for some images like `redislabs/redis` where the very high number of exposed ports make testcontainers hang.