### PR TITLE
#5032 - MS SQL Server disable encrypt by default

### DIFF
--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -92,6 +92,14 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
     }
 
     @Override
+    protected String constructUrlForConnection(String queryString) {
+        if (urlParameters.keySet().stream().map(String::toLowerCase).noneMatch("encrypt"::equals)) {
+            urlParameters.put("encrypt", "false");
+        }
+        return super.constructUrlForConnection(queryString);
+    }
+
+    @Override
     public String getJdbcUrl() {
         String additionalUrlParams = constructUrlParameters(";", ";");
         return "jdbc:sqlserver://" + getHost() + ":" + getMappedPort(MS_SQL_SERVER_PORT) + additionalUrlParams;

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/ConnectionParamMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/ConnectionParamMSSQLServerTest.java
@@ -1,0 +1,26 @@
+package org.testcontainers.junit.mssqlserver;
+
+import org.junit.Test;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectionParamMSSQLServerTest {
+
+    @Test
+    public void turnOffEncryptByDefaultInJDBCUrl() {
+        // given: An instance of MS SQL Server container
+        try (MSSQLServerContainer<?> mssqlServerContainer = new MSSQLServerContainer<>(DockerImageName.parse("mcr.microsoft.com/mssql/server").withTag("2017-CU12"))) {
+            mssqlServerContainer.start();
+            // expect: getting JDBC url will contain param for turning off encrypt
+            assertTrue(
+                "The JDBC driver of MS SQL Server enables encryption by default for versions > 10.1.0. " +
+                    "We need to disable it by default to be able to use the container without having to pass extra params.",
+                mssqlServerContainer.getJdbcUrl().contains("encrypt=false")
+            );
+            assertFalse(mssqlServerContainer.getJdbcUrl().contains("encrypt=true"));
+        }
+    }
+}


### PR DESCRIPTION
This PR disables the JDBC driver encrypt option by default for MS SQL Server containers. Since release 10.1.0 of MS JDBC driver the encrypt option is enabled by default (see https://github.com/microsoft/mssql-jdbc/releases/tag/v10.1.0). To be able to use the container without having to manually add params the encrypt option will be switched off if it is not set.