### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.6'
+    id 'org.springframework.boot' version '2.6.1'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.6.1"
     id("org.jetbrains.kotlin.jvm") version "1.6.0"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.5.31"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.6.0"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.5.6"
+    id("org.springframework.boot") version "2.6.1"
     id("org.jetbrains.kotlin.jvm") version "1.6.0"
     id("org.jetbrains.kotlin.plugin.spring") version "1.5.31"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.6'
+    id 'org.springframework.boot' version '2.6.1'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.12'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.13'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.122'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.122'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.100'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.124'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.122'
     testImplementation 'software.amazon.awssdk:s3:2.17.72'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,12 +10,12 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:0.8.7.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.4.0.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.5.0.jre8-preview'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:0.8.7.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.4.0.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:9.5.0.jre8-preview'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:22.0.0'
+    compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -1,7 +1,7 @@
 description = "Testcontainers :: JDBC :: MySQL"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
     compileOnly 'com.google.auto.service:auto-service:1.0'
 
     api project(':jdbc')


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump aws-java-sdk-sqs from 1.12.100 to 1.12.124 in /modules/localstack (#4766) @dependabot
* Bump org.springframework.boot from 2.5.6 to 2.6.1 in /examples (#4752) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.5.31 to 1.6.0 in /examples (#4737) @dependabot
* Bump mssql-jdbc from 9.4.0.jre8 to 9.5.0.jre8-preview in /modules/mssqlserver (#4739) @dependabot
* Bump tomcat-jdbc from 10.0.12 to 10.0.13 in /modules/jdbc (#4736) @dependabot
* Bump annotations from 22.0.0 to 23.0.0 in /modules/mysql (#4738) @dependabot
* Bump auto-service from 1.0 to 1.0.1 in /modules/mysql (#4730) @dependabot
