### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -95,7 +95,7 @@ configurations.all {
 }
 
 dependencies {
-    baseline 'org.testcontainers:testcontainers:1.15.3', {
+    baseline 'org.testcontainers:testcontainers:1.16.0', {
         exclude group: "*", module: "*"
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,7 +100,7 @@ dependencies {
     }
 
     api 'junit:junit:4.12'
-    api 'org.slf4j:slf4j-api:1.7.30'
+    api 'org.slf4j:slf4j-api:1.7.32'
     compileOnly 'org.jetbrains:annotations:21.0.1'
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'
     api 'org.apache.commons:commons-compress:1.20'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -138,7 +138,7 @@ dependencies {
     }
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:3.6.1'
+    testImplementation 'redis.clients:jedis:3.6.3'
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.7'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -140,7 +140,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:3.6.3'
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
-    testImplementation 'org.mongodb:mongo-java-driver:3.12.7'
+    testImplementation 'org.mongodb:mongo-java-driver:3.12.9'
 
     testImplementation ('org.mockito:mockito-core:3.11.2') {
         exclude(module: 'hamcrest-core')

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.30'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.json:json:20210307'
-    testImplementation 'org.postgresql:postgresql:42.2.22'
+    testImplementation 'org.postgresql:postgresql:42.2.23'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -6,7 +6,7 @@ repositories {
     jcenter()
 }
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:1.7.30'
+    compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.json:json:20210307'
     testImplementation 'org.postgresql:postgresql:42.2.23'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:1.7.30'
+    compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'redis.clients:jedis:3.6.1'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:1.7.30'
+    compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'redis.clients:jedis:3.6.1'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'redis.clients:jedis:3.6.1'
     implementation 'com.google.code.gson:gson:2.8.7'
     implementation 'com.google.guava:guava:23.0'
-    compileOnly 'org.slf4j:slf4j-api:1.7.30'
+    compileOnly 'org.slf4j:slf4j-api:1.7.32'
 
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.5.2"
     id("org.jetbrains.kotlin.jvm") version "1.5.10"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.5.20"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.5.21"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.couchbase.client:java-client:3.1.6'
+    testImplementation 'com.couchbase.client:java-client:3.2.0'
     testImplementation 'org.awaitility:awaitility:4.1.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.13.0"
-    testImplementation "org.elasticsearch.client:transport:7.13.2"
+    testImplementation "org.elasticsearch.client:transport:7.13.4"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -16,5 +16,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.7'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.25'
+    api 'mysql:mysql-connector-java:8.0.26'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:3.6.1'
+    testImplementation 'redis.clients:jedis:3.6.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation ('org.mockito:mockito-core:3.11.2') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.22'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.26'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }
 

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.16'
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.37'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.19'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.37'
     testImplementation 'software.amazon.awssdk:s3:2.16.97'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.16'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.11.1030'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.19'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.16'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.37'
     testImplementation 'software.amazon.awssdk:s3:2.16.97'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.25'
+    testImplementation 'mysql:mysql-connector-java:8.0.26'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.2.22'
+    testImplementation 'org.postgresql:postgresql:42.2.23'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.2.22'
+    testRuntimeOnly 'org.postgresql:postgresql:42.2.23'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'
 
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
 
-    testImplementation 'com.zaxxer:HikariCP:4.0.3'
+    testImplementation 'com.zaxxer:HikariCP:5.0.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.23'


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump org.jetbrains.kotlin.plugin.spring from 1.5.20 to 1.5.21 in /examples (#4351) @dependabot
* Bump postgresql from 42.2.22 to 42.2.23 in /examples (#4350) @dependabot
* Bump jedis from 3.6.1 to 3.6.3 in /core (#4348) @dependabot
* Bump logback-classic from 1.2.3 to 1.2.5 in /examples (#4347) @dependabot
* Bump aws-java-sdk-logs from 1.12.16 to 1.12.37 in /modules/localstack (#4345) @dependabot
* Bump testcontainers from 1.15.3 to 1.16.0 in /core (#4344) @dependabot
* Bump postgresql from 42.2.22 to 42.2.23 in /modules/spock (#4343) @dependabot
* Bump slf4j-api from 1.7.30 to 1.7.32 in /examples (#4342) @dependabot
* Bump amqp-client from 5.12.0 to 5.13.0 in /core (#4340) @dependabot
* Bump transport from 7.13.2 to 7.13.4 in /modules/elasticsearch (#4336) @dependabot
* Bump aws-java-sdk-s3 from 1.12.16 to 1.12.37 in /modules/localstack (#4338) @dependabot
* Bump mysql-connector-java from 8.0.25 to 8.0.26 in /modules/spock (#4339) @dependabot
* Bump HikariCP from 4.0.3 to 5.0.0 in /modules/spock (#4334) @dependabot
* Bump mysql-connector-java from 8.0.25 to 8.0.26 in /modules/mysql (#4333) @dependabot
* Bump mongo-java-driver from 3.12.7 to 3.12.9 in /core (#4332) @dependabot
* Bump jedis from 3.6.1 to 3.6.3 in /modules/junit-jupiter (#4329) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.5.10 to 1.5.21 in /examples (#4331) @dependabot
* Bump elasticsearch-rest-client from 7.13.0 to 7.13.4 in /modules/elasticsearch (#4330) @dependabot
* Bump jedis from 3.6.1 to 3.6.3 in /examples (#4326) @dependabot
* Bump slf4j-api from 1.7.30 to 1.7.32 in /core (#4322) @dependabot
* Bump postgresql from 42.2.22 to 42.2.23 in /modules/postgresql (#4325) @dependabot
* Bump mysql-connector-java from 8.0.25 to 8.0.26 in /modules/junit-jupiter (#4323) @dependabot
* Bump java-client from 3.1.6 to 3.2.0 in /modules/couchbase (#4321) @dependabot
* Bump mysql-connector-java from 8.0.25 to 8.0.26 in /modules/jdbc-test (#4318) @dependabot
* Bump s3 from 2.16.97 to 2.17.9 in /modules/localstack (#4319) @dependabot
