### PR TITLE
Don't run tests as part of the release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: docker image prune -af
 
       - name: Run Gradle Build
-        run: ./gradlew build --scan --no-daemon -i
+        run: ./gradlew build --scan --no-daemon -i -x test
 
       - name: Run Gradle Publish
         run: |


### PR DESCRIPTION
We just saw the release build fail because of lacking disk space to run the test suite as a whole:
https://github.com/testcontainers/testcontainers-java/runs/3975944533?check_suite_focus=true

```
BUILD FAILED in 1h 11m 13s
    java.lang.IllegalStateException: Check failed: Docker environment should have more than 2GB free disk space
```

In addition, the tests don't come from cache anymore and the whole build, therefore, takes unnecessary long, especially considering that we only release if we have a green master build.

This PR disables test execution during the release build.