### PR TITLE
Set Elasticsearch default heap size to 2GB

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -62,6 +62,11 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     @Deprecated
     protected static final String DEFAULT_TAG = "7.9.2";
 
+    /**
+     * Elasticsearch Default max heap size
+     */
+    private static final long DEFAULT_MAX_HEAP_SIZE_IN_BYTES = 2147483648L;
+
     private final boolean isOss;
 
     private final boolean isAtLeastMajorVersion8;
@@ -98,6 +103,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         logger().info("Starting an elasticsearch container using [{}]", dockerImageName);
         withNetworkAliases("elasticsearch-" + Base58.randomString(6));
         withEnv("discovery.type", "single-node");
+        withMaxHeapSizeInBytes(DEFAULT_MAX_HEAP_SIZE_IN_BYTES);
         addExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT);
         this.isAtLeastMajorVersion8 =
             new ComparableVersion(dockerImageName.getVersionPart()).isGreaterThanOrEqualTo("8.0.0");
@@ -198,5 +204,17 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     @Deprecated // The TransportClient will be removed in Elasticsearch 8. No need to expose this port anymore in the future.
     public InetSocketAddress getTcpHost() {
         return new InetSocketAddress(getHost(), getMappedPort(ELASTICSEARCH_DEFAULT_TCP_PORT));
+    }
+
+    /**
+     * Configure max heap size, using ES_JAVA_OPTS environment variable
+     *
+     * @param maxHeapSizeInBytes Maximum and start heap size in bytes
+     * @return this
+     */
+    public ElasticsearchContainer withMaxHeapSizeInBytes(long maxHeapSizeInBytes) {
+        String options = String.format("-Xms%d -Xmx%d", maxHeapSizeInBytes, maxHeapSizeInBytes);
+        withEnv("ES_JAVA_OPTS", options);
+        return this;
     }
 }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -367,6 +367,39 @@ public class ElasticsearchContainerTest {
         }
     }
 
+    @Test
+    public void testElasticsearchDefaultMaxHeapSize() throws Exception {
+        long defaultHeapSize = 2147483648L;
+
+        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)) {
+            container.start();
+
+            Response response = getClient(container).performRequest(new Request("GET", "/_nodes/_all/jvm"));
+            String responseBody = EntityUtils.toString(response.getEntity());
+            assertThat(response.getStatusLine().getStatusCode(), is(200));
+            assertThat(responseBody, containsString("\"heap_init_in_bytes\":" + defaultHeapSize));
+            assertThat(responseBody, containsString("\"heap_max_in_bytes\":" + defaultHeapSize));
+        }
+    }
+
+    @Test
+    public void testElasticsearchCustomMaxHeapSize() throws Exception {
+        long customHeapSize = 1073741824L;
+
+        try (
+            ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)
+                .withMaxHeapSizeInBytes(customHeapSize)
+        ) {
+            container.start();
+
+            Response response = getClient(container).performRequest(new Request("GET", "/_nodes/_all/jvm"));
+            String responseBody = EntityUtils.toString(response.getEntity());
+            assertThat(response.getStatusLine().getStatusCode(), is(200));
+            assertThat(responseBody, containsString("\"heap_init_in_bytes\":" + customHeapSize));
+            assertThat(responseBody, containsString("\"heap_max_in_bytes\":" + customHeapSize));
+        }
+    }
+
     private void tagImage(String sourceImage, String targetImage, String targetTag) throws InterruptedException {
         DockerClient dockerClient = DockerClientFactory.instance().client();
         dockerClient


### PR DESCRIPTION
Proposed fix for https://github.com/testcontainers/testcontainers-java/issues/5393

- Set default and max heap size for Elastic Search container to 2g
- Add a method to override this default value

