### PR TITLE
Use `gradle-build-action` in GHA

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -23,7 +23,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Clear existing docker image cache
         run: docker image prune -af
-      - name: Build and test Examples with Gradle (${{matrix.gradle_args}})
+      - name: Build and test Examples with Gradle
         working-directory: ./examples/
         run: |
-          ./gradlew --no-daemon --continue --scan --info ${{matrix.gradle_args}}
+          ./gradlew --no-daemon --continue --scan --info check

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -21,12 +21,8 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
-        continue-on-error: true
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-testmatrix-examples-${{ hashFiles('**/*.gradle') }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - id: set-matrix
         working-directory: ./examples/
         env:
@@ -49,12 +45,8 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
-        continue-on-error: true
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-examples-${{matrix.gradle_args}}_check-${{ hashFiles('**/*.gradle') }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Clear existing docker image cache
         run: docker image prune -af
       - name: Build and test Examples with Gradle (${{matrix.gradle_args}})

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -11,33 +11,7 @@ env:
   GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GRADLE_ENTERPRISE_CACHE_PASSWORD }}
 
 jobs:
-  find_gradle_jobs:
-    runs-on: ubuntu-18.04
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.5.0
-        with:
-          java-version: '8.0.302'
-          distribution: temurin
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-      - id: set-matrix
-        working-directory: ./examples/
-        env:
-          # Since we override the tests executor,
-          # we should not push empty results to the cache
-          READ_ONLY_REMOTE_GRADLE_CACHE: true
-        run: |
-          TASKS=$(./gradlew --no-daemon --parallel -q testMatrix)
-          echo $TASKS
-          echo "::set-output name=matrix::{\"gradle_args\":$TASKS}"
   check:
-    needs: find_gradle_jobs
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -17,8 +17,8 @@ jobs:
       XDG_RUNTIME_DIR: ${{ matrix.XDG_RUNTIME_DIR }}
     steps:
       - uses: actions/checkout@v2
-      - name: debug
-        run: id -u; whoami
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: uninstall rootful Docker
         run: sudo apt-get -q -y --purge remove moby-engine moby-buildx && sudo rm -rf /var/run/docker.sock
       - name: install rootless Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,32 +19,9 @@ jobs:
       - uses: actions/checkout@v2
       - id: thundra_test_initializer
         uses: thundra-io/thundra-test-init-action@v1
-  find_gradle_jobs:
-    runs-on: ubuntu-18.04
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.5.0
-        with:
-          java-version: '8.0.302'
-          distribution: temurin
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-      - id: set-matrix
-        env:
-          # Since we override the tests executor,
-          # we should not push empty results to the cache
-          READ_ONLY_REMOTE_GRADLE_CACHE: true
-        run: |
-          TASKS=$(./gradlew --no-daemon --parallel -q testMatrix)
-          echo $TASKS
-          echo "::set-output name=matrix::{\"gradle_args\":$TASKS}"
+
   check:
-    needs: [find_gradle_jobs, thundra_test_initializer]
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
+    needs: [thundra_test_initializer]
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -64,7 +41,7 @@ jobs:
           project_id: ${{ secrets.THUNDRA_PROJECT_ID }}
       - name: Build and test with Gradle (${{matrix.gradle_args}})
         run: |
-          ./gradlew --no-daemon --continue --scan ${{matrix.gradle_args}} \
+          ./gradlew --no-daemon --continue --scan \
             $([[ -f $THUNDRA_GRADLE_INIT_SCRIPT_PATH ]] && echo "--init-script $THUNDRA_GRADLE_INIT_SCRIPT_PATH")
         env:
           THUNDRA_AGENT_TEST_RUN_ID: ${{ needs.thundra_test_initializer.outputs.thundra_agent_testrun_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           project_id: ${{ secrets.THUNDRA_PROJECT_ID }}
       - name: Build and test with Gradle (${{matrix.gradle_args}})
         run: |
-          ./gradlew --no-daemon --continue --scan \
+          ./gradlew --no-daemon --continue --scan check \
             $([[ -f $THUNDRA_GRADLE_INIT_SCRIPT_PATH ]] && echo "--init-script $THUNDRA_GRADLE_INIT_SCRIPT_PATH")
         env:
           THUNDRA_AGENT_TEST_RUN_ID: ${{ needs.thundra_test_initializer.outputs.thundra_agent_testrun_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,8 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - id: set-matrix
         env:
           # Since we override the tests executor,
@@ -55,12 +52,8 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
-        continue-on-error: true
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-${{matrix.gradle_args}}_check-${{ hashFiles('**/*.gradle') }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Clear existing docker image cache
         run: docker image prune -af
       - name: Thundra Gradle Test Instrumentation

--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ MS SQL Server module is (c) 2017 - 2021 G DATA Software AG and other authors.
 Hashicorp Vault module is (c) 2017 - 2021 Capital One Services, LLC and other authors.
 
 See [contributors](https://github.com/testcontainers/testcontainers-java/graphs/contributors) for all contributors.
+
+A change that should not lead to CI build.


### PR DESCRIPTION
Replaces our manual steps for caching of Gradle files with the dedicated GHA:
https://github.com/marketplace/actions/gradle-build-action

