### PR TITLE
Upgrades kafka version to 7.0.1

### DIFF
--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -11,7 +11,7 @@ import org.testcontainers.utility.DockerImageName;
 public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
-    private static final String DEFAULT_TAG = "5.4.3";
+    private static final String DEFAULT_TAG = "7.0.1";
 
     public static final int KAFKA_PORT = 9093;
 

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -29,8 +29,8 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class KafkaContainerTest {
 
-    private static final DockerImageName KAFKA_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:6.2.1");
-    private static final DockerImageName ZOOKEEPER_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-zookeeper:4.0.0");
+    private static final DockerImageName KAFKA_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:7.0.1");
+    private static final DockerImageName ZOOKEEPER_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-zookeeper:7.0.1");
 
     @Test
     public void testUsage() throws Exception {
@@ -45,7 +45,7 @@ public class KafkaContainerTest {
     public void testUsageWithSpecificImage() throws Exception {
         try (
             // constructorWithVersion {
-            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
+            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.0.1"))
             // }
         ) {
             kafka.start();
@@ -60,7 +60,7 @@ public class KafkaContainerTest {
     @Test
     public void testUsageWithVersion() throws Exception {
         try (
-            KafkaContainer kafka = new KafkaContainer("6.2.1")
+            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka/7.0.1"))
         ) {
             kafka.start();
             testKafkaFunctionality(kafka.getBootstrapServers());
@@ -72,21 +72,20 @@ public class KafkaContainerTest {
         try (
             Network network = Network.newNetwork();
 
-            // withExternalZookeeper {
+	    @SuppressWarnings({"resource"})
             KafkaContainer kafka = new KafkaContainer(KAFKA_TEST_IMAGE)
                 .withNetwork(network)
                 .withExternalZookeeper("zookeeper:2181");
-            // }
 
+	    @SuppressWarnings({"resource"})
             GenericContainer<?> zookeeper = new GenericContainer<>(ZOOKEEPER_TEST_IMAGE)
                 .withNetwork(network)
                 .withNetworkAliases("zookeeper")
                 .withEnv("ZOOKEEPER_CLIENT_PORT", "2181");
 
-            // withKafkaNetwork {
+	    @SuppressWarnings({"resource"})
             GenericContainer<?> application = new GenericContainer<>(DockerImageName.parse("alpine"))
                 .withNetwork(network)
-            // }
                 .withNetworkAliases("dummy")
                 .withCommand("sleep 10000")
         ) {
@@ -95,6 +94,8 @@ public class KafkaContainerTest {
             application.start();
 
             testKafkaFunctionality(kafka.getBootstrapServers());
+	    
+	    
         }
     }
 


### PR DESCRIPTION
* 5.4.3 is very far behind, and cp-kafka 7.0.1 is the latest
version. It should be the version used by default.