### PR TITLE
Remove privileged flag from DB2 container class

### DIFF
--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -27,7 +27,7 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
     private String password = "foobar1234";
 
     /**
-     * @deprecated use {@link Db2Container(DockerImageName)} instead
+     * @deprecated use {@link Db2Container#Db2Container(DockerImageName)} instead
      */
     @Deprecated
     public Db2Container() {
@@ -43,7 +43,6 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        withPrivilegedMode(true);
         this.waitStrategy = new LogMessageWaitStrategy()
                 .withRegEx(".*Setup has completed\\..*")
                 .withStartupTimeout(Duration.of(10, ChronoUnit.MINUTES));
@@ -78,6 +77,8 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
     /**
      * Accepts the license for the DB2 container by setting the LICENSE=accept
      * variable as described at <a href="https://hub.docker.com/r/ibmcom/db2">https://hub.docker.com/r/ibmcom/db2</a>
+     *
+     * @return self
      */
     public Db2Container acceptLicense() {
         addEnv("LICENSE", "accept");


### PR DESCRIPTION
Background:

https://db2indocker.blogspot.com/2015/04/db2-do-not-start-in-un-privileged.html

> The main reason behind this is that DB2 needs larger shared memory segments. By default, Linux containers get shared memory segments of 32 MB in Kernel Versions less than 3.16.
> In kernel versions 3.16 and above this issue has been addressed and Linux containers get much larger shared memory segments.
> That’s why we add —privileged=true parameter when running it.

Kernel 3.15 went EOL in 2014, so this seems like a workaround that shouldn’t be particularly necessary - if it’s just for the reason cited in that blog post.