### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -15,7 +15,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.1.0
+      - uses: actions/setup-java@v2.3.0
         with:
           java-version: '8.0.292+10'
           distribution: adopt-hotspot
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.1.0
+      - uses: actions/setup-java@v2.3.0
         with:
           java-version: '8.0.292+10'
           distribution: adopt-hotspot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.1.0
+      - uses: actions/setup-java@v2.3.0
         with:
           java-version: '8.0.292+10'
           distribution: adopt-hotspot
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.1.0
+      - uses: actions/setup-java@v2.3.0
         with:
           java-version: '8.0.292+10'
           distribution: adopt-hotspot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2.3.0
         with:
           java-version: '1.8'
       - name: Clear existing docker image cache

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@6356f411fa7c14aab1fb2ac2fd20762a629e2fbf # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@a116d8b533be6c4e71a8b3c3871b7344ca72bf12 # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
-    testImplementation ('org.mockito:mockito-core:3.11.2') {
+    testImplementation ('org.mockito:mockito-core:3.12.4') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     }
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:3.6.3'
+    testImplementation 'redis.clients:jedis:3.7.0'
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,7 +70,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.32'
     compileOnly 'org.jetbrains:annotations:21.0.1'
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'
-    api 'org.apache.commons:commons-compress:1.20'
+    api 'org.apache.commons:commons-compress:1.21'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:3.6.3'
     testImplementation 'com.rabbitmq:amqp-client:5.12.0'
-    testImplementation 'org.mongodb:mongo-java-driver:3.12.9'
+    testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
     testImplementation ('org.mockito:mockito-core:3.11.2') {
         exclude(module: 'hamcrest-core')

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:6.9.1'
-    testImplementation 'io.cucumber:cucumber-junit:6.9.1'
+    testImplementation 'io.cucumber:cucumber-junit:6.11.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'biz.paluch.redis:spinach:0.3'
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
     testImplementation 'org.mockito:mockito-all:1.10.19'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.20"
     annotationProcessor "org.projectlombok:lombok:1.18.20"
     implementation 'biz.paluch.redis:spinach:0.3'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.mockito:mockito-all:1.10.19'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.json:json:20210307'
     testImplementation 'org.postgresql:postgresql:42.2.23'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
     testImplementation 'org.testcontainers:postgresql'
 }
 

--- a/examples/mongodb-container/build.gradle
+++ b/examples/mongodb-container/build.gradle
@@ -9,5 +9,5 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testCompileClasspath 'org.jetbrains:annotations:21.0.1'
+    testCompileClasspath 'org.jetbrains:annotations:22.0.0'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
     testImplementation 'org.testng:testng:7.4.0'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'redis.clients:jedis:3.6.1'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.2.3'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'redis.clients:jedis:3.6.1'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.2'
+    id 'org.springframework.boot' version '2.5.4'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:3.6.1'
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.5.2"
     id("org.jetbrains.kotlin.jvm") version "1.5.10"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.5.21"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.5.30"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.5.2"
+    id("org.springframework.boot") version "2.5.4"
     id("org.jetbrains.kotlin.jvm") version "1.5.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.5.30"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.2'
+    id 'org.springframework.boot' version '2.5.4'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.couchbase.client:java-client:3.2.0'
+    testImplementation 'com.couchbase.client:java-client:3.2.1'
     testImplementation 'org.awaitility:awaitility:4.1.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.37'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.60'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.37'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.13.0"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.14.1"
     testImplementation "org.elasticsearch.client:transport:7.13.4"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.8'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.10'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.26'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':database-commons')
     testImplementation project(':test-support')
 
