### PR TITLE
Use POSIX mode for large numbers in tar archives (#4384)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -272,6 +272,7 @@ public interface ContainerState {
             TarArchiveOutputStream tarArchive = new TarArchiveOutputStream(byteArrayOutputStream)
         ) {
             tarArchive.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            tarArchive.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
 
             transferable.transferTo(tarArchive, containerPath);
             tarArchive.finish();

--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -123,6 +123,7 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
             // To build an image, we have to send the context to Docker in TAR archive format
             try (TarArchiveOutputStream tarArchive = new TarArchiveOutputStream(new GZIPOutputStream(out))) {
                 tarArchive.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+                tarArchive.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
 
                 for (Map.Entry<String, Transferable> entry : transferables.entrySet()) {
                     Transferable transferable = entry.getValue();


### PR DESCRIPTION
Resolves #4384