### PR TITLE
Update default Docker Hub registry name to fix Docker Desktop authentication

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -32,7 +32,7 @@ import static org.testcontainers.utility.AuthConfigUtil.toSafeString;
 public class RegistryAuthLocator {
 
     private static final Logger log = getLogger(RegistryAuthLocator.class);
-    private static final String DEFAULT_REGISTRY_NAME = "index.docker.io";
+    private static final String DEFAULT_REGISTRY_NAME = "https://index.docker.io/v1/";
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private static RegistryAuthLocator instance;


### PR DESCRIPTION
There seem to have been different changes around Docker Desktop, its used authentication mechanisms in conjunction with `docker-credential-desktop` and the Docker Hub registry. 

This led to the problem, that Testcontainers would interact with `docker-credential-desktop` in a way, that would provide us with wrong credentials, depending on how the Docker Hub login was performed (although this is not completely understood yet).

This is an experimental fix, that tries to restore the previous behavior. 

Fixes #5121