### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.4.0
+      - uses: actions/setup-java@v2.5.0
         with:
           java-version: '8.0.302'
           distribution: temurin
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.4.0
+      - uses: actions/setup-java@v2.5.0
         with:
           java-version: '8.0.302'
           distribution: temurin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.4.0
+      - uses: actions/setup-java@v2.5.0
         with:
           java-version: '8.0.302'
           distribution: temurin
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.4.0
+      - uses: actions/setup-java@v2.5.0
         with:
           java-version: '8.0.302'
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.4.0
+      - uses: actions/setup-java@v2.5.0
         with:
           java-version: '8.0.302'
           distribution: temurin

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -17,7 +17,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@67df31e08a133c6a77008b89689677067fef169e # v3.10.1
+        uses: peter-evans/create-pull-request@dcd5fd746d53dd8de555c0f10bca6c35628be47a # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@a116d8b533be6c4e71a8b3c3871b7344ca72bf12 # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@f31ab392a9d75029f9fd0883d8d6745c0139a006 # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -82,7 +82,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded "org.yaml:snakeyaml:1.29"
+    shaded "org.yaml:snakeyaml:1.30"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     shaded 'org.zeroturnaround:zt-exec:1.12'
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:3.7.0'
+    testImplementation 'redis.clients:jedis:4.0.1'
     testImplementation 'com.rabbitmq:amqp-client:5.14.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.14.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
-    testImplementation ('org.mockito:mockito-core:4.1.0') {
+    testImplementation ('org.mockito:mockito-core:4.2.0') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
-    implementation 'org.json:json:20210307'
+    implementation 'org.json:json:20211205'
     testImplementation 'org.postgresql:postgresql:42.3.1'
     testImplementation 'ch.qos.logback:logback-classic:1.2.7'
     testImplementation 'org.testcontainers:postgresql'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:3.7.0'
+    implementation 'redis.clients:jedis:4.0.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:3.7.0'
+    implementation 'redis.clients:jedis:4.0.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:3.7.0'
+    implementation 'redis.clients:jedis:4.0.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.22"
     annotationProcessor "org.projectlombok:lombok:1.18.22"
 
-    implementation 'org.apache.solr:solr-solrj:8.10.1'
+    implementation 'org.apache.solr:solr-solrj:8.11.1'
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("org.springframework.boot") version "2.6.1"
-    id("org.jetbrains.kotlin.jvm") version "1.6.0"
+    id("org.jetbrains.kotlin.jvm") version "1.6.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.6.0"
 }
 

--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -5,5 +5,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.1-patch'
+    testImplementation 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.couchbase.client:java-client:3.2.3'
+    testImplementation 'com.couchbase.client:java-client:3.2.4'
     testImplementation 'org.awaitility:awaitility:4.1.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.122'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.100'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.131'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.131'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.15.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.16.2"
     testImplementation "org.elasticsearch.client:transport:7.15.2"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.13'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.14'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.27'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.13'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.14'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:3.7.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.1.0') {
+    testImplementation ('org.mockito:mockito-core:4.2.0') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.21.0'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:3.7.0'
+    testImplementation 'redis.clients:jedis:4.0.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation ('org.mockito:mockito-core:4.2.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/inheritance/InheritedTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/inheritance/InheritedTests.java
@@ -12,15 +12,15 @@ class InheritedTests extends AbstractTestBase {
 
     @Test
     void step1() {
-        assertEquals(1, redisPerClass.getJedis().incr("key").longValue());
-        assertEquals(1, redisPerTest.getJedis().incr("key").longValue());
-        assertEquals(1, myRedis.getJedis().incr("key").longValue());
+        assertEquals(1, redisPerClass.getJedis().incr("key"));
+        assertEquals(1, redisPerTest.getJedis().incr("key"));
+        assertEquals(1, myRedis.getJedis().incr("key"));
     }
 
     @Test
     void step2() {
-        assertEquals(2, redisPerClass.getJedis().incr("key").longValue());
-        assertEquals(1, redisPerTest.getJedis().incr("key").longValue());
-        assertEquals(1, myRedis.getJedis().incr("key").longValue());
+        assertEquals(2, redisPerClass.getJedis().incr("key"));
+        assertEquals(1, redisPerTest.getJedis().incr("key"));
+        assertEquals(1, myRedis.getJedis().incr("key"));
     }
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.122'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.124'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.122'
-    testImplementation 'software.amazon.awssdk:s3:2.17.72'
+    testImplementation 'software.amazon.awssdk:s3:2.17.102'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.122'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.131'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.122'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.124'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.122'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.131'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.122'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.124'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.131'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.122'
     testImplementation 'software.amazon.awssdk:s3:2.17.102'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.5'
 
-    testImplementation 'redis.clients:jedis:3.0.1'
+    testImplementation 'redis.clients:jedis:4.0.1'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 
     testImplementation project(':test-support')


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.jetbrains.kotlin.jvm from 1.6.0 to 1.6.10 in /examples (#4839) @dependabot
* Bump json from 20210307 to 20211205 in /examples (#4838) @dependabot
* Bump org.springframework.boot from 2.6.1 to 2.6.2 in /examples (#4837) @dependabot
* Bump jedis from 3.7.0 to 4.0.1 in /examples (#4835) @dependabot
* Bump peter-evans/create-pull-request from 3.11.0 to 3.12.0 (#4834) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.6.0 to 1.6.10 in /examples (#4833) @dependabot
* Bump actions/setup-java from 2.4.0 to 2.5.0 (#4832) @dependabot
* Bump gradle-update/update-gradle-wrapper-action from 1.0.15 to 1.0.16 (#4829) @dependabot
* Bump solr-solrj from 8.10.1 to 8.11.1 in /examples (#4830) @dependabot
* Bump jedis from 3.0.1 to 4.0.1 in /modules/toxiproxy (#4828) @dependabot
* Bump aws-java-sdk-s3 from 1.12.122 to 1.12.131 in /modules/localstack (#4827) @dependabot
* Bump snakeyaml from 1.29 to 1.30 in /core (#4826) @dependabot
* Bump s3 from 2.17.72 to 2.17.102 in /modules/localstack (#4824) @dependabot
* Bump aws-java-sdk-sqs from 1.12.124 to 1.12.131 in /modules/localstack (#4825) @dependabot
* Bump elasticsearch-rest-client from 7.15.2 to 7.16.2 in /modules/elasticsearch (#4823) @dependabot
* Bump jedis from 3.7.0 to 4.0.1 in /core (#4822) @dependabot
* Bump mockito-core from 4.1.0 to 4.2.0 in /modules/junit-jupiter (#4821) @dependabot
* Bump mockito-core from 4.1.0 to 4.2.0 in /core (#4819) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.122 to 1.12.131 in /modules/dynalite (#4820) @dependabot
* Bump transport from 7.15.2 to 7.16.2 in /modules/elasticsearch (#4818) @dependabot
* Bump java-client from 3.2.3 to 3.2.4 in /modules/couchbase (#4815) @dependabot
* Bump jedis from 3.7.0 to 4.0.1 in /modules/junit-jupiter (#4814) @dependabot
* Bump tomcat-jdbc from 10.0.13 to 10.0.14 in /modules/jdbc-test (#4812) @dependabot
* Bump clickhouse-jdbc from 0.3.1-patch to 0.3.2 in /modules/clickhouse (#4813) @dependabot
* Bump tomcat-jdbc from 10.0.12 to 10.0.14 in /modules/jdbc (#4775) @dependabot
