### PR TITLE
Fix KafkaContainer with multiple networks defined

### DIFF
--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public class KafkaContainerTest {
@@ -108,6 +109,24 @@ public class KafkaContainerTest {
         try (
             KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.0.0"))
         ) {
+            kafka.start();
+            testKafkaFunctionality(kafka.getBootstrapServers());
+        }
+    }
+
+    @Test
+    public void testWithHostExposedPort() throws Exception {
+        Testcontainers.exposeHostPorts(12345);
+        try (KafkaContainer kafka = new KafkaContainer(KAFKA_TEST_IMAGE)) {
+            kafka.start();
+            testKafkaFunctionality(kafka.getBootstrapServers());
+        }
+    }
+
+    @Test
+    public void testWithHostExposedPortAndExternalNetwork() throws Exception {
+        Testcontainers.exposeHostPorts(12345);
+        try (KafkaContainer kafka = new KafkaContainer(KAFKA_TEST_IMAGE).withNetwork(Network.newNetwork())) {
             kafka.start();
             testKafkaFunctionality(kafka.getBootstrapServers());
         }


### PR DESCRIPTION
Current implementation exposes only two listeners PLAINTEXT and BROKER.
BROKER must be advertised to the explicitly specified network or bridge. 
When a host port is exposed using Testcontainers.exposeHostPorts and a network is specified, the current implementation iterates through both network (specified and proxy container), incorrectly creating two listener with the same name "BROKER"