### PR TITLE
Fix: Create a way for networks to be reusable

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -22,7 +22,14 @@ import java.util.function.Consumer;
 
 public interface Network extends AutoCloseable, TestRule {
 
-    Network SHARED = new NetworkImpl(false, null, Collections.emptySet(), null) {
+    Network SHARED = new NetworkImpl(
+        UUID.randomUUID().toString(),
+        false,
+        false,
+        null,
+        Collections.emptySet(),
+        null
+    ) {
         @Override
         public void close() {
             // Do not allow users to close SHARED network, only ResourceReaper is allowed to close (destroy) it
@@ -67,18 +74,6 @@ public interface Network extends AutoCloseable, TestRule {
         private String id;
 
         private final AtomicBoolean initialized = new AtomicBoolean();
-
-        public NetworkImpl(
-            Boolean enableIpv6,
-            String driver,
-            Set<Consumer<CreateNetworkCmd>> createNetworkCmdModifiers,
-            String id
-        ) {
-            this.enableIpv6 = enableIpv6;
-            this.driver = driver;
-            this.createNetworkCmdModifiers = createNetworkCmdModifiers;
-            this.id = id;
-        }
 
         @Override
         public synchronized String getId() {

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -50,8 +50,10 @@ public interface Network extends AutoCloseable, TestRule {
     @Getter
     class NetworkImpl extends ExternalResource implements Network {
 
+        @Builder.Default
         private String name = UUID.randomUUID().toString();
 
+        @Builder.Default
         private Boolean withReuse = false;
 
         private Boolean enableIpv6;

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -4,7 +4,6 @@ import com.github.dockerjava.api.command.CreateNetworkCmd;
 import com.github.dockerjava.api.command.ListNetworksCmd;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.Singular;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;

--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.command.CreateNetworkCmd;
 import com.github.dockerjava.api.command.ListNetworksCmd;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Singular;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
@@ -46,7 +47,10 @@ public interface Network extends AutoCloseable, TestRule {
     }
 
     static Network newNetwork(String networkName) {
-        return builder().name(networkName).withReuse(true).build();
+        return builder()
+            .name(networkName)
+            .withReuse(true)
+            .build();
     }
 
     static NetworkImpl.NetworkImplBuilder builder() {


### PR DESCRIPTION
1. Create Network with custom name
2. Prevent Autoclose if withReuse is passed
3. On create check if network with same name exists and fetch it, instead of creating a new one