### PR TITLE
Fail on wrong image name with two colons and no custom registry.

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -165,6 +165,9 @@ public final class DockerImageName {
         if (!versioning.isValid()) {
             throw new IllegalArgumentException(versioning + " is not a valid image versioning identifier (in " + rawName + ")");
         }
+        if (!rawName.contains("/") && rawName.split(":").length > 2) {
+            throw new IllegalArgumentException(rawName + " is not a valid Docker image name.");
+        }
     }
 
     /**

--- a/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DockerImageNameTest.java
@@ -48,7 +48,8 @@ public class DockerImageNameTest {
                 "/myname:latest",
                 "/myname@sha256:latest",
                 "/myname@sha256:gggggggggggggggggggggggggggggggg",
-                "repo:notaport/myname:latest"};
+                "repo:notaport/myname:latest",
+                "repo:repo:version"};
         }
 
         @Parameterized.Parameter


### PR DESCRIPTION
This PR makes the `DockerImageName#assertValid` method throw an exception if the image name contains more than one colon and there is no custom registry.
Tried to do as minimal impact as possible here and not bother with regexp because I think the naive way is the simplest solution for the problem.

#5190 