### PR TITLE
removed hardcoded log level setting on mockserver

### DIFF
--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -38,7 +38,7 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
         waitingFor(Wait.forHttp("/mockserver/status").withMethod("PUT").forStatusCode(200));
 
-        withCommand("-logLevel INFO -serverPort " + PORT);
+        withCommand("-serverPort " + PORT);
         addExposedPorts(PORT);
     }
 


### PR DESCRIPTION
Hello, 
This pr is only a housekeeping, because by default logLevel of mockserver is set to INFO https://github.com/mock-server/mockserver/blob/master/mockserver-core/src/main/java/org/mockserver/configuration/ConfigurationProperties.java#L39
and by setting this log level this way (through command line arg), we cannot change it later on the client side code of MockserverContainer by env variable "MOCKSERVER_LOG_LEVEL" so this change also allows to change log level of mockserver