### PR TITLE
Add docs for official-modules concept

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -91,6 +91,14 @@ New modules should have the following warning at the top of their documentation 
 
 We will evaluate incubating modules periodically, and remove the label when appropriate.
 
+### Official modules
+
+In case you are a vendor and are interested in contributing, maintaining and support an Official module to Testcontainers, the same contribution guidelines as outlined above apply.
+As opposed to other Testcontainers modules, Official modules can specify additional [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) in their module.
+Those code owner act as the vendor-appointed stewards for the module with regards to support and maintenance.
+As a rule-of-thumb, PRs for an Official module can be accepted when at least 1 review of a corresponding code owner (for the technology specific changes), as well as an additional review of a Testcontainers maintainer (to ensure overall alignment with the Testcontainers project) is present.
+
+Please reach out to the Testcontainers maintainers if you are interested in contributing an Official module.
 
 ## Combining Dependabot PRs
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,7 +96,9 @@ We will evaluate incubating modules periodically, and remove the label when appr
 If you are a vendor and are interested in contributing, maintaining and supporting an Official module to Testcontainers, the same contribution guidelines as outlined above apply.
 As opposed to other Testcontainers modules, Official modules can specify additional [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) in their module.
 Those code owners act as the vendor-appointed stewards for the module with regards to support and maintenance.
-As a rule-of-thumb, PRs for an Official module can be accepted when at least 1 review of a corresponding code owner (for the technology specific changes), as well as an additional review of a Testcontainers maintainer (to ensure overall alignment with the Testcontainers project) is present.
+As a rule-of-thumb, PRs for an Official module can be accepted when both of the following are present:
+* at least 1 approval by a corresponding code owner (for the vendor/technology specific changes), 
+* an additional approval by a Testcontainers core maintainer (to ensure overall alignment with Testcontainers project and idioms)
 
 Please reach out to the Testcontainers maintainers if you are interested in contributing an Official module.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -95,7 +95,7 @@ We will evaluate incubating modules periodically, and remove the label when appr
 
 If you are a vendor and are interested in contributing, maintaining and supporting an Official module to Testcontainers, the same contribution guidelines as outlined above apply.
 As opposed to other Testcontainers modules, Official modules can specify additional [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) in their module.
-Those code owner act as the vendor-appointed stewards for the module with regards to support and maintenance.
+Those code owners act as the vendor-appointed stewards for the module with regards to support and maintenance.
 As a rule-of-thumb, PRs for an Official module can be accepted when at least 1 review of a corresponding code owner (for the technology specific changes), as well as an additional review of a Testcontainers maintainer (to ensure overall alignment with the Testcontainers project) is present.
 
 Please reach out to the Testcontainers maintainers if you are interested in contributing an Official module.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -93,7 +93,7 @@ We will evaluate incubating modules periodically, and remove the label when appr
 
 ### Official modules
 
-In case you are a vendor and are interested in contributing, maintaining and support an Official module to Testcontainers, the same contribution guidelines as outlined above apply.
+If you are a vendor and are interested in contributing, maintaining and supporting an Official module to Testcontainers, the same contribution guidelines as outlined above apply.
 As opposed to other Testcontainers modules, Official modules can specify additional [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) in their module.
 Those code owner act as the vendor-appointed stewards for the module with regards to support and maintenance.
 As a rule-of-thumb, PRs for an Official module can be accepted when at least 1 review of a corresponding code owner (for the technology specific changes), as well as an additional review of a Testcontainers maintainer (to ensure overall alignment with the Testcontainers project) is present.

--- a/docs/index.md
+++ b/docs/index.md
@@ -104,7 +104,7 @@ Modules are characterized through the following categories:
 | 🚀 **Official** | Official modules are mainly **supported and maintained by the technology vendor**. The vendor is supported in their activities by the Testcontainers project. |
 | 🤖 **Standard** | Standard modules are **maintained by the Testcontainers project and its community**. They are supported on a **best-effort-basis** with regards to their integration with 3rd party technologies. |
 | 🍼 **Incubating** | Incubating modules are exclusively **maintained and supported by the Testcontainers community**. In case they prove their usefulness and stability overt time, they are eventually promoted to Offical or Standard modules. |
-| 🗑️ **Deprecated** | Deprecated modules are no longer supported by the Testcontainers project and we don't accept new features of fixes for them. We will eventually decide to stop publishing them altogether. |
+| 🗑️ **Deprecated** | Deprecated modules are no longer supported by the Testcontainers project and we don't accept new features or fixes for them. We will eventually stop publishing them altogether. |
 
 ## Sponsors
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,20 @@ testImplementation('org.testcontainers:mysql') //no version specified
     But there are also "private", implementation detail dependencies (e.g. docker-java-core, Guava, OkHttp, etc etc) that are not exposed to public API but prone to conflicts with test code/application under test code. 
     As such, **these libraries are 'shaded' into the core testcontainers JAR** and relocated under `org.testcontainers.shaded` to prevent class conflicts.
 
