### PR TITLE
Basic K3S module

### DIFF
--- a/docs/modules/k3s.md
+++ b/docs/modules/k3s.md
@@ -8,11 +8,6 @@ This module is intended to be used for testing components that interact with Kub
 
 ## Usage example
 
-!!! warning
-    K3sContainer runs as a privileged container and needs to be able to spawn its own containers. For these reasons,
-    K3sContainer will not work in certain rootless Docker, Docker-in-Docker, or other environments where privileged
-    containers are disallowed.
-
 Start a K3s server as follows:
 
 <!--codeinclude-->
@@ -30,6 +25,15 @@ This may be used with Kubernetes clients - e.g. for the [official Java client](c
 [Official Java client](../../modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java) inside_block:connecting_with_k8sio
 [Fabric8 Kubernetes client](../../modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java) inside_block:connecting_with_fabric8
 <!--/codeinclude-->
+
+## Known limitations
+
+!!! warning
+    * K3sContainer runs as a privileged container and needs to be able to spawn its own containers. For these reasons,
+    K3sContainer will not work in certain rootless Docker, Docker-in-Docker, or other environments where privileged
+    containers are disallowed.
+
+    * k3s containers may be unable to run on host machines where `/var/lib/docker` is on a BTRFS filesystem. See [k3s-io/k3s#4863](https://github.com/k3s-io/k3s/issues/4863) for an example.
 
 ## Adding this module to your project dependencies
 

--- a/docs/modules/k3s.md
+++ b/docs/modules/k3s.md
@@ -1,0 +1,49 @@
+# K3s Module
+
+!!! note
+    This module is INCUBATING. While it is ready for use and operational in the current version of Testcontainers, it is possible that it may receive breaking changes in the future. See [our contributing guidelines](/contributing/#incubating-modules) for more information on our incubating modules policy.
+
+Testcontainers module for Rancher's [K3s](https://rancher.com/products/k3s/) lightweight Kubernetes.
+This module is intended to be used for testing components that interact with Kubernetes APIs - for example, operators.
+
+## Usage example
+
+!!! warning
+    K3sContainer runs as a privileged container and needs to be able to spawn its own containers. For these reasons,
+    K3sContainer will not work in certain rootless Docker, Docker-in-Docker, or other environments where privileged
+    containers are disallowed.
+
+Start a K3s server as follows:
+
+<!--codeinclude-->
+[Starting a K3S server](../../modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java) inside_block:starting_k3s
+<!--/codeinclude-->
+
+### Connecting to the server
+
+`K3sContainer` exposes a working Kubernetes client configuration, as a YAML String, via the `getKubeConfigYaml()` method.
+
+This may be used with Kubernetes clients - e.g. for the [official Java client](connecting_with_k8sio) and 
+[the Fabric8 Kubernetes client](https://github.com/fabric8io/kubernetes-client):
+
+<!--codeinclude-->
+[Official Java client](../../modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java) inside_block:connecting_with_k8sio
+[Fabric8 Kubernetes client](../../modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java) inside_block:connecting_with_fabric8
+<!--/codeinclude-->
+
+## Adding this module to your project dependencies
+
+Add the following dependency to your `pom.xml`/`build.gradle` file:
+
+```groovy tab='Gradle'
+testImplementation "org.testcontainers:k3s:{{latest_version}}"
+```
+
+```xml tab='Maven'
+<dependency>
+    <groupId>org.testcontainers</groupId>
+    <artifactId>k3s</artifactId>
+    <version>{{latest_version}}</version>
+    <scope>test</scope>
+</dependency>
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,7 @@ nav:
           - modules/docker_compose.md
           - modules/elasticsearch.md
           - modules/gcloud.md
+          - modules/k3s.md
           - modules/kafka.md
           - modules/localstack.md
           - modules/mockserver.md

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -7,5 +7,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0'
 
     testImplementation 'io.fabric8:kubernetes-client:5.8.0'
+    testImplementation 'io.kubernetes:client-java:13.0.0'
     testImplementation 'org.assertj:assertj-core:3.21.0'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -1,0 +1,9 @@
+description = "Testcontainers :: K3S"
+
+dependencies {
+	api project(":testcontainers")
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0'
+
+    testImplementation 'io.fabric8:kubernetes-client:5.8.0'
+    testImplementation 'org.assertj:assertj-core:3.15.0'
+}

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -1,9 +1,11 @@
 description = "Testcontainers :: K3S"
 
 dependencies {
-	api project(":testcontainers")
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0'
+    api project(":testcontainers")
+
+    shaded 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0'
 
     testImplementation 'io.fabric8:kubernetes-client:5.8.0'
-    testImplementation 'org.assertj:assertj-core:3.15.0'
+    testImplementation 'org.assertj:assertj-core:3.21.0'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -3,7 +3,6 @@ description = "Testcontainers :: K3S"
 dependencies {
     api project(":testcontainers")
 
-    shaded 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
 
     testImplementation 'io.fabric8:kubernetes-client:5.11.0'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -3,10 +3,10 @@ description = "Testcontainers :: K3S"
 dependencies {
     api project(":testcontainers")
 
-    shaded 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
-    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.0'
+    shaded 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
 
-    testImplementation 'io.fabric8:kubernetes-client:5.8.0'
-    testImplementation 'io.kubernetes:client-java:13.0.0'
+    testImplementation 'io.fabric8:kubernetes-client:5.11.0'
+    testImplementation 'io.kubernetes:client-java:14.0.0'
     testImplementation 'org.assertj:assertj-core:3.21.0'
 }

--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import lombok.SneakyThrows;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
@@ -24,6 +25,7 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
 
         addExposedPorts(6443, 8443);
         setPrivilegedMode(true);
+        addFileSystemBind("/sys/fs/cgroup", "/sys/fs/cgroup", BindMode.READ_WRITE);
 
         Map<String, String> tmpFsMapping = new HashMap<>();
         tmpFsMapping.put("/run", "");

--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -9,7 +9,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse;
 import lombok.SneakyThrows;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
-import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashMap;
@@ -18,6 +17,8 @@ import java.util.Map;
 public class K3sContainer extends GenericContainer<K3sContainer> {
 
     private String kubeConfigYaml;
+
+    private static final String TOKEN = "deadbeef";
 
     public K3sContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
@@ -31,12 +32,10 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
         tmpFsMapping.put("/var/run", "");
         setTmpFsMapping(tmpFsMapping);
 
-        final String randomToken = Base58.randomString(16);
-
         setCommand(
             "server",
             "--no-deploy=traefik",
-            "--token=" + randomToken,
+            "--token=" + TOKEN,
             "--tls-san=" + this.getHost()
         );
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*Node controller sync successful.*"));

--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -18,7 +18,7 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
 
     private String kubeConfigYaml;
 
-    private static final String TOKEN = "deadbeef";
+    private static final String TOKEN = "fixedtoken";
 
     public K3sContainer(DockerImageName dockerImageName) {
         super(dockerImageName);

--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -18,8 +18,6 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
 
     private String kubeConfigYaml;
 
-    private static final String TOKEN = "fixedtoken";
-
     public K3sContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DockerImageName.parse("rancher/k3s"));
@@ -35,7 +33,6 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
         setCommand(
             "server",
             "--no-deploy=traefik",
-            "--token=" + TOKEN,
             "--tls-san=" + this.getHost()
         );
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*Node controller sync successful.*"));

--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -1,0 +1,66 @@
+package org.testcontainers.k3s;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import lombok.SneakyThrows;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.utility.Base58;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class K3sContainer extends GenericContainer<K3sContainer> {
+
+    private String kubeConfigYaml;
+
+    public K3sContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+        dockerImageName.assertCompatibleWith(DockerImageName.parse("rancher/k3s"));
+
+        addExposedPorts(6443, 8443);
+        setPrivilegedMode(true);
+
+        Map<String, String> tmpFsMapping = new HashMap<>();
+        tmpFsMapping.put("/run", "");
+        tmpFsMapping.put("/var/run", "");
+        setTmpFsMapping(tmpFsMapping);
+
+        final String randomToken = Base58.randomString(16);
+
+        setCommand(
+            "server",
+            "--no-deploy=traefik",
+            "--token=" + randomToken,
+            "--tls-san=" + this.getHost()
+        );
+        setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*Node controller sync successful.*"));
+    }
+
+    @SneakyThrows
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+        JsonNode rawKubeConfig = copyFileFromContainer(
+            "/etc/rancher/k3s/k3s.yaml",
+            is -> objectMapper.readValue(is, JsonNode.class)
+        );
+
+        ObjectNode clusterConfig = (ObjectNode) rawKubeConfig.get("clusters").get(0).get("cluster");
+        clusterConfig.replace("server", new TextNode("https://" + this.getHost() + ":" + this.getMappedPort(6443)));
+
+        ((ObjectNode) rawKubeConfig).set("current-context", new TextNode("default"));
+
+        kubeConfigYaml = objectMapper.writeValueAsString(rawKubeConfig);
+    }
+
+    public String getKubeConfigYaml() {
+        return kubeConfigYaml;
+    }
+}

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
@@ -9,14 +9,13 @@ import org.junit.Test;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.IOException;
 import java.util.List;
 
 @Slf4j
 public class Fabric8K3sContainerTest {
 
     @Test
-    public void shouldStartAndHaveListableNode() throws IOException {
+    public void shouldStartAndHaveListableNode() {
         try (
             // starting_k3s {
             K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
@@ -26,13 +25,9 @@ public class Fabric8K3sContainerTest {
             k3s.start();
 
             // connecting_with_fabric8 {
+            // obtain a kubeconfig file which allows us to connect to k3s
             String kubeConfigYaml = k3s.getKubeConfigYaml();
-
             Config config = Config.fromKubeconfig(kubeConfigYaml);
-            // workaround for undiagnosed issue; fabric8 seems to not identify
-            // the client key algorithm correctly, so fails to work with K3s
-            // ECDSA keys unless configured explicitly
-            config.setClientKeyAlgo("EC");
 
             DefaultKubernetesClient client = new DefaultKubernetesClient(config);
 

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
@@ -13,25 +13,33 @@ import java.io.IOException;
 import java.util.List;
 
 @Slf4j
-public class K3sContainerTest {
+public class Fabric8K3sContainerTest {
 
     @Test
     public void shouldStartAndHaveListableNode() throws IOException {
         try (
+            // starting_k3s {
             K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
                 .withLogConsumer(new Slf4jLogConsumer(log))
+            // }
         ) {
             k3s.start();
 
+            // connecting_with_fabric8 {
             String kubeConfigYaml = k3s.getKubeConfigYaml();
 
             Config config = Config.fromKubeconfig(kubeConfigYaml);
-            // workaround for undiagnosed issue; fabric8 seems to not identify the client key algorithm correctly,
-            //  and k3s uses ECDSA keys
+            // workaround for undiagnosed issue; fabric8 seems to not identify
+            // the client key algorithm correctly, so fails to work with K3s
+            // ECDSA keys unless configured explicitly
             config.setClientKeyAlgo("EC");
 
             DefaultKubernetesClient client = new DefaultKubernetesClient(config);
+
+            // interact with the running K3s server, e.g.:
             List<Node> nodes = client.nodes().list().getItems();
+            // }
+
             Assertions.assertThat(nodes).hasSize(1);
         }
     }

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
@@ -27,6 +27,8 @@ public class Fabric8K3sContainerTest {
             // connecting_with_fabric8 {
             // obtain a kubeconfig file which allows us to connect to k3s
             String kubeConfigYaml = k3s.getKubeConfigYaml();
+
+            // requires io.fabric8:kubernetes-client:5.11.0 or higher
             Config config = Config.fromKubeconfig(kubeConfigYaml);
 
             DefaultKubernetesClient client = new DefaultKubernetesClient(config);

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/K3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/K3sContainerTest.java
@@ -1,0 +1,38 @@
+package org.testcontainers.k3s;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+public class K3sContainerTest {
+
+    @Test
+    public void shouldStartAndHaveListableNode() throws IOException {
+        try (
+            K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
+                .withLogConsumer(new Slf4jLogConsumer(log))
+        ) {
+            k3s.start();
+
+            String kubeConfigYaml = k3s.getKubeConfigYaml();
+
+            Config config = Config.fromKubeconfig(kubeConfigYaml);
+            // workaround for undiagnosed issue; fabric8 seems to not identify the client key algorithm correctly,
+            //  and k3s uses ECDSA keys
+            config.setClientKeyAlgo("EC");
+
+            DefaultKubernetesClient client = new DefaultKubernetesClient(config);
+            List<Node> nodes = client.nodes().list().getItems();
+            Assertions.assertThat(nodes).hasSize(1);
+        }
+    }
+}

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
@@ -1,0 +1,43 @@
+package org.testcontainers.k3s;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1NodeList;
+import io.kubernetes.client.util.Config;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+@Slf4j
+public class OfficialClientK3sContainerTest {
+
+    @Test
+    public void shouldStartAndHaveListableNode() throws IOException, ApiException {
+        try (
+            // starting_k3s {
+            K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
+                .withLogConsumer(new Slf4jLogConsumer(log))
+            // }
+        ) {
+            k3s.start();
+
+            // connecting_with_k8sio {
+            String kubeConfigYaml = k3s.getKubeConfigYaml();
+
+            ApiClient client = Config.fromConfig(new StringReader(kubeConfigYaml));
+            CoreV1Api api = new CoreV1Api(client);
+
+            // interact with the running K3s server, e.g.:
+            V1NodeList nodes = api.listNode(null, null, null, null, null, null, null, null, null, null);
+            // }
+
+            Assertions.assertThat(nodes.getItems()).hasSize(1);
+        }
+    }
+}

--- a/modules/k3s/src/test/resources/logback-test.xml
+++ b/modules/k3s/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="DEBUG"/>
+</configuration>


### PR DESCRIPTION
Fixes #4485

Keeping config options simple for now, and assuming that the k8s API is sufficient for any setup that people need to do.

TODO:

- [x] Docs
- [x] ~Possibly more extensive usage examples?~ I reckon what's there is probably good enough to get started.
- [x] Possibly usage example/test using the `io.kubernetes` client
- [x] Look into `EC` client key workaround in test - is this a bug that we need to report to the fabric8 team?