### PR TITLE
Disable Chrome's GPU support in `BrowserWebDriverContainer`

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -166,8 +166,9 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
             }
         }
 
-        // hack for new Chrome image
-        if (capabilities instanceof ChromeOptions) {
+        // hack for new selenium-chrome image that contains Chrome 92
+        // If not disabled, container startup will fail in most cases and consume excessive amounts of CPU
+        if (seleniumVersion.equals("3.141.59")  && capabilities instanceof ChromeOptions) {
             ChromeOptions options = (ChromeOptions) this.capabilities;
             options.addArguments("--disable-gpu");
         }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -166,9 +166,9 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
             }
         }
 
-        // hack for new selenium-chrome image that contains Chrome 92
-        // If not disabled, container startup will fail in most cases and consume excessive amounts of CPU
-        if (seleniumVersion.equals("3.141.59")  && capabilities instanceof ChromeOptions) {
+        // Hack for new selenium-chrome image that contains Chrome 92.
+        // If not disabled, container startup will fail in most cases and consume excessive amounts of CPU.
+        if (capabilities instanceof ChromeOptions) {
             ChromeOptions options = (ChromeOptions) this.capabilities;
             options.addArguments("--disable-gpu");
         }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -166,6 +166,12 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
             }
         }
 
+        // hack for new Chrome image
+        if (capabilities instanceof ChromeOptions) {
+            ChromeOptions options = (ChromeOptions) this.capabilities;
+            options.addArguments("--disable-gpu");
+        }
+
         if (recordingMode != VncRecordingMode.SKIP) {
 
             if (vncRecordingDirectory == null) {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -14,7 +14,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
     // junitRule {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
-        .withCapabilities(new ChromeOptions())
+        .withCapabilities(new ChromeOptions().addArguments("--disable-gpu"))
     // }
         .withNetwork(NETWORK);
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -14,7 +14,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
     // junitRule {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
-        .withCapabilities(new ChromeOptions().addArguments("--disable-gpu", "--disable-dev-shm-usage"))
+        .withCapabilities(new ChromeOptions())
     // }
         .withNetwork(NETWORK);
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -14,7 +14,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
     // junitRule {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
-        .withCapabilities(new ChromeOptions())
+        .withCapabilities(new ChromeOptions().addArguments(""))
     // }
         .withNetwork(NETWORK);
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -14,7 +14,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
     // junitRule {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
-        .withCapabilities(new ChromeOptions().addArguments(""))
+        .withCapabilities(new ChromeOptions())
     // }
         .withNetwork(NETWORK);
 
@@ -25,6 +25,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Test
     public void simpleExploreTest() {
+        System.out.println("force ci");
         doSimpleExplore(chrome);
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -14,7 +14,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
     // junitRule {
     @Rule
     public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
-        .withCapabilities(new ChromeOptions().addArguments("--disable-gpu"))
+        .withCapabilities(new ChromeOptions().addArguments("--disable-gpu", "--disable-dev-shm-usage"))
     // }
         .withNetwork(NETWORK);
 

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -25,7 +25,6 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Test
     public void simpleExploreTest() {
-        System.out.println("force ci");
         doSimpleExplore(chrome);
     }
 }


### PR DESCRIPTION
Yesterday's [release of docker-selenium `3.141.59-20210729`](https://github.com/SeleniumHQ/docker-selenium/releases/tag/3.141.59-20210729) seems to fail to start under different circumstances and in different environments.

A potential fix is setting `--disable-gpu` in the `ChromeOptions`. 

It is not yet clear what is the root cause of this issue (the update to Chrome 92?), but other users of docker-selenium report issues as well:
https://github.com/SeleniumHQ/docker-selenium/issues/1346

This PR shall act as a way to further debug this issue in GitHub Actions and to discuss potential workarounds on our side.