### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -66,7 +66,7 @@ dependencies {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
 
-    shaded 'org.awaitility:awaitility:4.1.0'
+    shaded 'org.awaitility:awaitility:4.1.1'
 
     api platform('com.github.docker-java:docker-java-bom:3.2.12')
     shaded platform('com.github.docker-java:docker-java-bom:3.2.12')

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:6.11.0'
+    testImplementation 'io.cucumber:cucumber-java:7.1.0'
     testImplementation 'io.cucumber:cucumber-junit:7.0.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.20"
+    compileOnly "org.projectlombok:lombok:1.18.22"
     annotationProcessor "org.projectlombok:lombok:1.18.20"
     implementation 'biz.paluch.redis:spinach:0.3'
     implementation 'com.google.code.gson:gson:2.8.9'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.20"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.10"
+    testCompileOnly "org.projectlombok:lombok:1.18.22"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.22"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.0.0'
     testImplementation 'org.assertj:assertj-core:3.21.0'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.squareup.okhttp3:okhttp:4.9.2'
     implementation 'org.json:json:20210307'
-    testImplementation 'org.postgresql:postgresql:42.2.24'
+    testImplementation 'org.postgresql:postgresql:42.3.1'
     testImplementation 'ch.qos.logback:logback-classic:1.2.6'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.20"
-    annotationProcessor "org.projectlombok:lombok:1.18.16"
+    compileOnly "org.projectlombok:lombok:1.18.22"
+    annotationProcessor "org.projectlombok:lombok:1.18.22"
 
     implementation 'org.apache.solr:solr-solrj:8.10.1'
 

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.couchbase.client:java-client:3.2.2'
-    testImplementation 'org.awaitility:awaitility:4.1.0'
+    testImplementation 'org.awaitility:awaitility:4.1.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.15.0"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.15.2"
     testImplementation "org.elasticsearch.client:transport:7.15.1"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:3.7.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:3.12.4') {
+    testImplementation ('org.mockito:mockito-core:4.1.0') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.21.0'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.3.1'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.26'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
 }
 

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.100'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.80'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.100'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.60'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.119'
     testImplementation 'software.amazon.awssdk:s3:2.17.72'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.2.24'
+    testImplementation 'org.postgresql:postgresql:42.3.1'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.5.RELEASE'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.2'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.3'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.21.0'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.3'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.2.24'
+    testRuntimeOnly 'org.postgresql:postgresql:42.3.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
 
     testCompileClasspath 'org.jetbrains:annotations:22.0.0'

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: Toxiproxy"
 
 dependencies {
     api project(':testcontainers')
-    api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.4'
+    api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.5'
 
     testImplementation 'redis.clients:jedis:3.0.1'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump aws-java-sdk-logs from 1.12.60 to 1.12.119 in /modules/localstack (#4710) @dependabot
* Bump cucumber-java from 6.11.0 to 7.1.0 in /examples (#4709) @dependabot
* Bump elasticsearch-rest-client from 7.15.0 to 7.15.2 in /modules/elasticsearch (#4707) @dependabot
* Bump mockito-core from 3.12.4 to 4.1.0 in /modules/junit-jupiter (#4706) @dependabot
* Bump toxiproxy-java from 2.1.4 to 2.1.5 in /modules/toxiproxy (#4654) @dependabot
* Bump lombok from 1.18.20 to 1.18.22 in /examples (#4649) @dependabot
* Bump postgresql from 42.2.24 to 42.3.1 in /examples (#4648) @dependabot
* Bump awaitility from 4.1.0 to 4.1.1 in /core (#4640) @dependabot
* Bump mysql-connector-java from 8.0.26 to 8.0.27 in /modules/junit-jupiter (#4630) @dependabot
* Bump postgresql from 42.2.24 to 42.3.1 in /modules/spock (#4629) @dependabot
* Bump pulsar-client from 2.7.2 to 2.7.3 in /modules/pulsar (#4627) @dependabot
* Bump postgresql from 42.2.24 to 42.3.1 in /modules/postgresql (#4620) @dependabot
* Bump awaitility from 4.1.0 to 4.1.1 in /modules/couchbase (#4622) @dependabot
