### PR TITLE
Fixed NPE

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -130,6 +130,10 @@ public class MountableFile implements Transferable {
         classLoadersToSearch.add(MountableFile.class.getClassLoader());
 
         for (final ClassLoader classLoader : classLoadersToSearch) {
+            if (classLoader == null) {
+                continue;
+            }
+
             URL resource = classLoader.getResource(resourcePath);
             if (resource != null) {
                 return resource;


### PR DESCRIPTION
Class loaders can be null.

In my case context class loader was `null`.