### PR TITLE
Use sshd container 1.1.0

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
@@ -31,14 +31,17 @@ public enum PortForwardingContainer {
     private Connection createSSHSession() {
         String password = UUID.randomUUID().toString();
         container =
-            new GenericContainer<>(DockerImageName.parse("testcontainers/sshd:1.0.0"))
+            new GenericContainer<>(DockerImageName.parse("testcontainers/sshd:1.1.0"))
                 .withExposedPorts(22)
                 .withEnv("PASSWORD", password)
                 .withCommand(
                     "sh",
                     "-c",
                     // Disable ipv6 & Make it listen on all interfaces, not just localhost
-                    "echo \"root:$PASSWORD\" | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes -o AddressFamily=inet -o GatewayPorts=yes"
+                    // Enable Us supported by our ssh client library
+                    "echo \"root:$PASSWORD\" | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes "
+                        + "-o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes "
+                        + "-o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa "
                 );
         container.start();
 

--- a/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
@@ -38,7 +38,7 @@ public enum PortForwardingContainer {
                     "sh",
                     "-c",
                     // Disable ipv6 & Make it listen on all interfaces, not just localhost
-                    // Enable Us supported by our ssh client library
+                    // Enable algorithms supported by our ssh client library
                     "echo \"root:$PASSWORD\" | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes "
                         + "-o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes "
                         + "-o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa "

--- a/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
@@ -39,9 +39,9 @@ public enum PortForwardingContainer {
                     "-c",
                     // Disable ipv6 & Make it listen on all interfaces, not just localhost
                     // Enable algorithms supported by our ssh client library
-                    "echo \"root:$PASSWORD\" | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes "
-                        + "-o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes "
-                        + "-o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa "
+                    "echo \"root:$PASSWORD\" | chpasswd && /usr/sbin/sshd -D -o PermitRootLogin=yes " +
+                    "-o AddressFamily=inet -o GatewayPorts=yes -o AllowAgentForwarding=yes -o AllowTcpForwarding=yes " +
+                    "-o KexAlgorithms=+diffie-hellman-group1-sha1 -o HostkeyAlgorithms=+ssh-rsa "
                 );
         container.start();
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -53,7 +53,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **tinyimage.container.image = alpine:3.14**  
 > Used to check whether images can be pulled at startup, and always required (unless [startup checks are disabled](#disabling-the-startup-checks))
 
-> **sshd.container.image = testcontainers/sshd:1.0.0**  
+> **sshd.container.image = testcontainers/sshd:1.1.0**  
 > Required if [exposing host ports to containers](./networking.md#exposing-host-ports-to-the-container)
 
 > **vncrecorder.container.image = testcontainers/vnc-recorder:1.1.0**


### PR DESCRIPTION
Fixes #5482

I had to allow algorithms which are disabled by default in the latest OpenSSH. Unfortunately, the ssh client used in TestContainers does not support newer algos. 