### PR TITLE
Retry internal port checking in the same exec

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheck.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheck.java
@@ -24,7 +24,7 @@ public class InternalCommandPortListeningCheck implements java.util.concurrent.C
     @Override
     public Boolean call() {
          String command = internalPorts.stream()
-             .map(it -> String.format("(cat /proc/net/tcp* | awk '{print $2}' | grep -i ':0*%x')", it))
+             .map(it -> String.format("grep -i ':0*%x' /proc/net/tcp*", it))
              .collect(Collectors.joining(
              " && ",
              "while true; do ( ",

--- a/core/src/test/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheckTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheckTest.java
@@ -7,14 +7,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.rnorth.ducttape.TimeoutException;
 import org.rnorth.ducttape.unreliables.Unreliables;
+import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.util.concurrent.TimeUnit;
 
 import static java.util.Arrays.asList;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertFalse;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
 
 @RunWith(Parameterized.class)
 public class InternalCommandPortListeningCheckTest {
@@ -45,9 +44,7 @@ public class InternalCommandPortListeningCheckTest {
 
         Unreliables.retryUntilTrue(5, TimeUnit.SECONDS, check);
 
-        final Boolean result = check.call();
-
-        assertTrue("InternalCommandPortListeningCheck identifies a single listening port", result);
+        VisibleAssertions.pass("InternalCommandPortListeningCheck identifies a single listening port");
     }
 
     @Test
@@ -56,13 +53,9 @@ public class InternalCommandPortListeningCheckTest {
 
         try {
             Unreliables.retryUntilTrue(5, TimeUnit.SECONDS, check);
+            VisibleAssertions.fail("expected to fail");
         } catch (TimeoutException e) {
-            // we expect it to timeout
         }
-
-        final Boolean result = check.call();
-
-        assertFalse("InternalCommandPortListeningCheck detects a non-listening port among many", result);
     }
 
     @Test
@@ -71,8 +64,6 @@ public class InternalCommandPortListeningCheckTest {
 
         Unreliables.retryUntilTrue(5, TimeUnit.SECONDS, check);
 
-        final Boolean result = check.call();
-
-        assertTrue("InternalCommandPortListeningCheck identifies a low and a high port", result);
+        VisibleAssertions.pass("InternalCommandPortListeningCheck identifies a low and a high port");
     }
 }


### PR DESCRIPTION
Exec'ing with Docker is slow. Even if the command itself takes 10ms to execute, `docker exec` would take 300ms or so. This PR adds `while true`-style waiting in the same `exec` session, so that we pay the overhead of `exec` only once.

Before:
```
Container confluentinc/cp-kafka:5.4.3 started in PT5.492S
```

After:
```
Container confluentinc/cp-kafka:5.4.3 started in PT4.387S
```