### PR TITLE
Execute Docker credential programm through shell on Windows 

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.dockerjava.api.model.AuthConfig;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.SystemUtils;
 import org.slf4j.Logger;
 import org.zeroturnaround.exec.InvalidResultException;
 import org.zeroturnaround.exec.ProcessExecutor;
@@ -337,8 +338,9 @@ public class RegistryAuthLocator {
     private String runCredentialProgram(String hostName, String credentialHelperName)
         throws InvalidResultException, InterruptedException, TimeoutException, IOException {
 
+        String[] command = SystemUtils.IS_OS_WINDOWS ? new String[] {"cmd", "/c", credentialHelperName, "get"} : new String[]{credentialHelperName, "get"};
         return new ProcessExecutor()
-                        .command(credentialHelperName, "get")
+                        .command(command)
                         .redirectInput(new ByteArrayInputStream(hostName.getBytes()))
                         .readOutput(true)
                         .exitValueNormal()


### PR DESCRIPTION
We are trying to run testcontainers on Windows with an internal repository hosted by Google. This requires to run the"docker-credential-gcloud" (from Google Cloud SDK) to obtain credentials by using zt-exec. Eventhough the bin folder of the SDK is listed in the Path environment variables the ProcessExecutor is not able to run it and fails with the error message "Cannot run program "docker-credential-gcloud": CreateProcess error=2, Das System kann die angegebene Datei nicht finden"
 (meaning "The system could not find the specified file."). 

The reason is that the PATH envionment variable is not honored when starting a process on Windows. See zt-exec bug report https://github.com/zeroturnaround/zt-exec/issues/98#issue-1068573737

The following patch forces the command to be executed on cmd shell on Windows to ensure PATH is used.