### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@fe52e97d262833ae07d05efaf1a239df3f1b5cd4 # v5.15.0
+      - uses: release-drafter/release-drafter@436492609a0c75979acf131d57f61b5321571950 # v5.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -17,7 +17,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@dcd5fd746d53dd8de555c0f10bca6c35628be47a # v3.10.1
+        uses: peter-evans/create-pull-request@f22a7da129c901513876a2380e2dae9f8e145330 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@f31ab392a9d75029f9fd0883d8d6745c0139a006 # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@5b865a8b4d09fdf6afaaa20397ba68455bb48f0d # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     }
 
     api 'junit:junit:4.13.2'
-    api 'org.slf4j:slf4j-api:1.7.32'
+    api 'org.slf4j:slf4j-api:1.7.35'
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'
     api 'org.apache.commons:commons-compress:1.21'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -90,7 +90,7 @@ dependencies {
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.0.1'
-    testImplementation 'com.rabbitmq:amqp-client:5.14.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.14.1'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
     testImplementation ('org.mockito:mockito-core:4.2.0') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -53,7 +53,7 @@ configurations.all {
 }
 
 dependencies {
-    baseline 'org.testcontainers:testcontainers:1.16.2', {
+    baseline 'org.testcontainers:testcontainers:1.16.3', {
         exclude group: "*", module: "*"
     }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.14.1'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
-    testImplementation ('org.mockito:mockito-core:4.2.0') {
+    testImplementation ('org.mockito:mockito-core:4.3.1') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:7.2.2'
+    testImplementation 'io.cucumber:cucumber-java:7.2.3'
     testImplementation 'io.cucumber:cucumber-junit:7.2.2'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.22"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.22"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.0.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.1.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'org.json:json:20211205'
-    testImplementation 'org.postgresql:postgresql:42.3.1'
+    testImplementation 'org.postgresql:postgresql:42.3.2'
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:4.0.1'
+    implementation 'redis.clients:jedis:4.1.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:4.0.1'
+    implementation 'redis.clients:jedis:4.1.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.2'
+    id 'org.springframework.boot' version '2.6.3'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:4.0.1'
+    implementation 'redis.clients:jedis:4.1.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.6.2"
+    id("org.springframework.boot") version "2.6.3"
     id("org.jetbrains.kotlin.jvm") version "1.6.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.6.10"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.2'
+    id 'org.springframework.boot' version '2.6.3'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.3.1'
+    testImplementation 'org.postgresql:postgresql:42.3.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.couchbase.client:java-client:3.2.4'
+    testImplementation 'com.couchbase.client:java-client:3.2.5'
     testImplementation 'org.awaitility:awaitility:4.1.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.137'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.131'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.150'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.150'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.16.2"
-    testImplementation "org.elasticsearch.client:transport:7.16.2"
+    testImplementation "org.elasticsearch.client:transport:7.17.0"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.2.2'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.10'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.11'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.2'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.10'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.1'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.14'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.16'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.27'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.14'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.16'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.0.1'
+    testImplementation 'redis.clients:jedis:4.1.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation ('org.mockito:mockito-core:4.2.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.1.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.2.0') {
+    testImplementation ('org.mockito:mockito-core:4.3.1') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.3.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.3.2'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:5.11.0'
     testImplementation 'io.kubernetes:client-java:14.0.0'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: K3S"
 dependencies {
     api project(":testcontainers")
 
-    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.1'
 
     testImplementation 'io.fabric8:kubernetes-client:5.11.0'
     testImplementation 'io.kubernetes:client-java:14.0.0'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.137'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.150'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.137'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.139'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.139'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.150'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.137'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.139'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.150'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.139'
     testImplementation 'software.amazon.awssdk:s3:2.17.108'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:2.7.4'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.3'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.2'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.3'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.14.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.14.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.3.1'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.28'
 
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:367'
+    testImplementation 'io.trino:trino-jdbc:369'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump google-cloud-bigtable from 2.5.1 to 2.5.2 in /modules/gcloud (#5015) @dependabot
* Bump assertj-core from 3.21.0 to 3.22.0 in /modules/k3s (#5012) @dependabot
* Bump jackson-dataformat-yaml from 2.8.8 to 2.13.1 in /modules/k3s (#5011) @dependabot
* Bump amqp-client from 5.14.0 to 5.14.1 in /modules/rabbitmq (#5008) @dependabot
* Bump google-cloud-firestore from 3.0.10 to 3.0.11 in /modules/gcloud (#5006) @dependabot
* Bump postgresql from 42.3.1 to 42.3.2 in /modules/cockroachdb (#5005) @dependabot
* Bump trino-jdbc from 367 to 369 in /modules/trino (#5004) @dependabot
* Bump peter-evans/create-pull-request from 3.12.0 to 3.12.1 (#5003) @dependabot
* Bump gradle-update/update-gradle-wrapper-action from 1.0.16 to 1.0.17 (#5002) @dependabot
* Bump release-drafter/release-drafter from 5.15.0 to 5.17.6 (#5001) @dependabot
* Bump cucumber-java from 7.2.2 to 7.2.3 in /examples (#4999) @dependabot
* Bump amqp-client from 5.14.0 to 5.14.1 in /core (#4997) @dependabot
* Bump kafka-clients from 3.0.0 to 3.1.0 in /examples (#4998) @dependabot
* Bump postgresql from 42.3.1 to 42.3.2 in /examples (#4996) @dependabot
* Bump mockito-core from 4.2.0 to 4.3.1 in /core (#4995) @dependabot
* Bump postgresql from 42.3.1 to 42.3.2 in /modules/junit-jupiter (#4994) @dependabot
* Bump slf4j-api from 1.7.32 to 1.7.35 in /core (#4991) @dependabot
* Bump org.springframework.boot from 2.6.2 to 2.6.3 in /examples (#4992) @dependabot
* Bump jedis from 4.0.1 to 4.1.1 in /modules/junit-jupiter (#4990) @dependabot
* Bump transport from 7.16.2 to 7.17.0 in /modules/elasticsearch (#4988) @dependabot
* Bump aws-java-sdk-s3 from 1.12.137 to 1.12.150 in /modules/localstack (#4989) @dependabot
* Bump jedis from 4.0.1 to 4.1.1 in /examples (#4986) @dependabot
* Bump mockito-core from 4.2.0 to 4.3.1 in /modules/junit-jupiter (#4987) @dependabot
* Bump mysql-connector-java from 8.0.27 to 8.0.28 in /modules/spock (#4985) @dependabot
* Bump testcontainers from 1.16.2 to 1.16.3 in /core (#4984) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.137 to 1.12.150 in /modules/dynalite (#4980) @dependabot
* Bump mariadb-java-client from 2.7.4 to 3.0.3 in /modules/mariadb (#4981) @dependabot
* Bump neo4j-java-driver from 4.4.2 to 4.4.3 in /modules/neo4j (#4977) @dependabot
* Bump aws-java-sdk-sqs from 1.12.139 to 1.12.150 in /modules/localstack (#4978) @dependabot
* Bump cucumber-junit from 7.2.2 to 7.2.3 in /examples (#4976) @dependabot
* Bump tomcat-jdbc from 10.0.14 to 10.0.16 in /modules/jdbc-test (#4973) @dependabot
* Bump mysql-connector-java from 8.0.27 to 8.0.28 in /modules/junit-jupiter (#4970) @dependabot
* Bump tomcat-jdbc from 10.0.14 to 10.0.16 in /modules/jdbc (#4967) @dependabot
* Bump java-client from 3.2.4 to 3.2.5 in /modules/couchbase (#4966) @dependabot