-    compileOnly 'org.jetbrains:annotations:21.0.1'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.8'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:22.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.8'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.10'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:3.6.3'
+    testImplementation 'redis.clients:jedis:3.7.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation ('org.mockito:mockito-core:3.12.4') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:3.6.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:3.11.2') {
+    testImplementation ('org.mockito:mockito-core:3.12.4') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.20.2'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.20.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.7.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.2.22'
+    testRuntimeOnly 'org.postgresql:postgresql:42.2.23'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.26'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.37'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.37'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'
     testImplementation 'software.amazon.awssdk:s3:2.17.9'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.2'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:2.7.3'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:2.7.4'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:21.0.1'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
 }

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -2,6 +2,6 @@ description = "Testcontainers :: Nginx"
 
 dependencies {
     api project(':testcontainers')
-    compileOnly 'org.jetbrains:annotations:21.0.1'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:21.0.1'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     testImplementation project(':nginx')
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 
-    compileOnly 'org.jetbrains:annotations:21.0.1'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.2.23'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'
 
-    testCompileClasspath 'org.jetbrains:annotations:21.0.1'
+    testCompileClasspath 'org.jetbrains:annotations:22.0.0'
 }
 
 sourceJar {

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.23'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.25'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.26'
 
     testCompileClasspath 'org.jetbrains:annotations:22.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one:


* Bump actions/setup-java from 2.1.0 to 2.3.0 (#4439) @dependabot
* Bump gradle-update/update-gradle-wrapper-action from 1.0.14 to 1.0.15 (#4438) @dependabot
* Bump gson from 2.8.7 to 2.8.8 in /examples (#4437) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.5.21 to 1.5.30 in /examples (#4436) @dependabot
* Bump org.springframework.boot from 2.5.2 to 2.5.4 in /examples (#4435) @dependabot
* Bump mongo-java-driver from 3.12.9 to 3.12.10 in /core (#4434) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /examples (#4433) @dependabot
* Bump jedis from 3.6.1 to 3.7.0 in /examples (#4432) @dependabot
* Bump amqp-client from 5.12.0 to 5.13.1 in /core (#4430) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.5.10 to 1.5.30 in /examples (#4428) @dependabot
* Bump aws-java-sdk-logs from 1.12.37 to 1.12.60 in /modules/localstack (#4425) @dependabot
* Bump cucumber-junit from 6.9.1 to 6.11.0 in /examples (#4426) @dependabot
* Bump elasticsearch-rest-client from 7.13.0 to 7.14.1 in /modules/elasticsearch (#4424) @dependabot
* Bump mockito-core from 3.11.2 to 3.12.4 in /core (#4422) @dependabot
* Bump mockito-core from 3.11.2 to 3.12.4 in /modules/junit-jupiter (#4421) @dependabot
* Bump cucumber-java from 6.9.1 to 6.11.0 in /examples (#4418) @dependabot
* Bump java-client from 3.2.0 to 3.2.1 in /modules/couchbase (#4415) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /modules/postgresql (#4416) @dependabot
* Bump transport from 7.13.4 to 7.14.1 in /modules/elasticsearch (#4417) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /modules/selenium (#4412) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.37 to 1.12.60 in /modules/dynalite (#4413) @dependabot
* Bump jedis from 3.6.3 to 3.7.0 in /modules/junit-jupiter (#4409) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /modules/mysql (#4408) @dependabot
* Bump mariadb-java-client from 2.7.3 to 2.7.4 in /modules/mariadb (#4407) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /modules/jdbc (#4406) @dependabot
* Bump tomcat-jdbc from 10.0.8 to 10.0.10 in /modules/jdbc (#4411) @dependabot
* Bump jedis from 3.6.3 to 3.7.0 in /core (#4410) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /modules/spock (#4404) @dependabot
* Bump tomcat-jdbc from 10.0.8 to 10.0.10 in /modules/jdbc-test (#4403) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /modules/nginx (#4405) @dependabot
* Bump commons-compress from 1.20 to 1.21 in /core (#4349) @dependabot
* Bump logback-classic from 1.2.3 to 1.2.5 in /examples (#4347) @dependabot
* Bump postgresql from 42.2.22 to 42.2.23 in /modules/junit-jupiter (#4341) @dependabot
* Bump mysql-connector-java from 8.0.25 to 8.0.26 in /modules/spock (#4339) @dependabot
