### PR TITLE
Don't delete images if `deleteOnExit` is false

### DIFF
--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -87,9 +87,6 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
         DockerClient dockerClient = DockerClientFactory.instance().client();
 
         try {
-            if (deleteOnExit) {
-                ResourceReaper.instance().registerImageForCleanup(dockerImageName);
-            }
 
             BuildImageResultCallback resultCallback = new BuildImageResultCallback() {
                 @Override
@@ -114,9 +111,12 @@ public class ImageFromDockerfile extends LazyFuture<String> implements
             if (buildImageCmd.getLabels() != null) {
                 labels.putAll(buildImageCmd.getLabels());
             }
+
             labels.putAll(DockerClientFactory.DEFAULT_LABELS);
-            //noinspection deprecation
-            labels.putAll(ResourceReaper.instance().getLabels());
+            if (deleteOnExit) {
+                //noinspection deprecation
+                labels.putAll(ResourceReaper.instance().getLabels());
+            }
             buildImageCmd.withLabels(labels);
 
             prePullDependencyImages(dependencyImageNames);

--- a/core/src/test/java/org/testcontainers/images/builder/ImageFromDockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/ImageFromDockerfileTest.java
@@ -35,7 +35,7 @@ public class ImageFromDockerfileTest {
         try {
             InspectImageResponse inspectImageResponse = dockerClient.inspectImageCmd(imageId).exec();
             assertThat(inspectImageResponse.getConfig().getLabels())
-                .doesNotContainKey(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL).containsKey("foobar");
+                .doesNotContainKey(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL);
         } finally {
             // ensure the image is deleted, even if the test fails
             dockerClient.removeImageCmd(imageId).exec();

--- a/core/src/test/java/org/testcontainers/images/builder/ImageFromDockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/ImageFromDockerfileTest.java
@@ -28,7 +28,7 @@ public class ImageFromDockerfileTest {
     @Test
     public void shouldNotAddSessionLabelIfDeleteOnExitIsFalse() {
         ImageFromDockerfile image = new ImageFromDockerfile("localhost/testcontainers/" + Base58.randomString(16).toLowerCase(), false)
-            .withDockerfileFromBuilder(it -> it.from("scratch").user("testcontainers"));
+            .withDockerfileFromBuilder(it -> it.from("scratch"));
 
         String imageId = image.resolve();
 

--- a/core/src/test/java/org/testcontainers/images/builder/ImageFromDockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/images/builder/ImageFromDockerfileTest.java
@@ -38,7 +38,7 @@ public class ImageFromDockerfileTest {
                 .doesNotContainKey(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL).containsKey("foobar");
         } finally {
             // ensure the image is deleted, even if the test fails
-            dockerClient.removeImageCmd(imageId);
+            dockerClient.removeImageCmd(imageId).exec();
         }
 
     }


### PR DESCRIPTION
It seems we had a regression in `ImageFromDockerfile` (maybe already since https://github.com/testcontainers/testcontainers-java/pull/2809?), which meant that images built by TC were removed by Ryuk, even if `deleteOnExit` was set to `false`.

This PR removes the now superfluous call to `registerImageForCleanup()` and instead adds the Ryuk cleanup marker labels only if `deleteOnExit` is set to `true`.