### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:30.1-jre'
+        classpath 'com.google.guava:guava:30.1.1-jre'
     }
 }
 

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.json:json:20210307'
-    testImplementation 'org.postgresql:postgresql:42.2.18'
+    testImplementation 'org.postgresql:postgresql:42.2.20'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/mongodb-container/build.gradle
+++ b/examples/mongodb-container/build.gradle
@@ -9,5 +9,5 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testCompileClasspath 'org.jetbrains:annotations:20.1.0'
+    testCompileClasspath 'org.jetbrains:annotations:21.0.1'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'redis.clients:jedis:3.4.0'
+    implementation 'redis.clients:jedis:3.6.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'redis.clients:jedis:3.4.0'
+    implementation 'redis.clients:jedis:3.6.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:3.4.0'
+    implementation 'redis.clients:jedis:3.6.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.30'

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':jdbc')
     compile project(':test-support')
 
-    compile 'com.google.guava:guava:30.1-jre'
+    compile 'com.google.guava:guava:30.1.1-jre'
     compile 'org.apache.commons:commons-lang3:3.12.0'
     compile 'com.zaxxer:HikariCP-java6:2.3.13'
     compile 'commons-dbutils:commons-dbutils:1.7'

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     compile project(':testcontainers')
 
     testCompile 'org.apache.kafka:kafka-clients:2.8.0'
-    testCompile 'org.assertj:assertj-core:3.18.1'
+    testCompile 'org.assertj:assertj-core:3.19.0'
     testCompile 'com.google.guava:guava:23.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     compile project(':testcontainers')
 
     testCompile group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.2'
-    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.18.1'
+    testCompile group: 'org.assertj', name: 'assertj-core', version: '3.19.0'
     testCompile group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.2'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump annotations from 20.1.0 to 21.0.1 in /examples (#4141) @dependabot
* Bump postgresql from 42.2.18 to 42.2.20 in /examples (#4114) @dependabot
* Bump jedis from 3.4.0 to 3.6.0 in /examples (#4031) @dependabot
* Bump guava from 30.1-jre to 30.1.1-jre in /modules/jdbc-test (#3911) @dependabot
* Bump guava from 30.1-jre to 30.1.1-jre in /core (#3908) @dependabot
* Bump assertj-core from 3.18.1 to 3.19.0 in /modules/kafka (#3720) @dependabot
* Bump assertj-core from 3.18.1 to 3.19.0 in /modules/pulsar (#3718) @dependabot
