### PR TITLE
Fix race condition in external port check

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
@@ -68,6 +68,7 @@ public class HostPortWaitStrategy extends AbstractWaitStrategy {
                         .pollInSameThread()
                         .pollInterval(Duration.ofMillis(100))
                         .pollDelay(Duration.ZERO)
+                        .ignoreExceptions()
                         .forever()
                         .until(externalCheck);
 


### PR DESCRIPTION
Makes Awaitility ignore exception during checking external ports, which are excepted to occur during checking for connectivity of external ports, depending on the environment.

This is likely the fix for issues #4594 and #4591.