### PR TITLE
Add withName method to set container name

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -204,6 +204,14 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     SELF withEnv(Map<String, String> env);
 
     /**
+     * Set the name of the container.
+     *
+     * @param name container name
+     * @return this
+     */
+    SELF withName(String name);
+
+    /**
      * Add a label to the container.
      *
      * @param key   label key

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -150,6 +150,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @NonNull
     private Map<String, String> env = new HashMap<>();
 
+    private String name;
+
     @NonNull
     private Map<String, String> labels = new HashMap<>();
 
@@ -861,6 +863,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             createCommand.withPrivileged(privilegedMode);
         }
 
+        if (name != null) {
+            createCommand.withName(name);
+        }
+
         createContainerCmdModifiers.forEach(hook -> hook.accept(createCommand));
 
         Map<String, String> combinedLabels = new HashMap<>();
@@ -1142,6 +1148,16 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withEnv(Map<String, String> env) {
         env.forEach(this::addEnv);
+        return self();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public SELF withName(String name)
+    {
+        this.name = name;
         return self();
     }
 

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -246,6 +246,17 @@ public class GenericContainerRuleTest {
     }
 
     @Test
+    public void customNameTest() {
+        String name = "name-test-" + Base58.randomString(16);
+        try (GenericContainer<?> container = new GenericContainer<>(TINY_IMAGE)
+            .withName(name)
+        ) {
+            container.start();
+            assertEquals("Name is configured", "/" + name, container.getContainerName());
+        }
+    }
+
+    @Test
     public void customLabelTest() {
         try (final GenericContainer alpineCustomLabel = new GenericContainer<>(ALPINE_IMAGE)
             .withLabel("our.custom", "label")


### PR DESCRIPTION
This provides a simpler way than using `withCreateContainerCmdModifier()` and doesn't require adding an explicit dependency on `docker-java-api`.