### PR TITLE
Add JdbcQueryWaitStrategy

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -9,6 +9,7 @@ import org.testcontainers.containers.traits.LinkableContainer;
 import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.ext.ScriptUtils;
 import org.testcontainers.jdbc.JdbcDatabaseDelegate;
+import org.testcontainers.jdbc.wait.JdbcQueryWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
@@ -316,6 +317,10 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
 
     protected DatabaseDelegate getDatabaseDelegate() {
         return new JdbcDatabaseDelegate(this, "");
+    }
+
+    protected JdbcQueryWaitStrategy getJdbcQueryWaitStrategy() {
+        return new JdbcQueryWaitStrategy(getDatabaseDelegate());
     }
 
     public static class NoDriverFoundException extends RuntimeException {

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
@@ -1,6 +1,7 @@
 package org.testcontainers.jdbc;
 
 import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.delegate.AbstractDatabaseDelegate;
 import org.testcontainers.exception.ConnectionCreationException;

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/wait/JdbcQueryWaitStrategy.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/wait/JdbcQueryWaitStrategy.java
@@ -1,0 +1,44 @@
+package org.testcontainers.jdbc.wait;
+
+import org.rnorth.ducttape.TimeoutException;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.delegate.DatabaseDelegate;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
+
+/**
+ * Waits until database returns its version
+ *
+ * @author Eddú
+ */
+public class JdbcQueryWaitStrategy extends AbstractWaitStrategy {
+
+    private static final String SELECT_VERSION_QUERY = "SELECT 1";
+    private static final String TIMEOUT_ERROR = "Timed out waiting for database to be accessible for query execution";
+
+    private final DatabaseDelegate databaseDelegate;
+
+    public JdbcQueryWaitStrategy(DatabaseDelegate databaseDelegate) {
+        this.databaseDelegate = databaseDelegate;
+    }
+
+    @Override
+    protected void waitUntilReady() {
+        try {
+            retryUntilSuccess((int) startupTimeout.getSeconds(), TimeUnit.SECONDS, () -> {
+                getRateLimiter().doWhenReady(() -> {
+                    try (DatabaseDelegate databaseDelegate = this.databaseDelegate) {
+                        databaseDelegate.execute(SELECT_VERSION_QUERY, "", 1, false, false);
+                    }
+                });
+                return true;
+            });
+        } catch (TimeoutException e) {
+            throw new ContainerLaunchException(TIMEOUT_ERROR);
+        }
+    }
+
+}

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -1,13 +1,10 @@
 package org.testcontainers.containers;
 
 import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
-import java.time.Duration;
 import java.util.Set;
 
-import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Collections.singleton;
 
 /**
@@ -49,10 +46,7 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        this.waitStrategy = new LogMessageWaitStrategy()
-                .withRegEx(".*database system is ready to accept connections.*\\s")
-                .withTimes(2)
-                .withStartupTimeout(Duration.of(60, SECONDS));
+        this.waitStrategy = getJdbcQueryWaitStrategy();
         this.setCommand("postgres", "-c", FSYNC_OFF_OPTION);
 
         addExposedPort(POSTGRESQL_PORT);

--- a/modules/postgresql/src/test/resources/Dockerfile
+++ b/modules/postgresql/src/test/resources/Dockerfile
@@ -1,0 +1,15 @@
+FROM postgres:9.6.12 AS dumper
+
+COPY somepath/init_postgresql.sql /docker-entrypoint-initdb.d
+
+RUN ["sed", "-i", "s/exec \"$@\"/echo \"skipping...\"/", "/usr/local/bin/docker-entrypoint.sh"]
+
+ENV POSTGRES_USER=test
+ENV POSTGRES_PASSWORD=test
+ENV PGDATA=/data
+
+RUN ["/usr/local/bin/docker-entrypoint.sh", "postgres"]
+
+FROM postgres:9.6.12
+
+COPY --from=dumper /data $PGDATA


### PR DESCRIPTION
A more generic wait strategy for jdbc. i.e Postgres has different
output when the container database has data that doesn't match with
the default wait strategy.

See gh-5359
