### PR TITLE
run `core` tests in parallel

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,6 +6,8 @@ sourceSets {
     jarFileTest
 }
 
+test.maxParallelForks = 4
+
 idea.module.testSourceDirs += sourceSets.jarFileTest.allSource.srcDirs
 
 shadowJar {

--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -1,17 +1,15 @@
 package org.testcontainers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import com.github.dockerjava.api.exception.NotFoundException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.rnorth.visibleassertions.VisibleAssertions;
 import org.testcontainers.DockerClientFactory.DiskSpaceUsage;
 import org.testcontainers.dockerclient.LogToStringContainerCallback;
-import org.testcontainers.images.LocalImagesCacheAccessor;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MockTestcontainersConfigurationRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test for {@link DockerClientFactory}.
@@ -23,30 +21,22 @@ public class DockerClientFactoryTest {
 
     @Test
     public void runCommandInsideDockerShouldNotFailIfImageDoesNotExistsLocally() {
+        try (DockerRegistryContainer registryContainer = new DockerRegistryContainer()) {
+            registryContainer.start();
+            DockerImageName imageName = registryContainer.createImage();
 
-        final DockerClientFactory dockFactory = DockerClientFactory.instance();
+            final DockerClientFactory dockFactory = DockerClientFactory.instance();
 
-        DockerImageName imageName = DockerImageName.parse("testcontainers/helloworld:1.1.0");
-
-        try {
-            //remove tiny image, so it will be pulled during next command run
-            dockFactory.client()
-                    .removeImageCmd(imageName.asCanonicalNameString())
-                    .withForce(true).exec();
-        } catch (NotFoundException ignored) {
-            // Do not fail if it's not pulled yet
-        }
-        LocalImagesCacheAccessor.clearCache();
-
-        dockFactory.runInsideDocker(
+            dockFactory.runInsideDocker(
                 imageName,
                 cmd -> cmd.withCmd("sh", "-c", "echo 'SUCCESS'"),
                 (client, id) ->
-                        client.logContainerCmd(id)
-                                .withStdOut(true)
-                                .exec(new LogToStringContainerCallback())
-                                .toString()
-        );
+                    client.logContainerCmd(id)
+                        .withStdOut(true)
+                        .exec(new LogToStringContainerCallback())
+                        .toString()
+            );
+        }
     }
 
     @Test

--- a/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
+++ b/core/src/test/java/org/testcontainers/DockerClientFactoryTest.java
@@ -25,7 +25,7 @@ public class DockerClientFactoryTest {
             registryContainer.start();
             DockerImageName imageName = registryContainer.createImage();
 
-            final DockerClientFactory dockFactory = DockerClientFactory.instance();
+            DockerClientFactory dockFactory = DockerClientFactory.instance();
 
             dockFactory.runInsideDocker(
                 imageName,

--- a/core/src/test/java/org/testcontainers/DockerRegistryContainer.java
+++ b/core/src/test/java/org/testcontainers/DockerRegistryContainer.java
@@ -1,6 +1,9 @@
 package org.testcontainers;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.PullImageResultCallback;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.SneakyThrows;
@@ -8,7 +11,10 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.FrameConsumerResultCallback;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.WaitingConsumer;
+import org.testcontainers.utility.Base58;
+import org.testcontainers.utility.DockerImageName;
 
+import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -64,5 +70,35 @@ public class DockerRegistryContainer extends GenericContainer<DockerRegistryCont
         }
 
         endpoint = getHost() + ":" + port.get();
+    }
+
+    public DockerImageName createImage() {
+        return createImage(UUID.randomUUID().toString());
+    }
+
+    public DockerImageName createImage(String tag) {
+        return createImage("testcontainers/helloworld:latest", tag);
+    }
+
+    @SneakyThrows(InterruptedException.class)
+    public DockerImageName createImage(String originalImage, String tag) {
+        DockerClient client = getDockerClient();
+        client.pullImageCmd(originalImage).exec(new PullImageResultCallback()).awaitCompletion();
+
+        String dummyImageId = client.inspectImageCmd(originalImage).exec().getId();
+
+        DockerImageName imageName = DockerImageName.parse(getEndpoint() + "/" + Base58.randomString(8).toLowerCase()).withTag(tag);
+
+        // push the image to the registry
+        client.tagImageCmd(dummyImageId, imageName.asCanonicalNameString(), tag).exec();
+
+        client.pushImageCmd(imageName.asCanonicalNameString())
+            .exec(new ResultCallback.Adapter<>())
+            .awaitCompletion(1, TimeUnit.MINUTES);
+
+        // Remove from local cache, tests should pull the image themselves
+        client.removeImageCmd(imageName.asCanonicalNameString()).exec();
+
+        return imageName;
     }
 }

--- a/core/src/test/java/org/testcontainers/DockerRegistryContainer.java
+++ b/core/src/test/java/org/testcontainers/DockerRegistryContainer.java
@@ -87,7 +87,7 @@ public class DockerRegistryContainer extends GenericContainer<DockerRegistryCont
 
         String dummyImageId = client.inspectImageCmd(originalImage).exec().getId();
 
-        DockerImageName imageName = DockerImageName.parse(getEndpoint() + "/" + Base58.randomString(8).toLowerCase()).withTag(tag);
+        DockerImageName imageName = DockerImageName.parse(getEndpoint() + "/" + Base58.randomString(6).toLowerCase()).withTag(tag);
 
         // push the image to the registry
         client.tagImageCmd(dummyImageId, imageName.asCanonicalNameString(), tag).exec();

--- a/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/AmbiguousImagePullTest.java
@@ -1,32 +1,25 @@
 package org.testcontainers.dockerclient;
 
-import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.model.Image;
 import org.junit.Test;
-import org.testcontainers.DockerClientFactory;
+import org.testcontainers.DockerRegistryContainer;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
-
-import java.util.List;
 
 public class AmbiguousImagePullTest {
 
     @Test(timeout = 30_000)
     public void testNotUsingParse() {
-        DockerClient client = DockerClientFactory.instance().client();
-        List<Image> alpineImages = client.listImagesCmd()
-            .withImageNameFilter("testcontainers/helloworld:latest")
-            .exec();
-        for (Image alpineImage : alpineImages) {
-            client.removeImageCmd(alpineImage.getId()).exec();
-        }
-
-        try (
-            final GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("testcontainers/helloworld"))
-                .withExposedPorts(8080)
-        ) {
-            container.start();
-            // do nothing other than start and stop
+        try (DockerRegistryContainer registryContainer = new DockerRegistryContainer()) {
+            registryContainer.start();
+            DockerImageName imageName = registryContainer.createImage("latest");
+            String imageNameWithoutTag = imageName.getRegistry() + "/" + imageName.getRepository();
+            try (
+                final GenericContainer<?> container = new GenericContainer<>(imageNameWithoutTag)
+                    .withExposedPorts(8080)
+            ) {
+                container.start();
+                // do nothing other than start and stop
+            }
         }
     }
 }


### PR DESCRIPTION
To speed-up our CI, we can run the tests in parallel.

I noticed that a few tests were deleting shared images that broke the test isolation. This PR changes these tests to use a registry instead.