### PR TITLE
Use 2.8.8 compatible Jackson API in k8s module

### DIFF
--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -50,7 +50,12 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
             is -> objectMapper.readValue(is, ObjectNode.class)
         );
 
-        ObjectNode clusterConfig = rawKubeConfig.at("/clusters/0/cluster").require();
+        JsonNode clusterNode = rawKubeConfig.at("/clusters/0/cluster");
+        if (!clusterNode.isObject()) {
+            throw new IllegalStateException("'/clusters/0/cluster' expected to be an object");
+        }
+        ObjectNode clusterConfig = (ObjectNode) clusterNode;
+
         clusterConfig.replace("server", new TextNode("https://" + this.getHost() + ":" + this.getMappedPort(6443)));
 
         rawKubeConfig.set("current-context", new TextNode("default"));


### PR DESCRIPTION
Unfortunately, #4928 alone was not enough to restore compatibility with Jackson 2.8.8. This PR changes the implementation in the k8s module to only use Jackson 2.8.8 compatible APIs.