### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -106,7 +106,7 @@ dependencies {
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:3.7.0'
-    testImplementation 'com.rabbitmq:amqp-client:5.12.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.13.1'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
     testImplementation ('org.mockito:mockito-core:3.12.4') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,7 +68,7 @@ dependencies {
 
     api 'junit:junit:4.12'
     api 'org.slf4j:slf4j-api:1.7.32'
-    compileOnly 'org.jetbrains:annotations:21.0.1'
+    compileOnly 'org.jetbrains:annotations:22.0.0'
     testCompileClasspath 'org.jetbrains:annotations:21.0.1'
     api 'org.apache.commons:commons-compress:1.21'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:6.9.1'
+    testImplementation 'io.cucumber:cucumber-java:6.11.0'
     testImplementation 'io.cucumber:cucumber-junit:6.11.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:3.6.1'
+    implementation 'redis.clients:jedis:3.7.0'
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:3.6.1'
+    implementation 'redis.clients:jedis:3.7.0'
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:3.6.1'
+    implementation 'redis.clients:jedis:3.7.0'
     implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("org.springframework.boot") version "2.5.4"
-    id("org.jetbrains.kotlin.jvm") version "1.5.10"
+    id("org.jetbrains.kotlin.jvm") version "1.5.30"
     id("org.jetbrains.kotlin.plugin.spring") version "1.5.30"
 }
 

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.14.1"
-    testImplementation "org.elasticsearch.client:transport:7.13.4"
+    testImplementation "org.elasticsearch.client:transport:7.14.1"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.37'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.37'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.62'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'
     testImplementation 'software.amazon.awssdk:s3:2.17.34'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'
-    testImplementation 'software.amazon.awssdk:s3:2.17.9'
+    testImplementation 'software.amazon.awssdk:s3:2.17.34'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.37'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.62'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.37'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.62'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,12 +10,12 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:0.8.6.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.3.1.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.4.0.jre8'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:0.8.5.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.3.1.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.4.0.jre8'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump s3 from 2.17.9 to 2.17.34 in /modules/localstack (#4447) @dependabot
* Bump aws-java-sdk-sqs from 1.12.37 to 1.12.62 in /modules/localstack (#4446) @dependabot
* Bump aws-java-sdk-s3 from 1.12.37 to 1.12.62 in /modules/localstack (#4445) @dependabot
* Bump jedis from 3.6.1 to 3.7.0 in /examples (#4432) @dependabot
* Bump amqp-client from 5.12.0 to 5.13.1 in /core (#4430) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.5.10 to 1.5.30 in /examples (#4428) @dependabot
* Bump annotations from 21.0.1 to 22.0.0 in /core (#4427) @dependabot
* Bump cucumber-java from 6.9.1 to 6.11.0 in /examples (#4418) @dependabot
* Bump transport from 7.13.4 to 7.14.1 in /modules/elasticsearch (#4417) @dependabot
* Bump mssql-jdbc from 9.3.1.jre8-preview to 9.4.0.jre8 in /modules/mssqlserver (#4414) @dependabot
