### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:2.8.0'
     testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'org.slf4j:slf4j-simple:1.7.30'
+    testImplementation 'org.slf4j:slf4j-simple:1.7.32'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.16'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.11.1030'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.37'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.37'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.7'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.8'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.26'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.37'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.19'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.37'
     testImplementation 'software.amazon.awssdk:s3:2.16.97'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.37'
-    testImplementation 'software.amazon.awssdk:s3:2.16.97'
+    testImplementation 'software.amazon.awssdk:s3:2.17.9'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -7,11 +7,11 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'org.mariadb:r2dbc-mariadb:1.0.1'
+    compileOnly 'org.mariadb:r2dbc-mariadb:1.0.2'
 
     testImplementation project(':jdbc-test')
     testImplementation 'org.mariadb.jdbc:mariadb-java-client:2.7.3'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'org.mariadb:r2dbc-mariadb:1.0.0'
+    testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump slf4j-simple from 1.7.30 to 1.7.32 in /examples (#4346) @dependabot
* Bump aws-java-sdk-sqs from 1.12.19 to 1.12.37 in /modules/localstack (#4328) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.16 to 1.12.37 in /modules/dynalite (#4327) @dependabot
* Bump r2dbc-mariadb from 1.0.1 to 1.0.2 in /modules/mariadb (#4324) @dependabot
* Bump s3 from 2.16.97 to 2.17.9 in /modules/localstack (#4319) @dependabot
* Bump tomcat-jdbc from 10.0.7 to 10.0.8 in /modules/jdbc-test (#4320) @dependabot
