### PR TITLE
Skip japicmp for new modules

### DIFF
--- a/gradle/japicmp.gradle
+++ b/gradle/japicmp.gradle
@@ -11,6 +11,10 @@ dependencies {
 tasks.japicmp {
     dependsOn(tasks.shadowJar)
 
+    // Disable if baseline dependencies cannot be resolved - such as when developing a new module that doesn't
+    // have an existing published version.
+    enabled = ! configurations.baseline.copy().resolvedConfiguration.lenientConfiguration.getFiles().empty
+
     oldClasspath = configurations.baseline
     newClasspath = shadowJar.outputs.files
     ignoreMissingClasses = true


### PR DESCRIPTION
Unblocks #4303

Have tested on #4303's branch; `./gradlew japicmp` (across the entire codebase) works as it should.﻿

e.g. for an unpublished module that has no available baseline:
```
> Task :azure:japicmp SKIPPED
Skipping task ':azure:japicmp' as task onlyIf is false.
:azure:japicmp (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.0 secs.
```


and for a published module:
```
> Task :trino:japicmp
Deleting stale output file: /Users/rnorth/github.com/testcontainers/testcontainers-java/modules/trino/build/reports/japi.html
Build cache key for task ':trino:japicmp' is e6e0b417a3a36294106bc367c2fff84f
Task ':trino:japicmp' is not up-to-date because:
  No history is available.
Stored cache entry for task ':trino:japicmp' with cache key e6e0b417a3a36294106bc367c2fff84f
:trino:japicmp (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 0.252 secs.
```
