### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -30,7 +30,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4.0.2
         id: fetch-branch-names
         name: Fetch branch names
         with:
@@ -121,7 +121,7 @@ jobs:
           git pull origin $sourcebranches --no-edit
           git push origin $COMBINE_BRANCH_NAME
       # Creates a PR with the new combined branch
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v4.0.2
         name: Create Combined Pull Request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@af940e8bff73d435137caae9d08cf7a1badf5497 # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@6356f411fa7c14aab1fb2ac2fd20762a629e2fbf # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.7'
 
-    testImplementation ('org.mockito:mockito-core:3.10.0') {
+    testImplementation ('org.mockito:mockito-core:3.11.2') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     }
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:3.6.0'
+    testImplementation 'redis.clients:jedis:3.6.1'
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.7'
 

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.20"
     annotationProcessor "org.projectlombok:lombok:1.18.20"
     implementation 'biz.paluch.redis:spinach:0.3'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.mockito:mockito-all:1.10.19'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.10"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:2.8.0'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.json:json:20210307'
-    testImplementation 'org.postgresql:postgresql:42.2.20'
+    testImplementation 'org.postgresql:postgresql:42.2.22'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'redis.clients:jedis:3.6.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'redis.clients:jedis:3.6.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.0'
+    id 'org.springframework.boot' version '2.5.2'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:3.6.0'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
 

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.20"
     annotationProcessor "org.projectlombok:lombok:1.18.16"
 
-    implementation 'org.apache.solr:solr-solrj:8.8.2'
+    implementation 'org.apache.solr:solr-solrj:8.9.0'
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.5.0"
     id("org.jetbrains.kotlin.jvm") version "1.5.10"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.5.10"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.5.20"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.5.0"
+    id("org.springframework.boot") version "2.5.2"
     id("org.jetbrains.kotlin.jvm") version "1.5.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.5.20"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.0'
+    id 'org.springframework.boot' version '2.5.2'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.couchbase.client:java-client:3.1.6'
-    testImplementation 'org.awaitility:awaitility:3.0.0'
+    testImplementation 'org.awaitility:awaitility:4.1.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.13.0"
-    testImplementation "org.elasticsearch.client:transport:7.13.1"
+    testImplementation "org.elasticsearch.client:transport:7.13.2"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.6'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.7'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.25'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:3.6.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:3.10.0') {
+    testImplementation ('org.mockito:mockito-core:3.11.2') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.19.0'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.2.20'
+    testRuntimeOnly 'org.postgresql:postgresql:42.2.22'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:3.6.0'
+    testImplementation 'redis.clients:jedis:3.6.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation ('org.mockito:mockito-core:3.11.2') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:3.11.2') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.22'

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:2.8.0'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.1'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.11.807'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.16'
     testImplementation 'software.amazon.awssdk:s3:2.16.80'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.16'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.1'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.16'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation "org.neo4j.driver:neo4j-java-driver:1.7.5"
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.2.20'
+    testImplementation 'org.postgresql:postgresql:42.2.22'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.2'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.19.0'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.20.2'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.2'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.2.20'
+    testRuntimeOnly 'org.postgresql:postgresql:42.2.22'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'
 
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
 
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump gradle-update/update-gradle-wrapper-action from 1.0.13 to 1.0.14 (#4262) @dependabot
* Bump actions/github-script from 3 to 4.0.2 (#4261) @dependabot
* Bump gson from 2.8.6 to 2.8.7 in /examples (#4260) @dependabot
* Bump postgresql from 42.2.20 to 42.2.22 in /examples (#4259) @dependabot
* Bump jedis from 3.6.0 to 3.6.1 in /examples (#4258) @dependabot
* Bump aws-java-sdk-logs from 1.11.807 to 1.12.16 in /modules/localstack (#4256) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.5.10 to 1.5.20 in /examples (#4255) @dependabot
* Bump solr-solrj from 8.8.2 to 8.9.0 in /examples (#4254) @dependabot
* Bump mockito-core from 3.10.0 to 3.11.2 in /modules/junit-jupiter (#4252) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.5.10 to 1.5.20 in /examples (#4253) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /examples (#4248) @dependabot
* Bump mockito-core from 3.10.0 to 3.11.2 in /core (#4247) @dependabot
* Bump transport from 7.13.1 to 7.13.2 in /modules/elasticsearch (#4250) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /modules/pulsar (#4246) @dependabot
* Bump postgresql from 42.2.20 to 42.2.22 in /modules/junit-jupiter (#4245) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /modules/neo4j (#4244) @dependabot
* Bump org.springframework.boot from 2.5.0 to 2.5.2 in /examples (#4243) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /modules/junit-jupiter (#4239) @dependabot
* Bump s3 from 2.16.80 to 2.16.94 in /modules/localstack (#4238) @dependabot
* Bump elasticsearch-rest-client from 7.13.0 to 7.13.2 in /modules/elasticsearch (#4237) @dependabot
* Bump postgresql from 42.2.20 to 42.2.22 in /modules/postgresql (#4235) @dependabot
* Bump jedis from 3.6.0 to 3.6.1 in /core (#4234) @dependabot
* Bump postgresql from 42.2.20 to 42.2.22 in /modules/spock (#4232) @dependabot
* Bump aws-java-sdk-s3 from 1.11.1030 to 1.12.16 in /modules/localstack (#4233) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /modules/jdbc (#4229) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /modules/kafka (#4230) @dependabot
* Bump awaitility from 3.0.0 to 4.1.0 in /modules/couchbase (#4228) @dependabot
* Bump jedis from 3.6.0 to 3.6.1 in /modules/junit-jupiter (#4226) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /modules/vault (#4225) @dependabot
* Bump tomcat-jdbc from 10.0.6 to 10.0.7 in /modules/jdbc-test (#4224) @dependabot
