### PR TITLE
startup timeout will be ignored when enabling functionsWorkerEnabled in pulsar container

### DIFF
--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -60,6 +60,8 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
                 new WaitAllStrategy()
                     .withStrategy(waitStrategy)
                     .withStrategy(Wait.forLogMessage(".*Function worker service started.*", 1)
+                        // NOTE withStartupTimeout must be called at the end, because start timeout will be
+                        // applied to all strategies above
                     .withStartupTimeout(startupTimeout))
             );
         }

--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -59,7 +59,8 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
             waitingFor(
                 new WaitAllStrategy()
                     .withStrategy(waitStrategy)
-                    .withStrategy(createLogWaitingStrategy())
+                    .withStrategy(Wait.forLogMessage(".*Function worker service started.*", 1)
+                    .withStartupTimeout(startupTimeout))
             );
         }
     }
@@ -73,13 +74,6 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     public PulsarContainer withFunctionsWorker() {
         functionsWorkerEnabled = true;
         return this;
-    }
-
-    private WaitStrategy createLogWaitingStrategy() {
-        if (startupTimeout != null) {
-            return Wait.forLogMessage(".*Function worker service started.*", 1).withStartupTimeout(startupTimeout);
-        }
-        return Wait.forLogMessage(".*Function worker service started.*", 1);
     }
 
     public String getPulsarBrokerUrl() {

--- a/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
+++ b/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
@@ -9,8 +9,6 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.junit.Test;
 import org.testcontainers.utility.DockerImageName;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -46,9 +44,7 @@ public class PulsarContainerTest {
 
     @Test
     public void shouldWaitForFunctionsWorkerStarted() throws Exception {
-        try (PulsarContainer pulsar = new PulsarContainer(PULSAR_IMAGE)
-            .withFunctionsWorker()
-            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))) {
+        try (PulsarContainer pulsar = new PulsarContainer(PULSAR_IMAGE).withFunctionsWorker()) {
 
             pulsar.start();
 

--- a/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
+++ b/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
@@ -9,6 +9,8 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.junit.Test;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -30,7 +32,7 @@ public class PulsarContainerTest {
 
     @Test
     public void shouldNotEnableFunctionsWorkerByDefault() throws Exception {
-        try (PulsarContainer pulsar = new PulsarContainer("2.5.1")) {
+        try (PulsarContainer pulsar = new PulsarContainer(PULSAR_IMAGE)) {
             pulsar.start();
 
             PulsarAdmin pulsarAdmin = PulsarAdmin.builder()
@@ -44,7 +46,10 @@ public class PulsarContainerTest {
 
     @Test
     public void shouldWaitForFunctionsWorkerStarted() throws Exception {
-        try (PulsarContainer pulsar = new PulsarContainer("2.5.1").withFunctionsWorker()) {
+        try (PulsarContainer pulsar = new PulsarContainer(PULSAR_IMAGE)
+            .withFunctionsWorker()
+            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES))) {
+
             pulsar.start();
 
             PulsarAdmin pulsarAdmin = PulsarAdmin.builder()


### PR DESCRIPTION
When using 
```java
private static final PulsarContainer pulsarContainer =
        new PulsarContainer(DockerImageName.parse("apachepulsar/pulsar:latest"))
            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
```
120 seconds will be used as waiting strategy timeout. See logs: 
`/pensive_antonelli: Waiting for 120 seconds for URL: http://localhost:54554/metrics`

But when using 
```java
private static final PulsarContainer pulsarContainer =
        new PulsarContainer(DockerImageName.parse("apachepulsar/pulsar:latest"))
            .withFunctionsWorker()
            .withStartupTimeout(Duration.of(2, ChronoUnit.MINUTES));
```
startup timeout will be set to default (30 seconds). See logs:
`/jolly_cerf: Waiting for 30 seconds for URL: http://localhost:54640/metrics`

This is because when enabling functions worker a new log waiting strategy will be used. This fix will cache startup timeout and add (if exists) this to log waiting strategy. 