### PR TITLE
Tune Cassandra options for faster startup

### DIFF
--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -58,8 +58,16 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
         addExposedPort(CQL_PORT);
-        setStartupAttempts(3);
+        setStartupAttempts(1);
         this.enableJmxReporting = false;
+
+        withEnv("CASSANDRA_SNITCH", "GossipingPropertyFileSnitch");
+        withEnv(
+            "JVM_OPTS",
+            "-Dcassandra.skip_wait_for_gossip_to_settle=0 -Dcassandra.initial_token=0"
+        );
+        withEnv("HEAP_NEWSIZE", "128M");
+        withEnv("MAX_HEAP_SIZE", "1024M");
     }
 
     @Override

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -58,7 +58,6 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
         addExposedPort(CQL_PORT);
-        setStartupAttempts(1);
         this.enableJmxReporting = false;
 
         withEnv("CASSANDRA_SNITCH", "GossipingPropertyFileSnitch");


### PR DESCRIPTION
We never attempted at tuning Cassandra options to make it start faster. Apparently, there are a few low hanging fruits (focused on single-node scenario) that make it start significantly faster:

Before:
```
Container cassandra:3.11.2 started in PT32.628781S
```

After:
```
Container cassandra:3.11.2 started in PT10.720409S
```