### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,13 +100,13 @@ dependencies {
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation project(':test-support')
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
     jarFileTestImplementation 'junit:junit:4.13.2'
-    jarFileTestImplementation 'org.assertj:assertj-core:3.20.2'
+    jarFileTestImplementation 'org.assertj:assertj-core:3.22.0'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'
 }
 

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.1.0'
-    testImplementation 'io.cucumber:cucumber-junit:7.1.0'
+    testImplementation 'io.cucumber:cucumber-junit:7.2.2'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
-    testImplementation 'org.testng:testng:7.4.0'
+    testImplementation 'org.testng:testng:7.5'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.15.0'
-    testImplementation 'com.azure:azure-cosmos:4.16.0'
+    testImplementation 'com.azure:azure-cosmos:4.24.0'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.2.12'
+    testImplementation 'org.postgresql:postgresql:42.3.1'
 }

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.ibm.db2:jcc:11.5.0.0'
+    testImplementation 'com.ibm.db2:jcc:11.5.7.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.131'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.137'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.131'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.2.1'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.9'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.0'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.17.3'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.4.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.2.1'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.9'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.10'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.0'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.4.0'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.2.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.3.1'

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.0.0'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.131'
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.122'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.137'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.137'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.131'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.132'
     testImplementation 'software.amazon.awssdk:s3:2.17.108'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.122'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.131'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.132'
-    testImplementation 'software.amazon.awssdk:s3:2.17.102'
+    testImplementation 'software.amazon.awssdk:s3:2.17.108'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.2'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.0.24"
 
-    testImplementation 'org.assertj:assertj-core:3.12.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.3.4'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.0.18"
 }

--- a/modules/presto/build.gradle
+++ b/modules/presto/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.prestosql:presto-jdbc:331'
+    testImplementation 'io.prestosql:presto-jdbc:350'
     compileOnly 'org.jetbrains:annotations:20.0.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.3'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.4'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.21.0'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.3'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.4'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.21.0'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.3'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.4'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.8.1.RELEASE'
 
-    testImplementation 'org.assertj:assertj-core:3.14.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.1.RELEASE'
     testImplementation project(':postgresql')
 

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -5,7 +5,7 @@ plugins {
 description = "Testcontainers :: R2DBC"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0-rc6'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
     compileOnly 'com.google.auto.service:auto-service:1.0-rc6'
 
     api project(':testcontainers')

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.1.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.3.4.RELEASE'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.14'
     testFixturesImplementation 'org.assertj:assertj-core:3.14.0'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.7.0'
-    testImplementation 'org.assertj:assertj-core:3.12.2'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     compileOnly 'org.jetbrains:annotations:20.0.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:352'
+    testImplementation 'io.trino:trino-jdbc:367'
     compileOnly 'org.jetbrains:annotations:20.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump cucumber-junit from 7.1.0 to 7.2.2 in /examples (#4911) @dependabot
* Bump auto-service from 1.0-rc6 to 1.0.1 in /modules/r2dbc (#4909) @dependabot
* Bump s3 from 2.17.102 to 2.17.108 in /modules/localstack (#4908) @dependabot
* Bump cucumber-java from 7.1.0 to 7.2.2 in /examples (#4907) @dependabot
* Bump aws-java-sdk-s3 from 1.12.131 to 1.12.137 in /modules/localstack (#4904) @dependabot
* Bump testng from 7.4.0 to 7.5 in /examples (#4899) @dependabot
* Bump google-cloud-spanner from 6.17.3 to 6.17.4 in /modules/gcloud (#4901) @dependabot
* Bump assertj-core from 3.14.0 to 3.22.0 in /modules/r2dbc (#4900) @dependabot
* Bump pulsar-client from 2.7.3 to 2.7.4 in /modules/pulsar (#4902) @dependabot
* Bump assertj-core from 3.12.2 to 3.22.0 in /modules/rabbitmq (#4898) @dependabot
* Bump aws-java-sdk-sqs from 1.12.131 to 1.12.137 in /modules/localstack (#4895) @dependabot
* Bump assertj-core from 3.12.0 to 3.22.0 in /modules/orientdb (#4897) @dependabot
* Bump annotations from 20.0.0 to 23.0.0 in /modules/rabbitmq (#4894) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/pulsar (#4893) @dependabot
* Bump amqp-client from 5.7.0 to 5.14.0 in /modules/rabbitmq (#4889) @dependabot
* Bump presto-jdbc from 331 to 350 in /modules/presto (#4887) @dependabot
* Bump trino-jdbc from 352 to 367 in /modules/trino (#4885) @dependabot
* Bump annotations from 20.0.0 to 23.0.0 in /modules/presto (#4880) @dependabot
* Bump pulsar-client-admin from 2.7.3 to 2.7.4 in /modules/pulsar (#4882) @dependabot
* Bump reactor-core from 3.3.4.RELEASE to 3.4.14 in /modules/r2dbc (#4883) @dependabot
* Bump google-cloud-bigtable from 2.4.0 to 2.5.1 in /modules/gcloud (#4879) @dependabot
* Bump azure-cosmos from 4.16.0 to 4.24.0 in /modules/azure (#4877) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/neo4j (#4876) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /core (#4874) @dependabot
* Bump google-cloud-firestore from 3.0.9 to 3.0.10 in /modules/gcloud (#4875) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/kafka (#4873) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.131 to 1.12.137 in /modules/dynalite (#4871) @dependabot
* Bump assertj-core from 3.15.0 to 3.22.0 in /modules/azure (#4870) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/database-commons (#4867) @dependabot
* Bump postgresql from 42.2.12 to 42.3.1 in /modules/cockroachdb (#4868) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/junit-jupiter (#4869) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/jdbc (#4866) @dependabot
* Bump jcc from 11.5.0.0 to 11.5.7.0 in /modules/db2 (#4865) @dependabot
