### PR TITLE
Increase default client ping timeout from 5 to 10 seconds

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -198,7 +198,7 @@ public class TestcontainersConfiguration {
     }
 
     public Integer getClientPingTimeout() {
-        return Integer.parseInt(getEnvVarOrProperty("client.ping.timeout", "5"));
+        return Integer.parseInt(getEnvVarOrProperty("client.ping.timeout", "10"));
     }
 
     @Nullable


### PR DESCRIPTION
We learned that the default `client.ping.timeout` can be a bit tight in certain environments, where the Docker daemon might be under higher load (e.g., see #5174). By increasing the default timeout from 5 to 10 seconds, we hope to strike a better compromise. 

Of course, it is still possible to configure to manually using `client.ping.timeout`.