### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-docker-wormhole.yml
+++ b/.github/workflows/ci-docker-wormhole.yml
@@ -8,7 +8,7 @@ jobs:
   in-docker_test:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build with Gradle
         run: |
           docker run -i --rm \

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v3.0.1
         continue-on-error: true
         with:
           path: ~/.gradle/caches
@@ -50,7 +50,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v3.0.1
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'
@@ -44,7 +44,7 @@ jobs:
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       XDG_RUNTIME_DIR: ${{ matrix.XDG_RUNTIME_DIR }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: debug
         run: id -u; whoami
       - name: uninstall rootful Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v3.0.1
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
@@ -56,7 +56,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v2.1.7
+        uses: actions/cache@v3.0.1
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       thundra_agent_testrun_id: ${{ steps.thundra_test_initializer.outputs.thundra_agent_testrun_id }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - id: thundra_test_initializer
         uses: thundra-io/thundra-test-init-action@v1
   find_gradle_jobs:
@@ -24,7 +24,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'
@@ -50,7 +50,7 @@ jobs:
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: '8.0.302'

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -9,7 +9,7 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: master
       - name: Update latest_version property in mkdocs.yml

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -17,7 +17,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@f22a7da129c901513876a2380e2dae9f8e145330 # v3.10.1
+        uses: peter-evans/create-pull-request@f1a7646cead32c950d90344a4fb5d4e926972a8f # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@5b865a8b4d09fdf6afaaa20397ba68455bb48f0d # v1.0.13

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,7 +71,7 @@ dependencies {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
 
-    shaded 'org.awaitility:awaitility:4.1.1'
+    shaded 'org.awaitility:awaitility:4.2.0'
 
     api platform('com.github.docker-java:docker-java-bom:3.2.13')
     shaded platform('com.github.docker-java:docker-java-bom:3.2.13')

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'biz.paluch.redis:spinach:0.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.10'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.mockito:mockito-all:1.10.19'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.1.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.10'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'org.json:json:20211205'
     testImplementation 'org.postgresql:postgresql:42.3.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.10'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'
 }
 

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.3'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.5'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.10'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testng:testng:7.5'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:4.1.1'
+    implementation 'redis.clients:jedis:4.2.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.10'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:4.1.1'
+    implementation 'redis.clients:jedis:4.2.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:4.1.1'
+    implementation 'redis.clients:jedis:4.2.1'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.2.10'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.6.4"
     id("org.jetbrains.kotlin.jvm") version "1.6.10"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.6.10"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.6.20"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
-    testImplementation 'com.couchbase.client:java-client:3.2.5'
+    testImplementation 'com.couchbase.client:java-client:3.2.6'
     testImplementation 'org.awaitility:awaitility:4.1.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.16.2"
-    testImplementation "org.elasticsearch.client:transport:7.17.1"
+    testImplementation "org.elasticsearch.client:transport:7.17.2"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.2.2'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.14'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.0.21'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.20.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.2'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.21'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.115.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.20.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.5.2'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.6.1'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     shaded("org.javassist:javassist:3.28.0-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
-    shaded("net.lingala.zip4j:zip4j:2.9.1")
+    shaded("net.lingala.zip4j:zip4j:2.10.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation(project(":junit-jupiter"))

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.7.4")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.7.5")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.2.10")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.16'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.20'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.28'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.16'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.20'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.1.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.3.1') {
+    testImplementation ('org.mockito:mockito-core:4.4.0') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:5.12.1'
-    testImplementation 'io.kubernetes:client-java:14.0.0'
+    testImplementation 'io.kubernetes:client-java:15.0.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.169'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.191'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.169'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.150'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.169'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.169'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.150'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.169'
-    testImplementation 'software.amazon.awssdk:s3:2.17.108'
+    testImplementation 'software.amazon.awssdk:s3:2.17.162'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.5.0")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.5.1")
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.3'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.5'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api 'io.r2dbc:r2dbc-spi:0.8.1.RELEASE'
 
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'
+    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.4.16'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.15'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.16'
     testFixturesImplementation 'org.assertj:assertj-core:3.14.0'
 }

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Solr"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:3.14.9'
+    shaded 'com.squareup.okhttp3:okhttp:4.9.3'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.1'
 

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:369'
+    testImplementation 'io.trino:trino-jdbc:375'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:4.5.1'
+    testImplementation 'io.rest-assured:rest-assured:5.0.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump zip4j from 2.9.1 to 2.10.0 in /modules/hivemq (#5242) @dependabot
* Bump hivemq-extension-sdk from 4.7.4 to 4.7.5 in /modules/hivemq (#5241) @dependabot
* Bump google-cloud-firestore from 3.0.14 to 3.0.21 in /modules/gcloud (#5239) @dependabot
* Bump google-cloud-pubsub from 1.115.1 to 1.116.3 in /modules/gcloud (#5238) @dependabot
* Bump google-cloud-datastore from 2.2.2 to 2.3.0 in /modules/gcloud (#5236) @dependabot
* Bump reactor-core from 3.4.15 to 3.4.16 in /modules/r2dbc (#5234) @dependabot
* Bump google-cloud-bigtable from 2.5.2 to 2.6.1 in /modules/gcloud (#5233) @dependabot
* Bump mongodb-driver-sync from 4.5.0 to 4.5.1 in /modules/mongodb (#5231) @dependabot
* Bump client-java from 14.0.0 to 15.0.0 in /modules/k3s (#5230) @dependabot
* Bump trino-jdbc from 369 to 375 in /modules/trino (#5228) @dependabot
* Bump r2dbc-postgresql from 0.8.11.RELEASE to 0.8.12.RELEASE in /modules/r2dbc (#5227) @dependabot
* Bump okhttp from 3.14.9 to 4.9.3 in /modules/solr (#5229) @dependabot
* Bump peter-evans/create-pull-request from 3.12.1 to 4.0.1 (#5226) @dependabot
* Bump actions/cache from 2.1.7 to 3.0.1 (#5225) @dependabot
* Bump neo4j-java-driver from 4.4.3 to 4.4.5 in /examples (#5223) @dependabot
* Bump s3 from 2.17.108 to 2.17.162 in /modules/localstack (#5222) @dependabot
* Bump aws-java-sdk-logs from 1.12.169 to 1.12.191 in /modules/localstack (#5221) @dependabot
* Bump awaitility from 4.1.1 to 4.2.0 in /core (#5219) @dependabot
* Bump logback-classic from 1.2.10 to 1.2.11 in /examples (#5216) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.6.10 to 1.6.20 in /examples (#5215) @dependabot
* Bump transport from 7.17.1 to 7.17.2 in /modules/elasticsearch (#5214) @dependabot
* Bump mockito-core from 4.3.1 to 4.4.0 in /modules/junit-jupiter (#5212) @dependabot
* Bump jedis from 4.1.1 to 4.2.1 in /examples (#5210) @dependabot
* Bump java-client from 3.2.5 to 3.2.6 in /modules/couchbase (#5209) @dependabot
* Bump aws-java-sdk-s3 from 1.12.169 to 1.12.191 in /modules/localstack (#5206) @dependabot
* Bump rest-assured from 4.5.1 to 5.0.0 in /modules/vault (#5207) @dependabot
* Bump neo4j-java-driver from 4.4.3 to 4.4.5 in /modules/neo4j (#5205) @dependabot
* Bump elasticsearch-rest-client from 7.16.2 to 8.1.2 in /modules/elasticsearch (#5202) @dependabot
* Bump awaitility from 4.1.1 to 4.2.0 in /modules/couchbase (#5199) @dependabot
* Bump tomcat-jdbc from 10.0.16 to 10.0.20 in /modules/jdbc (#5196) @dependabot
* Bump tomcat-jdbc from 10.0.16 to 10.0.20 in /modules/jdbc-test (#5195) @dependabot
* Bump actions/checkout from 2 to 3 (#5140) @dependabot
