### PR TITLE
Fix dangling constructor reference in deprecation note

### DIFF
--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -35,7 +35,8 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     private static final String QUERY_PARAM_SEPARATOR = "&";
 
     /**
-     * @deprecated use {@link PostgreSQLContainer(DockerImageName)} instead
+     * @deprecated use {@link PostgreSQLContainer#PostgreSQLContainer(DockerImageName)} or
+     * {@link PostgreSQLContainer#PostgreSQLContainer(String)} instead
      */
     @Deprecated
     public PostgreSQLContainer() {

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -35,8 +35,7 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     private static final String QUERY_PARAM_SEPARATOR = "&";
 
     /**
-     * @deprecated use {@link PostgreSQLContainer#PostgreSQLContainer(DockerImageName)} or
-     * {@link PostgreSQLContainer#PostgreSQLContainer(String)} instead
+     * @deprecated use {@link #PostgreSQLContainer(DockerImageName)} or {@link #PostgreSQLContainer(String)} instead
      */
     @Deprecated
     public PostgreSQLContainer() {


### PR DESCRIPTION
# Description

This replaces dangling Javadoc reference with the correct one in `PostgreSQLContainer()` deprecation note.