### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.0.3
         continue-on-error: true
         with:
           path: ~/.gradle/caches
@@ -50,7 +50,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.0.3
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.0.3
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
@@ -56,7 +56,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.2
+        uses: actions/cache@v3.0.3
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@e9ee02fbac03d922bac6212003695e8358dd88b0 # v5.19.0
+      - uses: release-drafter/release-drafter@ac463ffd9cc4c6ad5682af93dc3e3591c4657ee3 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -17,7 +17,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@bd72e1b7922d417764d27d30768117ad7da78a0e # v3.10.1
+        uses: peter-evans/create-pull-request@f094b77505fb89581e68a1163fbd2fffece39da1 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.14.2'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 
-    testImplementation ('org.mockito:mockito-core:4.3.1') {
+    testImplementation ('org.mockito:mockito-core:4.6.0') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation project(':test-support')
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     shaded 'org.zeroturnaround:zt-exec:1.12'
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:4.2.2'
+    testImplementation 'redis.clients:jedis:4.2.3'
     testImplementation 'com.rabbitmq:amqp-client:5.14.2'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
 

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'org.json:json:20211205'
-    testImplementation 'org.postgresql:postgresql:42.3.3'
+    testImplementation 'org.postgresql:postgresql:42.3.6'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.6.2"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7"
     }
 }
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
     testImplementation 'org.assertj:assertj-core:3.22.0'
-    testImplementation 'com.azure:azure-cosmos:4.29.1'
+    testImplementation 'com.azure:azure-cosmos:4.30.0'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.3.4'
+    testImplementation 'org.postgresql:postgresql:42.3.6'
 }

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.210'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.232'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.210'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.16.2"
-    testImplementation "org.elasticsearch.client:transport:7.17.3"
+    testImplementation "org.elasticsearch.client:transport:7.17.4"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.21'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.116.4'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.20.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.6.2'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.8.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.4.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.21'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.116.4'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.119.0'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.20.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.8.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.8.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.8.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.2.10")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.20'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.21'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.29'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.20'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.21'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.22.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.3.4'
+    testRuntimeOnly 'org.postgresql:postgresql:42.3.6'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.4.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.3.6'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:5.12.2'
     testImplementation 'io.kubernetes:client-java:15.0.0'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.0.0'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.191'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.169'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.210'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.169'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'
     testImplementation 'software.amazon.awssdk:s3:2.17.181'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.191'
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.169'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.231'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.210'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'
     testImplementation 'software.amazon.awssdk:s3:2.17.181'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.3'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.5'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.5'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -29,7 +29,7 @@ task customNeo4jPluginJar(type: Jar) {
 processTestResources.dependsOn customNeo4jPluginJar
 
 dependencies {
-    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.32"
+    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.33"
 
     api project(":testcontainers")
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.0.24"
 
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.3.4'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.0.18"
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.3.4'
+    testImplementation 'org.postgresql:postgresql:42.3.6'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.7.4'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.22.0'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.7.4'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.17'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.18'
     testFixturesImplementation 'org.assertj:assertj-core:3.14.0'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.14.2'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.3.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.3.6'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.29'
 
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:379'
+    testImplementation 'io.trino:trino-jdbc:382'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:5.0.1'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.6.5"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7"
     }
 }
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump common-custom-user-data-gradle-plugin from 1.6.5 to 1.7 (#5462) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.10 to 3.10.1 (#5461) @dependabot
* Bump hivemq-extension-sdk from 4.8.0 to 4.8.1 in /modules/hivemq (#5459) @dependabot
* Bump reactor-core from 3.4.17 to 3.4.18 in /modules/r2dbc (#5457) @dependabot
* Bump google-cloud-bigtable from 2.6.2 to 2.8.0 in /modules/gcloud (#5456) @dependabot
* Bump google-cloud-spanner from 6.20.0 to 6.25.5 in /modules/gcloud (#5455) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/gcloud (#5453) @dependabot
* Bump azure-cosmos from 4.29.1 to 4.30.0 in /modules/azure (#5452) @dependabot
* Bump postgresql from 42.3.4 to 42.3.6 in /modules/cockroachdb (#5450) @dependabot
* Bump google-cloud-pubsub from 1.116.4 to 1.119.0 in /modules/gcloud (#5449) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/k3s (#5447) @dependabot
* Bump trino-jdbc from 379 to 382 in /modules/trino (#5446) @dependabot
* Bump google-cloud-firestore from 3.0.21 to 3.2.0 in /modules/gcloud (#5444) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/rabbitmq (#5442) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/orientdb (#5441) @dependabot
* Bump release-drafter/release-drafter from 5.19.0 to 5.20.0 (#5440) @dependabot
* Bump actions/cache from 3.0.2 to 3.0.3 (#5439) @dependabot
* Bump peter-evans/create-pull-request from 4.0.2 to 4.0.3 (#5438) @dependabot
* Bump postgresql from 42.3.3 to 42.3.6 in /examples (#5437) @dependabot
* Bump transport from 7.17.3 to 7.17.4 in /modules/elasticsearch (#5435) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/database-commons (#5436) @dependabot
* Bump aws-java-sdk-logs from 1.12.169 to 1.12.232 in /modules/localstack (#5434) @dependabot
* Bump postgresql from 42.3.4 to 42.3.6 in /modules/junit-jupiter (#5433) @dependabot
* Bump jedis from 4.2.2 to 4.2.3 in /core (#5432) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /core (#5431) @dependabot
* Bump elasticsearch-rest-client from 7.16.2 to 8.2.2 in /modules/elasticsearch (#5430) @dependabot
* Bump postgresql from 42.3.1 to 42.3.6 in /modules/spock (#5428) @dependabot
* Bump aws-java-sdk-sqs from 1.12.210 to 1.12.231 in /modules/localstack (#5427) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/vault (#5425) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.6.2 to 1.7 in /examples (#5423) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/junit-jupiter (#5422) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.210 to 1.12.232 in /modules/dynalite (#5421) @dependabot
* Bump aws-java-sdk-s3 from 1.12.191 to 1.12.231 in /modules/localstack (#5420) @dependabot
* Bump tomcat-jdbc from 10.0.20 to 10.0.21 in /modules/jdbc (#5417) @dependabot
* Bump rest-assured from 5.0.1 to 5.1.0 in /modules/vault (#5419) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/neo4j (#5415) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/jdbc (#5410) @dependabot
* Bump mockito-core from 4.3.1 to 4.6.0 in /core (#5411) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/kafka (#5413) @dependabot
* Bump postgresql from 42.3.4 to 42.3.6 in /modules/postgresql (#5412) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/pulsar (#5414) @dependabot
* Bump neo4j from 3.5.32 to 3.5.33 in /modules/neo4j (#5408) @dependabot
* Bump mariadb-java-client from 3.0.3 to 3.0.5 in /modules/mariadb (#5409) @dependabot
* Bump tomcat-jdbc from 10.0.20 to 10.0.21 in /modules/jdbc-test (#5407) @dependabot
