### PR TITLE
Upgrade to Docker Compose 1.29.2 (#4164)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -608,7 +608,7 @@ interface DockerCompose {
 class ContainerisedDockerCompose extends GenericContainer<ContainerisedDockerCompose> implements DockerCompose {
 
     public static final char UNIX_PATH_SEPERATOR = ':';
-    public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker/compose:1.24.1");
+    public static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker/compose:1.29.2");
 
     public ContainerisedDockerCompose(List<File> composeFiles, String identifier) {
 


### PR DESCRIPTION
While the discussions for making the Compose image configurable are underway in #4377 we can make an immediate improvement and use the latest available version of Compose.