### PR TITLE
Ensure that directory permissions are properly set on MySQL and MariaDB

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -5,9 +5,11 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.testcontainers.containers.traits.LinkableContainer;
 import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.ext.ScriptUtils;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -285,15 +287,25 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
         return urlParameters;
     }
 
+    @Deprecated
     protected void optionallyMapResourceParameterAsVolume(
         @NotNull String paramName,
         @NotNull String pathNameInContainer,
         @NotNull String defaultResource
     ) {
+        optionallyMapResourceParameterAsVolume(paramName, pathNameInContainer, defaultResource, null);
+    }
+
+    protected void optionallyMapResourceParameterAsVolume(
+        @NotNull String paramName,
+        @NotNull String pathNameInContainer,
+        @NotNull String defaultResource,
+        @Nullable Integer fileMode
+    ) {
         String resourceName = parameters.getOrDefault(paramName, defaultResource);
 
         if (resourceName != null) {
-            final MountableFile mountableFile = MountableFile.forClasspathResource(resourceName);
+            final MountableFile mountableFile = MountableFile.forClasspathResource(resourceName, fileMode);
             withCopyFileToContainer(mountableFile, pathNameInContainer);
         }
     }

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
 import com.google.common.collect.Sets;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.Set;
@@ -67,7 +68,8 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         optionallyMapResourceParameterAsVolume(
             MY_CNF_CONFIG_OVERRIDE_PARAM_NAME,
             "/etc/mysql/conf.d",
-            "mariadb-default-conf"
+            "mariadb-default-conf",
+            Transferable.DEFAULT_FILE_MODE
         );
 
         addEnv("MYSQL_DATABASE", databaseName);

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.containers;
 
 import org.jetbrains.annotations.NotNull;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.HashSet;
@@ -67,7 +68,8 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
         optionallyMapResourceParameterAsVolume(
             MY_CNF_CONFIG_OVERRIDE_PARAM_NAME,
             "/etc/mysql/conf.d",
-            "mysql-default-conf"
+            "mysql-default-conf",
+            Transferable.DEFAULT_DIR_MODE
         );
 
         addEnv("MYSQL_DATABASE", databaseName);


### PR DESCRIPTION
Fixes #914 #4952

Forces Directory/File to have the `Others` permission set (755 for Dir, 644 for Files), to avoid `umask` issues