### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -147,13 +147,13 @@ dependencies {
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation project(':test-support')
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
     jarFileTestImplementation 'junit:junit:4.12'
-    jarFileTestImplementation 'org.assertj:assertj-core:3.18.1'
+    jarFileTestImplementation 'org.assertj:assertj-core:3.20.2'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'
 }
 

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'redis.clients:jedis:3.6.0'
+    implementation 'redis.clients:jedis:3.6.1'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
-    implementation 'redis.clients:jedis:3.6.0'
+    implementation 'redis.clients:jedis:3.6.1'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:3.6.0'
+    implementation 'redis.clients:jedis:3.6.1'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.30'

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.19.0'
+    testImplementation 'org.assertj:assertj-core:3.20.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.11.1030'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.16'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.11.1030'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:21.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.6'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.8'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.19'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.16'
-    testImplementation 'software.amazon.awssdk:s3:2.16.80'
+    testImplementation 'software.amazon.awssdk:s3:2.16.97'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.16'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.1'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.19'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.16'
     testImplementation 'software.amazon.awssdk:s3:2.16.80'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump aws-java-sdk-sqs from 1.12.1 to 1.12.19 in /modules/localstack (#4274) @dependabot
* Bump tomcat-jdbc from 10.0.6 to 10.0.8 in /modules/jdbc (#4272) @dependabot
* Bump s3 from 2.16.80 to 2.16.97 in /modules/localstack (#4271) @dependabot
* Bump jedis from 3.6.0 to 3.6.1 in /examples (#4258) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /core (#4257) @dependabot
* Bump assertj-core from 3.19.0 to 3.20.2 in /modules/database-commons (#4241) @dependabot
* Bump aws-java-sdk-dynamodb from 1.11.1030 to 1.12.16 in /modules/dynalite (#4240) @dependabot
