### PR TITLE
Remove OkHttp transport

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -79,7 +79,6 @@ dependencies {
     api "com.github.docker-java:docker-java-api"
 
     shaded 'com.github.docker-java:docker-java-core'
-    shaded 'com.github.docker-java:docker-java-transport-okhttp'
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -6,7 +6,6 @@ import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.core.RemoteApiVersion;
-import com.github.dockerjava.okhttp.OkDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import com.github.dockerjava.zerodep.ZerodepDockerHttpClient;
 import com.google.common.annotations.VisibleForTesting;
@@ -255,12 +254,6 @@ public abstract class DockerClientProviderStrategy {
 
         String transportType = TestcontainersConfiguration.getInstance().getTransportType();
         switch (transportType) {
-            case "okhttp":
-                dockerHttpClient = new OkDockerHttpClient.Builder()
-                    .dockerHost(transportConfig.getDockerHost())
-                    .sslConfig(transportConfig.getSslConfig())
-                    .build();
-                break;
             case "httpclient5":
                 dockerHttpClient = new ZerodepDockerHttpClient.Builder()
                     .dockerHost(transportConfig.getDockerHost())

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -2,6 +2,9 @@ description = "Testcontainers :: Solr"
 
 dependencies {
     api project(':testcontainers')
+    // TODO use JDK's HTTP client and/or Apache HttpClient5
+    shaded 'com.squareup.okhttp3:okhttp:3.14.9'
+
     testImplementation 'org.apache.solr:solr-solrj:8.11.1'
 
 }


### PR DESCRIPTION
AHC5 was the default transport for 7 months now and we never had any reports about issues caused by it.

Since [OkHttp transport's future in docker-java is unclear](https://github.com/docker-java/docker-java/blob/master/docs/transports.md#okhttp), and AHC5 covers everything, let's remove OkHttp transport option to reduce our set of dependencies.