### PR TITLE
Fix incorrect path for RABBITMQ_CONFIG_FILE

### DIFF
--- a/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
+++ b/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
@@ -396,7 +396,7 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
      * @return This container.
      */
     public RabbitMQContainer withRabbitMQConfigSysctl(MountableFile rabbitMQConf) {
-        withEnv("RABBITMQ_CONFIG_FILE", "/etc/rabbitmq/rabbitmq-custom");
+        withEnv("RABBITMQ_CONFIG_FILE", "/etc/rabbitmq/rabbitmq-custom.conf");
         return withCopyFileToContainer(rabbitMQConf, "/etc/rabbitmq/rabbitmq-custom.conf");
     }
 

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
@@ -118,25 +118,19 @@ public class RabbitMQContainerTest {
     }
 
     @Test
-    public void shouldMountConfigurationFile() throws IOException, InterruptedException {
+    public void shouldMountConfigurationFile() {
         try (RabbitMQContainer container = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE)) {
-
-            final String resourceLocation = "/rabbitmq-custom.conf";
-            container.withRabbitMQConfig(MountableFile.forClasspathResource(resourceLocation));
+            container.withRabbitMQConfig(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
             container.start();
 
-            assertThat(container.getLogs()).contains("config file(s) : /etc/rabbitmq/rabbitmq-custom.conf");
             assertThat(container.getLogs()).contains("debug"); // config file changes log level to `debug`
         }
     }
 
 
     @Test
-    public void shouldMountConfigurationFileErlang() throws IOException, InterruptedException {
+    public void shouldMountConfigurationFileErlang() {
         try (RabbitMQContainer container = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE)) {
-
-            final String resourceLocation = "/rabbitmq-custom.config";
-
             container.withRabbitMQConfigErlang(MountableFile.forClasspathResource("/rabbitmq-custom.config"));
             container.start();
 
@@ -146,20 +140,12 @@ public class RabbitMQContainerTest {
 
 
     @Test
-    public void shouldMountConfigurationFileSysctl() throws IOException, InterruptedException {
+    public void shouldMountConfigurationFileSysctl() {
         try (RabbitMQContainer container = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE)) {
-
-            final String resourceLocation = "/rabbitmq-custom.conf";
-            container.withRabbitMQConfigSysctl(MountableFile.forClasspathResource(resourceLocation));
-            InputStream inputStream = this.getClass().getResourceAsStream(resourceLocation);
-            Scanner s = new Scanner(Objects.requireNonNull(inputStream)).useDelimiter("\\A");
-            String configContents = s.hasNext() ? s.next() : "";
+            container.withRabbitMQConfigSysctl(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
             container.start();
 
-            assertThat(container.getLogs()).contains("config file(s) : /etc/rabbitmq/rabbitmq-custom.conf");
-            assertThat(container.execInContainer("cat", "/etc/rabbitmq/rabbitmq-custom.conf")
-                .getStdout()
-            ).contains(configContents);
+            assertThat(container.getLogs()).contains("debug"); // config file changes log level to `debug`
         }
     }
 

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
@@ -123,16 +123,10 @@ public class RabbitMQContainerTest {
 
             final String resourceLocation = "/rabbitmq-custom.conf";
             container.withRabbitMQConfig(MountableFile.forClasspathResource(resourceLocation));
-            InputStream inputStream = this.getClass().getResourceAsStream(resourceLocation);
-            Scanner s = new Scanner(Objects.requireNonNull(inputStream)).useDelimiter("\\A");
-            String configContents = s.hasNext() ? s.next() : "";
             container.start();
 
             assertThat(container.getLogs()).contains("config file(s) : /etc/rabbitmq/rabbitmq-custom.conf");
-            assertThat(container.execInContainer("cat", "/etc/rabbitmq/rabbitmq-custom.conf")
-                .getStdout()
-            ).contains(configContents);
-            assertThat(container.getLogs()).doesNotContain(" (not found)");
+            assertThat(container.getLogs()).contains("debug"); // config file changes log level to `debug`
         }
     }
 
@@ -142,18 +136,11 @@ public class RabbitMQContainerTest {
         try (RabbitMQContainer container = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE)) {
 
             final String resourceLocation = "/rabbitmq-custom.config";
-            InputStream inputStream = this.getClass().getResourceAsStream(resourceLocation);
-            Scanner s = new Scanner(Objects.requireNonNull(inputStream)).useDelimiter("\\A");
-            String configContents = s.hasNext() ? s.next() : "";
 
             container.withRabbitMQConfigErlang(MountableFile.forClasspathResource("/rabbitmq-custom.config"));
             container.start();
 
-            assertThat(container.getLogs()).contains("config file(s) : /etc/rabbitmq/rabbitmq-custom.config");
-            assertThat(container.execInContainer("cat", "/etc/rabbitmq/rabbitmq-custom.config")
-                .getStdout()
-            ).contains(configContents);
-            assertThat(container.getLogs()).doesNotContain(" (not found)");
+            assertThat(container.getLogs()).contains("debug"); // config file changes log level to `debug`
         }
     }
 

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
@@ -14,6 +14,7 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -21,6 +22,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 import java.util.Collections;
+import java.util.Objects;
+import java.util.Scanner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -115,43 +118,61 @@ public class RabbitMQContainerTest {
     }
 
     @Test
-    public void shouldMountConfigurationFile()
-    {
+    public void shouldMountConfigurationFile() throws IOException, InterruptedException {
         try (RabbitMQContainer container = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE)) {
 
-            container.withRabbitMQConfig(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
+            final String resourceLocation = "/rabbitmq-custom.conf";
+            container.withRabbitMQConfig(MountableFile.forClasspathResource(resourceLocation));
+            InputStream inputStream = this.getClass().getResourceAsStream(resourceLocation);
+            Scanner s = new Scanner(Objects.requireNonNull(inputStream)).useDelimiter("\\A");
+            String configContents = s.hasNext() ? s.next() : "";
             container.start();
 
             assertThat(container.getLogs()).contains("config file(s) : /etc/rabbitmq/rabbitmq-custom.conf");
+            assertThat(container.execInContainer("cat", "/etc/rabbitmq/rabbitmq-custom.conf")
+                .getStdout()
+            ).contains(configContents);
             assertThat(container.getLogs()).doesNotContain(" (not found)");
         }
     }
 
 
     @Test
-    public void shouldMountConfigurationFileErlang()
-    {
+    public void shouldMountConfigurationFileErlang() throws IOException, InterruptedException {
         try (RabbitMQContainer container = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE)) {
+
+            final String resourceLocation = "/rabbitmq-custom.config";
+            InputStream inputStream = this.getClass().getResourceAsStream(resourceLocation);
+            Scanner s = new Scanner(Objects.requireNonNull(inputStream)).useDelimiter("\\A");
+            String configContents = s.hasNext() ? s.next() : "";
 
             container.withRabbitMQConfigErlang(MountableFile.forClasspathResource("/rabbitmq-custom.config"));
             container.start();
 
             assertThat(container.getLogs()).contains("config file(s) : /etc/rabbitmq/rabbitmq-custom.config");
+            assertThat(container.execInContainer("cat", "/etc/rabbitmq/rabbitmq-custom.config")
+                .getStdout()
+            ).contains(configContents);
             assertThat(container.getLogs()).doesNotContain(" (not found)");
         }
     }
 
 
     @Test
-    public void shouldMountConfigurationFileSysctl()
-    {
+    public void shouldMountConfigurationFileSysctl() throws IOException, InterruptedException {
         try (RabbitMQContainer container = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE)) {
 
-            container.withRabbitMQConfigSysctl(MountableFile.forClasspathResource("/rabbitmq-custom.conf"));
+            final String resourceLocation = "/rabbitmq-custom.conf";
+            container.withRabbitMQConfigSysctl(MountableFile.forClasspathResource(resourceLocation));
+            InputStream inputStream = this.getClass().getResourceAsStream(resourceLocation);
+            Scanner s = new Scanner(Objects.requireNonNull(inputStream)).useDelimiter("\\A");
+            String configContents = s.hasNext() ? s.next() : "";
             container.start();
 
             assertThat(container.getLogs()).contains("config file(s) : /etc/rabbitmq/rabbitmq-custom.conf");
-            assertThat(container.getLogs()).doesNotContain(" (not found)");
+            assertThat(container.execInContainer("cat", "/etc/rabbitmq/rabbitmq-custom.conf")
+                .getStdout()
+            ).contains(configContents);
         }
     }
 

--- a/modules/rabbitmq/src/test/resources/logback-test.xml
+++ b/modules/rabbitmq/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="DEBUG"/>
+</configuration>

--- a/modules/rabbitmq/src/test/resources/rabbitmq-custom.conf
+++ b/modules/rabbitmq/src/test/resources/rabbitmq-custom.conf
@@ -1,2 +1,1 @@
-loopback_users.guest = false
-listeners.tcp.default = 5555
+log.console.level = debug

--- a/modules/rabbitmq/src/test/resources/rabbitmq-custom.config
+++ b/modules/rabbitmq/src/test/resources/rabbitmq-custom.config
@@ -1,13 +1,9 @@
 [
-{ rabbit, [
-{ loopback_users, [ ] },
-		{ tcp_listeners, [ 5555 ] },
-		{ ssl_listeners, [ ] },
-		{ default_vhost, <<"vhost">> },
-		{ hipe_compile, false }
-	] },
-	{ rabbitmq_management, [ { listener, [
-		{ port, 15672 },
-		{ ssl, false }
-	] } ] }
+{rabbit,
+    [
+        {log,
+            [{console, [{level, debug}]}]
+        }
+    ]
+}
 ].


### PR DESCRIPTION
Fixes a bug where the `RABBITMQ_CONFIG_FILE` was pointing to an incorrect path (i.e. `"/etc/rabbitmq/rabbitmq-custom"` rather than `"/etc/rabbitmq/rabbitmq-custom.conf"` ) which meant that the `withEnv` didn't end up doing anything since it was pointing to a path rather than a file. The tests didn't pick up this bug because they were just testing the existence of `/etc/rabbitmq/rabbitmq-custom.conf` and not the contents. Due to this the test/s were updated to make sure the actual contents of `/etc/rabbitmq/rabbitmq-custom.conf` is the same as the `MountableFile` that gets passed in (the other related tests have also been updated to make sure that they work as expected)