### PR TITLE
Allow DockerClientProviderStrategy to provide remote docker host uri

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -159,7 +159,9 @@ public class DockerClientFactory {
             return dockerSocketOverride;
         }
 
-        URI dockerHost = getTransportConfig().getDockerHost();
+        URI dockerHost = getTransportConfig().getRemoteDockerHost() != null
+            ? getTransportConfig().getRemoteDockerHost()
+            : getTransportConfig().getDockerHost();
         String path = "unix".equals(dockerHost.getScheme())
             ? dockerHost.getRawPath()
             : "/var/run/docker.sock";

--- a/core/src/main/java/org/testcontainers/dockerclient/TransportConfig.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/TransportConfig.java
@@ -14,5 +14,8 @@ public class TransportConfig {
     URI dockerHost;
 
     @Nullable
+    URI remoteDockerHost;
+
+    @Nullable
     SSLConfig sslConfig;
 }


### PR DESCRIPTION
After testcontainers-cloud announcement, I prototyped support for `docker over ssh`:
https://gist.github.com/darl/7215ec147558d371d9c34430fde2add9

The ugly part is unix socket path mapping.
`ryuk` uses local dockerHost path, but it runs on a remote machine, where it's not accessible.

With this change, DockerClientProviderStrategy can provide different path to unix socket when needed.