### PR TITLE
Modernize Oracle Container Logic

### DIFF
--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -5,4 +5,6 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.ojdbc:ojdbc8:19.3.0.0'
+
+    compileOnly 'org.jetbrains:annotations:21.0.1'
 }

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -41,7 +41,6 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     // Restricted user and database names
     private static final List<String> ORACLE_SYSTEM_USERS = Arrays.asList(DEFAULT_SYSTEM_USER, DEFAULT_SYS_USER);
-    private static final List<String> ORACLE_DEFAULT_DBS = Arrays.asList(DEFAULT_DATABASE_NAME);
 
     private String databaseName = DEFAULT_DATABASE_NAME;
     private String username = APP_USER;
@@ -106,7 +105,7 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     public String getUsername() {
-        //An application user is tied to the database, and therefore not authenticated to connect to SID.
+        // An application user is tied to the database, and therefore not authenticated to connect to SID.
         return isUsingSid() ? DEFAULT_SYSTEM_USER : username;
     }
 
@@ -120,7 +119,7 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
         return databaseName;
     }
 
-    public boolean isUsingSid() {
+    protected boolean isUsingSid() {
         return usingSid;
     }
 
@@ -151,8 +150,8 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
             throw new IllegalArgumentException("Database name cannot be null or empty");
         }
 
-        if (ORACLE_DEFAULT_DBS.contains(databaseName.toLowerCase())) {
-            throw new IllegalArgumentException("Database name cannot be one of " + ORACLE_DEFAULT_DBS);
+        if (DEFAULT_DATABASE_NAME.equals(databaseName.toLowerCase())) {
+            throw new IllegalArgumentException("Database name cannot be set to " + DEFAULT_DATABASE_NAME);
         }
 
         this.databaseName = databaseName;
@@ -192,7 +191,7 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
     protected void configure() {
         withEnv("ORACLE_PASSWORD", password);
 
-        //Only set ORACLE_DATABASE if different than the default
+        // Only set ORACLE_DATABASE if different than the default.
         if(databaseName != DEFAULT_DATABASE_NAME) {
             withEnv("ORACLE_DATABASE", databaseName);
         }

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -2,18 +2,23 @@ package org.testcontainers.containers;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Collections.singleton;
+
 public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     public static final String NAME = "oracle";
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("gvenzl/oracle-xe");
-
 
     static final String DEFAULT_TAG = "18.4.0-slim";
     static final String IMAGE = DEFAULT_IMAGE_NAME.getUnversionedPart();
@@ -23,10 +28,25 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
     private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 120;
-    private static final List<String> ORACLE_SYSTEM_USERS = Arrays.asList("system", "sys");
 
-    private String username = "test";
-    private String password = "test";
+    // Container defaults
+    static final String DEFAULT_DATABASE_NAME = "xepdb1";
+    static final String DEFAULT_SID = "xe";
+    static final String DEFAULT_SYSTEM_USER = "system";
+    static final String DEFAULT_SYS_USER = "sys";
+    
+    // Test container defaults
+    static final String APP_USER = "test";
+    static final String APP_USER_PASSWORD = "test";
+
+    // Restricted user and database names
+    private static final List<String> ORACLE_SYSTEM_USERS = Arrays.asList(DEFAULT_SYSTEM_USER, DEFAULT_SYS_USER);
+    private static final List<String> ORACLE_DEFAULT_DBS = Arrays.asList(DEFAULT_DATABASE_NAME);
+
+    private String databaseName = DEFAULT_DATABASE_NAME;
+    private String username = APP_USER;
+    private String password = APP_USER_PASSWORD;
+    private boolean usingSid = false;
 
     /**
      * @deprecated use {@link OracleContainer(DockerImageName)} instead
@@ -42,6 +62,7 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     public OracleContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
         preconfigure();
     }
 
@@ -51,14 +72,24 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
     }
 
     private void preconfigure() {
-        withStartupTimeoutSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS);
+        this.waitStrategy = new LogMessageWaitStrategy()
+            .withRegEx(".*DATABASE IS READY TO USE!.*\\s")
+            .withTimes(1)
+            .withStartupTimeout(Duration.of(DEFAULT_STARTUP_TIMEOUT_SECONDS, SECONDS));
+        
         withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
         addExposedPorts(ORACLE_PORT, APEX_HTTP_PORT);
     }
 
     @Override
+    protected void waitUntilContainerStarted() {
+        getWaitStrategy().waitUntilReady(this);
+    }
+
+    @NotNull
+    @Override
     public Set<Integer> getLivenessCheckPortNumbers() {
-        return Sets.newHashSet(ORACLE_PORT);
+        return singleton(getMappedPort(ORACLE_PORT));
     }
 
     @Override
@@ -68,17 +99,29 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     public String getJdbcUrl() {
-        return "jdbc:oracle:thin:" + getUsername() + "/" + getPassword() + "@" + getHost() + ":" + getOraclePort() + "/xepdb1";
+        return isUsingSid() ? 
+            "jdbc:oracle:thin:" + "@" + getHost() + ":" + getOraclePort() + ":" + getSid() :
+            "jdbc:oracle:thin:" + "@" + getHost() + ":" + getOraclePort() + "/" + getDatabaseName();
     }
 
     @Override
     public String getUsername() {
-        return username;
+        //An application user is tied to the database, and therefore not authenticated to connect to SID.
+        return isUsingSid() ? DEFAULT_SYSTEM_USER : username;
     }
 
     @Override
     public String getPassword() {
         return password;
+    }
+
+    @Override
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public boolean isUsingSid() {
+        return usingSid;
     }
 
     @Override
@@ -103,13 +146,32 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
     }
 
     @Override
+    public OracleContainer withDatabaseName(String databaseName) {
+        if (StringUtils.isEmpty(databaseName)) {
+            throw new IllegalArgumentException("Database name cannot be null or empty");
+        }
+
+        if (ORACLE_DEFAULT_DBS.contains(databaseName.toLowerCase())) {
+            throw new IllegalArgumentException("Database name cannot be one of " + ORACLE_DEFAULT_DBS);
+        }
+
+        this.databaseName = databaseName;
+        return self();
+    }
+
+    public OracleContainer usingSid() {
+        this.usingSid = true;
+        return self();
+    }
+
+    @Override
     public OracleContainer withUrlParam(String paramName, String paramValue) {
-        throw new UnsupportedOperationException("The OracleDb does not support this");
+        throw new UnsupportedOperationException("The Oracle Database driver does not support this");
     }
 
     @SuppressWarnings("SameReturnValue")
     public String getSid() {
-        return "xe";
+        return DEFAULT_SID;
     }
 
     public Integer getOraclePort() {
@@ -129,6 +191,12 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
     @Override
     protected void configure() {
         withEnv("ORACLE_PASSWORD", password);
+
+        //Only set ORACLE_DATABASE if different than the default
+        if(databaseName != DEFAULT_DATABASE_NAME) {
+            withEnv("ORACLE_DATABASE", databaseName);
+        }
+        
         withEnv("APP_USER", username);
         withEnv("APP_USER_PASSWORD", password);
     }

--- a/modules/oracle-xe/src/test/java/org/testcontainers/containers/jdbc/OracleJDBCDriverTest.java
+++ b/modules/oracle-xe/src/test/java/org/testcontainers/containers/jdbc/OracleJDBCDriverTest.java
@@ -12,10 +12,6 @@ import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
-/**
- * @author gusohal
- */
-@Ignore
 public class OracleJDBCDriverTest {
 
     @Test

--- a/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
+++ b/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
@@ -1,5 +1,9 @@
 package org.testcontainers.junit.oracle;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Test;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
@@ -8,26 +12,86 @@ import org.testcontainers.utility.DockerImageName;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
-
 public class SimpleOracleTest extends AbstractContainerDatabaseTest {
 
     public static final DockerImageName ORACLE_DOCKER_IMAGE_NAME = DockerImageName.parse("gvenzl/oracle-xe:18.4.0-slim");
 
-    @Test
-    public void testSimple() throws SQLException {
+    private void runTest(OracleContainer container, String databaseName, String username, String password) throws SQLException {
+        //Test config was honored
+        assertEquals(container.getDatabaseName(), databaseName);
+        assertEquals(container.getUsername(), username);
+        assertEquals(container.getPassword(), password);
+        
+        //Test we can get a connection
+        container.start();
+        ResultSet resultSet = performQuery(container, "SELECT 1 FROM dual");
+        int resultSetInt = resultSet.getInt(1);
+        assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+    }
 
+    @Test
+    public void testDefaultSettings() throws SQLException {
+        try (
+            OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME);
+        ) {
+            assertFalse(oracle.isUsingSid());
+            runTest(oracle, "xepdb1", "test", "test");
+        }
+    }
+
+    @Test
+    public void testPluggableDatabase() throws SQLException {
         try (
             OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME)
-                .withUsername("baz")
-                .withPassword("bar")
+                .withDatabaseName("testDB")
         ) {
-            oracle.start();
-            ResultSet resultSet = performQuery(oracle, "SELECT 1 FROM dual");
+            runTest(oracle, "testDB", "test", "test");
+        }
+    }
 
-            int resultSetInt = resultSet.getInt(1);
+    @Test
+    public void testPluggableDatabaseAndCustomUser() throws SQLException {
+        try (
+            OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME)
+                .withDatabaseName("testDB")
+                .withUsername("testUser")
+                .withPassword("testPassword")
+        ) {
+            runTest(oracle, "testDB", "testUser", "testPassword");
+        }
+    }
 
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+    @Test
+    public void testCustomUser() throws SQLException {
+        try (
+            OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME)
+                .withUsername("testUser")
+                .withPassword("testPassword")
+        ) {
+            runTest(oracle, "xepdb1", "testUser", "testPassword");
+        }
+    }
+
+    @Test
+    public void testSID() throws SQLException {
+        try (
+            OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME)
+                .usingSid();
+        ) {
+            assertTrue(oracle.isUsingSid());
+            runTest(oracle, "xepdb1", "system", "test");
+        }
+    }
+
+    @Test
+    public void testSIDAndCustomPassword() throws SQLException {
+        try (
+            OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME)
+                .usingSid()
+                .withPassword("testPassword");
+        ) {
+            assertTrue(oracle.isUsingSid());
+            runTest(oracle, "xepdb1", "system", "testPassword");
         }
     }
 }


### PR DESCRIPTION
Now that we are using a standard Oracle image.  
The Oracle Container logic needs to change to support the oracle database config options on `gvenzl/oracle-xe`

The following options are now configurable and no longer static:
- system / sys password
- Application username and password
- Pluggable database name

The following options are still static but need to be accounted for:
- SID is static and will always be `XE`

Additional method paths:
- Connect using SID, or service name (pluggable database name)

Finally: 
- Add a waitStrategy that aligns with other JDBC containers. 

Expanding on the work done under #4382 