### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -147,7 +147,7 @@ dependencies {
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
-    testImplementation 'org.assertj:assertj-core:3.18.1'
+    testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation project(':test-support')
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.10"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:2.8.0'
-    testImplementation 'org.assertj:assertj-core:3.14.0'
+    testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 }

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.4.1'
+    id 'org.springframework.boot' version '2.5.0'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.4.1"
+    id("org.springframework.boot") version "2.5.0"
     id("org.jetbrains.kotlin.jvm") version "1.5.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.5.10"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.4.1'
+    id 'org.springframework.boot' version '2.5.0'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:3.10.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.18.1'
+    testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.20'

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:2.8.0'
-    testImplementation 'org.assertj:assertj-core:3.18.1'
+    testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.2'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.18.1'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.19.0'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.2'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump org.springframework.boot from 2.4.1 to 2.5.0 in /examples (#4123) @dependabot
* Bump assertj-core from 3.14.0 to 3.19.0 in /examples (#3765) @dependabot
* Bump assertj-core from 3.18.1 to 3.19.0 in /modules/junit-jupiter (#3729) @dependabot
* Bump assertj-core from 3.18.1 to 3.19.0 in /core (#3727) @dependabot
* Bump assertj-core from 3.18.1 to 3.19.0 in /modules/kafka (#3720) @dependabot
* Bump assertj-core from 3.18.1 to 3.19.0 in /modules/pulsar (#3718) @dependabot
