### PR TITLE
Fix failing `PublicBinaryAPITest` for `DynamicPollInterval`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -50,6 +50,7 @@ task jarFileTest(type: Test) {
     testClassesDirs = sourceSets.jarFileTest.output.classesDirs
     classpath = sourceSets.jarFileTest.runtimeClasspath
 
+    file(shadowJar.outputs.files.singleFile) // input for correct caching
     systemProperty("jarFile", shadowJar.outputs.files.singleFile)
 
     dependsOn(shadowJar)

--- a/core/src/jarFileTest/java/org/testcontainers/PublicBinaryAPITest.java
+++ b/core/src/jarFileTest/java/org/testcontainers/PublicBinaryAPITest.java
@@ -93,6 +93,7 @@ public class PublicBinaryAPITest extends AbstractJarFileTest {
             case "org/testcontainers/dockerclient/UnixSocketClientProviderStrategy":
             case "org/testcontainers/dockerclient/DockerClientProviderStrategy":
             case "org/testcontainers/dockerclient/WindowsClientProviderStrategy":
+            case "org/testcontainers/utility/DynamicPollInterval":
                 Assume.assumeTrue(false);
         }
     }


### PR DESCRIPTION
#4263 introduced `DynamicPollInterval` as a new class for internal use, that technically exposes a shaded class as part of the public API. I have added  `DynamicPollInterval` to our allow list in `PublicBinaryAPITest`.

Also, change `jarFileTest` to take the shadowJar into consideration as input for the cache key, since we missed this failure in CI because of a false Gradle cache hit before.