### PR TITLE
Increase AzureCI timeout to 120 minutes instead of using the default of 60 minutes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,7 @@
 jobs:
 
 - job: azure_pipeline_tests
+  timeoutInMinutes: 120
   steps:
 
   # Run all core tests when running the Windows CI tests


### PR DESCRIPTION
After evicting the Gradle Remote Cache, we saw our Windows10 build on AzureCI timeout:
https://dev.azure.com/testcontainers/testcontainers-java/_build/results?buildId=11729&view=logs&j=28ca4d66-d8a1-504b-08ee-20bf28cc3e75

However, it is reasonable that a completely uncached build of the whole project takes more than 60 minutes, so this PR increases the timeout to 120 minutes.

An alternative would be to use no timeout (which is possible on self-hosted notes), but this would carry the risk of blocking our Windows CI in case of hanging builds. 