### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -17,7 +17,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.5.0
+      - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'
           distribution: temurin
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.5.0
+      - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'
           distribution: temurin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.5.0
+      - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'
           distribution: temurin
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.5.0
+      - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'
           distribution: temurin

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@436492609a0c75979acf131d57f61b5321571950 # v5.15.0
+      - uses: release-drafter/release-drafter@2f7ebf8ab5ef7f9835ee4b0b1eebaa2a14ca1669 # v5.15.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2.5.0
+      - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'
           distribution: temurin

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.0.1'
-    testImplementation 'com.rabbitmq:amqp-client:5.14.1'
+    testImplementation 'com.rabbitmq:amqp-client:5.14.2'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
     testImplementation ('org.mockito:mockito-core:4.3.1') {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.2.3'
-    testImplementation 'io.cucumber:cucumber-junit:7.2.2'
+    testImplementation 'io.cucumber:cucumber-junit:7.2.3'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'org.json:json:20211205'
-    testImplementation 'org.postgresql:postgresql:42.3.2'
+    testImplementation 'org.postgresql:postgresql:42.3.3'
     testImplementation 'ch.qos.logback:logback-classic:1.2.10'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.3'
+    id 'org.springframework.boot' version '2.6.4'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.6.3"
+    id("org.springframework.boot") version "2.6.4"
     id("org.jetbrains.kotlin.jvm") version "1.6.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.6.10"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.3'
+    id 'org.springframework.boot' version '2.6.4'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'com.azure:azure-cosmos:4.24.0'
+    testImplementation 'com.azure:azure-cosmos:4.26.0'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.3.2'
+    testImplementation 'org.postgresql:postgresql:42.3.3'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.150'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.169'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.150'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.16.2"
-    testImplementation "org.elasticsearch.client:transport:7.17.0"
+    testImplementation "org.elasticsearch.client:transport:7.17.1"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.2.2'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.11'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.14'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.2'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.2.2'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.14'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.17.4'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.20.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.7.3")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.7.4")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.2.10")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(':jdbc')
     api project(':test-support')
 
-    api 'com.google.guava:guava:31.0.1-jre'
+    api 'com.google.guava:guava:31.1-jre'
     api 'org.apache.commons:commons-lang3:3.12.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.7'

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -16,5 +16,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.16'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.27'
+    api 'mysql:mysql-connector-java:8.0.28'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.3.2'
+    testRuntimeOnly 'org.postgresql:postgresql:42.3.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:5.11.0'
+    testImplementation 'io.fabric8:kubernetes-client:5.12.1'
     testImplementation 'io.kubernetes:client-java:14.0.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.150'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.137'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.150'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.139'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.169'
     testImplementation 'software.amazon.awssdk:s3:2.17.108'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.150'
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.137'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.169'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.169'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.150'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.169'
     testImplementation 'software.amazon.awssdk:s3:2.17.108'

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.4.1")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.5.0")
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.27'
+    testImplementation 'mysql:mysql-connector-java:8.0.28'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -29,7 +29,7 @@ task customNeo4jPluginJar(type: Jar) {
 test.dependsOn customNeo4jPluginJar
 
 dependencies {
-    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.29"
+    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.31"
 
     api project(":testcontainers")
 

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.3.1'
+    testImplementation 'org.postgresql:postgresql:42.3.3'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.14'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.15'
     testFixturesImplementation 'org.assertj:assertj-core:3.14.0'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.14.1'
+    testImplementation 'com.rabbitmq:amqp-client:5.14.2'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -6,7 +6,7 @@ description = "Testcontainers :: Spock-Extension"
 
 dependencies {
     api project(':testcontainers')
-    api 'org.spockframework:spock-core:2.0-groovy-3.0'
+    api 'org.spockframework:spock-core:2.1-groovy-3.0'
 
     testImplementation project(':selenium')
     testImplementation project(':mysql')

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:4.4.0'
+    testImplementation 'io.rest-assured:rest-assured:4.5.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump google-cloud-firestore from 3.0.11 to 3.0.14 in /modules/gcloud (#5143) @dependabot
* Bump google-cloud-spanner from 6.17.4 to 6.20.0 in /modules/gcloud (#5142) @dependabot
* Bump actions/setup-java from 2.5.0 to 3 (#5141) @dependabot
* Bump actions/checkout from 2 to 3 (#5140) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.150 to 1.12.169 in /modules/dynalite (#5138) @dependabot
* Bump transport from 7.17.0 to 7.17.1 in /modules/elasticsearch (#5136) @dependabot
* Bump org.springframework.boot from 2.6.3 to 2.6.4 in /examples (#5137) @dependabot
* Bump elasticsearch-rest-client from 7.16.2 to 8.0.1 in /modules/elasticsearch (#5135) @dependabot
* Bump guava from 31.0.1-jre to 31.1-jre in /modules/jdbc-test (#5133) @dependabot
* Bump aws-java-sdk-logs from 1.12.139 to 1.12.169 in /modules/localstack (#5132) @dependabot
* Bump neo4j from 3.5.29 to 3.5.31 in /modules/neo4j (#5131) @dependabot
* Bump aws-java-sdk-sqs from 1.12.150 to 1.12.169 in /modules/localstack (#5130) @dependabot
* Bump aws-java-sdk-s3 from 1.12.150 to 1.12.169 in /modules/localstack (#5127) @dependabot
* Bump postgresql from 42.3.2 to 42.3.3 in /examples (#5090) @dependabot
* Bump google-cloud-datastore from 2.2.2 to 2.2.4 in /modules/gcloud (#5088) @dependabot
* Bump release-drafter/release-drafter from 5.17.6 to 5.18.1 (#5087) @dependabot
* Bump amqp-client from 5.14.1 to 5.14.2 in /core (#5080) @dependabot
* Bump azure-cosmos from 4.24.0 to 4.26.0 in /modules/azure (#5079) @dependabot
* Bump google-cloud-bigtable from 2.5.2 to 2.5.3 in /modules/gcloud (#5075) @dependabot
* Bump kubernetes-client from 5.11.0 to 5.12.1 in /modules/k3s (#5071) @dependabot
* Bump amqp-client from 5.14.1 to 5.14.2 in /modules/rabbitmq (#5070) @dependabot
* Bump rest-assured from 4.4.0 to 4.5.1 in /modules/vault (#5072) @dependabot
* Bump postgresql from 42.3.1 to 42.3.3 in /modules/postgresql (#5064) @dependabot
* Bump postgresql from 42.3.2 to 42.3.3 in /modules/cockroachdb (#5063) @dependabot
* Bump reactor-core from 3.4.14 to 3.4.15 in /modules/r2dbc (#5065) @dependabot
* Bump postgresql from 42.3.2 to 42.3.3 in /modules/junit-jupiter (#5059) @dependabot
* Bump hivemq-extension-sdk from 4.7.3 to 4.7.4 in /modules/hivemq (#5061) @dependabot
* Bump mongodb-driver-sync from 4.4.1 to 4.5.0 in /modules/mongodb (#5062) @dependabot
* Bump spock-core from 2.0-groovy-3.0 to 2.1-groovy-3.0 in /modules/spock (#5057) @dependabot
* Bump google-cloud-datastore from 2.2.2 to 2.2.3 in /modules/gcloud (#5013) @dependabot
* Bump cucumber-junit from 7.2.2 to 7.2.3 in /examples (#4976) @dependabot
* Bump mysql-connector-java from 8.0.27 to 8.0.28 in /modules/jdbc-test (#4971) @dependabot
* Bump mysql-connector-java from 8.0.27 to 8.0.28 in /modules/mysql (#4972) @dependabot
