### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:7.1.0'
+    testImplementation 'io.cucumber:cucumber-java:7.2.2'
     testImplementation 'io.cucumber:cucumber-junit:7.2.2'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.22"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.0.0'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Azure"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.15.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.azure:azure-cosmos:4.24.0'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.2.1'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.10'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.0'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.4.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.2.1'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.2.2'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.10'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.10'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.4.0'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.137'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.137'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.131'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.139'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.132'
     testImplementation 'software.amazon.awssdk:s3:2.17.108'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.0.2")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.4.1")
 }

--- a/modules/presto/build.gradle
+++ b/modules/presto/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'io.prestosql:presto-jdbc:350'
-    compileOnly 'org.jetbrains:annotations:20.0.0'
+    compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.4'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.21.0'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.22.0'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.4'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api 'io.r2dbc:r2dbc-spi:0.8.1.RELEASE'
 
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.1.RELEASE'
+    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.4.14'

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.7.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    compileOnly 'org.jetbrains:annotations:20.0.0'
+    compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.7.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.14.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -2,6 +2,6 @@ description = "Testcontainers :: Solr"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation 'org.apache.solr:solr-solrj:8.3.0'
+    testImplementation 'org.apache.solr:solr-solrj:8.11.1'
 
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'io.trino:trino-jdbc:367'
-    compileOnly 'org.jetbrains:annotations:20.0.0'
+    compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
 
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump r2dbc-postgresql from 0.8.1.RELEASE to 0.8.11.RELEASE in /modules/r2dbc (#4921) @dependabot
* Bump aws-java-sdk-sqs from 1.12.131 to 1.12.139 in /modules/localstack (#4920) @dependabot
* Bump aws-java-sdk-logs from 1.12.132 to 1.12.139 in /modules/localstack (#4919) @dependabot
* Bump cucumber-java from 7.1.0 to 7.2.2 in /examples (#4907) @dependabot
* Bump solr-solrj from 8.3.0 to 8.11.1 in /modules/solr (#4906) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /examples (#4896) @dependabot
* Bump annotations from 20.0.0 to 23.0.0 in /modules/trino (#4892) @dependabot
* Bump google-cloud-pubsub from 1.115.0 to 1.115.1 in /modules/gcloud (#4890) @dependabot
* Bump annotations from 20.0.0 to 23.0.0 in /modules/rabbitmq (#4894) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/pulsar (#4893) @dependabot
* Bump amqp-client from 5.7.0 to 5.14.0 in /modules/rabbitmq (#4889) @dependabot
* Bump mongodb-driver-sync from 4.0.2 to 4.4.1 in /modules/mongodb (#4888) @dependabot
* Bump annotations from 20.0.0 to 23.0.0 in /modules/presto (#4880) @dependabot
* Bump google-cloud-bigtable from 2.4.0 to 2.5.1 in /modules/gcloud (#4879) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/vault (#4878) @dependabot
* Bump assertj-core from 3.15.0 to 3.22.0 in /modules/azure (#4870) @dependabot
* Bump google-cloud-datastore from 2.2.1 to 2.2.2 in /modules/gcloud (#4872) @dependabot
