### PR TITLE
Added ability to add platform override or retry in configuration

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -331,7 +331,9 @@ public class DockerClientFactory {
         try {
             client.inspectImageCmd(image).exec();
         } catch (NotFoundException e) {
-            client.pullImageCmd(image).exec(new TimeLimitedLoggedPullImageResultCallback(log)).awaitCompletion();
+            client.pullImageCmd(image)
+                .withPlatform(TestcontainersConfiguration.getInstance().getPlatformOverride()) // Null value is fine
+                .exec(new TimeLimitedLoggedPullImageResultCallback(log)).awaitCompletion();
         }
     }
 

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -240,7 +240,7 @@ public abstract class DockerClientProviderStrategy {
         DefaultDockerClientConfig.Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder();
 
         if (configBuilder.build().getApiVersion() == RemoteApiVersion.UNKNOWN_VERSION) {
-            configBuilder.withApiVersion(RemoteApiVersion.VERSION_1_30);
+            configBuilder.withApiVersion(RemoteApiVersion.VERSION_1_34);
         }
         return DockerClientImpl.getInstance(
             new AuthDelegatingDockerClientConfig(

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -347,4 +347,12 @@ public class TestcontainersConfiguration {
         }
         return original;
     }
+
+    public String getPlatformRetry() {
+        return getEnvVarOrProperty("platform.retry", null);
+    }
+
+    public String getPlatformOverride() {
+        return getEnvVarOrProperty("platform.override", null);
+    }
 }


### PR DESCRIPTION
Added ability to add platform override or retry in configuration. 

This is useful for M1 Silicon Mac to automatically fetch images where Arm platform variants are not available and linux/amd64 ones would work under emulation.