### PR TITLE
addShutdownHook() for singleton container in docs

### DIFF
--- a/docs/test_framework_integration/manual_lifecycle_control.md
+++ b/docs/test_framework_integration/manual_lifecycle_control.md
@@ -30,6 +30,9 @@ abstract class AbstractContainerBaseTest {
     static {
         MY_SQL_CONTAINER = new MySQLContainer();
         MY_SQL_CONTAINER.start();
+        
+        // Gracefully shutdown container at the end of the JVM's lifecycle.
+        Runtime.getRuntime().addShutdownHook(new MY_SQL_CONTAINER::close));
     }
 }
 


### PR DESCRIPTION
While relying on Ryuk to shutdown singleton containers after JVM shutdown is probably fine I have the impression it might be a valuable addition to shutdown singleton containers explicitly _before_ the JVM terminates. That way no containers would be left running after the test runtime has completed.