### PR TITLE
Fix `AuthenticatedImagePullTest`

### DIFF
--- a/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/utility/AuthenticatedImagePullTest.java
@@ -1,21 +1,10 @@
 package org.testcontainers.utility;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.when;
-import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
-import static org.testcontainers.TestImages.DOCKER_REGISTRY_IMAGE;
-import static org.testcontainers.TestImages.TINY_IMAGE;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.PullImageResultCallback;
+import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.AuthConfig;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.concurrent.TimeUnit;
 import org.intellij.lang.annotations.Language;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -27,8 +16,26 @@ import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.DockerComposeContainer;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.output.FrameConsumerResultCallback;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.output.WaitingConsumer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.rnorth.visibleassertions.VisibleAssertions.assertTrue;
+import static org.testcontainers.TestImages.DOCKER_REGISTRY_IMAGE;
+import static org.testcontainers.TestImages.TINY_IMAGE;
 
 /**
  * This test checks the integration between Testcontainers and an authenticated registry, but uses
@@ -52,8 +59,10 @@ public class AuthenticatedImagePullTest {
                 .env("REGISTRY_AUTH_HTPASSWD_PATH", "/htpasswd")
                 .env("REGISTRY_AUTH_HTPASSWD_REALM", "Test");
         }))
-        .withExposedPorts(5000)
-        .waitingFor(new HttpWaitStrategy());
+        .withEnv("REGISTRY_HTTP_ADDR", "127.0.0.1:0")
+        .withCreateContainerCmdModifier(cmd -> {
+            cmd.getHostConfig().withNetworkMode("host");
+        });
 
     private static RegistryAuthLocator originalAuthLocatorSingleton;
     private static DockerClient client;
@@ -62,11 +71,34 @@ public class AuthenticatedImagePullTest {
     private static RegistryAuthLocator mockAuthLocator;
 
     @BeforeClass
-    public static void setUp() throws InterruptedException {
+    public static void setUp() throws Exception {
         originalAuthLocatorSingleton = RegistryAuthLocator.instance();
         client = DockerClientFactory.instance().client();
 
-        String testRegistryAddress = authenticatedRegistry.getHost() + ":" + authenticatedRegistry.getFirstMappedPort();
+        AtomicInteger port = new AtomicInteger(-1);
+        try (FrameConsumerResultCallback resultCallback = new FrameConsumerResultCallback()) {
+            WaitingConsumer waitingConsumer = new WaitingConsumer();
+            resultCallback.addConsumer(OutputFrame.OutputType.STDERR, waitingConsumer);
+
+            client.logContainerCmd(authenticatedRegistry.getContainerId())
+                .withStdErr(true)
+                .withFollowStream(true)
+                .exec(resultCallback);
+
+            Pattern pattern = Pattern.compile(".*listening on .*:(\\d+).*", Pattern.DOTALL | Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+            waitingConsumer.waitUntil(it -> {
+                String s = it.getUtf8String();
+                Matcher matcher = pattern.matcher(s);
+                if (matcher.matches()) {
+                    port.set(Integer.parseInt(matcher.group(1)));
+                    return true;
+                } else {
+                    return false;
+                }
+            }, 10, TimeUnit.SECONDS);
+        }
+
+        String testRegistryAddress = authenticatedRegistry.getHost() + ":" + port.get();
         testImageName = testRegistryAddress + "/alpine";
 
         final DockerImageName expectedName = DockerImageName.parse(testImageName);
@@ -88,7 +120,11 @@ public class AuthenticatedImagePullTest {
     @Before
     public void removeImageFromLocalDocker() {
         // remove the image tag from local docker so that it must be pulled before use
-        client.removeImageCmd(testImageName).withForce(true).exec();
+        try {
+            client.removeImageCmd(testImageName).withForce(true).exec();
+        } catch (NotFoundException ignored) {
+
+        }
     }
 
     @AfterClass


### PR DESCRIPTION
Previous implementation was assuming that Docker can pull from the gateway, which may not always be the case (eg Docker Desktop).
This change makes the temporary registry run with host network, so that Docker can always pull from it.