### PR TITLE
Rollback jedis to 3.0.1

### DIFF
--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.5'
 
-    testImplementation 'redis.clients:jedis:4.0.1'
+    testImplementation 'redis.clients:jedis:3.0.1'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 
     testImplementation project(':test-support')


### PR DESCRIPTION
The recent dependabot update to `redis.clients:jedis:4.0.1` have seemingly introduced some flakiness to one of the Toxiproxy tests (`testConnectionCut()`).

While it might be better to investigate the root cause, this rollback will at least stabilize the `master` branch again.