### PR TITLE
Enable Neo4j labs plugin definition.

### DIFF
--- a/docs/modules/databases/neo4j.md
+++ b/docs/modules/databases/neo4j.md
@@ -52,6 +52,21 @@ Whole directories work as well:
 [Plugin folder](../../../modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java) inside_block:registerPluginsPath
 <!--/codeinclude-->
 
+### Add Neo4j Docker Labs plugins
+
+Add any Neo4j Labs plugin from the [Neo4j Docker Labs plugin list](https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins).
+
+!!! note
+    At the moment only the plugins available from the list Neo4j Docker 4.4 are supported by type.
+    If you want to register another supported Neo4j Labs plugin, you have to add the environment manually
+    by using the method `withEnv("NEO4JLABS_PLUGINS", "[\"anotherPlugin\"]")`.
+    Please refer to the list of [supported Docker image plugins](https://neo4j.com/docs/operations-manual/current/docker/operations/#docker-neo4jlabs-plugins).
+
+<!--codeinclude-->
+[Configure Neo4j Labs Plugins](../../../modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java) inside_block:configureLabsPlugins
+<!--/codeinclude-->
+
+
 ### Start the container with a predefined database
 
 If you have an existing database (`graph.db`) you want to work with, copy it over to the container like this:
@@ -61,7 +76,7 @@ If you have an existing database (`graph.db`) you want to work with, copy it ove
 <!--/codeinclude-->
 
 !!! note
-The `withDatabase` method will only work with Neo4j 3.5 and throw an exception if used in combination with a newer version.
+    The `withDatabase` method will only work with Neo4j 3.5 and throw an exception if used in combination with a newer version.
 
 ## Choose your Neo4j license
 

--- a/docs/modules/databases/neo4j.md
+++ b/docs/modules/databases/neo4j.md
@@ -58,8 +58,8 @@ Add any Neo4j Labs plugin from the [Neo4j Docker Labs plugin list](https://neo4j
 
 !!! note
     At the moment only the plugins available from the list Neo4j Docker 4.4 are supported by type.
-    If you want to register another supported Neo4j Labs plugin, you have to add the environment manually
-    by using the method `withEnv("NEO4JLABS_PLUGINS", "[\"anotherPlugin\"]")`.
+    If you want to register another supported Neo4j Labs plugin, you have to add it manually
+    by using the method `withLabsPlugins(String... neo4jLabsPlugins)`.
     Please refer to the list of [supported Docker image plugins](https://neo4j.com/docs/operations-manual/current/docker/operations/#docker-neo4jlabs-plugins).
 
 <!--codeinclude-->

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toSet;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -63,7 +64,7 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
 
     private String adminPassword = DEFAULT_ADMIN_PASSWORD;
 
-    private final Set<Neo4jLabsPlugin> labsPlugins = new HashSet<>();
+    private final Set<String> labsPlugins = new HashSet<>();
 
     /**
      * Creates a Neo4jContainer using the official Neo4j docker image.
@@ -127,7 +128,7 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
 
         if (!this.labsPlugins.isEmpty()) {
             String enabledPlugins = this.labsPlugins.stream()
-                .map(plugin -> "\"" + plugin.pluginName + "\"")
+                .map(pluginName -> "\"" + pluginName + "\"")
                 .collect(Collectors.joining(","));
 
             addEnv("NEO4JLABS_PLUGINS", "[" + enabledPlugins + "]");
@@ -272,6 +273,21 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
      * @return This container.
      */
     public S withLabsPlugins(Neo4jLabsPlugin... neo4jLabsPlugins) {
+        List<String> pluginNames = Arrays.stream(neo4jLabsPlugins)
+            .map(plugin -> plugin.pluginName)
+            .collect(Collectors.toList());
+
+        this.labsPlugins.addAll(pluginNames);
+        return self();
+    }
+
+    /**
+     * Registers one or more {@link Neo4jLabsPlugin} for download and server startup.
+
+     * @param neo4jLabsPlugins The Neo4j plugins that should get started with the server.
+     * @return This container.
+     */
+    public S withLabsPlugins(String... neo4jLabsPlugins) {
         this.labsPlugins.addAll(Arrays.asList(neo4jLabsPlugins));
         return self();
     }

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -4,7 +4,10 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static java.util.stream.Collectors.toSet;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
@@ -59,6 +62,8 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
     private final boolean standardImage;
 
     private String adminPassword = DEFAULT_ADMIN_PASSWORD;
+
+    private final Set<Neo4jLabsPlugin> labsPlugins = new HashSet<>();
 
     /**
      * Creates a Neo4jContainer using the official Neo4j docker image.
@@ -119,6 +124,15 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
         boolean emptyAdminPassword = this.adminPassword == null || this.adminPassword.isEmpty();
         String neo4jAuth = emptyAdminPassword ? "none" : String.format(AUTH_FORMAT, this.adminPassword);
         addEnv("NEO4J_AUTH", neo4jAuth);
+
+        if (!this.labsPlugins.isEmpty()) {
+            String enabledPlugins = this.labsPlugins.stream()
+                .map(plugin -> "\"" + plugin.pluginName + "\"")
+                .collect(Collectors.joining(","));
+
+            addEnv("NEO4JLABS_PLUGINS", "[" + enabledPlugins + "]");
+        }
+
     }
 
     /**
@@ -249,6 +263,17 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
      */
     public String getAdminPassword() {
         return adminPassword;
+    }
+
+    /**
+     * Registers one or more {@link Neo4jLabsPlugin} for download and server startup.
+
+     * @param neo4jLabsPlugins The Neo4j plugins that should get started with the server.
+     * @return This container.
+     */
+    public S withLabsPlugins(Neo4jLabsPlugin... neo4jLabsPlugins) {
+        this.labsPlugins.addAll(Arrays.asList(neo4jLabsPlugins));
+        return self();
     }
 
     private static String formatConfigurationKey(String plainConfigKey) {

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jLabsPlugin.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jLabsPlugin.java
@@ -1,0 +1,21 @@
+package org.testcontainers.containers;
+
+/**
+ * Reflects a plugin from the official Neo4j 4.4.
+ * <a href="https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins">Neo4j Labs Plugin list</a>.
+ * There might be plugins not supported by your selected version of Neo4j.
+ */
+public enum Neo4jLabsPlugin {
+    APOC("apoc"),
+    APOC_CORE("apoc-core"),
+    BLOOM("bloom"),
+    STREAMS("streams"),
+    GRAPH_DATA_SCIENCE("graph-data-science"),
+    NEO_SEMANTICS("n10s");
+
+    final String pluginName;
+
+    Neo4jLabsPlugin(String pluginName) {
+        this.pluginName = pluginName;
+    }
+}

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -9,7 +9,6 @@ import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
-import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.util.Collections;
@@ -185,28 +184,59 @@ public class Neo4jContainerTest {
 
     @Test
     public void shouldConfigureSingleLabsPlugin() {
-        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
-            .withLabsPlugins(Neo4jLabsPlugin.APOC);
+        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
+            .withLabsPlugins(Neo4jLabsPlugin.APOC)) {
 
-        // needs to get called explicitly for setup
-        neo4jContainer.configure();
 
-        assertThat(neo4jContainer.getEnvMap())
-            .containsEntry("NEO4JLABS_PLUGINS", "[\"apoc\"]");
+            // needs to get called explicitly for setup
+            neo4jContainer.configure();
+
+            assertThat(neo4jContainer.getEnvMap())
+                .containsEntry("NEO4JLABS_PLUGINS", "[\"apoc\"]");
+        }
     }
 
     @Test
     public void shouldConfigureMultipleLabsPlugins() {
+        try(
         // configureLabsPlugins {
         Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
             .withLabsPlugins(Neo4jLabsPlugin.APOC, Neo4jLabsPlugin.BLOOM);
         // }
+        ) {
+            // needs to get called explicitly for setup
+            neo4jContainer.configure();
 
-        // needs to get called explicitly for setup
-        neo4jContainer.configure();
+            assertThat(neo4jContainer.getEnvMap().get("NEO4JLABS_PLUGINS"))
+                .containsAnyOf("[\"apoc\",\"bloom\"]", "[\"bloom\",\"apoc\"]");
+        }
+    }
 
-        assertThat(neo4jContainer.getEnvMap().get("NEO4JLABS_PLUGINS"))
-            .containsAnyOf("[\"apoc\",\"bloom\"]", "[\"bloom\",\"apoc\"]");
+    @Test
+    public void shouldConfigureSingleLabsPluginWithString() {
+        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
+            .withLabsPlugins("myApoc")) {
+
+            // needs to get called explicitly for setup
+            neo4jContainer.configure();
+
+            assertThat(neo4jContainer.getEnvMap())
+                .containsEntry("NEO4JLABS_PLUGINS", "[\"myApoc\"]");
+        }
+    }
+
+    @Test
+    public void shouldConfigureMultipleLabsPluginsWithString() {
+
+        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
+            .withLabsPlugins("myApoc", "myBloom")) {
+
+            // needs to get called explicitly for setup
+            neo4jContainer.configure();
+
+            assertThat(neo4jContainer.getEnvMap().get("NEO4JLABS_PLUGINS"))
+                .containsAnyOf("[\"myApoc\",\"myBloom\"]", "[\"myBloom\",\"myApoc\"]");
+        }
     }
 
     private static Driver getDriver(Neo4jContainer<?> container) {

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -183,6 +183,32 @@ public class Neo4jContainerTest {
             .containsEntry("NEO4J_dbms_tx__log_rotation_size", "42M");
     }
 
+    @Test
+    public void shouldConfigureSingleLabsPlugin() {
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
+            .withLabsPlugins(Neo4jLabsPlugin.APOC);
+
+        // needs to get called explicitly for setup
+        neo4jContainer.configure();
+
+        assertThat(neo4jContainer.getEnvMap())
+            .containsEntry("NEO4JLABS_PLUGINS", "[\"apoc\"]");
+    }
+
+    @Test
+    public void shouldConfigureMultipleLabsPlugins() {
+        // configureLabsPlugins {
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
+            .withLabsPlugins(Neo4jLabsPlugin.APOC, Neo4jLabsPlugin.BLOOM);
+        // }
+
+        // needs to get called explicitly for setup
+        neo4jContainer.configure();
+
+        assertThat(neo4jContainer.getEnvMap().get("NEO4JLABS_PLUGINS"))
+            .containsAnyOf("[\"apoc\",\"bloom\"]", "[\"bloom\",\"apoc\"]");
+    }
+
     private static Driver getDriver(Neo4jContainer<?> container) {
 
         AuthToken authToken = AuthTokens.none();


### PR DESCRIPTION
This PR would provide the functionality to define predefined plugins for the Neo4j image.
It is a shortcut for defining an environment variable with a not very intuitive array definition:
```
.withEnv("NEO4JLABS_PLUGINS", "[\"apoc\"]")
```
becomes
```
.withLabsPlugin(Neo4jLabsPlugin.APOC);
```
Reference: https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins