### PR TITLE
Fix k3s for latest Docker for Mac (cgroupsv2)

### DIFF
--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.model.DockerObjectAccessor;
 import lombok.SneakyThrows;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
@@ -25,6 +26,11 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
 
         addExposedPorts(6443, 8443);
         setPrivilegedMode(true);
+        withCreateContainerCmdModifier(it -> {
+            DockerObjectAccessor.overrideRawValue(
+                it.getHostConfig(), "CgroupnsMode", "host"
+            );
+        });
         addFileSystemBind("/sys/fs/cgroup", "/sys/fs/cgroup", BindMode.READ_WRITE);
 
         Map<String, String> tmpFsMapping = new HashMap<>();


### PR DESCRIPTION
Adds failing test step that fails on Docker for Mac 4.3.2 (72729)