### PR TITLE
Deperecate `getContainerIpAddress`

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -47,6 +47,7 @@ public interface ContainerState {
      * @deprecated use {@link #getHost()}
      * @see #getHost()
      */
+    @Deprecated
     default String getContainerIpAddress() {
         return getHost();
     }


### PR DESCRIPTION
#5149 did already deprecated `getContainerIpAddress`, but only in the Javadoc and it missed the `@Deprecated` annotation. This PR is simply the follow-up.

The correct deprecation implicitly fixes #4715, since the deprecation now advocates for using the correctly defined `getHost()` method.