### PR TITLE
Enable `JUnitPlatform` for Spock tests

### DIFF
--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
 
-    testImplementation 'com.zaxxer:HikariCP:5.0.0'
+    testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.24'


### PR DESCRIPTION
When Dependabot bumped Spock to 2.0 in #4152, our test execution for the Spock module was implicitly disabled. Since Spock 2.0 is based on the JUnit platform, Gradle needs to be configured explicitly to discover and run the tests.

This also has been proven to introduce some unexpected issues to our users before (see https://twitter.com/musketyr/status/1446084194048827397).

While I think it is okay to go ahead using Spock 2.0, it might also be a good idea to document the required change in the Gradle config.
