### PR TITLE
Remove the `INCUBATING` note from CockroachDB module docs

### DIFF
--- a/docs/modules/databases/cockroachdb.md
+++ b/docs/modules/databases/cockroachdb.md
@@ -1,8 +1,5 @@
 # CockroachDB Module
 
-!!! note
-    This module is INCUBATING. While it is ready for use and operational in the current version of Testcontainers, it is possible that it may receive breaking changes in the future. See [our contributing guidelines](/contributing/#incubating-modules) for more information on our incubating modules policy.
-
 See [Database containers](./index.md) for documentation and usage that is common to all relational database container types.
 
 ## Adding this module to your project dependencies


### PR DESCRIPTION
The `CockroachDB` module has been available for some years now and generally has a stable codebase, that is very similar to other `JdbcDatabaseContainer` implementations. In addition, we can see quite some usage, while having very few reported issues so far. 

Therefore, it seems like a good idea to remove the `INCUBATING` note.