### PR TITLE
Added the ability to specify multiple init scripts for the CassandraContainer.

### DIFF
--- a/modules/cassandra/src/test/resources/initial_2.cql
+++ b/modules/cassandra/src/test/resources/initial_2.cql
@@ -1,0 +1,3 @@
+USE keySpaceTest;
+
+INSERT INTO catalog_category (id, name) VALUES (2, 'test_category_2');


### PR DESCRIPTION
Currently, the CassandraContainer allows you to specify only one file containing the initialization script. I added the ability to specify multiple init scripts for the CassandraContainer.