### PR TITLE
Fix connection leak in JDBC waitUntilContainerStarted

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -1,7 +1,6 @@
 package org.testcontainers.containers;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import java.sql.Statement;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
@@ -16,6 +15,7 @@ import org.testcontainers.utility.MountableFile;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -144,7 +144,8 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
             if (!isRunning()) {
                 Thread.sleep(100L);
             } else {
-                try (Statement statement = createConnection("").createStatement()) {
+                try (Connection connection = createConnection("");
+                     Statement statement = connection.createStatement()) {
                     boolean testQuerySucceeded = statement.execute(this.getTestQueryString());
                     if (testQuerySucceeded) {
                         logger().info("Container is started (JDBC URL: {})", this.getJdbcUrl());


### PR DESCRIPTION
Only the Statement was auto-closed, but not the Connection against which the Statement was created.

Aside from being a resource leak, this can cause database rename transactions to fail due to the presence of a lingering idle session.