### PR TITLE
Use key=value format for GRADLE_ENTERPRISE_ACCESS_KEY value

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -7,7 +7,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GRADLE_ENTERPRISE_ACCESS_KEY: ge.testcontainers.org=${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 jobs:
   find_gradle_jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  GRADLE_ENTERPRISE_ACCESS_KEY: ge.testcontainers.org=${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
 jobs:
   thundra_test_initializer:


### PR DESCRIPTION
After integrating Gradle Enterprise through #4057, CI is broken for builds that don't have access to `secrets.GRADLE_ENTERPRISE_ACCESS_KEY`.

This PR fixes this issue.

The value of the secret has already been updated to cater to this change.