### PR TITLE
Refactor JDBC URL parsing

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -244,6 +244,13 @@ public class ConnectionUrl {
         );
 
         Pattern DAEMON_MATCHING_PATTERN = Pattern.compile(".*([?&]?)TC_DAEMON=([^?&]+).*");
+
+        /**
+         * @deprecated for removal
+         */
+        @Deprecated
+        Pattern INITSCRIPT_MATCHING_PATTERN = Pattern.compile(".*([?&]?)TC_INITSCRIPT=([^?&]+).*");
+
         Pattern INITFUNCTION_MATCHING_PATTERN = Pattern.compile(".*([?&]?)TC_INITFUNCTION=" +
             "((\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)*\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +
             "::" +

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -221,9 +221,11 @@ public class ConnectionUrl {
         Pattern ORACLE_URL_MATCHING_PATTERN = Pattern.compile(
             "jdbc:tc:" +
                 "(?<databaseType>[a-z]+)" +
-                "(:(?<imageTag>[^(:thin:)]+))?:" +
-                "thin:(//)?" +
-                "((?<username>[^?^/]+)/(?<password>[^?^/]+))?" +
+                "(:(?<imageTag>(?!thin).+))?:thin:(//)?" +
+                "(" +
+                "(?<username>[^:" +
+                "?^/]+)/(?<password>[^?^/]+)" +
+                ")?" +
                 "@" +
                 "(?<dbHostString>[^?]+)" +
                 "(?<queryParameters>\\?.*)?"

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -149,7 +150,7 @@ public class ConnectionUrl {
     }
 
     private Map<String, String> parseTmpfsOptions(Map<String, String> containerParameters) {
-        if(!containerParameters.containsKey("TC_TMPFS")){
+        if (!containerParameters.containsKey("TC_TMPFS")) {
             return Collections.emptyMap();
         }
 
@@ -209,24 +210,37 @@ public class ConnectionUrl {
      * @author manikmagar
      */
     public interface Patterns {
-        Pattern URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:" +
-            "(?<databaseType>[a-z0-9]+)" +
-            "(:(?<imageTag>[^:]+))?" +
-            "://" +
-            "(?<dbHostString>[^\\?]+)" +
-            "(?<queryParameters>\\?.*)?");
+        Pattern URL_MATCHING_PATTERN = Pattern.compile(
+            "jdbc:tc:" +
+                "(?<databaseType>[a-z0-9]+)" +
+                "(:(?<imageTag>[^:]+))?" +
+                "://" +
+                "(?<dbHostString>[^\\?]+)" +
+                "(?<queryParameters>\\?.*)?"
+        );
 
-        Pattern ORACLE_URL_MATCHING_PATTERN = Pattern.compile("jdbc:tc:" +
-            "(?<databaseType>[a-z]+)" +
-            "(:(?<imageTag>[^(:thin:)]+))?:" +
-            "thin:(//)?" +
-            "((?<username>[^\\?^/]+)/(?<password>[^\\?^/]+))?" +
-            "@" +
-            "(?<dbHostString>[^\\?]+)" +
-            "(?<queryParameters>\\?.*)?");
+        Pattern ORACLE_URL_MATCHING_PATTERN = Pattern.compile(
+            "jdbc:tc:" +
+                "(?<databaseType>[a-z]+)" +
+                "(:(?<imageTag>[^(:thin:)]+))?:" +
+                "thin:(//)?" +
+                "((?<username>[^\\?^/]+)/(?<password>[^\\?^/]+))?" +
+                "@" +
+                "(?<dbHostString>[^\\?]+)" +
+                "(?<queryParameters>\\?.*)?"
+        );
 
         //Matches to part of string - hostname:port/databasename
-        Pattern DB_INSTANCE_MATCHING_PATTERN = Pattern.compile("(?<databaseHost>[^:]+)(:(?<databasePort>[0-9]+))?((?<sidOrServiceName>[:/])|;databaseName=)(?<databaseName>[^\\\\?]+)");
+        Pattern DB_INSTANCE_MATCHING_PATTERN = Pattern.compile(
+            "(?<databaseHost>[^:]+)" +
+                "(:(?<databasePort>[0-9]+))?" +
+                "(" +
+                "(?<sidOrServiceName>[:/])" +
+                "|" +
+                ";databaseName=" +
+                ")" +
+                "(?<databaseName>[^\\\\?]+)"
+        );
 
         Pattern DAEMON_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_DAEMON=([^\\?&]+).*");
         Pattern INITSCRIPT_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITSCRIPT=([^\\?&]+).*");

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -110,7 +109,7 @@ public class ConnectionUrl {
         Matcher dbInstanceMatcher = Patterns.DB_INSTANCE_MATCHING_PATTERN.matcher(dbHostString);
         if (dbInstanceMatcher.matches()) {
             databaseHost = Optional.of(dbInstanceMatcher.group("databaseHost"));
-            databasePort = Optional.ofNullable(dbInstanceMatcher.group("databasePort")).map(value -> Integer.valueOf(value));
+            databasePort = Optional.ofNullable(dbInstanceMatcher.group("databasePort")).map(Integer::valueOf);
             databaseName = Optional.of(dbInstanceMatcher.group("databaseName"));
         }
 
@@ -124,7 +123,7 @@ public class ConnectionUrl {
             .map(e -> e.getKey() + "=" + e.getValue())
             .collect(Collectors.joining("&"));
 
-        if (query == null || query.trim().length() == 0) {
+        if (query.trim().length() == 0) {
             queryString = Optional.empty();
         } else {
             queryString = Optional.of("?" + query);
@@ -215,7 +214,7 @@ public class ConnectionUrl {
                 "(?<databaseType>[a-z0-9]+)" +
                 "(:(?<imageTag>[^:]+))?" +
                 "://" +
-                "(?<dbHostString>[^\\?]+)" +
+                "(?<dbHostString>[^?]+)" +
                 "(?<queryParameters>\\?.*)?"
         );
 
@@ -224,9 +223,9 @@ public class ConnectionUrl {
                 "(?<databaseType>[a-z]+)" +
                 "(:(?<imageTag>[^(:thin:)]+))?:" +
                 "thin:(//)?" +
-                "((?<username>[^\\?^/]+)/(?<password>[^\\?^/]+))?" +
+                "((?<username>[^?^/]+)/(?<password>[^?^/]+))?" +
                 "@" +
-                "(?<dbHostString>[^\\?]+)" +
+                "(?<dbHostString>[^?]+)" +
                 "(?<queryParameters>\\?.*)?"
         );
 
@@ -242,9 +241,8 @@ public class ConnectionUrl {
                 "(?<databaseName>[^\\\\?]+)"
         );
 
-        Pattern DAEMON_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_DAEMON=([^\\?&]+).*");
-        Pattern INITSCRIPT_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITSCRIPT=([^\\?&]+).*");
-        Pattern INITFUNCTION_MATCHING_PATTERN = Pattern.compile(".*([\\?&]?)TC_INITFUNCTION=" +
+        Pattern DAEMON_MATCHING_PATTERN = Pattern.compile(".*([?&]?)TC_DAEMON=([^?&]+).*");
+        Pattern INITFUNCTION_MATCHING_PATTERN = Pattern.compile(".*([?&]?)TC_INITFUNCTION=" +
             "((\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)*\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +
             "::" +
             "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*)" +
@@ -252,9 +250,9 @@ public class ConnectionUrl {
 
         String TC_PARAM_NAME_PATTERN = "(TC_[A-Z_]+)";
 
-        Pattern TC_PARAM_MATCHING_PATTERN = Pattern.compile(TC_PARAM_NAME_PATTERN + "=([^\\?&]+)");
+        Pattern TC_PARAM_MATCHING_PATTERN = Pattern.compile(TC_PARAM_NAME_PATTERN + "=([^?&]+)");
 
-        Pattern QUERY_PARAM_MATCHING_PATTERN = Pattern.compile("([^\\?&=]+)=([^\\?&]*)");
+        Pattern QUERY_PARAM_MATCHING_PATTERN = Pattern.compile("([^?&=]+)=([^?&]*)");
 
     }
 

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -46,6 +46,7 @@ public class ConnectionUrlDriversTests {
                 {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", Optional.empty(), "localhost:1521/test", "test"},
                 {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521:test", "oracle", Optional.of("1.2.3"), "localhost:1521:test", "test"},
                 {"jdbc:tc:oracle:1.2.3:thin://@localhost:1521:test", "oracle", Optional.of("1.2.3"), "localhost:1521:test", "test"},
+                {"jdbc:tc:oracle:1.2.3-anything:thin://@localhost:1521:test", "oracle", Optional.of("1.2.3-anything"), "localhost:1521:test", "test"},
                 {"jdbc:tc:oracle:thin:@localhost:1521:test", "oracle", Optional.empty(), "localhost:1521:test", "test"}
             });
     }

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -37,12 +37,16 @@ public class ConnectionUrlDriversTests {
                 {"jdbc:tc:mysql://hostname/test", "mysql", Optional.empty(), "hostname/test", "test"},
                 {"jdbc:tc:postgresql:1.2.3://hostname/test", "postgresql", Optional.of("1.2.3"), "hostname/test", "test"},
                 {"jdbc:tc:postgresql://hostname/test", "postgresql", Optional.empty(), "hostname/test", "test"},
-                {"jdbc:tc:sqlserver:1.2.3://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.of("1.2.3"), "localhost;instance=SQLEXPRESS:1433;databaseName=test", ""},
-                {"jdbc:tc:sqlserver://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.empty(), "localhost;instance=SQLEXPRESS:1433;databaseName=test", ""},
+                {"jdbc:tc:sqlserver:1.2.3://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.of("1.2.3"), "localhost;instance=SQLEXPRESS:1433;databaseName=test", "test"},
+                {"jdbc:tc:sqlserver://localhost;instance=SQLEXPRESS:1433;databaseName=test", "sqlserver", Optional.empty(), "localhost;instance=SQLEXPRESS:1433;databaseName=test", "test"},
                 {"jdbc:tc:mariadb:1.2.3://localhost:3306/test", "mariadb", Optional.of("1.2.3"), "localhost:3306/test", "test"},
                 {"jdbc:tc:mariadb://localhost:3306/test", "mariadb", Optional.empty(), "localhost:3306/test", "test"},
+                {"jdbc:tc:oracle:1.2.3:thin://@localhost:1521/test", "oracle", Optional.of("1.2.3"), "localhost:1521/test", "test"},
                 {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521/test", "oracle", Optional.of("1.2.3"), "localhost:1521/test", "test"},
-                {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", Optional.empty(), "localhost:1521/test", "test"}
+                {"jdbc:tc:oracle:thin:@localhost:1521/test", "oracle", Optional.empty(), "localhost:1521/test", "test"},
+                {"jdbc:tc:oracle:1.2.3:thin:@localhost:1521:test", "oracle", Optional.of("1.2.3"), "localhost:1521:test", "test"},
+                {"jdbc:tc:oracle:1.2.3:thin://@localhost:1521:test", "oracle", Optional.of("1.2.3"), "localhost:1521:test", "test"},
+                {"jdbc:tc:oracle:thin:@localhost:1521:test", "oracle", Optional.empty(), "localhost:1521:test", "test"}
             });
     }
 


### PR DESCRIPTION
Credit belongs mainly to @justinwyer. Split out from #4382 

- Detect SID `:` or service name `/` in the supplied TC jdbc URL and honor this in the underlying JDBC URL.  
- Switched affected regex patterns to use named groups  
- Add tests for both SID and service name connections
- Further tidying
- Fix image tag extraction Tags containing any of the chars [t,h,i,n] would break
