### PR TITLE
Added support for reuseable containers to the JUnit Jupiter extension

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1428,6 +1428,13 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         return self();
     }
 
+    @UnstableAPI
+    public boolean isReuseable() {
+        return shouldBeReused
+            && canBeReused()
+            && TestcontainersConfiguration.getInstance().environmentSupportsReuse();
+    }
+
     /**
      * Forces access to the tests host machine.
      * Use this method if you need to call {@link org.testcontainers.Testcontainers#exposeHostPorts(int...)}

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -18,6 +18,7 @@ import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.Preconditions;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.lifecycle.TestDescription;
 import org.testcontainers.lifecycle.TestLifecycleAware;
@@ -245,6 +246,9 @@ class TestcontainersExtension implements BeforeEachCallback, BeforeAllCallback, 
 
         @Override
         public void close() {
+            if (container instanceof GenericContainer<?> && ((GenericContainer<?>) container).isReuseable()) {
+                return;
+            }
             container.stop();
         }
     }


### PR DESCRIPTION
Using reusable container cut our integration test time in half.

Right now we are using

```
    @Override
    public void stop() {
        if (TestcontainersConfiguration.getInstance().environmentSupportsReuse()) {
            return;
        }

        super.stop();
    }
```

in our reusable containers, but it would be nice if the JUnit Jupiter extension has native support for reusable containers.