### PR TITLE
JdbcDatabaseContainer: fix wrong instance call

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -229,7 +229,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
                     logger()
                         .debug(
                             "Trying to create JDBC connection using {} to {} with properties: {}",
-                            driver.getClass().getName(),
+                            jdbcDriverInstance.getClass().getName(),
                             url,
                             info
                         );


### PR DESCRIPTION
createConnection() method calls a wrong driver instance when logging.

Reason behind this fix: if you override method `getJdbcDriverInstance`, you will get an exception here.