### PR TITLE
Update GitLab CI docs: Add `--tls=false` to docker-in-docker to avoid startup delays

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
@@ -1,14 +1,18 @@
 # GitLab CI
 
 In order to use Testcontainers in a Gitlab CI pipeline, you need to run the job as a Docker container (see [Patterns for running inside Docker](dind_patterns.md)).
-So edit your `.gitlab-ci.yml` to include the [Docker-In-Docker service](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker-workflow-with-docker-executor) (`docker:dind`) and set the `DOCKER_HOST` variable to `tcp://docker:2375` and `DOCKER_TLS_CERTDIR` to empty string.
+So edit your `.gitlab-ci.yml` to include the [Docker-In-Docker service](https://docs.gitlab.com/ee/ci/docker/using_docker_build.html#use-docker-in-docker-workflow-with-docker-executor) (`docker:dind`) and set the `DOCKER_HOST` variable to `tcp://docker:2375` and `DOCKER_TLS_CERTDIR` to empty string. 
+
+Caveat: Current docker releases (verified for 20.10.9) intentionally delay the startup, if the docker api is bound to a network address but not TLS protected. To avoid this delay, the docker process needs to be started with the argument `--tls=false`.  Otherwise jobs which access the docker api at the very beginning might fail.
 
 Here is a sample `.gitlab-ci.yml` that executes test with gradle:
 
 ```yml
 # DinD service is required for Testcontainers
 services:
-  - docker:dind
+  - name: docker:dind
+    # explicitly disable tls to avoid docker startup interruption
+    command: ["--tls=false"]
 
 variables:
   # Instruct Testcontainers to use the daemon of DinD.


### PR DESCRIPTION
Starting the docker:dind service in GitLab CI without `--tls=false` leads to the following warning within the docker sidecar container:

> Binding to an IP address without --tlsverify is deprecated. Startup is intentionally being slowed down to show this message

If a gitlab-ci build job accesses the docker api right at the start, the job might fail.

This behaviour has been observed with docker 20.10.9 and a kubernetes-executor for the gitlab-runner.
It can be reproduced with the pipeline job below, but the public gitlab runner from gitlab.com is not affected by this behaviour.

Therefore I suggest to provide a hint to this `--tls=false` argument within the testcontainer docs.

```yaml
# DinD service is required for Testcontainers
services:
  - docker:dind

variables:
  # Instruct Testcontainers to use the daemon of DinD.
  DOCKER_HOST: "tcp://docker:2375"
  # Instruct Docker not to start over TLS.
  DOCKER_TLS_CERTDIR: ""
  # Improve performance with overlayfs.
  DOCKER_DRIVER: overlay2

test:
  image: docker:20.10.9
  stage: test
  script:
    - docker info
```



