### PR TITLE
Update Kafka config dynamically

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -135,7 +135,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @NonNull
     private String networkMode;
 
-    @NonNull
+    @Nullable
     private Network network;
 
     @NonNull

--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -2,10 +2,8 @@ package org.testcontainers.containers;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import lombok.SneakyThrows;
-import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Comparator;
 
 /**
@@ -17,19 +15,13 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
     private static final String DEFAULT_TAG = "5.4.3";
 
-    private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
-
     public static final int KAFKA_PORT = 9093;
 
     public static final int ZOOKEEPER_PORT = 2181;
 
     private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
 
-    private static final int PORT_NOT_ASSIGNED = -1;
-
     protected String externalZookeeperConnect = null;
-
-    private int port = PORT_NOT_ASSIGNED;
 
     /**
      * @deprecated use {@link KafkaContainer(DockerImageName)} instead
@@ -80,58 +72,49 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
     }
 
     public String getBootstrapServers() {
-        if (port == PORT_NOT_ASSIGNED) {
-            throw new IllegalStateException("You should start Kafka container first");
-        }
-        return String.format("PLAINTEXT://%s:%s", getHost(), port);
+        return String.format("PLAINTEXT://%s:%s", getHost(), getMappedPort(KAFKA_PORT));
     }
 
     @Override
     protected void doStart() {
-        withCommand("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
-
-        if (externalZookeeperConnect == null) {
-            addExposedPort(ZOOKEEPER_PORT);
-        }
-
-        super.doStart();
-    }
-
-    @Override
-    @SneakyThrows
-    protected void containerIsStarting(InspectContainerResponse containerInfo, boolean reused) {
-        super.containerIsStarting(containerInfo, reused);
-
-        port = getMappedPort(KAFKA_PORT);
-
-        if (reused) {
-            return;
-        }
+        withEnv("KAFKA_ADVERTISED_LISTENERS", "BROKER://localhost:9092");
 
         String command = "#!/bin/bash\n";
-        final String zookeeperConnect;
         if (externalZookeeperConnect != null) {
-            zookeeperConnect = externalZookeeperConnect;
+            withEnv("KAFKA_ZOOKEEPER_CONNECT", externalZookeeperConnect);
         } else {
-            zookeeperConnect = "localhost:" + ZOOKEEPER_PORT;
+            addExposedPort(ZOOKEEPER_PORT);
+            withEnv("KAFKA_ZOOKEEPER_CONNECT", "localhost:" + ZOOKEEPER_PORT);
             command += "echo 'clientPort=" + ZOOKEEPER_PORT + "' > zookeeper.properties\n";
             command += "echo 'dataDir=/var/lib/zookeeper/data' >> zookeeper.properties\n";
             command += "echo 'dataLogDir=/var/lib/zookeeper/log' >> zookeeper.properties\n";
             command += "zookeeper-server-start zookeeper.properties &\n";
         }
 
-        command += "export KAFKA_ZOOKEEPER_CONNECT='" + zookeeperConnect + "'\n";
-
-        command += "export KAFKA_ADVERTISED_LISTENERS='" + String.join(",", getBootstrapServers(), brokerAdvertisedListener(containerInfo)) + "'\n";
-
         command += ". /etc/confluent/docker/bash-config \n";
         command += "/etc/confluent/docker/configure \n";
         command += "/etc/confluent/docker/launch \n";
+        withCommand("sh", "-c", command);
 
-        copyFileToContainer(
-            Transferable.of(command.getBytes(StandardCharsets.UTF_8), 0777),
-            STARTER_SCRIPT
+        super.doStart();
+    }
+
+    @Override
+    @SneakyThrows
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        String brokerAdvertisedListener = brokerAdvertisedListener(containerInfo);
+        ExecResult result = execInContainer(
+            "kafka-configs",
+            "--alter",
+            "--bootstrap-server", brokerAdvertisedListener,
+            "--entity-type", "brokers",
+            "--entity-name", getEnvMap().get("KAFKA_BROKER_ID"),
+            "--add-config",
+            "advertised.listeners=[" + String.join(",", getBootstrapServers(), brokerAdvertisedListener) + "]"
         );
+        if (result.getExitCode() != 0) {
+            throw new IllegalStateException(result.getStderr());
+        }
     }
 
     protected String brokerAdvertisedListener(InspectContainerResponse containerInfo) {


### PR DESCRIPTION
This PR dramatically simplifies our Kafka integration by updating Kafka's config on the fly, so that we don't need to generate the entry point script at all.

It _may_ make it more compatible with M1 - need to test it separately.