+## Modules
+
+Testcontainers comes with many modules, that extend the functionality of Testcontainers and provide integration and better supoort for certain Docker images.
+Those modules are either supported and maintianed by the Testcontainers project, or directly by maintainers of the technology vendor.
+
+Modules are characterized through the following categories:
+
+| Module Category | Description |
+| --- | --- |
+| 🚀 **Official** | Official modules are mainly **supported and maintainted by the technology vendor**. The vendor is supported in their activities by the Testcontainers project. |
+| 🤖 **Standard** | Standard modules are **maintained by the Testcontainers project and its community**. They are supported on a **best-effort-basis** with regards to their integration with 3rd party technologies. |
+| 🍼 **Incubating** | Incubating modules are exclusively **maintained and supported by the Testcontainers community**. In case they prove their usefulness and stability overt time, they are eventually promoted to Offical or Standard modules. |
+| 🗑️ **Deprecated** | Deprecated modules are no longer supported by the Testcontainers project and we don't accept new features of fixes for them. We will eventually decide to stop publishing them altogether. |
+
 ## Sponsors
 
 A huge thank you to our sponsors:

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ testImplementation('org.testcontainers:mysql') //no version specified
 
 ## Modules
 
-Testcontainers comes with many modules, that extend the functionality of Testcontainers and provide integration and better supoort for certain Docker images.
+Testcontainers comes with many modules that extend the functionality of Testcontainers. These modules provide integration and better supoort for certain Docker images.
 Those modules are either supported and maintianed by the Testcontainers project, or directly by maintainers of the technology vendor.
 
 Modules are characterized through the following categories:

--- a/docs/index.md
+++ b/docs/index.md
@@ -101,7 +101,7 @@ Modules are characterized through the following categories:
 
 | Module Category | Description |
 | --- | --- |
-| 🚀 **Official** | Official modules are mainly **supported and maintainted by the technology vendor**. The vendor is supported in their activities by the Testcontainers project. |
+| 🚀 **Official** | Official modules are mainly **supported and maintained by the technology vendor**. The vendor is supported in their activities by the Testcontainers project. |
 | 🤖 **Standard** | Standard modules are **maintained by the Testcontainers project and its community**. They are supported on a **best-effort-basis** with regards to their integration with 3rd party technologies. |
 | 🍼 **Incubating** | Incubating modules are exclusively **maintained and supported by the Testcontainers community**. In case they prove their usefulness and stability overt time, they are eventually promoted to Offical or Standard modules. |
 | 🗑️ **Deprecated** | Deprecated modules are no longer supported by the Testcontainers project and we don't accept new features of fixes for them. We will eventually decide to stop publishing them altogether. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -103,7 +103,7 @@ Modules are characterized through the following categories:
 | --- | --- |
 | 🚀 **Official** | Official modules are mainly **supported and maintained by the technology vendor**. The vendor is supported in their activities by the Testcontainers project. |
 | 🤖 **Standard** | Standard modules are **maintained by the Testcontainers project and its community**. They are supported on a **best-effort-basis** with regards to their integration with 3rd party technologies. |
-| 🍼 **Incubating** | Incubating modules are exclusively **maintained and supported by the Testcontainers community**. In case they prove their usefulness and stability overt time, they are eventually promoted to Offical or Standard modules. |
+| 🍼 **Incubating** | Incubating modules are exclusively **maintained and supported by the Testcontainers community**. If they prove their usefulness and stability over time, they are eventually promoted to Offical or Standard modules. |
 | 🗑️ **Deprecated** | Deprecated modules are no longer supported by the Testcontainers project and we don't accept new features or fixes for them. We will eventually stop publishing them altogether. |
 
 ## Sponsors

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,7 +95,7 @@ testImplementation('org.testcontainers:mysql') //no version specified
 ## Modules
 
 Testcontainers comes with many modules that extend the functionality of Testcontainers. These modules provide integration and better supoort for certain Docker images.
-Those modules are either supported and maintianed by the Testcontainers project, or directly by maintainers of the technology vendor.
+Those modules are either supported and maintained by the Testcontainers project, or directly by maintainers of the technology vendor.
 
 Modules are characterized through the following categories:
 


### PR DESCRIPTION
This is the first draft for adding docs regarding the official-module concept.
I consciously added a user-facing paragraph to the main index page, since we don't have index pages for the actual subpages (e.g. modules in this case). 