### PR TITLE
Fix `StackOverflowError` in `DockerClientFactory#client`

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -187,7 +187,6 @@ public class DockerClientFactory {
 
         final DockerClientProviderStrategy strategy = getOrInitializeStrategy();
 
-        log.info("Docker host IP address is {}", strategy.getDockerHostIpAddress());
         client = new DockerClientDelegate() {
 
             @Getter
@@ -198,6 +197,7 @@ public class DockerClientFactory {
                 throw new IllegalStateException("You should never close the global DockerClient!");
             }
         };
+        log.info("Docker host IP address is {}", strategy.getDockerHostIpAddress());
 
         Info dockerInfo = client.infoCmd().exec();
         Version version = client.versionCmd().exec();


### PR DESCRIPTION
We need to set the `client` variable before anything else, and the log line accidentally slipped before `client` is set.

Fixes #5261 