### PR TITLE
Add support for setting owner of MountableFile, default to root

### DIFF
--- a/core/src/main/java/org/testcontainers/images/builder/Transferable.java
+++ b/core/src/main/java/org/testcontainers/images/builder/Transferable.java
@@ -21,6 +21,10 @@ public interface Transferable {
     }
 
     static Transferable of(byte[] bytes, int fileMode) {
+        return of(bytes, fileMode, 0, 0);
+    }
+
+    static Transferable of(byte[] bytes, int fileMode, int userId, int groupId) {
         return new Transferable() {
             @Override
             public long getSize() {
@@ -40,6 +44,16 @@ public interface Transferable {
             @Override
             public int getFileMode() {
                 return fileMode;
+            }
+
+            @Override
+            public long getUserId() {
+                return userId;
+            }
+
+            @Override
+            public long getGroupId() {
+                return groupId;
             }
         };
     }
@@ -62,6 +76,24 @@ public interface Transferable {
     long getSize();
 
     /**
+     * User ID owning the file
+     *
+     * @return ID of user owner
+     */
+    default long getUserId() {
+        return 0;
+    }
+
+    /**
+     * Group ID owning the file
+     *
+     * @return ID of group owner
+     */
+    default long getGroupId() {
+        return 0;
+    }
+
+    /**
      * transfer content of this Transferable to the output stream. <b>Must not</b> close the stream.
      *
      * @param tarArchiveOutputStream stream to output
@@ -71,6 +103,8 @@ public interface Transferable {
         TarArchiveEntry tarEntry = new TarArchiveEntry(destination);
         tarEntry.setSize(getSize());
         tarEntry.setMode(getFileMode());
+        tarEntry.setUserId(getUserId());
+        tarEntry.setGroupId(getGroupId());
 
         try {
             tarArchiveOutputStream.putArchiveEntry(tarEntry);

--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -2,6 +2,7 @@ package org.testcontainers.utility;
 
 import lombok.Cleanup;
 import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.jetbrains.annotations.NotNull;
@@ -130,6 +131,43 @@ public class MountableFileTest {
         ArchiveEntry entry;
         while ((entry = tais.getNextEntry()) != null) {
             assertFalse("no entries should have a trailing slash", entry.getName().endsWith("/"));
+        }
+    }
+
+    @Test
+    public void rootIsDefaultOwner() throws Exception {
+        final MountableFile mountableFile = MountableFile.forClasspathResource("mappable-resource/test-resource.txt");
+
+        @Cleanup
+        final TarArchiveInputStream tais = intoTarArchive(taos -> {
+            mountableFile.transferTo(taos, "path.txt");
+        });
+
+        TarArchiveEntry entry;
+        while ((entry = tais.getNextTarEntry()) != null) {
+            assertEquals("User ID should be 0", 0, entry.getLongUserId());
+            assertEquals("Group ID should be 0", 0, entry.getLongGroupId());
+        }
+    }
+
+    @Test
+    public void canSetOtherOwner() throws Exception {
+        final MountableFile mountableFile = MountableFile.forClasspathResource(
+            "mappable-resource/test-resource.txt",
+            null,
+            1,
+            2
+        );
+
+        @Cleanup
+        final TarArchiveInputStream tais = intoTarArchive(taos -> {
+            mountableFile.transferTo(taos, "path.txt");
+        });
+
+        TarArchiveEntry entry;
+        while ((entry = tais.getNextTarEntry()) != null) {
+            assertEquals("User ID should be 1", 1L, entry.getLongUserId());
+            assertEquals("Group ID should be 2", 2L, entry.getLongGroupId());
         }
     }
 


### PR DESCRIPTION
Commons compress changed the default behavior of tar users and groups in 1.21.

- 1.20 and below, entries default to the root user and group.
- 1.21, entries default to the current user and group, see https://github.com/apache/commons-compress/blob/d57b8e9068bc0184b783aa488e613f4fcf2140d6/src/changes/changes.xml#L153-L157

This means that testcontainers bumping the dependency to 1.21 caused files uploaded via `copyFileToContainer` to be owned by the host user rather than root.

This PR:

- Reinstates root as the default user. I don't think there are many situations where it makes sense to default to the current user, as that is unlikely to correlate with the user in the container. This is a breaking change, but one where we undo a previous accidental breaking change.
-  Adds support for `MountableFile` to select a different user.