### PR TITLE
Update GE plugin in examples to 3.6.1

### DIFF
--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.2.1"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.6.1"
     }
 }
 


### PR DESCRIPTION
This aligns the version between the examples and the project.

It is further a blind-fix to check if this solves:
```
Settings file '/home/runner/work/testcontainers-java/testcontainers-java/examples/settings.gradle' line: 14

* What went wrong:
A problem occurred evaluating settings 'examples'.
> Failed to apply plugin 'com.gradle.enterprise'.
   > Failed to parse GRADLE_ENTERPRISE_ACCESS_KEY environment variable: value is malformed (expected format: 'server-host=access-key').
```