### PR TITLE
Normalize disabling ryuk container

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -211,7 +211,7 @@ public class DockerClientFactory {
 
         final String ryukContainerId;
 
-        boolean useRyuk = !Boolean.parseBoolean(System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
+        boolean useRyuk = TestcontainersConfiguration.getInstance().isRyukEnabled();
         if (useRyuk) {
             log.debug("Ryuk is enabled");
             try {

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -120,6 +120,13 @@ public class TestcontainersConfiguration {
         return getImage(ALPINE_IMAGE).asCanonicalNameString();
     }
 
+    public boolean isRyukEnabled() {
+        // Environment variable TESTCONTAINERS_RYUK_DISABLED is legacy. Having this boolean expression ensure legacy
+        // systems will not break.
+        return !Boolean.parseBoolean(System.getenv("TESTCONTAINERS_RYUK_DISABLED")) &&
+            Boolean.parseBoolean(getEnvVarOrProperty("ryuk.container.enabled", "true"));
+    }
+
     public boolean isRyukPrivileged() {
         return Boolean
             .parseBoolean(getEnvVarOrProperty("ryuk.container.privileged", "false"));

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -81,10 +81,9 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > In some environments ryuk must be started in privileged mode to work properly (--privileged flag)
 
 ### Disabling Ryuk
-Ryuk must be started as a privileged container.  
-If your environment already implements automatic cleanup of containers after the execution,
-but does not allow starting privileged containers, you can turn off the Ryuk container by setting
-`TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
+> **ryuk.container.enabled = true**
+> If your environment already implements automatic cleanup of containers after the execution,
+but does not allow starting privileged containers, you can turn off the Ryuk container by setting it to false.
 
 !!!tip
     Note that Testcontainers will continue doing the cleanup at JVM's shutdown, unless you `kill -9` your JVM process.


### PR DESCRIPTION
Disabling ryuk was only doable using environment variable. This PR aims
to configure it the same way other configuration parameters are.