### PR TITLE
Upgrade alpine images for better M1 compatibility

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -65,7 +65,7 @@ public class DockerClientFactory {
             TESTCONTAINERS_SESSION_ID_LABEL, SESSION_ID
     );
 
-    private static final DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.5");
+    private static final DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.14");
     private static DockerClientFactory instance;
 
     // Cached client configuration

--- a/core/src/test/java/org/testcontainers/TestImages.java
+++ b/core/src/test/java/org/testcontainers/TestImages.java
@@ -6,7 +6,7 @@ public interface TestImages {
     DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:3.0.2");
     DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.5.3");
     DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:3.1.5");
-    DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.2");
+    DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.14");
     DockerImageName DOCKER_REGISTRY_IMAGE = DockerImageName.parse("registry:2.7.0");
-    DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.5");
+    DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.14");
 }

--- a/core/src/test/java/org/testcontainers/containers/DockerComposeFilesTest.java
+++ b/core/src/test/java/org/testcontainers/containers/DockerComposeFilesTest.java
@@ -20,6 +20,6 @@ public class DockerComposeFilesTest {
             Lists.newArrayList(new File("src/test/resources/docker-compose-imagename-overriding-a.yml"),
                                new File("src/test/resources/docker-compose-imagename-overriding-b.yml")));
         Assertions.assertThat(dockerComposeFiles.getDependencyImages())
-            .containsExactlyInAnyOrder("alpine:3.2", "redis:b", "mysql:b", "aservice");
+            .containsExactlyInAnyOrder("alpine:3.14", "redis:b", "mysql:b", "aservice");
     }
 }

--- a/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
@@ -104,8 +104,8 @@ public class ParsedDockerComposeFileValidationTest {
             .contains(
                 entry("mysql", Sets.newHashSet("mysql")),
                 entry("redis", Sets.newHashSet("redis")),
-                entry("custom", Sets.newHashSet("alpine:3.2")))
-            .as("all defined images are found"); // r/ redis, mysql from compose file, alpine:3.2 from Dockerfile build
+                entry("custom", Sets.newHashSet("alpine:3.14")))
+            .as("all defined images are found"); // r/ redis, mysql from compose file, alpine:3.14 from Dockerfile build
     }
 
     @Test
@@ -116,7 +116,7 @@ public class ParsedDockerComposeFileValidationTest {
             .contains(
                 entry("mysql", Sets.newHashSet("mysql")),
                 entry("redis", Sets.newHashSet("redis")),
-                entry("custom", Sets.newHashSet("alpine:3.2")))
-            .as("all defined images are found"); // redis, mysql from compose file, alpine:3.2 from Dockerfile build
+                entry("custom", Sets.newHashSet("alpine:3.14")))
+            .as("all defined images are found"); // redis, mysql from compose file, alpine:3.14 from Dockerfile build
     }
 }

