### PR TITLE
Add reset method for toxiproxy

### DIFF
--- a/docs/modules/toxiproxy.md
+++ b/docs/modules/toxiproxy.md
@@ -68,6 +68,12 @@ Additionally we can disable the proxy to simulate a complete interruption to the
 [Cutting a connection](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:disableProxy
 <!--/codeinclude-->
 
+To run multiple tests, we can reset all added toxics by calling reset on the container:
+
+<!--codeinclude-->
+[Resetting toxics](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:reset
+<!--/codeinclude-->
+
 ## Adding this module to your project dependencies
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -89,6 +89,17 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
     }
 
     /**
+     * Resets all proxies and removes all active toxics.
+     */
+    public void reset() {
+        try {
+            client.reset();
+        } catch (IOException e) {
+            throw new RuntimeException("Proxy could not be reset", e);
+        }
+    }
+
+    /**
      * Obtain a {@link ContainerProxy} instance for a specific hostname and port, which can be for any host
      * that is routable <b>from this {@link ToxiproxyContainer} instance</b> (e.g. on the same
      * Docker {@link Network} or on routable from the Docker host).


### PR DESCRIPTION
When trying to write multiple tests using a toxiproxy container I didn't find an easy way to reset everything before each test. Toxiproxy already does have a method for just that, so I'd like to expose it.