### PR TITLE
Tweak logging around reusable mode

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -423,6 +423,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
                 logger().info("Container {} is starting: {}", dockerImageName, containerId);
                 dockerClient.startContainerCmd(containerId).exec();
+            } else {
+                logger().info("Reusing existing container ({}) and not creating a new one", containerId);
             }
 
             // For all registered output consumers, start following as close to container startup as possible


### PR DESCRIPTION
So that some evidence is visible in logs.

Intended to resolve some concerns we had about #4844 