### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.13.1'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
-    testImplementation ('org.mockito:mockito-core:3.12.4') {
+    testImplementation ('org.mockito:mockito-core:4.0.0') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -53,7 +53,7 @@ configurations.all {
 }
 
 dependencies {
-    baseline 'org.testcontainers:testcontainers:1.16.0', {
+    baseline 'org.testcontainers:testcontainers:1.16.2', {
         exclude group: "*", module: "*"
     }
 

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:6.11.0'
-    testImplementation 'io.cucumber:cucumber-junit:6.11.0'
+    testImplementation 'io.cucumber:cucumber-junit:7.0.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.20"
     annotationProcessor "org.projectlombok:lombok:1.18.20"
     implementation 'biz.paluch.redis:spinach:0.3'
-    implementation 'com.google.code.gson:gson:2.8.8'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.6'
     testImplementation 'org.mockito:mockito-all:1.10.19'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'redis.clients:jedis:3.7.0'
-    implementation 'com.google.code.gson:gson:2.8.8'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.2.6'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'redis.clients:jedis:3.7.0'
-    implementation 'com.google.code.gson:gson:2.8.8'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.5'
+    id 'org.springframework.boot' version '2.5.6'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:3.7.0'
-    implementation 'com.google.code.gson:gson:2.8.8'
+    implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
 

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.20"
     annotationProcessor "org.projectlombok:lombok:1.18.16"
 
-    implementation 'org.apache.solr:solr-solrj:8.10.0'
+    implementation 'org.apache.solr:solr-solrj:8.10.1'
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.5.5"
+    id("org.springframework.boot") version "2.5.6"
     id("org.jetbrains.kotlin.jvm") version "1.5.31"
     id("org.jetbrains.kotlin.plugin.spring") version "1.5.31"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.5'
+    id 'org.springframework.boot' version '2.5.6'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.couchbase.client:java-client:3.2.1'
+    testImplementation 'com.couchbase.client:java-client:3.2.2'
     testImplementation 'org.awaitility:awaitility:4.1.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.60'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.37'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.100'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.100'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.15.0"
-    testImplementation "org.elasticsearch.client:transport:7.15.0"
+    testImplementation "org.elasticsearch.client:transport:7.15.1"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -16,5 +16,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.12'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.26'
+    api 'mysql:mysql-connector-java:8.0.27'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.21.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.2.24'
+    testRuntimeOnly 'org.postgresql:postgresql:42.3.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.26'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.80'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.100'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.80'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.100'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.80'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.82'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'
-    testImplementation 'software.amazon.awssdk:s3:2.17.52'
+    testImplementation 'software.amazon.awssdk:s3:2.17.72'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.80'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.80'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.82'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.100'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'
     testImplementation 'software.amazon.awssdk:s3:2.17.72'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.26'
+    testImplementation 'mysql:mysql-connector-java:8.0.27'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -29,7 +29,7 @@ task customNeo4jPluginJar(type: Jar) {
 test.dependsOn customNeo4jPluginJar
 
 dependencies {
-    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.9"
+    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.29"
 
     api project(":testcontainers")
 

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.21.0'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.2'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.3'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.2.24'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.26'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
 
     testCompileClasspath 'org.jetbrains:annotations:22.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.springframework.boot from 2.5.5 to 2.5.6 in /examples (#4653) @dependabot
* Bump gson from 2.8.8 to 2.8.9 in /examples (#4651) @dependabot
* Bump cucumber-junit from 6.11.0 to 7.0.0 in /examples (#4650) @dependabot
* Bump s3 from 2.17.52 to 2.17.72 in /modules/localstack (#4646) @dependabot
* Bump solr-solrj from 8.10.0 to 8.10.1 in /examples (#4644) @dependabot
* Bump postgresql from 42.2.24 to 42.3.1 in /modules/junit-jupiter (#4643) @dependabot
* Bump aws-java-sdk-logs from 1.12.60 to 1.12.100 in /modules/localstack (#4641) @dependabot
* Bump pulsar-client-admin from 2.7.2 to 2.7.3 in /modules/pulsar (#4638) @dependabot
* Bump aws-java-sdk-sqs from 1.12.82 to 1.12.100 in /modules/localstack (#4633) @dependabot
* Bump java-client from 3.2.1 to 3.2.2 in /modules/couchbase (#4636) @dependabot
* Bump transport from 7.15.0 to 7.15.1 in /modules/elasticsearch (#4637) @dependabot
* Bump mockito-core from 3.12.4 to 4.0.0 in /core (#4632) @dependabot
* Bump mysql-connector-java from 8.0.26 to 8.0.27 in /modules/junit-jupiter (#4630) @dependabot
* Bump mysql-connector-java from 8.0.26 to 8.0.27 in /modules/jdbc-test (#4628) @dependabot
* Bump elasticsearch-rest-client from 7.15.0 to 7.15.1 in /modules/elasticsearch (#4625) @dependabot
* Bump testcontainers from 1.16.0 to 1.16.2 in /core (#4619) @dependabot
* Bump mysql-connector-java from 8.0.26 to 8.0.27 in /modules/spock (#4623) @dependabot
* Bump awaitility from 4.1.0 to 4.1.1 in /modules/couchbase (#4622) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.60 to 1.12.100 in /modules/dynalite (#4621) @dependabot
* Bump mysql-connector-java from 8.0.26 to 8.0.27 in /modules/mysql (#4617) @dependabot
* Bump neo4j from 3.5.9 to 3.5.29 in /modules/neo4j (#4616) @dependabot
* Bump aws-java-sdk-s3 from 1.12.80 to 1.12.100 in /modules/localstack (#4618) @dependabot
