### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:30.1-jre'
+        classpath 'com.google.guava:guava:30.1.1-jre'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -127,7 +127,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep:3.2.8'
 
-    shaded "org.yaml:snakeyaml:1.27"
+    shaded "org.yaml:snakeyaml:1.29"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -101,8 +101,8 @@ dependencies {
 
     api 'junit:junit:4.12'
     api 'org.slf4j:slf4j-api:1.7.30'
-    compileOnly 'org.jetbrains:annotations:20.1.0'
-    testCompileClasspath 'org.jetbrains:annotations:20.0.0'
+    compileOnly 'org.jetbrains:annotations:21.0.1'
+    testCompileClasspath 'org.jetbrains:annotations:21.0.1'
     api 'org.apache.commons:commons-compress:1.20'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -137,7 +137,7 @@ dependencies {
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:3.6.0'
-    testImplementation 'com.rabbitmq:amqp-client:5.9.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.7'
 
     testImplementation ('org.mockito:mockito-core:3.10.0') {

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.20"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.10"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:2.3.1'
+    testImplementation 'org.apache.kafka:kafka-clients:2.8.0'
     testImplementation 'org.assertj:assertj-core:3.14.0'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'org.slf4j:slf4j-simple:1.7.30'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.json:json:20210307'
-    testImplementation 'org.postgresql:postgresql:42.2.18'
+    testImplementation 'org.postgresql:postgresql:42.2.20'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/mongodb-container/build.gradle
+++ b/examples/mongodb-container/build.gradle
@@ -9,5 +9,5 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testCompileClasspath 'org.jetbrains:annotations:20.1.0'
+    testCompileClasspath 'org.jetbrains:annotations:21.0.1'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'redis.clients:jedis:3.4.0'
+    implementation 'redis.clients:jedis:3.6.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'redis.clients:jedis:3.4.0'
+    implementation 'redis.clients:jedis:3.6.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:3.4.0'
+    implementation 'redis.clients:jedis:3.6.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.30'

--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -5,5 +5,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'ru.yandex.clickhouse:clickhouse-jdbc:0.2.4'
+    testImplementation 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.1-patch'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.13.0"
-    testImplementation "org.elasticsearch.client:transport:7.12.1"
+    testImplementation "org.elasticsearch.client:transport:7.13.1"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:9.0.40'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.6'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.25'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(':jdbc')
     api project(':test-support')
 
-    api 'com.google.guava:guava:30.1-jre'
+    api 'com.google.guava:guava:30.1.1-jre'
     api 'org.apache.commons:commons-lang3:3.12.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.7'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.18.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.20'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    api 'org.junit.jupiter:junit-jupiter-api:5.7.1'
+    api 'org.junit.jupiter:junit-jupiter-api:5.7.2'
 
     testImplementation project(':mysql')
     testImplementation project(':postgresql')

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.1'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.11.807'
-    testImplementation 'software.amazon.awssdk:s3:2.16.62'
+    testImplementation 'software.amazon.awssdk:s3:2.16.80'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.2.18'
+    testImplementation 'org.postgresql:postgresql:42.2.20'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.2.18'
+    testRuntimeOnly 'org.postgresql:postgresql:42.2.20'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'
 
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -6,7 +6,7 @@ description = "Testcontainers :: Spock-Extension"
 
 dependencies {
     api project(':testcontainers')
-    api 'org.spockframework:spock-core:1.3-groovy-2.5'
+    api 'org.spockframework:spock-core:2.0-groovy-3.0'
 
     testImplementation project(':selenium')
     testImplementation project(':mysql')


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump clickhouse-jdbc from 0.2.4 to 0.3.1-patch in /modules/clickhouse (#4190) @dependabot
* Bump snakeyaml from 1.27 to 1.29 in /core (#4188) @dependabot
* Bump s3 from 2.16.62 to 2.16.80 in /modules/localstack (#4186) @dependabot
* Bump transport from 7.12.1 to 7.13.1 in /modules/elasticsearch (#4184) @dependabot
* Bump annotations from 20.1.0 to 21.0.1 in /core (#4156) @dependabot
* Bump junit-jupiter-params from 5.7.1 to 5.7.2 in /modules/junit-jupiter (#4154) @dependabot
* Bump junit-jupiter-api from 5.7.1 to 5.7.2 in /modules/junit-jupiter (#4153) @dependabot
* Bump spock-core from 1.3-groovy-2.5 to 2.0-groovy-3.0 in /modules/spock (#4152) @dependabot
* Bump annotations from 20.1.0 to 21.0.1 in /examples (#4141) @dependabot
* Bump postgresql from 42.2.18 to 42.2.20 in /examples (#4114) @dependabot
* Bump tomcat-jdbc from 9.0.40 to 10.0.6 in /modules/jdbc-test (#4084) @dependabot
* Bump jedis from 3.4.0 to 3.6.0 in /examples (#4031) @dependabot
* Bump postgresql from 42.2.18 to 42.2.20 in /modules/spock (#4021) @dependabot
* Bump kafka-clients from 2.3.1 to 2.8.0 in /examples (#4022) @dependabot
* Bump postgresql from 42.2.18 to 42.2.20 in /modules/postgresql (#4015) @dependabot
* Bump amqp-client from 5.9.0 to 5.12.0 in /core (#3992) @dependabot
* Bump guava from 30.1-jre to 30.1.1-jre in /modules/jdbc-test (#3911) @dependabot
* Bump guava from 30.1-jre to 30.1.1-jre in /core (#3908) @dependabot
* Bump assertj-core from 3.14.0 to 3.19.0 in /examples (#3765) @dependabot
