### PR TITLE
Support to expose host ports via @Testcontainers for JUnit Jupiter

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
@@ -64,4 +64,10 @@ public @interface Testcontainers {
      * Whether tests should be disabled (rather than failing) when Docker is not available.
      */
     boolean disabledWithoutDocker() default false;
+    
+    /**
+     * Specifies the host ports that should be exposed to the containers.
+     */
+    int[] exposeHostPorts() default {};
+
 }

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -23,7 +23,6 @@ import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -52,6 +51,8 @@ class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, 
     public void beforeAll(ExtensionContext context) {
         Class<?> testClass = context.getTestClass()
             .orElseThrow(() -> new ExtensionConfigurationException("TestcontainersExtension is only supported for classes."));
+
+        exposeHostPorts(context);
 
         Store store = context.getStore(NAMESPACE);
         List<StoreAdapter> sharedContainersStoreAdapters = findSharedContainers(testClass);
@@ -116,6 +117,14 @@ class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, 
 
     private boolean isTestLifecycleAware(StoreAdapter adapter) {
         return adapter.container instanceof TestLifecycleAware;
+    }
+
+    private void exposeHostPorts(ExtensionContext context) {
+        findTestcontainers(context).ifPresent(annotation -> {
+            if (annotation.exposeHostPorts().length > 0) {
+                org.testcontainers.Testcontainers.exposeHostPorts(annotation.exposeHostPorts());
+            }
+        });
     }
 
     @Override

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExposeHostPortsTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/TestcontainersExposeHostPortsTests.java
@@ -1,0 +1,39 @@
+package org.testcontainers.junit.jupiter;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.ReflectionUtils;
+import org.junit.platform.commons.util.ReflectionUtils.HierarchyTraversalMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.PortForwardingContainer;
+
+@Testcontainers(exposeHostPorts = { 8080, 8081 })
+public class TestcontainersExposeHostPortsTests {
+
+    @Container
+    GenericContainer<?> foo = new GenericContainer<>(JUnitJupiterTestImages.HTTPD_IMAGE);
+
+    @Test
+    public void testExposeHostPosts() throws IllegalArgumentException, IllegalAccessException {
+        List<Field> fields = ReflectionUtils.findFields(PortForwardingContainer.class,
+            field -> field.getName().equals("exposedPorts"),
+            HierarchyTraversalMode.BOTTOM_UP);
+
+        Field field = fields.get(0);
+        field.setAccessible(true);
+
+        Set<Entry<Integer, Integer>> exposedPorts = (Set<Entry<Integer, Integer>>) field.get(PortForwardingContainer.INSTANCE);
+
+        assertThat(exposedPorts)
+            .hasSize(2)
+            .anyMatch(entry -> entry.getKey().equals(8080))
+            .anyMatch(entry -> entry.getKey().equals(8081));
+    }
+
+}


### PR DESCRIPTION
Currently, it is not possible to expose host ports when using the `@Testcontainers` annotation in JUnit Jupiter due to the execution order of `@BeforeAll` [1] and the registration order of extensions added with `@ExtendWith` [2]. A method annotated with `@BeforeAll` within a test class annotated with `@Testcontainers` is executed after the `@BeforeAll` of the Testcontainers extension. If you use another extension such as WireMock in combination with `@Testcontainers`, the same problem occurs. The documentation [3] notes that exposing host ports should be invoked before containers are started, but after the server is started on the host.

This change adds `exposeHostPorts` to `@Testcontainers` and configures it before the containers are started.

[1] https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/BeforeAll.html
[2] https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/extension/ExtendWith.html
[3] https://www.testcontainers.org/features/networking/#exposing-host-ports-to-the-container