### PR TITLE
Allow to proxy ports

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -86,6 +86,8 @@ dependencies {
 
     shaded 'org.zeroturnaround:zt-exec:1.12'
 
+    api 'com.github.terma:javaniotcpproxy:1.6'
+
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.2.3'
     testImplementation 'com.rabbitmq:amqp-client:5.14.2'

--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -449,6 +449,8 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
 
     void setExposedPorts(List<Integer> exposedPorts);
 
+    void setProxyPorts(List<Integer> exposedPorts);
+
     void setPortBindings(List<String> portBindings);
 
     void setExtraHosts(List<String> extraHosts);


### PR DESCRIPTION
> what if instead of statically mapping the port in Docker, we
instead start a local proxy on a static port and redirect everything
to the random port, while gracefully handling the port conflict
instead?

More [here](https://bsideup.github.io/posts/debugging_containers/)

Use cases:
* Connect to vnc client
* Debug applications attaching Java debugger
* Connect to databases to the already known port
* Testing against OIDC providers. i.e using localstack with cognito enabled.

`withProxyPorts` receive the ports that are gonna create a local proxy. We are not intended to proxy all `exposedPorts` by default. This responsibility is handled by each developer.