### PR TITLE
Replace jcenter with mavenCentral in all examples

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -5,6 +5,6 @@ subprojects {
     apply plugin:"java"
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,2 +1,10 @@
 // empty build.gradle for dependabot
 apply from: "$rootDir/../gradle/ci-support.gradle"
+
+subprojects {
+    apply plugin:"java"
+
+    repositories {
+        mavenCentral()
+    }
+}

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,10 +1,2 @@
 // empty build.gradle for dependabot
 apply from: "$rootDir/../gradle/ci-support.gradle"
-
-subprojects {
-    apply plugin:"java"
-
-    repositories {
-        mavenCentral()
-    }
-}

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'

--- a/examples/mongodb-container/build.gradle
+++ b/examples/mongodb-container/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -5,7 +5,7 @@ plugins {
 apply plugin: 'io.spring.dependency-management'
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Since jcenter has been deprecated and we saw some CI failures because of dependency resolution, it seemed to be about time to finally remove all remaning instances of jcenter.