### PR TITLE
Upgrade release drafter to v5.19.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -23,3 +23,4 @@ categories:
       - type/test-improvement
   - title: 📦 Dependency updates
     label: dependencies
+    collapse-after: 3

--- a/.github/workflows/run-release-drafter.yml
+++ b/.github/workflows/run-release-drafter.yml
@@ -12,6 +12,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@2f7ebf8ab5ef7f9835ee4b0b1eebaa2a14ca1669 # v5.15.0
+      - uses: release-drafter/release-drafter@e9ee02fbac03d922bac6212003695e8358dd88b0 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* includes new `collapse-after` mode to automatically collapse long lists of dependency updates
* includes a fix for unmerged PRs sometimes appearing (https://github.com/release-drafter/release-drafter/pull/1015)
* renamed GHA workflow file for DX reasons: the previous filename was being identified for JSON schema validation as a release drafter config file rather than as a GHA workflow. With the changed filename, IDE validation and autocompletion are now actually helpful.