### PR TITLE
[Selenium] Add option to disable the integrated tracer in the WebDriver

### DIFF
--- a/examples/cucumber/src/test/java/org/testcontainsers/examples/Stepdefs.java
+++ b/examples/cucumber/src/test/java/org/testcontainsers/examples/Stepdefs.java
@@ -6,6 +6,7 @@ import io.cucumber.java.Scenario;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -57,7 +58,7 @@ public class Stepdefs {
     public void iAskIsItPossibleToSearchHere() throws Exception {
         RemoteWebDriver driver = container.getWebDriver();
         driver.get(location);
-        List<WebElement> searchInputs = driver.findElementsByTagName("input");
+        List<WebElement> searchInputs = driver.findElements(By.tagName("input"));
         answer = searchInputs != null && searchInputs.size() > 0 ? "YES" : "NOPE";
     }
 

--- a/examples/selenium-container/src/test/java/SeleniumContainerTest.java
+++ b/examples/selenium-container/src/test/java/SeleniumContainerTest.java
@@ -2,6 +2,7 @@ import com.example.DemoApplication;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -43,7 +44,7 @@ public class SeleniumContainerTest {
         RemoteWebDriver driver = chrome.getWebDriver();
 
         driver.get("http://host.testcontainers.internal:" + port + "/foo.html");
-        List<WebElement> hElement = driver.findElementsByTagName("h");
+        List<WebElement> hElement = driver.findElements(By.tagName("h"));
 
         assertTrue("The h element is found", hElement != null && hElement.size() > 0);
     }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -3,10 +3,10 @@ description = "Testcontainers :: Selenium"
 dependencies {
     api project(':testcontainers')
 
-    provided 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
-    provided 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
-    testImplementation 'org.seleniumhq.selenium:selenium-support:3.141.59'
+    provided 'org.seleniumhq.selenium:selenium-remote-driver:4.1.2'
+    provided 'org.seleniumhq.selenium:selenium-chrome-driver:4.1.2'
+    testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.1.2'
+    testImplementation 'org.seleniumhq.selenium:selenium-support:4.1.2'
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'
     testImplementation project(':nginx')


### PR DESCRIPTION
Selenium 4.1.2 introduced `RemoteWebDriver#RemoteWebDriver(URL, Capabilities, boolean)` to disable the integrated tracer.