### PR TITLE
Switch from AdoptOpenJDK to Temurin and latest JDK 8.

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -17,9 +17,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8'
+          java-version: '8.0.302'
           distribution: temurin
-          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         continue-on-error: true
@@ -46,9 +45,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8'
+          java-version: '8.0.302'
           distribution: temurin
-          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         continue-on-error: true

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -17,8 +17,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8.0.292+10'
-          distribution: adopt-hotspot
+          java-version: '8'
+          distribution: temurin
+          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         continue-on-error: true
@@ -45,8 +46,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8.0.292+10'
-          distribution: adopt-hotspot
+          java-version: '8'
+          distribution: temurin
+          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8.0.292+10'
-          distribution: adopt-hotspot
+          java-version: '8'
+          distribution: temurin
+          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         with:
@@ -51,8 +52,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8.0.292+10'
-          distribution: adopt-hotspot
+          java-version: '8'
+          distribution: temurin
+          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8'
+          java-version: '8.0.302'
           distribution: temurin
-          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         with:
@@ -52,9 +51,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8'
+          java-version: '8.0.302'
           distribution: temurin
-          check-latest: true
       - name: Cache Gradle Home files
         uses: actions/cache@v2.1.6
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '8'
+          java-version: '8.0.302'
           distribution: temurin
-          check-latest: true
       - name: Clear existing docker image cache
         run: docker image prune -af
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2.3.0
         with:
-          java-version: '1.8'
+          java-version: '8'
+          distribution: temurin
+          check-latest: true
       - name: Clear existing docker image cache
         run: docker image prune -af
 


### PR DESCRIPTION
This change is for migrating from AdoptOpenJDK to Eclipse Temurin.
Perhaps going for the latest Java 8 version again is worth considering?