### PR TITLE
Improving Oracle-XE support

### DIFF
--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -37,12 +37,16 @@ public class ConnectionUrlDriversTests {
                 {"jdbc:tc:mysql://hostname/test", "mysql", Optional.empty(), "hostname/test", "test"},
                 {"jdbc:tc:postgresql:1.2.3://hostname/test", "postgresql", Optional.of("1.2.3"), "hostname/test", "test"},
                 {"jdbc:tc:postgresql://hostname/test", "postgresql", Optional.empty(), "hostname/test", "test"},
-                {"jdbc:tc:sqlserver:1.2.3://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.of("1.2.3"), "localhost;instance=SQLEXPRESS:1433;databaseName=test", ""},
-                {"jdbc:tc:sqlserver://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.empty(), "localhost;instance=SQLEXPRESS:1433;databaseName=test", ""},
+                {"jdbc:tc:sqlserver:1.2.3://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.of("1.2.3"), "localhost;instance=SQLEXPRESS:1433;databaseName=test", "test"},
+                {"jdbc:tc:sqlserver://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.empty(), "localhost;instance=SQLEXPRESS:1433;databaseName=test", "test"},
                 {"jdbc:tc:mariadb:1.2.3://localhost:3306/test", "mariadb", Optional.of("1.2.3"), "localhost:3306/test", "test"},
                 {"jdbc:tc:mariadb://localhost:3306/test", "mariadb", Optional.empty(), "localhost:3306/test", "test"},
+                {"jdbc:tc:oracle:1.2.3:thin://@localhost:1521/test", "oracle", Optional.of("1.2.3"), "localhost:1521/test", "test"},
                 {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521/test", "oracle", Optional.of("1.2.3"), "localhost:1521/test", "test"},
-                {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", Optional.empty(), "localhost:1521/test", "test"}
+                {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", Optional.empty(), "localhost:1521/test", "test"},
+                {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521:test", "oracle", Optional.of("1.2.3"), "localhost:1521:test", "test"},
+                {"jdbc:tc:oracle:1.2.3:thin://@localhost:1521:test", "oracle", Optional.of("1.2.3"), "localhost:1521:test", "test"},
+                {"jdbc:tc:oracle:thin:@localhost:1521:test", "oracle", Optional.empty(), "localhost:1521:test", "test"}
             });
     }
 

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainerProvider.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainerProvider.java
@@ -1,6 +1,14 @@
 package org.testcontainers.containers;
 
+import org.testcontainers.jdbc.ConnectionUrl;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Matcher;
+
 import org.testcontainers.utility.DockerImageName;
+
+import static org.testcontainers.containers.OracleContainer.DEFAULT_DATABASE_NAME;
 
 /**
  * Factory for Oracle containers.
@@ -22,5 +30,29 @@ public class OracleContainerProvider extends JdbcDatabaseContainerProvider {
             return new OracleContainer(DockerImageName.parse(OracleContainer.IMAGE).withTag(tag));
         }
         return newInstance();
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+        Objects.requireNonNull(connectionUrl, "Connection URL cannot be null");
+
+        final String databaseName = connectionUrl.getDatabaseName().orElse(DEFAULT_DATABASE_NAME);
+
+        final OracleContainer instance = new OracleContainer()
+            .withReuse(connectionUrl.isReusable())
+            .withDatabaseName(databaseName);
+
+        Matcher urlMatcher = ConnectionUrl.Patterns.ORACLE_URL_MATCHING_PATTERN.matcher(connectionUrl.getUrl());
+        if (urlMatcher.matches()) {
+            Optional.ofNullable(urlMatcher.group("username")).ifPresent(instance::withUsername);
+            Optional.ofNullable(urlMatcher.group("password")).ifPresent(instance::withPassword);
+
+            Matcher databaseHostMatcher = ConnectionUrl.Patterns.DB_INSTANCE_MATCHING_PATTERN.matcher(connectionUrl.getDbHostString());
+            if (databaseHostMatcher.matches()) {
+                Optional.ofNullable(databaseHostMatcher.group("sidOrServiceName")).ifPresent(instance::withSidOrServiceName);
+            }
+        }
+
+        return instance;
     }
 }

--- a/modules/oracle-xe/src/test/java/org/testcontainers/containers/jdbc/OracleJDBCDriverTest.java
+++ b/modules/oracle-xe/src/test/java/org/testcontainers/containers/jdbc/OracleJDBCDriverTest.java
@@ -4,36 +4,37 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.ResultSetHandler;
-import org.junit.Ignore;
 import org.junit.Test;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import static org.junit.Assert.fail;
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
-/**
- * @author gusohal
- */
-@Ignore
 public class OracleJDBCDriverTest {
 
     @Test
-    public void testOracleWithNoSpecifiedVersion() throws SQLException {
-        performSimpleTest("jdbc:tc:oracle://hostname/databasename");
+    public void testOracleWithCommonDatabaseServiceName() throws SQLException {
+        performSimpleTest("jdbc:tc:oracle:thin://hostname/xepdb1");
     }
 
+    @Test
+    public void testOracleWithCommonDatabaseSid() throws SQLException {
+        performSimpleTest("jdbc:tc:oracle:thin:system/mypassword@hostname:xe");
+    }
+
+    @Test
+    public void testOracleWithPluggableDatabaseServiceName() throws SQLException {
+        performSimpleTest("jdbc:tc:oracle:thin://username/password@hostname/xepdb1");
+    }
 
     private void performSimpleTest(String jdbcUrl) throws SQLException {
         HikariDataSource dataSource = getDataSource(jdbcUrl, 1);
-        new QueryRunner(dataSource).query("SELECT 1 FROM dual", new ResultSetHandler<Object>() {
-            @Override
-            public Object handle(ResultSet rs) throws SQLException {
-                rs.next();
-                int resultSetInt = rs.getInt(1);
-                assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
-                return true;
-            }
+        new QueryRunner(dataSource).query("SELECT 1 FROM dual", (ResultSetHandler<Object>) rs -> {
+            rs.next();
+            int resultSetInt = rs.getInt(1);
+            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            return true;
         });
         dataSource.close();
     }

--- a/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
+++ b/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
@@ -24,9 +24,7 @@ public class SimpleOracleTest extends AbstractContainerDatabaseTest {
         ) {
             oracle.start();
             ResultSet resultSet = performQuery(oracle, "SELECT 1 FROM dual");
-
             int resultSetInt = resultSet.getInt(1);
-
             assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
         }
     }


### PR DESCRIPTION
Current challenges:

 - The module only connects using SID and not service name, connecting to PDBs in Oracle 12+ typically requires to use a service name.
 - Username and password cannot be specified.

Changes:

 - Detect SID `:` or service name `/` in the supplied TC JDBC URL and honour this in the underlying JDBC URL.
 - Parse username and password from the supplied TC JDBC URL and pass to the underlying JDBC URL.
 - Switched affected regex patterns to use named groups
 - Enable tests
 - Add tests for both SID and service name connections

Additional notes:

Currently Oracle only provides docker scripts to build your own version of 18.4.0 which has a very slow start time (~7 minutes on a decent laptop) in order to make this useful for test cycles it is typical to start this container and then run a `docker commit` on it. This reduces start time to around 10 seconds. _**The tests now make use of such a container, we should probably retag this container and put it somewhere else other than my docker hub account.**_