### PR TITLE
Correct usage of deprecated method `createSubscription()`

### DIFF
--- a/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
@@ -20,6 +20,7 @@ import com.google.pubsub.v1.PubsubMessage;
 import com.google.pubsub.v1.PullRequest;
 import com.google.pubsub.v1.PullResponse;
 import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.SubscriptionName;
 import com.google.pubsub.v1.TopicName;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -104,7 +105,7 @@ public class PubSubEmulatorContainerTest {
                 .setCredentialsProvider(credentialsProvider)
                 .build();
         SubscriptionAdminClient subscriptionAdminClient = SubscriptionAdminClient.create(subscriptionAdminSettings);
-        ProjectSubscriptionName subscriptionName = ProjectSubscriptionName.of(PROJECT_ID, subscriptionId);
+        SubscriptionName subscriptionName = SubscriptionName.of(PROJECT_ID, subscriptionId);
         subscriptionAdminClient.createSubscription(subscriptionName, TopicName.of(PROJECT_ID, topicId), PushConfig.getDefaultInstance(), 10);
     }
     // }


### PR DESCRIPTION
Tests in `PubSubEmulator` now use a non-deprecated `createSubscription` method. 

All three deprecated `createSubscription()` methods are not used anymore.

Fixes issue #5289