### PR TITLE
Pulsar: update to Pulsar 2.8.0, with support for transactions

### DIFF
--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -15,7 +15,7 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("apachepulsar/pulsar");
     @Deprecated
-    private static final String DEFAULT_TAG = "2.2.0";
+    private static final String DEFAULT_TAG = "2.8.0";
 
     private boolean functionsWorkerEnabled = false;
 


### PR DESCRIPTION
Change default Pulsar version to 2.8.0, as 2.2.0 is very old.