### PR TITLE
Upgrade Neo4j server and driver dependencies.

### DIFF
--- a/docs/modules/databases/neo4j.md
+++ b/docs/modules/databases/neo4j.md
@@ -139,6 +139,9 @@ public class ExampleTest {
 }
 ```
 
+!!! note
+The `withDatabase` method will only work with Neo4j 3.5 and throw an exception if used in combination with a newer version.
+
 ## Choose your Neo4j license
 
 If you need the Neo4j enterprise license, you can declare your Neo4j container like this:

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation "org.neo4j.driver:neo4j-java-driver:1.7.5"
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.2'
     testImplementation 'org.assertj:assertj-core:3.21.0'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -18,8 +18,8 @@ sourceSets {
 
 task customNeo4jPluginJar(type: Jar) {
     from sourceSets.customNeo4jPlugin.output
-    archiveName = "hello-world.jar"
-    destinationDir = customNeo4jPluginDestinationDir
+    archiveFileName = "hello-world.jar"
+    destinationDirectory = customNeo4jPluginDestinationDir
 
     inputs.files(sourceSets.customNeo4jPlugin.java.srcDirs)
     outputs.cacheIf { true }

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -30,7 +30,7 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
     /**
      * The default tag (version) to use.
      */
-    private static final String DEFAULT_TAG = "3.5.0";
+    private static final String DEFAULT_TAG = "4.4.1";
     private static final String ENTERPRISE_TAG = DEFAULT_TAG + "-enterprise";
 
     /**
@@ -188,7 +188,7 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
     }
 
     /**
-     * Copies an existing {@code graph.db} folder into the container. This can either be a classpath resource or a
+     * Copies an existing database folder into the container. This can either be a classpath resource or a
      * host resource. Please have a look at the factory methods in {@link MountableFile}.
      * <br>
      * If you want to map your database into the container instead of copying them, please use {@code #withClasspathResourceMapping},
@@ -198,14 +198,14 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
      * <pre>
      *      &#64;Container
      *      private static final Neo4jContainer databaseServer = new Neo4jContainer&lt;&gt;()
-     *          .withClasspathResourceMapping("/test-graph.db", "/data/databases/graph.db", BindMode.READ_WRITE);
+     *          .withClasspathResourceMapping("/test-graph.db", "/data/databases/neo4j", BindMode.READ_WRITE);
      * </pre>
      *
-     * @param graphDb The graph.db folder to copy into the container
+     * @param databaseFolder The database folder to copy into the container
      * @return This container.
      */
-    public S withDatabase(MountableFile graphDb) {
-        return withCopyFileToContainer(graphDb, "/data/databases/graph.db");
+    public S withDatabase(MountableFile databaseFolder) {
+        return withCopyFileToContainer(databaseFolder, "/data/databases/neo4j");
     }
 
     /**

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -194,6 +194,8 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
      * If you want to map your database into the container instead of copying them, please use {@code #withClasspathResourceMapping},
      * but this will only work when your test does not run in a container itself.
      * <br>
+     * Note: This method only works with Neo4j 3.5.
+     * <br>
      * Mapping would work like this:
      * <pre>
      *      &#64;Container
@@ -202,10 +204,11 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
      * </pre>
      *
      * @param graphDb The graph.db folder to copy into the container
+     * @throws IllegalArgumentException If the database version is not 3.5.
      * @return This container.
      */
     public S withDatabase(MountableFile graphDb) {
-        if (!usesVersion("3")) {
+        if (!usesVersion("3.5")) {
             throw new IllegalArgumentException(
                 "Copying database folder is not supported for Neo4j instances with version 4.0 or higher.");
         }

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -30,7 +30,7 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
     /**
      * The default tag (version) to use.
      */
-    private static final String DEFAULT_TAG = "4.4.1";
+    private static final String DEFAULT_TAG = "4.4";
     private static final String ENTERPRISE_TAG = DEFAULT_TAG + "-enterprise";
 
     /**

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerJUnitIntegrationTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerJUnitIntegrationTest.java
@@ -2,10 +2,10 @@ package org.testcontainers.containers;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.neo4j.driver.v1.AuthTokens;
-import org.neo4j.driver.v1.Driver;
-import org.neo4j.driver.v1.GraphDatabase;
-import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Session;
 
 import java.util.Collections;
 

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -47,6 +47,7 @@ public class Neo4jContainerTest {
         try (
             Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(Neo4jTestImages.NEO4J_TEST_IMAGE)
                 .withDatabase(MountableFile.forClasspathResource("/test-graph.db"))
+                .withEnv("NEO4J_dbms_allow__upgrade", "true")
         ) {
             neo4jContainer.start();
             try (
@@ -103,7 +104,7 @@ public class Neo4jContainerTest {
     public void shouldCheckEnterpriseLicense() {
         assumeThat(Neo4jContainerTest.class.getResource(ACCEPTANCE_FILE_LOCATION)).isNull();
 
-        String expectedImageName = "neo4j:3.5.0-enterprise";
+        String expectedImageName = "neo4j:4.4.1-enterprise";
 
         assertThatExceptionOfType(IllegalStateException.class)
             .isThrownBy(() -> new Neo4jContainer<>(Neo4jTestImages.NEO4J_TEST_IMAGE).withEnterpriseEdition())

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -1,7 +1,6 @@
 package org.testcontainers.containers;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
@@ -74,6 +73,14 @@ public class Neo4jContainerTest {
     public void shouldFailOnCopyDatabaseForCustomNeo4j4Image() {
         Assertions.assertThatIllegalArgumentException()
             .isThrownBy(() -> new Neo4jContainer<>("neo4j:4.4.1")
+                .withDatabase(MountableFile.forClasspathResource("/test-graph.db")))
+            .withMessage("Copying database folder is not supported for Neo4j instances with version 4.0 or higher.");
+    }
+
+    @Test
+    public void shouldFailOnCopyDatabaseForCustomNonSemverNeo4j4Image() {
+        Assertions.assertThatIllegalArgumentException()
+            .isThrownBy(() -> new Neo4jContainer<>("neo4j:latest")
                 .withDatabase(MountableFile.forClasspathResource("/test-graph.db")))
             .withMessage("Copying database folder is not supported for Neo4j instances with version 4.0 or higher.");
     }

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -1,13 +1,13 @@
 package org.testcontainers.containers;
 
 import org.junit.Test;
-import org.neo4j.driver.v1.AuthToken;
-import org.neo4j.driver.v1.AuthTokens;
-import org.neo4j.driver.v1.Driver;
-import org.neo4j.driver.v1.GraphDatabase;
-import org.neo4j.driver.v1.Record;
-import org.neo4j.driver.v1.Session;
-import org.neo4j.driver.v1.StatementResult;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.AuthTokens;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
 import org.testcontainers.utility.MountableFile;
 
 import java.util.Collections;
@@ -53,7 +53,7 @@ public class Neo4jContainerTest {
                 Driver driver = getDriver(neo4jContainer);
                 Session session = driver.session()
             ) {
-                StatementResult result = session.run("MATCH (t:Thing) RETURN t");
+                Result result = session.run("MATCH (t:Thing) RETURN t");
                 assertThat(result.list().stream().map(r -> r.get("t").get("name").asString()))
                     .containsExactlyInAnyOrder("Thing", "Thing 2", "Thing 3", "A box");
             }
@@ -93,7 +93,7 @@ public class Neo4jContainerTest {
     }
 
     private static void assertThatCustomPluginWasCopied(Session session) {
-        StatementResult result = session.run("RETURN ac.simons.helloWorld('Testcontainers') AS greeting");
+        Result result = session.run("RETURN ac.simons.helloWorld('Testcontainers') AS greeting");
         Record singleRecord = result.single();
         assertThat(singleRecord).isNotNull();
         assertThat(singleRecord.get("greeting").asString()).isEqualTo("Hello, Testcontainers");

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jTestImages.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jTestImages.java
@@ -3,5 +3,5 @@ package org.testcontainers.containers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface Neo4jTestImages {
-    DockerImageName NEO4J_TEST_IMAGE = DockerImageName.parse("neo4j:3.5.0");
+    DockerImageName NEO4J_TEST_IMAGE = DockerImageName.parse("neo4j:4.4.1");
 }

--- a/modules/neo4j/src/test/resources/example-container-license-acceptance.txt
+++ b/modules/neo4j/src/test/resources/example-container-license-acceptance.txt
@@ -1,1 +1,1 @@
-neo4j:3.5.0-enterprise
+neo4j:4.4.1-enterprise


### PR DESCRIPTION
This PR upgrades
* Neo4j server from for testing and as the (deprecated) default to 4.4.1.
* The Neo4j Java driver for testing to the most current 4.4.2.

Two things that I would like to improve but do not know how to solve them:
1. ~~Having to explicitly say that the database from the test-resources needs to get upgraded every time. @michael-simons https://github.com/testcontainers/testcontainers-java/compare/master...meistermeier:upgrade-neo4j?expand=1#diff-7f1bb307bc0ede77f2ef4beb5966f2187e591768eabeb9733b4796df6a689137R50~~
2. For testing purposes we have to build a minimal plugin against the Neo4j 3.5 API and cannot use the better fitting 4.4.x library because Neo4j 4.x has a JDK 11 baseline and as a consequence I cannot compile a 4.x plugin with the current build pipeline (JDK 8). @kiview I heard you know somebody who knows how to use Gradle's toolchains ;)