### PR TITLE
Improve logging

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/output/BaseConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/BaseConsumer.java
@@ -2,16 +2,50 @@ package org.testcontainers.containers.output;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.testcontainers.containers.output.OutputFrame.OutputType;
 
+import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.function.Consumer;
 
+/**
+ * Base class for OutputFrame consumers, OutputTypes can be configured (all by default).
+ */
 public abstract class BaseConsumer<SELF extends BaseConsumer<SELF>> implements Consumer<OutputFrame> {
     @Getter
     @Setter
     private boolean removeColorCodes = true;
+    protected OutputType[] types;
 
+    public BaseConsumer() {
+        this(OutputType.values());
+    }
+
+    public BaseConsumer(OutputType... types) {
+        setTypes(types);
+    }
+
+    /**
+     * @return OutputTypes which will be consumed
+     */
+    public OutputType[] getTypes() {
+        return types;
+    }
+
+    /**
+     * @param types configure which OutputTypes will be consumed
+     */
+    @SuppressWarnings("unchecked")
+    public SELF setTypes(OutputType... types) {
+        this.types = types.length == 0 ? OutputType.values() : EnumSet
+            .of(types[0], Arrays.copyOfRange(types, 1, types.length)).toArray(new OutputType[0]);
+        return (SELF) this;
+    }
+
+    @SuppressWarnings("unchecked")
     public SELF withRemoveAnsiCodes(boolean removeAnsiCodes) {
         this.removeColorCodes = removeAnsiCodes;
         return (SELF) this;
     }
+
 }

