### PR TITLE
Reinstate usage of `READ_ONLY_REMOTE_GRADLE_CACHE` to avoid wrong cache hits

### DIFF
--- a/gradle/ci-support.gradle
+++ b/gradle/ci-support.gradle
@@ -23,6 +23,7 @@ gradle.taskGraph.whenReady {
     if (it.hasTask(tasks.testMatrix)) {
         for (subproject in subprojects) {
             subproject.tasks.withType(Test).all {
+                it.inputs.property("testExecutionSkipped", true) // indicate that tests were not executed, so we have a different cache key
                 testExecuter([execute: { spec, processor -> }, stopNow:{}] as org.gradle.api.internal.tasks.testing.TestExecuter)
             }
             subproject.tasks.findByName("shadowJar")?.enabled = false

--- a/gradle/ci-support.gradle
+++ b/gradle/ci-support.gradle
@@ -23,7 +23,6 @@ gradle.taskGraph.whenReady {
     if (it.hasTask(tasks.testMatrix)) {
         for (subproject in subprojects) {
             subproject.tasks.withType(Test).all {
-                it.inputs.property("testExecutionSkipped", true) // indicate that tests were not executed, so we have a different cache key
                 testExecuter([execute: { spec, processor -> }, stopNow:{}] as org.gradle.api.internal.tasks.testing.TestExecuter)
             }
             subproject.tasks.findByName("shadowJar")?.enabled = false

--- a/settings.gradle
+++ b/settings.gradle
@@ -42,10 +42,10 @@ buildCache {
     local {
         enabled = !isCI
     }
-    remote(HttpBuildCache) { 
-        push = isCI
+    remote(HttpBuildCache) {
+        push = isCI && !System.getenv("READ_ONLY_REMOTE_GRADLE_CACHE")
         enabled = true
-        url = 'https://ge.testcontainers.org/cache/' 
+        url = 'https://ge.testcontainers.org/cache/'
         credentials {
             username = 'ci'
             password = System.getenv("GRADLE_ENTERPRISE_CACHE_PASSWORD")


### PR DESCRIPTION
Through the Dependabot update of Jedis to 4.0.1, we saw that our `testMatrix` Gradle task falsely populates the cache for the test execution, although the tests are actually not executed. 

This PR adds an additional input to the test tasks during `testMatrix` execution, so we can ensure that we will end up with a different cache key, as opposed to the actual execution of tests. 