### PR TITLE
change external port check to it can timeout and retry

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/internal/ExternalPortListeningCheck.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/internal/ExternalPortListeningCheck.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.testcontainers.containers.ContainerState;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -22,7 +23,10 @@ public class ExternalPortListeningCheck implements Callable<Boolean> {
 
         externalLivenessCheckPorts.parallelStream().forEach(externalPort -> {
             try {
-                new Socket(address, externalPort).close();
+                Socket socket = new Socket();
+                InetSocketAddress inetSocketAddress = new InetSocketAddress(address, externalPort);
+                socket.connect(inetSocketAddress, 2000);
+                socket.close();
             } catch (IOException e) {
                 throw new IllegalStateException("Socket not listening yet: " + externalPort);
             }

--- a/core/src/main/java/org/testcontainers/containers/wait/internal/ExternalPortListeningCheck.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/internal/ExternalPortListeningCheck.java
@@ -22,11 +22,9 @@ public class ExternalPortListeningCheck implements Callable<Boolean> {
         String address = containerState.getHost();
 
         externalLivenessCheckPorts.parallelStream().forEach(externalPort -> {
-            try {
-                Socket socket = new Socket();
+            try (Socket socket = new Socket()) {
                 InetSocketAddress inetSocketAddress = new InetSocketAddress(address, externalPort);
-                socket.connect(inetSocketAddress, 2000);
-                socket.close();
+                socket.connect(inetSocketAddress, 1000);
             } catch (IOException e) {
                 throw new IllegalStateException("Socket not listening yet: " + externalPort);
             }


### PR DESCRIPTION
testcontainers version: 1.16.2
Java version: 1.8
Docker version: 20.10.6 (via minikube)

When trying to use the kafka container module i get the following error when attempting to use it.

```
org.testcontainers.containers.ContainerLaunchException: Container startup failed

	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:336)
	at org.testcontainers.containers.GenericContainer.start(GenericContainer.java:317)
	at example.KafkaProducerClientTest.setUp(KafkaProducerClientTest.java:55)
	at junit.framework.TestCase.runBare(TestCase.java:139)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:255)
	at junit.framework.TestSuite.run(TestSuite.java:250)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:160)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:33)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:235)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:54)
Caused by: org.rnorth.ducttape.RetryCountExceededException: Retry limit hit with exception
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:88)
	at org.testcontainers.containers.GenericContainer.doStart(GenericContainer.java:329)
	... 15 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Could not create/start container
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:525)
	at org.testcontainers.containers.GenericContainer.lambda$doStart$0(GenericContainer.java:331)
	at org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess(Unreliables.java:81)
	... 16 more
Caused by: org.testcontainers.containers.ContainerLaunchException: Timed out waiting for container port to open (192.168.64.19 ports: [49293, 49294] should be listening)
	at org.testcontainers.containers.wait.strategy.HostPortWaitStrategy.waitUntilReady(HostPortWaitStrategy.java:90)
	at org.testcontainers.containers.wait.strategy.AbstractWaitStrategy.waitUntilReady(AbstractWaitStrategy.java:51)
	at org.testcontainers.containers.GenericContainer.waitUntilContainerStarted(GenericContainer.java:929)
	at org.testcontainers.containers.GenericContainer.tryStart(GenericContainer.java:468)
	... 18 more


Process finished with exit code 255
```

doing some testing locally with netcat while the test was hanging i was able to connect fine. i was also able to connect fine using the debugger in intellij. Initially i was able to work-around the issue by using the `MinimumDurationRunningStartupCheckStrategy` startup check but wasn't wanting to use that long-term. After looking at the way the check was implemented I thought just adding a socket timeout to `ExternalPortListeningCheck` would be the appropriate place. After adding a socket timeout to the connection and doing some debugging i saw the connection attempt retry and succeed the second time.

If fix doesn't work for you or there's some other way to avoid this issue please let me know.