### PR TITLE
Use jackson 2.8.8 in k3s module

### DIFF
--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: K3S"
 dependencies {
     api project(":testcontainers")
 
-    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:5.11.0'
     testImplementation 'io.kubernetes:client-java:14.0.0'


### PR DESCRIPTION
To ensure the same Jackson version across TC core and modules, this commit manually aligns them, so we don't run into problems with our shaded dependencies. 

See also:
https://github.com/testcontainers/testcontainers-java/blob/f3fed54fe55d672af31806c6327051a26d297c55/core/build.gradle#L51

In the long term, we should align them automatically. 