--- a/core/src/test/java/org/testcontainers/containers/output/ToStringConsumerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/output/ToStringConsumerTest.java
@@ -24,7 +24,7 @@ public class ToStringConsumerTest {
 
     @Test
     public void newlines_are_not_added_to_exec_output() throws Exception {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.13")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.14")) {
             container.withCommand("sleep", "2m");
             container.start();
 
@@ -37,7 +37,7 @@ public class ToStringConsumerTest {
 
     @Test(timeout = 60_000L)
     public void newlines_are_not_added_to_exec_output_with_tty() throws Exception {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.13")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.14")) {
             container.withCreateContainerCmdModifier(cmd -> {
                 cmd
                     .withAttachStdin(true)
@@ -56,7 +56,7 @@ public class ToStringConsumerTest {
 
     @Test
     public void newlines_are_not_added_to_container_output() {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.13")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.14")) {
             container.withCommand("echo", "-n", LARGE_PAYLOAD);
             container.setStartupCheckStrategy(new OneShotStartupCheckStrategy());
             container.start();
@@ -71,7 +71,7 @@ public class ToStringConsumerTest {
 
     @Test
     public void newlines_are_not_added_to_container_output_with_tty() {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.13")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.14")) {
             container.withCreateContainerCmdModifier(cmd -> {
                 cmd.withTty(true);
             });

--- a/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
@@ -16,12 +16,9 @@ public class ImagePullTest {
     public static String[] parameters() {
         return new String[] {
             "alpine:latest",
-            "alpine:3.6",
+            "alpine:3.14",
             "alpine", // omitting the tag should work and default to latest
-            "alpine@sha256:8fd4b76819e1e5baac82bd0a3d03abfe3906e034cc5ee32100d12aaaf3956dc7",
-            "gliderlabs/alpine:latest",
-            "gliderlabs/alpine:3.5",
-            "gliderlabs/alpine@sha256:a19aa4a17a525c97e5a90a0c53a9f3329d2dc61b0a14df5447757a865671c085",
+            "alpine@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d",
             "quay.io/testcontainers/ryuk:latest",
             "quay.io/testcontainers/ryuk:0.2.3",
             "quay.io/testcontainers/ryuk@sha256:bb5a635cac4bd96c93cc476969ce11dc56436238ec7cd028d0524462f4739dd9",

--- a/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
@@ -23,7 +23,7 @@ public class DockerfileContainerTest {
     public GenericContainer dslContainer = new GenericContainer(
             new ImageFromDockerfile("tcdockerfile/nginx", false).withDockerfileFromBuilder(builder -> {
                     builder
-                            .from("alpine:3.5")
+                            .from("alpine:3.2")
                             .run("apk add --update nginx")
                             .cmd("nginx", "-g", "daemon off;")
                             .build(); }))

--- a/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
@@ -23,7 +23,7 @@ public class DockerfileContainerTest {
     public GenericContainer dslContainer = new GenericContainer(
             new ImageFromDockerfile("tcdockerfile/nginx", false).withDockerfileFromBuilder(builder -> {
                     builder
-                            .from("alpine:3.14")
+                            .from("alpine:3.5")
                             .run("apk add --update nginx")
                             .cmd("nginx", "-g", "daemon off;")
                             .build(); }))

--- a/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileContainerTest.java
@@ -23,7 +23,7 @@ public class DockerfileContainerTest {
     public GenericContainer dslContainer = new GenericContainer(
             new ImageFromDockerfile("tcdockerfile/nginx", false).withDockerfileFromBuilder(builder -> {
                     builder
-                            .from("alpine:3.2")
+                            .from("alpine:3.14")
                             .run("apk add --update nginx")
                             .cmd("nginx", "-g", "daemon off;")
                             .build(); }))

--- a/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
@@ -40,7 +40,7 @@ public class DockerfileTest {
                 super.configure(buildImageCmd);
 
                 List<String> dockerfile = Arrays.asList(
-                        "FROM alpine:3.2",
+                        "FROM alpine:3.14",
                         "RUN echo 'hello from Docker build process'",
                         "CMD yes"
                 );
@@ -59,7 +59,7 @@ public class DockerfileTest {
                 .withFileFromClasspath("test.txt", "mappable-resource/test-resource.txt")
                 .withFileFromString("folder/someFile.txt", "hello")
                 .withDockerfileFromBuilder(builder -> builder
-                        .from("alpine:3.2")
+                        .from("alpine:3.14")
                         .workDir("/app")
                         .add("test.txt", "test file.txt")
                         .run("ls", "-la", "/app/test file.txt")
@@ -101,7 +101,7 @@ public class DockerfileTest {
 
                 })
                 .withDockerfileFromBuilder(builder -> builder
-                        .from("alpine:3.2")
+                        .from("alpine:3.14")
                         .copy("someFile.txt", "/someFile.txt")
                         .cmd("stat -c \"%a\" /someFile.txt")
                 );

--- a/core/src/test/java/org/testcontainers/junit/FixedHostPortContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/FixedHostPortContainerTest.java
@@ -24,7 +24,7 @@ import static org.testcontainers.TestImages.TINY_IMAGE;
  */
 public class FixedHostPortContainerTest {
 
-    private static final String TEST_IMAGE = "alpine:3.2";
+    private static final String TEST_IMAGE = "alpine:3.14";
 
     /**
      * Default http server port (just something different from default)

--- a/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ParameterizedDockerfileContainerTest.java
@@ -35,11 +35,9 @@ public class ParameterizedDockerfileContainerTest {
     @Parameterized.Parameters(name = "{0}")
     public static Object[][] data() {
         return new Object[][] {
-                { "alpine:3.2", "3.2"},
-                { "alpine:3.3", "3.3"},
-                { "alpine:3.4", "3.4"},
-                { "alpine:3.5", "3.5"},
-                { "alpine:3.6", "3.6"}
+                { "alpine:3.12", "3.12"},
+                { "alpine:3.13", "3.13"},
+                { "alpine:3.14", "3.14"}
         };
     }
 

--- a/core/src/test/java/org/testcontainers/utility/DirectoryTarResourceTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DirectoryTarResourceTest.java
@@ -26,7 +26,7 @@ public class DirectoryTarResourceTest {
         GenericContainer container = new GenericContainer(
                 new ImageFromDockerfile()
                         .withDockerfileFromBuilder(builder ->
-                                builder.from("alpine:3.3")
+                                builder.from("alpine:3.14")
                                         .copy("/tmp/foo", "/foo")
                                         .cmd("cat /foo/test/resources/test-recursive-file.txt")
                                         .build()
@@ -45,7 +45,7 @@ public class DirectoryTarResourceTest {
         GenericContainer container = new GenericContainer(
                 new ImageFromDockerfile()
                         .withDockerfileFromBuilder(builder ->
-                                builder.from("alpine:3.3")
+                                builder.from("alpine:3.14")
                                         .copy("/tmp/foo", "/foo")
                                         .cmd("ls", "-al", "/")
                                         .build()
@@ -68,7 +68,7 @@ public class DirectoryTarResourceTest {
         GenericContainer container = new GenericContainer(
                 new ImageFromDockerfile()
                         .withDockerfileFromBuilder(builder ->
-                                builder.from("alpine:3.3")
+                                builder.from("alpine:3.14")
                                         .copy("/tmp/foo", "/foo")
                                         .cmd("ls -lRt /foo")
                                         .build()

--- a/core/src/test/resources/compose-dockerfile/Dockerfile
+++ b/core/src/test/resources/compose-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.14
 
 ADD passthrough.sh /passthrough.sh
 

--- a/core/src/test/resources/compose-scaling-multiple-containers.yml
+++ b/core/src/test/resources/compose-scaling-multiple-containers.yml
@@ -3,5 +3,5 @@ services:
   redis:
     image: redis
   other:
-    image: alpine:3.5
+    image: alpine:3.14
     command: sleep 10000

--- a/core/src/test/resources/dockerfile-build-invalid/Dockerfile
+++ b/core/src/test/resources/dockerfile-build-invalid/Dockerfile
@@ -1,1 +1,1 @@
-FROM alpine:3.2
+FROM alpine:3.14

--- a/core/src/test/resources/dockerfile-build-test/Dockerfile
+++ b/core/src/test/resources/dockerfile-build-test/Dockerfile
@@ -1,2 +1,2 @@
-FROM alpine:3.2
+FROM alpine:3.14
 COPY localfile.txt /test.txt

--- a/core/src/test/resources/dockerfile-build-test/Dockerfile-alt
+++ b/core/src/test/resources/dockerfile-build-test/Dockerfile-alt
@@ -1,2 +1,2 @@
-FROM alpine:3.2
+FROM alpine:3.14
 RUN echo "test4567" > /test.txt

--- a/core/src/test/resources/dockerfile-build-test/Dockerfile-buildarg
+++ b/core/src/test/resources/dockerfile-build-test/Dockerfile-buildarg
@@ -1,3 +1,3 @@
-FROM alpine:3.2
+FROM alpine:3.14
 ARG CUSTOM_ARG
 RUN echo "${CUSTOM_ARG}" > /test.txt

--- a/core/src/test/resources/dockerfile-build-test/Dockerfile-currentdir
+++ b/core/src/test/resources/dockerfile-build-test/Dockerfile-currentdir
@@ -1,2 +1,2 @@
-FROM alpine:3.2
+FROM alpine:3.14
 COPY . /

--- a/core/src/test/resources/health-wait-strategy-dockerfile/Dockerfile
+++ b/core/src/test/resources/health-wait-strategy-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.14
 
 HEALTHCHECK --interval=1s CMD test -e /testfile
 

--- a/core/src/test/resources/mappable-dockerfile/Dockerfile
+++ b/core/src/test/resources/mappable-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.2
+FROM alpine:3.14
 ADD folder/someFile.txt /someFile.txt
 RUN cat /someFile.txt
 ADD test.txt /test.txt

--- a/docs/examples/junit4/generic/src/test/java/generic/ContainerCreationTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ContainerCreationTest.java
@@ -20,7 +20,7 @@ public class ContainerCreationTest {
                 .withExposedPorts(6379);
     // }
 
-    public static final DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.2");
+    public static final DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.14");
 
     // withOptions {
     // Set up a plain OS container and customize environment,

--- a/docs/examples/junit4/generic/src/test/java/generic/ContainerLabelTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ContainerLabelTest.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public class ContainerLabelTest {
     // single_label {
-    public GenericContainer containerWithLabel = new GenericContainer(DockerImageName.parse("alpine:3.6"))
+    public GenericContainer containerWithLabel = new GenericContainer(DockerImageName.parse("alpine:3.14"))
         .withLabel("key", "value");
     // }
 
@@ -17,7 +17,7 @@ public class ContainerLabelTest {
     private Map<String, String> mapOfLabels = new HashMap<>();
     // populate map, e.g. mapOfLabels.put("key1", "value1");
 
-    public GenericContainer containerWithMultipleLabels = new GenericContainer(DockerImageName.parse("alpine:3.6"))
+    public GenericContainer containerWithMultipleLabels = new GenericContainer(DockerImageName.parse("alpine:3.14"))
         .withLabels(mapOfLabels);
     // }
 }

--- a/docs/examples/junit4/generic/src/test/java/generic/ExecTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ExecTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 public class ExecTest {
 
     @Rule
-    public GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine:3.6"))
+    public GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine:3.14"))
         .withCommand("top");
 
     @Test

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -50,7 +50,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **ryuk.container.image = testcontainers/ryuk:0.3.1**
 > Performs fail-safe cleanup of containers, and always required (unless [Ryuk is disabled](#disabling-ryuk))
 
-> **tinyimage.container.image = alpine:3.5**  
+> **tinyimage.container.image = alpine:3.14**  
 > Used to check whether images can be pulled at startup, and always required (unless [startup checks are disabled](#disabling-the-startup-checks))
 
 > **sshd.container.image = testcontainers/sshd:1.0.0**  

--- a/docs/features/creating_images.md
+++ b/docs/features/creating_images.md
@@ -51,7 +51,7 @@ new GenericContainer(
         new ImageFromDockerfile()
                 .withDockerfileFromBuilder(builder ->
                         builder
-                                .from("alpine:3.2")
+                                .from("alpine:3.14")
                                 .run("apk add --update nginx")
                                 .cmd("nginx", "-g", "daemon off;")
                                 .build()))

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
@@ -6,5 +6,5 @@ interface SpockTestImages {
     DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:5.7.34")
     DockerImageName POSTGRES_TEST_IMAGE = DockerImageName.parse("postgres:9.6.12")
     DockerImageName HTTPD_IMAGE = DockerImageName.parse("httpd:2.4-alpine")
-    DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.5")
+    DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.14")
 }


### PR DESCRIPTION
* 'Tiny image' used in startup checks
* Various alpine images used in Testcontainers' own tests
* in documentation