### PR TITLE
Add GE remote cache to examples project

### DIFF
--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -49,3 +49,14 @@ buildCache {
         }
     }
 }
+
+gradleEnterprise {
+    buildScan {
+        server = "https://ge.testcontainers.org/"
+        publishAlways()
+        publishIfAuthenticated()
+        uploadInBackground = !isCI
+        captureTaskInputFiles = true
+    }
+
+}

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,11 +7,12 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.8"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.6.2"
     }
 }
 
-apply plugin: 'ch.myniva.s3-build-cache'
 apply plugin: 'com.gradle.enterprise'
+apply plugin: "com.gradle.common-custom-user-data-gradle-plugin"
 
 rootProject.name = 'testcontainers-examples'
 
@@ -32,23 +33,19 @@ include 'cucumber'
 include 'spring-boot-kotlin-redis'
 include 'spock'
 
-ext.isMasterBuild = false ||
-    (System.getenv("GITHUB_REF") == "refs/heads/master") ||
-    (System.getenv("BUILD_SOURCEBRANCHNAME") == "master")
+ext.isCI = System.getenv("CI") != null
 
 buildCache {
     local {
-        enabled = !isMasterBuild
+        enabled = !isCI
     }
-
-    remote(ch.myniva.gradle.caching.s3.AwsS3BuildCache) {
-        endpoint = 'fra1.digitaloceanspaces.com'
-        region = 'fra1'
-        bucket = 'testcontainers'
-        path = 'cache'
-        push = isMasterBuild && !System.getenv("READ_ONLY_REMOTE_GRADLE_CACHE")
-        headers = [
-            'x-amz-acl': 'public-read'
-        ]
+    remote(HttpBuildCache) {
+        push = isCI && !System.getenv("READ_ONLY_REMOTE_GRADLE_CACHE")
+        enabled = true
+        url = 'https://ge.testcontainers.org/cache/'
+        credentials {
+            username = 'ci'
+            password = System.getenv("GRADLE_ENTERPRISE_CACHE_PASSWORD")
+        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.7.2"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.6.1"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.8"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.6.2"
     }
 }
 
@@ -31,10 +31,6 @@ include ':docs:examples:junit5:redis'
 include ':docs:examples:spock:redis'
 
 include 'test-support'
-
-ext.isMasterBuild = false ||
-    (System.getenv("GITHUB_REF") == "refs/heads/master") ||
-    (System.getenv("BUILD_SOURCEBRANCHNAME") == "master")
 
 ext.isCI = System.getenv("CI") != null
 


### PR DESCRIPTION
This enables the Gradle Enterprise remote cache for the examples project in the same fashion, as we use it in the main project.

I also used this PR to align the Gradle Enterprise plugin versions and add publication of Gradle build scans to the examples project.

One thing we should consider is if we want to read from the remote cache for master builds on CI. As I see it, we always used the remote cache before, only disabled the local cache on master CI builds (which was also not working well in conjunction with manually caching of Gradle files in the GHA).