--- a/core/src/main/java/org/testcontainers/containers/output/JavaUtilLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/JavaUtilLogConsumer.java
@@ -1,0 +1,40 @@
+package org.testcontainers.containers.output;
+
+import lombok.NonNull;
+import org.apache.commons.lang.StringUtils;
+import org.testcontainers.containers.output.OutputFrame.OutputType;
+
+import java.util.logging.Logger;
+
+/**
+ * A consumer for container output that logs with java.util.logging.
+ * stdout is mapped to info(), stderr to severe().
+ */
+public class JavaUtilLogConsumer extends LogConsumer<JavaUtilLogConsumer, Logger> {
+    /**
+     * @param logger stdout is mapped to info(), stderr to severe().
+     */
+    public JavaUtilLogConsumer(@NonNull Logger logger) {
+        super(logger);
+    }
+
+    /**
+     * @param logger stdout is mapped to info(), stderr to severe().
+     * @param types  OutputTypes which should be logged (empty logs all)
+     */
+    public JavaUtilLogConsumer(@NonNull Logger logger, @NonNull OutputType... types) {
+        super(logger, types);
+    }
+
+    @Override
+    public void log(OutputFrame outputFrame) {
+        String trimmed = StringUtils.stripEnd(outputFrame.getUtf8String(), null);
+        switch (outputFrame.getType()) {
+            case STDERR:
+                getLogger().severe(trimmed);
+                break;
+            case STDOUT:
+                getLogger().info(trimmed);
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/output/LogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/LogConsumer.java
@@ -1,0 +1,64 @@
+package org.testcontainers.containers.output;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+import org.testcontainers.containers.output.OutputFrame.OutputType;
+
+/**
+ * Base class for OutputFrame log consumers, OutputTypes can be configured (all by default).<br>
+ * Logging can be disabled at runtime by calling {@link #setSkip(boolean)}.
+ *
+ * @param <TYPE> Logger type, i.e. org.slf4j.Logger
+ */
+public abstract class LogConsumer<SELF extends LogConsumer<SELF, TYPE>, TYPE> extends BaseConsumer<LogConsumer<SELF, TYPE>> {
+    @Getter
+    @Setter
+    protected TYPE logger;
+    protected boolean skip;
+
+    /**
+     * @param logger Logger to write OutputFrames to (all OutputTypes)
+     */
+    public LogConsumer(@NonNull TYPE logger) {
+        this(logger, OutputType.values());
+    }
+
+    /**
+     * @param logger Logger to write OutputFrames to
+     * @param types  OutputTypes which should be logged (empty logs all)
+     */
+    public LogConsumer(@NonNull TYPE logger, OutputType... types) {
+        super(types);
+        this.logger = logger;
+    }
+
+    /**
+     * @return {@code true} if logging is disabled
+     */
+    public boolean isSkip() {
+        return skip;
+    }
+
+    /**
+     * @param skip Do not log anymore
+     */
+    @SuppressWarnings("unchecked")
+    public SELF setSkip(boolean skip) {
+        this.skip = skip;
+        return (SELF) this;
+    }
+
+    @Override
+    public void accept(OutputFrame outputFrame) {
+        if (skip) {
+            return;
+        }
+        log(outputFrame);
+    }
+
+    /**
+     * Log the outputFrame
+     */
+    public abstract void log(OutputFrame outputFrame);
+}

--- a/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
@@ -3,24 +3,24 @@ package org.testcontainers.containers.output;
 import java.util.HashMap;
 import java.util.Map;
 
+import lombok.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.MDC;
 
 /**
- * A consumer for container output that logs output to an SLF4J logger.
+ * A consumer for container output that logs with SLF4J.
  */
-public class Slf4jLogConsumer extends BaseConsumer<Slf4jLogConsumer> {
-    private final Logger logger;
+public class Slf4jLogConsumer extends LogConsumer<Slf4jLogConsumer, Logger> {
     private final Map<String, String> mdc = new HashMap<>();
     private boolean separateOutputStreams;
     private String prefix = "";
 
-    public Slf4jLogConsumer(Logger logger) {
+    public Slf4jLogConsumer(@NonNull Logger logger) {
         this(logger, false);
     }
 
-    public Slf4jLogConsumer(Logger logger, boolean separateOutputStreams) {
-        this.logger = logger;
+    public Slf4jLogConsumer(@NonNull Logger logger, boolean separateOutputStreams, OutputFrame.OutputType... types) {
+        super(logger, types);
         this.separateOutputStreams = separateOutputStreams;
     }
 
@@ -45,7 +45,7 @@ public class Slf4jLogConsumer extends BaseConsumer<Slf4jLogConsumer> {
     }
 
     @Override
-    public void accept(OutputFrame outputFrame) {
+    public void log(OutputFrame outputFrame) {
         OutputFrame.OutputType outputType = outputFrame.getType();
 
         String utf8String = outputFrame.getUtf8String();

--- a/core/src/main/java/org/testcontainers/utility/LogUtils.java
+++ b/core/src/main/java/org/testcontainers/utility/LogUtils.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.LogContainerCmd;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
+import org.testcontainers.containers.output.BaseConsumer;
 import org.testcontainers.containers.output.FrameConsumerResultCallback;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.ToStringConsumer;
@@ -52,6 +53,21 @@ public class LogUtils {
                              Consumer<OutputFrame> consumer) {
 
         followOutput(dockerClient, containerId, consumer, STDOUT, STDERR);
+    }
+
+    /**
+     * Attach a log consumer to a container's log outputs in follow mode. The consumer will receive all previous
+     * and all future log frames (stdout and stderr if configured in BaseConsumer).
+     *
+     * @param dockerClient a Docker client
+     * @param containerId  container ID to attach to
+     * @param consumer     a base consumer of {@link OutputFrame}s
+     */
+    public void followOutput(DockerClient dockerClient,
+                             String containerId,
+                             BaseConsumer<?> consumer) {
+
+        followOutput(dockerClient, containerId, consumer, consumer.getTypes());
     }
 
     /**


### PR DESCRIPTION
* BaseConsumer manages the OutputTypes which should be consumed.
* New abstract LogConsumer manages the logger instance and allows disabling at runtime.
* New JavaUtilLogConsumer as alternative to Slf4jLogConsumer.
* Container.hasLogConsumers() and clearLogConsumers() to avoid and remove unwanted loggers.
* GenericContainer.logConsumers is now a Set to prevent duplicate loggers.

Fixed some warnings.