### PR TITLE
Avoid commons-compress DOS vulnerability

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.32'
     compileOnly 'org.jetbrains:annotations:21.0.1'
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'
-    api 'org.apache.commons:commons-compress:1.20'
+    api 'org.apache.commons:commons-compress:1.21'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
Regard to https://github.com/apache/commons-compress/pull/172, which is an important fixed CVE.