### PR TITLE
Remove unneeded type variables

### DIFF
--- a/docs/examples/junit4/generic/src/test/java/generic/ImageNameSubstitutionTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ImageNameSubstitutionTest.java
@@ -13,7 +13,7 @@ public class ImageNameSubstitutionTest {
         try (
             // directDockerHubReference {
             // Referring directly to an image on Docker Hub (mysql:8.0.24)
-            final MySQLContainer<?> mysql = new MySQLContainer<>(
+            final MySQLContainer mysql = new MySQLContainer(
                 DockerImageName.parse("mysql:8.0.24")
             )
 
@@ -34,7 +34,7 @@ public class ImageNameSubstitutionTest {
         try (
             // hardcodedMirror {
             // Referring directly to an image on a private registry - image name will vary
-            final MySQLContainer<?> mysql = new MySQLContainer<>(
+            final MySQLContainer mysql = new MySQLContainer(
                 DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.24")
                                .asCompatibleSubstituteFor("mysql")
             )

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -23,7 +23,7 @@ import java.util.Optional;
  *
  * @author Eugeny Karpov
  */
-public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends GenericContainer<SELF> {
+public class CassandraContainer extends GenericContainer<CassandraContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("cassandra");
     private static final String DEFAULT_TAG = "3.11.2";
@@ -125,7 +125,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      *
      * @param configLocation relative classpath with the directory that contains cassandra.yaml and other configuration files
      */
-    public SELF withConfigurationOverride(String configLocation) {
+    public CassandraContainer withConfigurationOverride(String configLocation) {
         this.configLocation = configLocation;
         return self();
     }
@@ -137,7 +137,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
      *
      * @param initScriptPath relative classpath resource
      */
-    public SELF withInitScript(String initScriptPath) {
+    public CassandraContainer withInitScript(String initScriptPath) {
         this.initScriptPath = initScriptPath;
         return self();
     }
@@ -145,7 +145,7 @@ public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends G
     /**
      * Initialize Cassandra client with JMX reporting enabled or disabled
      */
-    public SELF withJmxReporting(boolean enableJmxReporting) {
+    public CassandraContainer withJmxReporting(boolean enableJmxReporting) {
         this.enableJmxReporting = enableJmxReporting;
         return self();
     }

--- a/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
+++ b/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
@@ -25,7 +25,7 @@ public class CassandraContainerTest {
 
     @Test
     public void testSimple() {
-        try (CassandraContainer<?> cassandraContainer = new CassandraContainer<>(CASSANDRA_IMAGE)) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer(CASSANDRA_IMAGE)) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer, "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());
@@ -36,7 +36,7 @@ public class CassandraContainerTest {
     @Test
     public void testSpecificVersion() {
         String cassandraVersion = "3.0.15";
-        try (CassandraContainer<?> cassandraContainer = new CassandraContainer<>(CASSANDRA_IMAGE.withTag(cassandraVersion))) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer(CASSANDRA_IMAGE.withTag(cassandraVersion))) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer, "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());
@@ -47,7 +47,7 @@ public class CassandraContainerTest {
     @Test
     public void testConfigurationOverride() {
         try (
-            CassandraContainer<?> cassandraContainer = new CassandraContainer<>(CASSANDRA_IMAGE)
+            CassandraContainer cassandraContainer = new CassandraContainer(CASSANDRA_IMAGE)
                 .withConfigurationOverride("cassandra-test-configuration-example")
         ) {
             cassandraContainer.start();
@@ -60,7 +60,7 @@ public class CassandraContainerTest {
     @Test(expected = ContainerLaunchException.class)
     public void testEmptyConfigurationOverride() {
         try (
-            CassandraContainer<?> cassandraContainer = new CassandraContainer<>(CASSANDRA_IMAGE)
+            CassandraContainer cassandraContainer = new CassandraContainer(CASSANDRA_IMAGE)
                 .withConfigurationOverride("cassandra-empty-configuration")
         ) {
             cassandraContainer.start();
@@ -70,7 +70,7 @@ public class CassandraContainerTest {
     @Test
     public void testInitScript() {
         try (
-            CassandraContainer<?> cassandraContainer = new CassandraContainer<>(CASSANDRA_IMAGE)
+            CassandraContainer cassandraContainer = new CassandraContainer(CASSANDRA_IMAGE)
                 .withInitScript("initial.cql")
         ) {
             cassandraContainer.start();
@@ -81,7 +81,7 @@ public class CassandraContainerTest {
     @Test
     public void testInitScriptWithLegacyCassandra() {
         try (
-            CassandraContainer<?> cassandraContainer = new CassandraContainer<>(DockerImageName.parse("cassandra:2.2.11"))
+            CassandraContainer cassandraContainer = new CassandraContainer(DockerImageName.parse("cassandra:2.2.11"))
                 .withInitScript("initial.cql")
         ) {
             cassandraContainer.start();
@@ -93,7 +93,7 @@ public class CassandraContainerTest {
     @Test
     public void testCassandraQueryWaitStrategy() {
         try (
-            CassandraContainer<?> cassandraContainer = new CassandraContainer<>()
+            CassandraContainer cassandraContainer = new CassandraContainer()
                 .waitingFor(new CassandraQueryWaitStrategy())
         ) {
             cassandraContainer.start();
@@ -105,7 +105,7 @@ public class CassandraContainerTest {
     @SuppressWarnings("deprecation") // Using deprecated constructor for verification of backwards compatibility
     @Test
     public void testCassandraGetCluster() {
-        try (CassandraContainer<?> cassandraContainer = new CassandraContainer<>()) {
+        try (CassandraContainer cassandraContainer = new CassandraContainer()) {
             cassandraContainer.start();
             ResultSet resultSet = performQuery(cassandraContainer.getCluster(), "SELECT release_version FROM system.local");
             assertTrue("Query was not applied", resultSet.wasApplied());
@@ -113,7 +113,7 @@ public class CassandraContainerTest {
         }
     }
 
-    private void testInitScript(CassandraContainer<?> cassandraContainer) {
+    private void testInitScript(CassandraContainer cassandraContainer) {
         ResultSet resultSet = performQuery(cassandraContainer, "SELECT * FROM keySpaceTest.catalog_category");
         assertTrue("Query was not applied", resultSet.wasApplied());
         Row row = resultSet.one();
@@ -121,7 +121,7 @@ public class CassandraContainerTest {
         assertEquals("Inserted row is not in expected state", "test_category", row.getString(1));
     }
 
-    private ResultSet performQuery(CassandraContainer<?> cassandraContainer, String cql) {
+    private ResultSet performQuery(CassandraContainer cassandraContainer, String cql) {
         Cluster explicitCluster = Cluster.builder()
             .addContactPoint(cassandraContainer.getHost())
             .withPort(cassandraContainer.getMappedPort(CassandraContainer.CQL_PORT))

--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.utility.DockerImageName;
 import java.time.Duration;
 import java.util.Set;
 
-public class ClickHouseContainer extends JdbcDatabaseContainer {
+public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContainer> {
     public static final String NAME = "clickhouse";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("yandex/clickhouse-server");

--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseProvider.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseProvider.java
@@ -2,14 +2,14 @@ package org.testcontainers.containers;
 
 import org.testcontainers.utility.DockerImageName;
 
-public class ClickHouseProvider extends JdbcDatabaseContainerProvider {
+public class ClickHouseProvider extends JdbcDatabaseContainerProvider<ClickHouseContainer> {
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(ClickHouseContainer.NAME);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public ClickHouseContainer newInstance(String tag) {
         return new ClickHouseContainer(DockerImageName.parse(ClickHouseContainer.IMAGE).withTag(tag));
     }
 }

--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainerProvider.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainerProvider.java
@@ -2,19 +2,19 @@ package org.testcontainers.containers;
 
 import org.testcontainers.utility.DockerImageName;
 
-public class CockroachContainerProvider extends JdbcDatabaseContainerProvider {
+public class CockroachContainerProvider extends JdbcDatabaseContainerProvider<CockroachContainer> {
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(CockroachContainer.NAME);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public CockroachContainer newInstance() {
         return newInstance(CockroachContainer.IMAGE_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public CockroachContainer newInstance(String tag) {
         return new CockroachContainer(DockerImageName.parse(CockroachContainer.IMAGE).withTag(tag));
     }
 }

--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2ContainerProvider.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2ContainerProvider.java
@@ -2,19 +2,19 @@ package org.testcontainers.containers;
 
 import org.testcontainers.utility.DockerImageName;
 
-public class Db2ContainerProvider extends JdbcDatabaseContainerProvider {
+public class Db2ContainerProvider extends JdbcDatabaseContainerProvider<Db2Container> {
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(Db2Container.NAME);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public Db2Container newInstance() {
         return newInstance(Db2Container.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public Db2Container newInstance(String tag) {
         return new Db2Container(DockerImageName.parse(Db2Container.DEFAULT_DB2_IMAGE_NAME).withTag(tag));
     }
 }

--- a/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
+++ b/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * See <a href="https://store.docker.com/images/influxdb">https://store.docker.com/images/influxdb</a>
  */
-public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends GenericContainer<SELF> {
+public class InfluxDBContainer extends GenericContainer<InfluxDBContainer> {
 
     public static final Integer INFLUXDB_PORT = 8086;
 
@@ -81,7 +81,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      * @param authEnabled Enables authentication.
      * @return a reference to this container instance
      */
-    public SELF withAuthEnabled(final boolean authEnabled) {
+    public InfluxDBContainer withAuthEnabled(final boolean authEnabled) {
         this.authEnabled = authEnabled;
         return self();
     }
@@ -92,7 +92,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      * @param admin The name of the admin user to be created. If this is unset, no admin user is created.
      * @return a reference to this container instance
      */
-    public SELF withAdmin(final String admin) {
+    public InfluxDBContainer withAdmin(final String admin) {
         this.admin = admin;
         return self();
     }
@@ -104,7 +104,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      *                      random password is generated and printed to standard out.
      * @return a reference to this container instance
      */
-    public SELF withAdminPassword(final String adminPassword) {
+    public InfluxDBContainer withAdminPassword(final String adminPassword) {
         this.adminPassword = adminPassword;
         return self();
     }
@@ -115,7 +115,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      * @param database Automatically initializes a database with the name of this environment variable.
      * @return a reference to this container instance
      */
-    public SELF withDatabase(final String database) {
+    public InfluxDBContainer withDatabase(final String database) {
         this.database = database;
         return self();
     }
@@ -127,7 +127,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      *                 be granted read and write permissions for that database.
      * @return a reference to this container instance
      */
-    public SELF withUsername(final String username) {
+    public InfluxDBContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
@@ -139,7 +139,7 @@ public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends Gen
      *                 is generated and printed to standard out.
      * @return a reference to this container instance
      */
-    public SELF withPassword(final String password) {
+    public InfluxDBContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/influxdb/src/test/java/org/testcontainers/containers/InfluxDBContainerTest.java
+++ b/modules/influxdb/src/test/java/org/testcontainers/containers/InfluxDBContainerTest.java
@@ -11,7 +11,7 @@ import static org.junit.Assert.assertThat;
 public class InfluxDBContainerTest {
 
     @ClassRule
-    public static InfluxDBContainer<?> influxDBContainer = new InfluxDBContainer<>(InfluxDBTestImages.INFLUXDB_TEST_IMAGE);
+    public static InfluxDBContainer influxDBContainer = new InfluxDBContainer(InfluxDBTestImages.INFLUXDB_TEST_IMAGE);
 
     @Test
     public void getUrl() {

--- a/modules/influxdb/src/test/java/org/testcontainers/containers/InfluxDBContainerWithUserTest.java
+++ b/modules/influxdb/src/test/java/org/testcontainers/containers/InfluxDBContainerWithUserTest.java
@@ -23,7 +23,7 @@ public class InfluxDBContainerWithUserTest {
     private static final String PASSWORD = "test-password";
 
     @Rule
-    public InfluxDBContainer<?> influxDBContainer = new InfluxDBContainer<>(InfluxDBTestImages.INFLUXDB_TEST_IMAGE)
+    public InfluxDBContainer influxDBContainer = new InfluxDBContainer(InfluxDBTestImages.INFLUXDB_TEST_IMAGE)
         .withDatabase(DATABASE)
         .withUsername(USER)
         .withPassword(PASSWORD);

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainerProvider.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainerProvider.java
@@ -10,7 +10,7 @@ import java.util.Objects;
  * Base class for classes that can provide a JDBC container.
  */
 @Slf4j
-public abstract class JdbcDatabaseContainerProvider {
+public abstract class JdbcDatabaseContainerProvider<T extends JdbcDatabaseContainer<T>> {
 
     /**
      * Tests if the specified database type is supported by this Container Provider. It should match to the base image name.
@@ -25,7 +25,7 @@ public abstract class JdbcDatabaseContainerProvider {
      *
      * @return Instance of {@link JdbcDatabaseContainer}
      */
-    public JdbcDatabaseContainer newInstance() {
+    public T newInstance() {
         log.warn("No explicit version tag was provided in JDBC URL and this class ({}) does not " +
             "override newInstance() to set a default tag. `latest` will be used but results may " +
             "be unreliable!", this.getClass().getCanonicalName());
@@ -37,15 +37,15 @@ public abstract class JdbcDatabaseContainerProvider {
      * @param tag
      * @return Instance of {@link JdbcDatabaseContainer}
      */
-    public abstract JdbcDatabaseContainer newInstance(String tag);
+    public abstract T newInstance(String tag);
 
     /**
      * Instantiate a new {@link JdbcDatabaseContainer} using information provided with {@link ConnectionUrl}.
      * @param url {@link ConnectionUrl}
      * @return Instance of {@link JdbcDatabaseContainer}
      */
-    public JdbcDatabaseContainer newInstance(ConnectionUrl url) {
-        final JdbcDatabaseContainer result;
+    public T newInstance(ConnectionUrl url) {
+        final T result;
         if (url.getImageTag().isPresent()) {
             result = newInstance(url.getImageTag().get());
         } else {
@@ -55,14 +55,14 @@ public abstract class JdbcDatabaseContainerProvider {
         return result;
     }
 
-    protected JdbcDatabaseContainer newInstanceFromConnectionUrl(ConnectionUrl connectionUrl, final String userParamName, final String pwdParamName) {
+    protected T newInstanceFromConnectionUrl(ConnectionUrl connectionUrl, final String userParamName, final String pwdParamName) {
         Objects.requireNonNull(connectionUrl, "Connection URL cannot be null");
 
         final String databaseName = connectionUrl.getDatabaseName().orElse("test");
         final String user = connectionUrl.getQueryParameters().getOrDefault(userParamName, "test");
         final String password = connectionUrl.getQueryParameters().getOrDefault(pwdParamName, "test");
 
-        final JdbcDatabaseContainer<?> instance;
+        final JdbcDatabaseContainer<T> instance;
         if (connectionUrl.getImageTag().isPresent()) {
             instance = newInstance(connectionUrl.getImageTag().get());
         } else {

--- a/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerTest.java
@@ -19,7 +19,7 @@ public class JdbcDatabaseContainerTest {
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(jdbcContainer::waitUntilContainerStarted);
     }
 
-    static class JdbcDatabaseContainerStub extends JdbcDatabaseContainer {
+    static class JdbcDatabaseContainerStub extends JdbcDatabaseContainer<JdbcDatabaseContainerStub> {
 
         public JdbcDatabaseContainerStub(@NonNull String dockerImageName) {
             super(dockerImageName);

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/MissingJdbcDriverTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/MissingJdbcDriverTest.java
@@ -36,7 +36,7 @@ public class MissingJdbcDriverTest {
     /**
      * Container class for the purposes of testing, with a known non-existent driver
      */
-    static class MissingDriverContainer extends JdbcDatabaseContainer {
+    static class MissingDriverContainer extends JdbcDatabaseContainer<MissingDriverContainer> {
         private final AtomicInteger connectionAttempts = new AtomicInteger();
 
         MissingDriverContainer() {

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/PostgresContainerTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/PostgresContainerTests.java
@@ -15,7 +15,7 @@ import static org.testcontainers.junit.jupiter.JUnitJupiterTestImages.POSTGRES_I
 class PostgresContainerTests {
 
     @Container
-    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(POSTGRES_IMAGE)
+    private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer(POSTGRES_IMAGE)
             .withDatabaseName("foo")
             .withUsername("foo")
             .withPassword("secret");

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -10,7 +10,7 @@ import java.util.Set;
  *
  * @author Miguel Gonzalez Sanchez
  */
-public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MariaDBContainer extends JdbcDatabaseContainer<MariaDBContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mariadb");
 
@@ -107,25 +107,25 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         return "SELECT 1";
     }
 
-    public SELF withConfigurationOverride(String s) {
+    public MariaDBContainer withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public MariaDBContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public MariaDBContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MariaDBContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainerProvider.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainerProvider.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for MariaDB org.testcontainers.containers.
  */
-public class MariaDBContainerProvider extends JdbcDatabaseContainerProvider {
+public class MariaDBContainerProvider extends JdbcDatabaseContainerProvider<MariaDBContainer> {
 
     private static final String USER_PARAM = "user";
 
@@ -18,17 +18,17 @@ public class MariaDBContainerProvider extends JdbcDatabaseContainerProvider {
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public MariaDBContainer newInstance() {
         return newInstance(MariaDBContainer.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public MariaDBContainer newInstance(String tag) {
         return new MariaDBContainer(DockerImageName.parse(MariaDBContainer.IMAGE).withTag(tag));
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+    public MariaDBContainer newInstance(ConnectionUrl connectionUrl) {
        return newInstanceFromConnectionUrl(connectionUrl, USER_PARAM, PASSWORD_PARAM);
     }
 

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainer.java
@@ -10,9 +10,9 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 public class MariaDBR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
 
     @Delegate(types = Startable.class)
-    private final MariaDBContainer<?> container;
+    private final MariaDBContainer container;
 
-    public static ConnectionFactoryOptions getOptions(MariaDBContainer<?> container) {
+    public static ConnectionFactoryOptions getOptions(MariaDBContainer container) {
         ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, MariaDBR2DBCDatabaseContainerProvider.DRIVER)
             .build();

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerProvider.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerProvider.java
@@ -22,7 +22,7 @@ public class MariaDBR2DBCDatabaseContainerProvider implements R2DBCDatabaseConta
     @Override
     public R2DBCDatabaseContainer createContainer(ConnectionFactoryOptions options) {
         String image = MariaDBContainer.IMAGE + ":" + options.getRequiredValue(IMAGE_TAG_OPTION);
-        MariaDBContainer<?> container = new MariaDBContainer<>(image)
+        MariaDBContainer container = new MariaDBContainer(image)
             .withDatabaseName(options.getRequiredValue(ConnectionFactoryOptions.DATABASE));
 
         if (Boolean.TRUE.equals(options.getValue(REUSABLE_OPTION))) {

--- a/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
@@ -4,10 +4,10 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
 import org.testcontainers.utility.DockerImageName;
 
-public class MariaDBR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MariaDBContainer<?>> {
+public class MariaDBR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MariaDBContainer> {
 
     @Override
-    protected ConnectionFactoryOptions getOptions(MariaDBContainer<?> container) {
+    protected ConnectionFactoryOptions getOptions(MariaDBContainer container) {
         return MariaDBR2DBCDatabaseContainer.getOptions(container);
     }
 
@@ -17,8 +17,8 @@ public class MariaDBR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseCont
     }
 
     @Override
-    protected MariaDBContainer<?> createContainer() {
-        return new MariaDBContainer<>(DockerImageName.parse("mariadb:10.3.6"));
+    protected MariaDBContainer createContainer() {
+        return new MariaDBContainer(DockerImageName.parse("mariadb:10.3.6"));
     }
 
 }

--- a/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
@@ -20,7 +20,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
-        try (MariaDBContainer<?> mariadb = new MariaDBContainer<>(MARIADB_IMAGE)) {
+        try (MariaDBContainer mariadb = new MariaDBContainer(MARIADB_IMAGE)) {
 
             mariadb.start();
 
@@ -33,7 +33,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSpecificVersion() throws SQLException {
-        try (MariaDBContainer<?> mariadbOldVersion = new MariaDBContainer<>(MARIADB_IMAGE.withTag("5.5.51"))) {
+        try (MariaDBContainer mariadbOldVersion = new MariaDBContainer(MARIADB_IMAGE.withTag("5.5.51"))) {
 
             mariadbOldVersion.start();
 
@@ -48,7 +48,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
     public void testMariaDBWithCustomIniFile() throws SQLException {
         assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
-        try (MariaDBContainer<?> mariadbCustomConfig = new MariaDBContainer<>(MARIADB_IMAGE.withTag("10.1.16"))
+        try (MariaDBContainer mariadbCustomConfig = new MariaDBContainer(MARIADB_IMAGE.withTag("10.1.16"))
             .withConfigurationOverride("somepath/mariadb_conf_override")) {
             mariadbCustomConfig.start();
 
@@ -62,7 +62,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
     @Test
     public void testMariaDBWithCommandOverride() throws SQLException {
 
-        try (MariaDBContainer<?> mariadbCustomConfig = new MariaDBContainer<>(MARIADB_IMAGE)
+        try (MariaDBContainer mariadbCustomConfig = new MariaDBContainer(MARIADB_IMAGE)
             .withCommand("mysqld --auto_increment_increment=10")) {
             mariadbCustomConfig.start();
             ResultSet resultSet = performQuery(mariadbCustomConfig, "show variables like 'auto_increment_increment'");
@@ -74,7 +74,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamInJdbcUrl() {
-        MariaDBContainer<?> mariaDBContainer = new MariaDBContainer<>(MARIADB_IMAGE)
+        MariaDBContainer mariaDBContainer = new MariaDBContainer(MARIADB_IMAGE)
             .withUrlParam("connectTimeout", "40000")
             .withUrlParam("rewriteBatchedStatements", "true");
 

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainer.java
@@ -10,9 +10,9 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 public class MSSQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
 
     @Delegate(types = Startable.class)
-    private final MSSQLServerContainer<?> container;
+    private final MSSQLServerContainer container;
 
-    public static ConnectionFactoryOptions getOptions(MSSQLServerContainer<?> container) {
+    public static ConnectionFactoryOptions getOptions(MSSQLServerContainer container) {
         ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, MSSQLR2DBCDatabaseContainerProvider.DRIVER)
             .build();

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerProvider.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerProvider.java
@@ -23,7 +23,7 @@ public class MSSQLR2DBCDatabaseContainerProvider implements R2DBCDatabaseContain
     public R2DBCDatabaseContainer createContainer(ConnectionFactoryOptions options) {
         // TODO work out how best to do this if these constants become private
         String image = MSSQLServerContainer.IMAGE + ":" + options.getRequiredValue(IMAGE_TAG_OPTION);
-        MSSQLServerContainer<?> container = new MSSQLServerContainer<>(image);
+        MSSQLServerContainer container = new MSSQLServerContainer(image);
 
         if (Boolean.TRUE.equals(options.getValue(REUSABLE_OPTION))) {
             container.withReuse(true);

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -11,7 +11,7 @@ import java.util.stream.Stream;
 /**
  * @author Stefan Hufschmidt
  */
-public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MSSQLServerContainer extends JdbcDatabaseContainer<MSSQLServerContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server");
     @Deprecated
@@ -81,7 +81,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
      * Accepts the license for the SQLServer container by setting the ACCEPT_EULA=Y
      * variable as described at <a href="https://hub.docker.com/_/microsoft-mssql-server">https://hub.docker.com/_/microsoft-mssql-server</a>
      */
-    public SELF acceptLicense() {
+    public MSSQLServerContainer acceptLicense() {
         addEnv("ACCEPT_EULA", "Y");
         return self();
     }
@@ -113,7 +113,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MSSQLServerContainer withPassword(final String password) {
         checkPasswordStrength(password);
         this.password = password;
         return self();

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainerProvider.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainerProvider.java
@@ -5,19 +5,19 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for MS SQL Server containers.
  */
-public class MSSQLServerContainerProvider extends JdbcDatabaseContainerProvider {
+public class MSSQLServerContainerProvider extends JdbcDatabaseContainerProvider<MSSQLServerContainer> {
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(MSSQLServerContainer.NAME);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public MSSQLServerContainer newInstance() {
         return newInstance(MSSQLServerContainer.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public MSSQLServerContainer newInstance(String tag) {
         return new MSSQLServerContainer(DockerImageName.parse(MSSQLServerContainer.IMAGE).withTag(tag));
     }
 }

--- a/modules/mssqlserver/src/test/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerTest.java
@@ -4,10 +4,10 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.MSSQLServerTestImages;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
 
-public class MSSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MSSQLServerContainer<?>> {
+public class MSSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MSSQLServerContainer> {
 
     @Override
-    protected ConnectionFactoryOptions getOptions(MSSQLServerContainer<?> container) {
+    protected ConnectionFactoryOptions getOptions(MSSQLServerContainer container) {
         return MSSQLR2DBCDatabaseContainer.getOptions(container);
     }
 
@@ -17,7 +17,7 @@ public class MSSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContai
     }
 
     @Override
-    protected MSSQLServerContainer<?> createContainer() {
-        return new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE);
+    protected MSSQLServerContainer createContainer() {
+        return new MSSQLServerContainer(MSSQLServerTestImages.MSSQL_SERVER_IMAGE);
     }
 }

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomPasswordMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomPasswordMSSQLServerTest.java
@@ -67,7 +67,7 @@ public class CustomPasswordMSSQLServerTest {
     @Test
     public void runPasswordTests() {
         try {
-            new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE).withPassword(this.password);
+            new MSSQLServerContainer(MSSQLServerTestImages.MSSQL_SERVER_IMAGE).withPassword(this.password);
             if (!valid)
                 fail("Password " + this.password + " is not valid. Expected exception");
         } catch (IllegalArgumentException e) {

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomizableMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomizableMSSQLServerTest.java
@@ -16,7 +16,7 @@ public class CustomizableMSSQLServerTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSqlServerConnection() throws SQLException {
-        try (MSSQLServerContainer<?> mssqlServerContainer = new MSSQLServerContainer<>(DockerImageName.parse("mcr.microsoft.com/mssql/server:2017-CU12"))
+        try (MSSQLServerContainer mssqlServerContainer = new MSSQLServerContainer(DockerImageName.parse("mcr.microsoft.com/mssql/server:2017-CU12"))
             .withPassword(STRONG_PASSWORD)) {
 
             mssqlServerContainer.start();

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
@@ -19,7 +19,7 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
-        try (MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQL_SERVER_IMAGE)) {
+        try (MSSQLServerContainer mssqlServer = new MSSQLServerContainer(MSSQL_SERVER_IMAGE)) {
             mssqlServer.start();
             ResultSet resultSet = performQuery(mssqlServer, "SELECT 1");
 
@@ -30,7 +30,7 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamInJdbcUrl() {
-        try (MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQL_SERVER_IMAGE)
+        try (MSSQLServerContainer mssqlServer = new MSSQLServerContainer(MSSQL_SERVER_IMAGE)
             .withUrlParam("integratedSecurity", "false")
             .withUrlParam("applicationName", "MyApp")) {
 
@@ -44,7 +44,7 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSetupDatabase() throws SQLException {
-        try (MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQL_SERVER_IMAGE)) {
+        try (MSSQLServerContainer mssqlServer = new MSSQLServerContainer(MSSQL_SERVER_IMAGE)) {
             mssqlServer.start();
             DataSource ds = getDataSource(mssqlServer);
             Statement statement = ds.getConnection().createStatement();

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -9,7 +9,7 @@ import java.util.Set;
 /**
  * @author richardnorth
  */
-public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class MySQLContainer extends JdbcDatabaseContainer<MySQLContainer> {
 
     public static final String NAME = "mysql";
 
@@ -132,25 +132,25 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         return "SELECT 1";
     }
 
-    public SELF withConfigurationOverride(String s) {
+    public MySQLContainer withConfigurationOverride(String s) {
         parameters.put(MY_CNF_CONFIG_OVERRIDE_PARAM_NAME, s);
         return self();
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public MySQLContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public MySQLContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public MySQLContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainerProvider.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for MySQL containers.
  */
-public class MySQLContainerProvider extends JdbcDatabaseContainerProvider {
+public class MySQLContainerProvider extends JdbcDatabaseContainerProvider<MySQLContainer> {
 
     private static final String USER_PARAM = "user";
 
@@ -18,12 +18,12 @@ public class MySQLContainerProvider extends JdbcDatabaseContainerProvider {
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public MySQLContainer newInstance() {
         return newInstance(MySQLContainer.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public MySQLContainer newInstance(String tag) {
         if (tag != null) {
             return new MySQLContainer(DockerImageName.parse(MySQLContainer.IMAGE).withTag(tag));
         } else {
@@ -32,7 +32,7 @@ public class MySQLContainerProvider extends JdbcDatabaseContainerProvider {
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+    public MySQLContainer newInstance(ConnectionUrl connectionUrl) {
         return newInstanceFromConnectionUrl(connectionUrl, USER_PARAM, PASSWORD_PARAM);
     }
 

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainer.java
@@ -10,9 +10,9 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 public class MySQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
 
     @Delegate(types = Startable.class)
-    private final MySQLContainer<?> container;
+    private final MySQLContainer container;
 
-    public static ConnectionFactoryOptions getOptions(MySQLContainer<?> container) {
+    public static ConnectionFactoryOptions getOptions(MySQLContainer container) {
         ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, MySQLR2DBCDatabaseContainerProvider.DRIVER)
             .build();

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerProvider.java
@@ -22,7 +22,7 @@ public class MySQLR2DBCDatabaseContainerProvider implements R2DBCDatabaseContain
     @Override
     public R2DBCDatabaseContainer createContainer(ConnectionFactoryOptions options) {
         String image = MySQLContainer.IMAGE + ":" + options.getRequiredValue(IMAGE_TAG_OPTION);
-        MySQLContainer<?> container = new MySQLContainer<>(image)
+        MySQLContainer container = new MySQLContainer(image)
             .withDatabaseName(options.getRequiredValue(ConnectionFactoryOptions.DATABASE));
 
         if (Boolean.TRUE.equals(options.getValue(REUSABLE_OPTION))) {

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerTest.java
@@ -4,10 +4,10 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.MySQLTestImages;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
 
-public class MySQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MySQLContainer<?>> {
+public class MySQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MySQLContainer> {
 
     @Override
-    protected ConnectionFactoryOptions getOptions(MySQLContainer<?> container) {
+    protected ConnectionFactoryOptions getOptions(MySQLContainer container) {
         return MySQLR2DBCDatabaseContainer.getOptions(container);
     }
 
@@ -17,8 +17,8 @@ public class MySQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContai
     }
 
     @Override
-    protected MySQLContainer<?> createContainer() {
-        return new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE);
+    protected MySQLContainer createContainer() {
+        return new MySQLContainer(MySQLTestImages.MYSQL_80_IMAGE);
     }
 
 }

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
@@ -29,20 +29,20 @@ public class MySQLRootAccountTest {
 
     @Test
     public void testRootAccountUsageWithDefaultPassword() throws SQLException {
-        testWithDB(new MySQLContainer<>(image).withUsername("root"));
+        testWithDB(new MySQLContainer(image).withUsername("root"));
     }
 
     @Test
     public void testRootAccountUsageWithEmptyPassword() throws SQLException {
-        testWithDB(new MySQLContainer<>(image).withUsername("root").withPassword(""));
+        testWithDB(new MySQLContainer(image).withUsername("root").withPassword(""));
     }
 
     @Test
     public void testRootAccountUsageWithCustomPassword() throws SQLException {
-        testWithDB(new MySQLContainer<>(image).withUsername("root").withPassword("not-default"));
+        testWithDB(new MySQLContainer(image).withUsername("root").withPassword("not-default"));
     }
 
-    private void testWithDB(MySQLContainer<?> db) throws SQLException {
+    private void testWithDB(MySQLContainer db) throws SQLException {
         try {
             db.withLogConsumer(new Slf4jLogConsumer(log)).start();
             Connection connection = DriverManager.getConnection(db.getJdbcUrl(), db.getUsername(), db.getPassword());

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
@@ -18,7 +18,7 @@ public class CustomizableMysqlTest extends AbstractContainerDatabaseTest {
     @Test
     public void testSimple() throws SQLException {
         // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
-        try (MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+        try (MySQLContainer mysql = new MySQLContainer(MySQLTestImages.MYSQL_57_IMAGE)
             .withDatabaseName(DB_NAME)
             .withUsername(USER)
             .withPassword(PWD)

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
@@ -32,7 +32,7 @@ public class MultiVersionMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void versionCheckTest() throws SQLException {
-        try (MySQLContainer<?> mysql = new MySQLContainer<>(dockerImageName)) {
+        try (MySQLContainer mysql = new MySQLContainer(dockerImageName)) {
             mysql.start();
             final ResultSet resultSet = performQuery(mysql, "SELECT VERSION()");
             final String resultSetString = resultSet.getString(1);

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
@@ -51,7 +51,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
-        try (MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
+        try (MySQLContainer mysql = new MySQLContainer(MYSQL_57_IMAGE)
             .withConfigurationOverride("somepath/mysql_conf_override")
             .withLogConsumer(new Slf4jLogConsumer(logger))) {
 
@@ -66,7 +66,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSpecificVersion() throws SQLException {
-        try (MySQLContainer<?> mysqlOldVersion = new MySQLContainer<>(MYSQL_56_IMAGE)
+        try (MySQLContainer mysqlOldVersion = new MySQLContainer(MYSQL_56_IMAGE)
             .withConfigurationOverride("somepath/mysql_conf_override")
             .withLogConsumer(new Slf4jLogConsumer(logger))) {
 
@@ -83,7 +83,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     public void testMySQLWithCustomIniFile() throws SQLException {
         assumeFalse(SystemUtils.IS_OS_WINDOWS);
 
-        try (MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MYSQL_56_IMAGE)
+        try (MySQLContainer mysqlCustomConfig = new MySQLContainer(MYSQL_56_IMAGE)
             .withConfigurationOverride("somepath/mysql_conf_override")) {
 
             mysqlCustomConfig.start();
@@ -97,7 +97,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testCommandOverride() throws SQLException {
-        try (MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MYSQL_57_IMAGE)
+        try (MySQLContainer mysqlCustomConfig = new MySQLContainer(MYSQL_57_IMAGE)
             .withCommand("mysqld --auto_increment_increment=42")) {
 
             mysqlCustomConfig.start();
@@ -111,7 +111,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testExplicitInitScript() throws SQLException {
-        try (MySQLContainer<?> container = new MySQLContainer<>(MYSQL_57_IMAGE)
+        try (MySQLContainer container = new MySQLContainer(MYSQL_57_IMAGE)
             .withInitScript("somepath/init_mysql.sql")
             .withLogConsumer(new Slf4jLogConsumer(logger))) {
             container.start();
@@ -125,7 +125,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test(expected = ContainerLaunchException.class)
     public void testEmptyPasswordWithNonRootUser() {
-        try (MySQLContainer<?> container = new MySQLContainer<>(MYSQL_56_IMAGE)
+        try (MySQLContainer container = new MySQLContainer(MYSQL_56_IMAGE)
                     .withDatabaseName("TEST")
                     .withUsername("test")
                     .withPassword("")
@@ -138,7 +138,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     @Test
     public void testEmptyPasswordWithRootUser() throws SQLException {
         // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
-        try (MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_56_IMAGE)
+        try (MySQLContainer mysql = new MySQLContainer(MYSQL_56_IMAGE)
             .withDatabaseName("foo")
             .withUsername("root")
             .withPassword("")
@@ -155,7 +155,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamTimeZone() throws SQLException {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
+        MySQLContainer mysql = new MySQLContainer(MYSQL_57_IMAGE)
             .withUrlParam("serverTimezone", "Europe/Zurich")
             .withEnv("TZ", "Europe/Zurich")
             .withLogConsumer(new Slf4jLogConsumer(logger));
@@ -185,7 +185,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamMultiQueries() throws SQLException {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
+        MySQLContainer mysql = new MySQLContainer(MYSQL_57_IMAGE)
             .withUrlParam("allowMultiQueries", "true")
             .withLogConsumer(new Slf4jLogConsumer(logger));
         mysql.start();
@@ -209,7 +209,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamInJdbcUrl() {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_57_IMAGE)
+        MySQLContainer mysql = new MySQLContainer(MYSQL_57_IMAGE)
             .withUrlParam("allowMultiQueries", "true")
             .withUrlParam("rewriteBatchedStatements", "true")
             .withLogConsumer(new Slf4jLogConsumer(logger));

--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -12,7 +12,7 @@ import java.util.Set;
 /**
  * @author richardnorth
  */
-public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer {
+public class NginxContainer extends GenericContainer<NginxContainer> implements LinkableContainer {
 
     private static final int NGINX_DEFAULT_PORT = 80;
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("nginx");
@@ -53,7 +53,7 @@ public class NginxContainer<SELF extends NginxContainer<SELF>> extends GenericCo
         addFileSystemBind(htmlContentPath, "/usr/share/nginx/html", BindMode.READ_ONLY);
     }
 
-    public SELF withCustomContent(String htmlContentPath) {
+    public NginxContainer withCustomContent(String htmlContentPath) {
         this.setCustomContent(htmlContentPath);
         return self();
     }

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -26,7 +26,7 @@ public class SimpleNginxTest {
 
     // creatingContainer {
     @Rule
-    public NginxContainer<?> nginx = new NginxContainer<>(NGINX_IMAGE)
+    public NginxContainer nginx = new NginxContainer(NGINX_IMAGE)
         .withCustomContent(tmpDirectory)
         .waitingFor(new HttpWaitStrategy());
     // }

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainerProvider.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainerProvider.java
@@ -5,19 +5,19 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for Oracle containers.
  */
-public class OracleContainerProvider extends JdbcDatabaseContainerProvider {
+public class OracleContainerProvider extends JdbcDatabaseContainerProvider<OracleContainer> {
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(OracleContainer.NAME);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public OracleContainer newInstance() {
         return newInstance(OracleContainer.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public OracleContainer newInstance(String tag) {
         if (tag != null) {
             return new OracleContainer(DockerImageName.parse(OracleContainer.IMAGE).withTag(tag));
         }

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgisContainerProvider.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for PostGIS containers, which are a special flavour of PostgreSQL.
  */
-public class PostgisContainerProvider extends JdbcDatabaseContainerProvider {
+public class PostgisContainerProvider extends JdbcDatabaseContainerProvider<PostgreSQLContainer> {
 
     private static final String NAME = "postgis";
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("postgis/postgis").asCompatibleSubstituteFor("postgres");
@@ -21,17 +21,17 @@ public class PostgisContainerProvider extends JdbcDatabaseContainerProvider {
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public PostgreSQLContainer newInstance() {
         return newInstance(DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
-        return new PostgreSQLContainer<>(DEFAULT_IMAGE_NAME.withTag(tag));
+    public PostgreSQLContainer newInstance(String tag) {
+        return new PostgreSQLContainer(DEFAULT_IMAGE_NAME.withTag(tag));
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+    public PostgreSQLContainer newInstance(ConnectionUrl connectionUrl) {
         return newInstanceFromConnectionUrl(connectionUrl, USER_PARAM, PASSWORD_PARAM);
     }
 }

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -13,7 +13,7 @@ import static java.util.Collections.singleton;
 /**
  * @author richardnorth
  */
-public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class PostgreSQLContainer extends JdbcDatabaseContainer<PostgreSQLContainer> {
     public static final String NAME = "postgresql";
     public static final String IMAGE = "postgres";
 
@@ -108,19 +108,19 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
     }
 
     @Override
-    public SELF withDatabaseName(final String databaseName) {
+    public PostgreSQLContainer withDatabaseName(final String databaseName) {
         this.databaseName = databaseName;
         return self();
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public PostgreSQLContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
 
     @Override
-    public SELF withPassword(final String password) {
+    public PostgreSQLContainer withPassword(final String password) {
         this.password = password;
         return self();
     }

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainerProvider.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for PostgreSQL containers.
  */
-public class PostgreSQLContainerProvider extends JdbcDatabaseContainerProvider {
+public class PostgreSQLContainerProvider extends JdbcDatabaseContainerProvider<PostgreSQLContainer> {
 
     public static final String USER_PARAM = "user";
     public static final String PASSWORD_PARAM = "password";
@@ -17,17 +17,17 @@ public class PostgreSQLContainerProvider extends JdbcDatabaseContainerProvider {
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public PostgreSQLContainer newInstance() {
         return newInstance(PostgreSQLContainer.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public PostgreSQLContainer newInstance(String tag) {
         return new PostgreSQLContainer(DockerImageName.parse(PostgreSQLContainer.IMAGE).withTag(tag));
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+    public PostgreSQLContainer newInstance(ConnectionUrl connectionUrl) {
         return newInstanceFromConnectionUrl(connectionUrl, USER_PARAM, PASSWORD_PARAM);
     }
 

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainer.java
@@ -10,9 +10,9 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 public final class PostgreSQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
 
     @Delegate(types = Startable.class)
-    private final PostgreSQLContainer<?> container;
+    private final PostgreSQLContainer container;
 
-    public static ConnectionFactoryOptions getOptions(PostgreSQLContainer<?> container) {
+    public static ConnectionFactoryOptions getOptions(PostgreSQLContainer container) {
         ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
             .option(ConnectionFactoryOptions.DRIVER, PostgreSQLR2DBCDatabaseContainerProvider.DRIVER)
             .build();

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
@@ -22,7 +22,7 @@ public final class PostgreSQLR2DBCDatabaseContainerProvider implements R2DBCData
     @Override
     public R2DBCDatabaseContainer createContainer(ConnectionFactoryOptions options) {
         String image = PostgreSQLContainer.IMAGE + ":" + options.getRequiredValue(IMAGE_TAG_OPTION);
-        PostgreSQLContainer<?> container = new PostgreSQLContainer<>(image)
+        PostgreSQLContainer container = new PostgreSQLContainer(image)
             .withDatabaseName(options.getRequiredValue(ConnectionFactoryOptions.DATABASE));
 
         if (Boolean.TRUE.equals(options.getValue(REUSABLE_OPTION))) {

--- a/modules/postgresql/src/test/java/org/testcontainers/containers/PostgreSQLConnectionURLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/containers/PostgreSQLConnectionURLTest.java
@@ -12,7 +12,7 @@ public class PostgreSQLConnectionURLTest {
 
     @Test
     public void shouldCorrectlyAppendQueryString() {
-        PostgreSQLContainer<?> postgres = new FixedJdbcUrlPostgreSQLContainer();
+        PostgreSQLContainer postgres = new FixedJdbcUrlPostgreSQLContainer();
         String connectionUrl = postgres.constructUrlForConnection("?stringtype=unspecified&stringtype=unspecified");
         String queryString = connectionUrl.substring(connectionUrl.indexOf('?'));
 
@@ -23,7 +23,7 @@ public class PostgreSQLConnectionURLTest {
 
     @Test
     public void shouldCorrectlyAppendQueryStringWhenNoBaseParams() {
-        PostgreSQLContainer<?> postgres = new NoParamsUrlPostgreSQLContainer();
+        PostgreSQLContainer postgres = new NoParamsUrlPostgreSQLContainer();
         String connectionUrl = postgres.constructUrlForConnection("?stringtype=unspecified&stringtype=unspecified");
         String queryString = connectionUrl.substring(connectionUrl.indexOf('?'));
 
@@ -34,7 +34,7 @@ public class PostgreSQLConnectionURLTest {
 
     @Test
     public void shouldReturnOriginalURLWhenEmptyQueryString() {
-        PostgreSQLContainer<?> postgres = new FixedJdbcUrlPostgreSQLContainer();
+        PostgreSQLContainer postgres = new FixedJdbcUrlPostgreSQLContainer();
         String connectionUrl = postgres.constructUrlForConnection("");
 
         assertTrue("Query String remains unchanged", postgres.getJdbcUrl().equals(connectionUrl));
@@ -46,7 +46,7 @@ public class PostgreSQLConnectionURLTest {
             () -> new NoParamsUrlPostgreSQLContainer().constructUrlForConnection("stringtype=unspecified"));
     }
 
-    static class FixedJdbcUrlPostgreSQLContainer extends PostgreSQLContainer<FixedJdbcUrlPostgreSQLContainer> {
+    static class FixedJdbcUrlPostgreSQLContainer extends PostgreSQLContainer {
         public FixedJdbcUrlPostgreSQLContainer() {
             super(PostgreSQLTestImages.POSTGRES_TEST_IMAGE);
         }
@@ -62,7 +62,7 @@ public class PostgreSQLConnectionURLTest {
         }
     }
 
-    static class NoParamsUrlPostgreSQLContainer extends PostgreSQLContainer<FixedJdbcUrlPostgreSQLContainer> {
+    static class NoParamsUrlPostgreSQLContainer extends PostgreSQLContainer {
         public NoParamsUrlPostgreSQLContainer() {
             super(PostgreSQLTestImages.POSTGRES_TEST_IMAGE);
         }

--- a/modules/postgresql/src/test/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerTest.java
@@ -4,15 +4,15 @@ import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.testcontainers.PostgreSQLTestImages;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
 
-public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<PostgreSQLContainer<?>> {
+public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<PostgreSQLContainer> {
 
     @Override
-    protected PostgreSQLContainer<?> createContainer() {
-        return new PostgreSQLContainer<>(PostgreSQLTestImages.POSTGRES_TEST_IMAGE);
+    protected PostgreSQLContainer createContainer() {
+        return new PostgreSQLContainer(PostgreSQLTestImages.POSTGRES_TEST_IMAGE);
     }
 
     @Override
-    protected ConnectionFactoryOptions getOptions(PostgreSQLContainer<?> container) {
+    protected ConnectionFactoryOptions getOptions(PostgreSQLContainer container) {
         // get_options {
         ConnectionFactoryOptions options = PostgreSQLR2DBCDatabaseContainer.getOptions(
             container

--- a/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/CustomizablePostgreSQLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/CustomizablePostgreSQLTest.java
@@ -20,7 +20,7 @@ public class CustomizablePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
-        try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(PostgreSQLTestImages.POSTGRES_TEST_IMAGE)
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer(PostgreSQLTestImages.POSTGRES_TEST_IMAGE)
                 .withDatabaseName(DB_NAME)
                 .withUsername(USER)
                 .withPassword(PWD)) {

--- a/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
@@ -24,7 +24,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testSimple() throws SQLException {
-        try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(POSTGRES_TEST_IMAGE)) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRES_TEST_IMAGE)) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT 1");
@@ -35,7 +35,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testCommandOverride() throws SQLException {
-        try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(POSTGRES_TEST_IMAGE).withCommand("postgres -c max_connections=42")) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRES_TEST_IMAGE).withCommand("postgres -c max_connections=42")) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
@@ -46,7 +46,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testUnsetCommand() throws SQLException {
-        try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(POSTGRES_TEST_IMAGE).withCommand("postgres -c max_connections=42").withCommand()) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRES_TEST_IMAGE).withCommand("postgres -c max_connections=42").withCommand()) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
@@ -57,7 +57,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testExplicitInitScript() throws SQLException {
-        try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(POSTGRES_TEST_IMAGE).withInitScript("somepath/init_postgresql.sql")) {
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRES_TEST_IMAGE).withInitScript("somepath/init_postgresql.sql")) {
             postgres.start();
 
             ResultSet resultSet = performQuery(postgres, "SELECT foo FROM bar");
@@ -69,7 +69,7 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamInJdbcUrl() {
-        try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(POSTGRES_TEST_IMAGE)
+        try (PostgreSQLContainer postgres = new PostgreSQLContainer(POSTGRES_TEST_IMAGE)
             .withUrlParam("charSet", "UNICODE")) {
 
             postgres.start();

--- a/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
+++ b/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainer.java
@@ -18,7 +18,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
  * @deprecated Use {@code TrinoContainer} instead.
  */
 @Deprecated
-public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
+public class PrestoContainer extends JdbcDatabaseContainer<PrestoContainer> {
     public static final String NAME = "presto";
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("ghcr.io/trinodb/presto");
     public static final String IMAGE = "ghcr.io/trinodb/presto";
@@ -90,7 +90,7 @@ public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDat
     }
 
     @Override
-    public SELF withUsername(final String username) {
+    public PrestoContainer withUsername(final String username) {
         this.username = username;
         return self();
     }
@@ -100,14 +100,14 @@ public class PrestoContainer<SELF extends PrestoContainer<SELF>> extends JdbcDat
      */
     @Override
     @Deprecated
-    public SELF withPassword(final String password) {
+    public PrestoContainer withPassword(final String password) {
         // ignored, Presto does not support password authentication without TLS
         // TODO: make JDBCDriverTest not pass a password unconditionally and remove this method
         return self();
     }
 
     @Override
-    public SELF withDatabaseName(String dbName) {
+    public PrestoContainer withDatabaseName(String dbName) {
         this.catalog = dbName;
         return self();
     }

--- a/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainerProvider.java
+++ b/modules/presto/src/main/java/org/testcontainers/containers/PrestoContainerProvider.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for Presto containers.
  */
-public class PrestoContainerProvider extends JdbcDatabaseContainerProvider {
+public class PrestoContainerProvider extends JdbcDatabaseContainerProvider<PrestoContainer> {
 
     public static final String USER_PARAM = "user";
     public static final String PASSWORD_PARAM = "password";
@@ -17,17 +17,17 @@ public class PrestoContainerProvider extends JdbcDatabaseContainerProvider {
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public PrestoContainer newInstance() {
         return newInstance(PrestoContainer.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public PrestoContainer newInstance(String tag) {
         return new PrestoContainer(DockerImageName.parse(PrestoContainer.IMAGE).withTag(tag));
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+    public PrestoContainer newInstance(ConnectionUrl connectionUrl) {
         return newInstanceFromConnectionUrl(connectionUrl, USER_PARAM, PASSWORD_PARAM);
     }
 

--- a/modules/presto/src/test/java/org/testcontainers/containers/PrestoContainerTest.java
+++ b/modules/presto/src/test/java/org/testcontainers/containers/PrestoContainerTest.java
@@ -27,7 +27,7 @@ public class PrestoContainerTest {
 
     @Test
     public void testSimple() throws Exception {
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>(PrestoTestImages.PRESTO_TEST_IMAGE)) {
+        try (PrestoContainer prestoSql = new PrestoContainer(PrestoTestImages.PRESTO_TEST_IMAGE)) {
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();
                  Statement statement = connection.createStatement();
@@ -40,7 +40,7 @@ public class PrestoContainerTest {
 
     @Test
     public void testSpecificVersion() throws Exception {
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>(PrestoTestImages.PRESTO_PREVIOUS_VERSION_TEST_IMAGE)) {
+        try (PrestoContainer prestoSql = new PrestoContainer(PrestoTestImages.PRESTO_PREVIOUS_VERSION_TEST_IMAGE)) {
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();
                  Statement statement = connection.createStatement();
@@ -53,7 +53,7 @@ public class PrestoContainerTest {
 
     @Test
     public void testQueryMemoryAndTpch() throws SQLException {
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>(PrestoTestImages.PRESTO_TEST_IMAGE)) {
+        try (PrestoContainer prestoSql = new PrestoContainer(PrestoTestImages.PRESTO_TEST_IMAGE)) {
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();
                  Statement statement = connection.createStatement()) {
@@ -79,7 +79,7 @@ public class PrestoContainerTest {
 
     @Test
     public void testInitScript() throws Exception {
-        try (PrestoContainer<?> prestoSql = new PrestoContainer<>(PrestoTestImages.PRESTO_TEST_IMAGE)) {
+        try (PrestoContainer prestoSql = new PrestoContainer(PrestoTestImages.PRESTO_TEST_IMAGE)) {
             prestoSql.withInitScript("initial.sql");
             prestoSql.start();
             try (Connection connection = prestoSql.createConnection();

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -42,7 +42,7 @@ import org.testcontainers.utility.DockerImageName;
  * <p>
  * The container should expose Selenium remote control protocol and VNC.
  */
-public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SELF>> extends GenericContainer<SELF> implements LinkableContainer, TestLifecycleAware {
+public class BrowserWebDriverContainer extends GenericContainer<BrowserWebDriverContainer> implements LinkableContainer, TestLifecycleAware {
 
     private static final DockerImageName CHROME_IMAGE = DockerImageName.parse("selenium/standalone-chrome-debug");
     private static final DockerImageName FIREFOX_IMAGE = DockerImageName.parse("selenium/standalone-firefox-debug");
@@ -122,7 +122,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         recordingMode = VncRecordingMode.SKIP;
     }
 
-    public SELF withCapabilities(Capabilities capabilities) {
+    public BrowserWebDriverContainer withCapabilities(Capabilities capabilities) {
         this.capabilities = capabilities;
         return self();
     }
@@ -135,7 +135,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      * @return SELF
      * */
     @Deprecated
-    public SELF withDesiredCapabilities(DesiredCapabilities capabilities) {
+    public BrowserWebDriverContainer withDesiredCapabilities(DesiredCapabilities capabilities) {
         this.capabilities = capabilities;
         return self();
     }
@@ -362,23 +362,23 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      * @deprecated Links are deprecated (see <a href="https://github.com/testcontainers/testcontainers-java/issues/465">#465</a>). Please use {@link Network} features instead.
      */
     @Deprecated
-    public SELF withLinkToContainer(LinkableContainer otherContainer, String alias) {
+    public BrowserWebDriverContainer withLinkToContainer(LinkableContainer otherContainer, String alias) {
         addLink(otherContainer, alias);
         return self();
     }
 
-    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory) {
+    public BrowserWebDriverContainer withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory) {
         return withRecordingMode(recordingMode, vncRecordingDirectory, null);
     }
 
-    public SELF withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory, VncRecordingFormat recordingFormat) {
+    public BrowserWebDriverContainer withRecordingMode(VncRecordingMode recordingMode, File vncRecordingDirectory, VncRecordingFormat recordingFormat) {
         this.recordingMode = recordingMode;
         this.vncRecordingDirectory = vncRecordingDirectory;
         this.recordingFormat = recordingFormat;
         return self();
     }
 
-    public SELF withRecordingFileFactory(RecordingFileFactory recordingFileFactory) {
+    public BrowserWebDriverContainer withRecordingFileFactory(RecordingFileFactory recordingFileFactory) {
         this.recordingFileFactory = recordingFileFactory;
         return self();
     }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -31,7 +31,7 @@ public class BaseWebDriverContainerTest {
         .withExposedPorts(8080, 8081)
         .waitingFor(new HttpWaitStrategy());
 
-    protected static void doSimpleExplore(BrowserWebDriverContainer<?> rule) {
+    protected static void doSimpleExplore(BrowserWebDriverContainer rule) {
         RemoteWebDriver driver = setupDriverFromRule(rule);
         System.out.println("Selenium remote URL is: " + rule.getSeleniumAddress());
         System.out.println("VNC URL is: " + rule.getVncAddress());
@@ -45,7 +45,7 @@ public class BaseWebDriverContainerTest {
         );
     }
 
-    protected void assertBrowserNameIs(BrowserWebDriverContainer<?> rule, String expectedName) {
+    protected void assertBrowserNameIs(BrowserWebDriverContainer rule, String expectedName) {
         RemoteWebDriver driver = setupDriverFromRule(rule);
         String actual = driver.getCapabilities().getBrowserName();
         assertTrue(format("actual browser name is %s", actual),
@@ -53,7 +53,7 @@ public class BaseWebDriverContainerTest {
     }
 
     @NotNull
-    private static RemoteWebDriver setupDriverFromRule(BrowserWebDriverContainer<?> rule) {
+    private static RemoteWebDriver setupDriverFromRule(BrowserWebDriverContainer rule) {
         RemoteWebDriver driver = rule.getWebDriver();
         driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);
         return driver;

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BrowserWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BrowserWebDriverContainerTest.java
@@ -67,7 +67,7 @@ public class BrowserWebDriverContainerTest {
     @Test
     public void createContainerWithoutShmVolume() {
         try (
-            BrowserWebDriverContainer webDriverContainer = new BrowserWebDriverContainer<>()
+            BrowserWebDriverContainer webDriverContainer = new BrowserWebDriverContainer()
                 .withSharedMemorySize(512 * FileUtils.ONE_MB)
                 .withCapabilities(new FirefoxOptions())
         ) {

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeRecordingWebDriverContainerTest.java
@@ -50,7 +50,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
             try (
                 // recordAll {
                 // To do this, simply add extra parameters to the rule constructor, so video will default to FLV format:
-                BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
                     .withCapabilities(new ChromeOptions())
                     .withRecordingMode(RECORD_ALL, target)
                     // }
@@ -62,7 +62,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
             }
         }
 
-        private File[] runSimpleExploreInContainer(BrowserWebDriverContainer<?> container, String fileNamePattern) throws InterruptedException {
+        private File[] runSimpleExploreInContainer(BrowserWebDriverContainer container, String fileNamePattern) throws InterruptedException {
             container.start();
 
             TimeUnit.MILLISECONDS.sleep(MINIMUM_VIDEO_DURATION_MILLISECONDS);
@@ -88,7 +88,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
             try (
                 // recordFlv {
                 // Set (explicitly) FLV format for recorded video:
-                BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
                     .withCapabilities(new ChromeOptions())
                     .withRecordingMode(RECORD_ALL, target, VncRecordingFormat.FLV)
                     // }
@@ -106,7 +106,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
             try (
                 // recordMp4 {
                 // Set MP4 format for recorded video:
-                BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
                     .withCapabilities(new ChromeOptions())
                     .withRecordingMode(RECORD_ALL, target, VncRecordingFormat.MP4)
                     // }
@@ -122,7 +122,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
         public void recordingTestThatShouldHaveCorrectDuration() throws IOException, InterruptedException {
             MountableFile mountableFile;
             try (
-                BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
                     .withCapabilities(new ChromeOptions())
                     .withRecordingMode(RECORD_ALL, vncRecordingDirectory.getRoot())
                     .withRecordingFileFactory(new DefaultRecordingFileFactory())
@@ -158,7 +158,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
         public void recordingTestThatShouldBeRecordedButNotPersisted() {
             try (
                 // withRecordingFileFactory {
-                BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
                     // }
                     .withCapabilities(new ChromeOptions())
                     // withRecordingFileFactory {
@@ -178,7 +178,7 @@ public class ChromeRecordingWebDriverContainerTest extends BaseWebDriverContaine
             try (
                 // recordFailing {
                 // or if you only want videos for test failures:
-                BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+                BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
                     .withCapabilities(new ChromeOptions())
                     .withRecordingMode(RECORD_FAILING, target)
                     // }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -13,7 +13,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     // junitRule {
     @Rule
-    public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
         .withCapabilities(new ChromeOptions())
     // }
         .withNetwork(NETWORK);

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
@@ -7,7 +7,7 @@ import org.testcontainers.containers.BrowserWebDriverContainer;
 public class ContainerWithoutCapabilitiesTest extends BaseWebDriverContainerTest{
 
     @Rule
-    public BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer chrome = new BrowserWebDriverContainer()
         .withNetwork(NETWORK);
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/CustomWaitTimeoutWebDriverContainerTest.java
@@ -15,7 +15,7 @@ import static java.time.temporal.ChronoUnit.SECONDS;
 public class CustomWaitTimeoutWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Rule
-    public BrowserWebDriverContainer<?> chromeWithCustomTimeout = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer chromeWithCustomTimeout = new BrowserWebDriverContainer()
         .withCapabilities(new ChromeOptions())
         .withStartupTimeout(Duration.of(30, SECONDS))
         .withNetwork(NETWORK);

--- a/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
@@ -13,7 +13,7 @@ public class FirefoxWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     // junitRule {
     @Rule
-    public BrowserWebDriverContainer<?> firefox = new BrowserWebDriverContainer<>()
+    public BrowserWebDriverContainer firefox = new BrowserWebDriverContainer()
             .withCapabilities(new FirefoxOptions())
     // }
         .withNetwork(NETWORK);

--- a/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/Selenium3xTest.java
@@ -26,7 +26,7 @@ public class Selenium3xTest {
         final DockerImageName imageName = DockerImageName
             .parse("selenium/standalone-chrome-debug")
             .withTag(tag);
-        try (BrowserWebDriverContainer<?> chrome = new BrowserWebDriverContainer<>(imageName)
+        try (BrowserWebDriverContainer chrome = new BrowserWebDriverContainer(imageName)
                 .withCapabilities(new ChromeOptions())) {
             chrome.start();
         }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/SpecificImageNameWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/SpecificImageNameWebDriverContainerTest.java
@@ -12,7 +12,7 @@ public class SpecificImageNameWebDriverContainerTest extends BaseWebDriverContai
         .parse("selenium/standalone-firefox:2.53.1-beryllium");
 
     @Rule
-    public BrowserWebDriverContainer<?> firefox = new BrowserWebDriverContainer<>(FIREFOX_IMAGE)
+    public BrowserWebDriverContainer firefox = new BrowserWebDriverContainer(FIREFOX_IMAGE)
         .withCapabilities(new FirefoxOptions())
         .withNetwork(NETWORK);
 

--- a/modules/trino/src/main/java/org/testcontainers/containers/TrinoContainerProvider.java
+++ b/modules/trino/src/main/java/org/testcontainers/containers/TrinoContainerProvider.java
@@ -5,19 +5,19 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Factory for Trino containers.
  */
-public class TrinoContainerProvider extends JdbcDatabaseContainerProvider {
+public class TrinoContainerProvider extends JdbcDatabaseContainerProvider<TrinoContainer> {
     @Override
     public boolean supports(String databaseType) {
         return databaseType.equals(TrinoContainer.NAME);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance() {
+    public TrinoContainer newInstance() {
         return newInstance(TrinoContainer.DEFAULT_TAG);
     }
 
     @Override
-    public JdbcDatabaseContainer newInstance(String tag) {
+    public TrinoContainer newInstance(String tag) {
         return new TrinoContainer(DockerImageName.parse(TrinoContainer.IMAGE).withTag(tag));
     }
 }

--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -24,7 +24,7 @@ import static com.github.dockerjava.api.model.Capability.IPC_LOCK;
  * <p>
  * Other helpful features include the withVaultPort, and withVaultToken methods for convenience.
  */
-public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericContainer<SELF> {
+public class VaultContainer extends GenericContainer<VaultContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("vault");
     private static final String DEFAULT_TAG = "1.1.3";
@@ -109,7 +109,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param token the root token value to set for Vault.
      * @return this
      */
-    public SELF withVaultToken(String token) {
+    public VaultContainer withVaultToken(String token) {
         withEnv("VAULT_DEV_ROOT_TOKEN_ID", token);
         withEnv("VAULT_TOKEN", token);
         return self();
@@ -123,7 +123,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @deprecated the exposed port will be randomized automatically. As calling this method provides no additional value, you are recommended to remove the call. getFirstMappedPort() may be used to obtain the listening vault port.
      */
     @Deprecated
-    public SELF withVaultPort(int port) {
+    public VaultContainer withVaultPort(int port) {
         this.port = port;
         return self();
     }
@@ -135,7 +135,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param level the logging level to set for Vault.
      * @return this
      */
-    public SELF withLogLevel(VaultLogLevel level) {
+    public VaultContainer withLogLevel(VaultLogLevel level) {
         return withEnv("VAULT_LOG_LEVEL", level.config);
     }
 
@@ -151,7 +151,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param remainingSecrets var args list of secrets to add to specified path
      * @return this
      */
-    public SELF withSecretInVault(String path, String firstSecret, String... remainingSecrets) {
+    public VaultContainer withSecretInVault(String path, String firstSecret, String... remainingSecrets) {
         List<String> list = new ArrayList<>();
         list.add(firstSecret);
         for (String secret : remainingSecrets) {
@@ -175,7 +175,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param commands The commands to send to the vault cli
      * @return this
      */
-    public SELF withInitCommand(String... commands) {
+    public VaultContainer withInitCommand(String... commands) {
         initCommands.addAll(Arrays.asList(commands));
         return self();
     }

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultClientTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultClientTest.java
@@ -19,7 +19,7 @@ public class VaultClientTest {
     @Test
     public void writeAndReadMultipleValues() throws VaultException {
         try (
-            VaultContainer<?> vaultContainer = new VaultContainer<>(VAULT_IMAGE)
+            VaultContainer vaultContainer = new VaultContainer(VAULT_IMAGE)
                     .withVaultToken(VAULT_TOKEN)
         ) {
 

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
@@ -19,7 +19,7 @@ public class VaultContainerTest {
     private static final String VAULT_TOKEN = "my-root-token";
 
     @ClassRule
-    public static VaultContainer<?> vaultContainer = new VaultContainer<>(VaultTestImages.VAULT_IMAGE)
+    public static VaultContainer vaultContainer = new VaultContainer(VaultTestImages.VAULT_IMAGE)
         .withVaultToken(VAULT_TOKEN)
         .withSecretInVault("secret/testing1", "top_secret=password123")
         .withSecretInVault("secret/testing2",


### PR DESCRIPTION
Many of the containers included unneeded type variables. This lead to clunky
client code such as ```MySQLContainer<?> mysql = new MysqlContainer<>()```
The type variable are removed from these classes make them much less clunky to
use. This change still preserves all previous functionality.

This is technically a breaking change, but consumers of the library only need
to remove a wild carded type variable when upgrading.