### PR TITLE
Upgrade ryuk image to 0.3.2

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -95,7 +95,7 @@ public final class ResourceReaper {
     @SneakyThrows(InterruptedException.class)
     public static String start(DockerClient client) {
         String ryukImage = ImageNameSubstitutor.instance()
-            .apply(DockerImageName.parse("testcontainers/ryuk:0.3.1"))
+            .apply(DockerImageName.parse("testcontainers/ryuk:0.3.2"))
             .asCanonicalNameString();
         DockerClientFactory.instance().checkAndPullImage(client, ryukImage);
 

--- a/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
+++ b/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
@@ -210,8 +210,8 @@ public class TestcontainersConfigurationTest {
 
     @Test
     public void shouldTrimImageNames() {
-        userProperties.setProperty("ryuk.container.image", " testcontainers/ryuk:0.3.1 ");
-        assertEquals("trailing whitespace was not removed from image name property", "testcontainers/ryuk:0.3.1",newConfig().getRyukImage());
+        userProperties.setProperty("ryuk.container.image", " testcontainers/ryuk:0.3.2 ");
+        assertEquals("trailing whitespace was not removed from image name property", "testcontainers/ryuk:0.3.2",newConfig().getRyukImage());
     }
 
     private TestcontainersConfiguration newConfig() {

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -47,7 +47,7 @@ It takes a couple of seconds, but if you want to speed up your tests, you can di
 Testcontainers uses public Docker images to perform different actions like startup checks, VNC recording and others. 
 Some companies disallow the usage of Docker Hub, but you can override `*.image` properties with your own images from your private registry to workaround that.
 
-> **ryuk.container.image = testcontainers/ryuk:0.3.1**
+> **ryuk.container.image = testcontainers/ryuk:0.3.2**
 > Performs fail-safe cleanup of containers, and always required (unless [Ryuk is disabled](#disabling-ryuk))
 
 > **tinyimage.container.image = alpine:3.14**  
@@ -74,7 +74,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 
 ## Customizing Ryuk resource reaper
 
-> **ryuk.container.image = testcontainers/ryuk:0.3.1**
+> **ryuk.container.image = testcontainers/ryuk:0.3.2**
 > The resource reaper is responsible for container removal and automatic cleanup of dead containers at JVM shutdown
 
 > **ryuk.container.privileged = false**


### PR DESCRIPTION
Includes https://github.com/testcontainers/moby-ryuk/pull/25, for better cleanup of images built by Testcontainers.