### PR TITLE
Fix `CmdModifierTest#testMemoryLimitModified` in cgroup2 environment.

### DIFF
--- a/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
@@ -39,7 +39,11 @@ public class CmdModifierTest {
 
     @Test
     public void testMemoryLimitModified() throws IOException, InterruptedException {
-        final Container.ExecResult execResult = memoryLimitedRedis.execInContainer("cat", "/sys/fs/cgroup/memory/memory.limit_in_bytes");
+        final Container.ExecResult execResult = memoryLimitedRedis.execInContainer(
+            "cat",
+            "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+            "/sys/fs/cgroup/memory.max"
+        );
         assertEquals(String.valueOf(memoryInBytes), execResult.getStdout().trim());
     }
 }

--- a/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
@@ -1,8 +1,10 @@
 package generic;
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Info;
 import org.junit.Rule;
 import org.junit.Test;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -46,7 +48,8 @@ public class CmdModifierTest {
     }
 
     private String getMemoryLimitFilePath() {
-        Info info = memoryLimitedRedis.getDockerClient().infoCmd().exec();
+        DockerClient dockerClient = DockerClientFactory.instance().client();
+        Info info = dockerClient.infoCmd().exec();
         Object cgroupVersion = info.getRawValues().get("CgroupVersion");
         boolean cgroup2 = Objects.equals("2", cgroupVersion);
         if (cgroup2) {


### PR DESCRIPTION
The `testMemoryLimitModified` was failing in cgroup2 environment because of the missing
`/sys/fs/cgroup/memory/memory.limit_in_bytes` file.

In the cgroup2 environment a new file should be checked instead -- `/sys/fs/cgroup/memory.max`.

This commit intrdocues changes to `cat` both files:

1. `/sys/fs/cgroup/memory/memory.limit_in_bytes` from the first version of cgroup
2. `/sys/fs/cgroup/memory.max` from the second

Similar issues:

1. oracle/docker-images#1939
2. apify/apify-js#693

---

In the test both files are `cat`ted, but only one of them will succeed.
The attempt to `cat` the other one result in an error added to `ExecResult#stderr`.
Is this acceptable in these tests?
