### PR TITLE
Fix ScriptUtils.runInitScript() in hierarchical classloader setup by using TCCL

### DIFF
--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -293,10 +293,13 @@ public abstract class ScriptUtils {
 	 */
 	public static void runInitScript(DatabaseDelegate databaseDelegate, String initScriptPath) {
 		try {
-			URL resource = ScriptUtils.class.getClassLoader().getResource(initScriptPath);
+			URL resource = Thread.currentThread().getContextClassLoader().getResource(initScriptPath);
 			if (resource == null) {
-				LOGGER.warn("Could not load classpath init script: {}", initScriptPath);
-				throw new ScriptLoadException("Could not load classpath init script: " + initScriptPath + ". Resource not found.");
+				resource = ScriptUtils.class.getClassLoader().getResource(initScriptPath);
+				if (resource == null) {
+					LOGGER.warn("Could not load classpath init script: {}", initScriptPath);
+					throw new ScriptLoadException("Could not load classpath init script: " + initScriptPath + ". Resource not found.");
+				}
 			}
 			String scripts = IOUtils.toString(resource, StandardCharsets.UTF_8);
 			executeDatabaseScript(databaseDelegate, initScriptPath, scripts);


### PR DESCRIPTION
This fixes e.g. `MariaDBContainer.withInitScript(...)` in Quarkus continuous testing, which is using a hierarchical classloading setup.

Btw, for comparison, `MountableFile` (e.g. `MariaDBContainer.withConfigurationOverride(...)`) does work already:
https://github.com/testcontainers/testcontainers-java/blob/14eff07a7cae8d48b07b80e309bba601f164ae66/core/src/main/java/org/testcontainers/utility/MountableFile.java#L128