### PR TITLE
Add clickhouse/clickhouse-server compatibility

### DIFF
--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
@@ -13,6 +13,8 @@ public class ClickHouseContainer extends JdbcDatabaseContainer {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("yandex/clickhouse-server");
 
+    private static final DockerImageName CLICKHOUSE_IMAGE_NAME = DockerImageName.parse("clickhouse/clickhouse-server");
+
     @Deprecated
     public static final String IMAGE = DEFAULT_IMAGE_NAME.getUnversionedPart();
 
@@ -49,7 +51,7 @@ public class ClickHouseContainer extends JdbcDatabaseContainer {
 
     public ClickHouseContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, CLICKHOUSE_IMAGE_NAME);
 
         withExposedPorts(HTTP_PORT, NATIVE_PORT);
         waitingFor(

--- a/modules/clickhouse/src/test/java/org/testcontainers/ClickhouseTestImages.java
+++ b/modules/clickhouse/src/test/java/org/testcontainers/ClickhouseTestImages.java
@@ -3,5 +3,6 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface ClickhouseTestImages {
-    DockerImageName CLICKHOUSE_IMAGE = DockerImageName.parse("yandex/clickhouse-server:18.10.3");
+    DockerImageName YANDEX_CLICKHOUSE_IMAGE = DockerImageName.parse("yandex/clickhouse-server:18.10.3");
+    DockerImageName CLICKHOUSE_IMAGE = DockerImageName.parse("clickhouse/clickhouse-server:21.9.2-alpine");
 }

--- a/modules/clickhouse/src/test/java/org/testcontainers/junit/clickhouse/SimpleClickhouseTest.java
+++ b/modules/clickhouse/src/test/java/org/testcontainers/junit/clickhouse/SimpleClickhouseTest.java
@@ -1,20 +1,38 @@
 package org.testcontainers.junit.clickhouse;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.testcontainers.ClickhouseTestImages;
 import org.testcontainers.containers.ClickHouseContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
+import org.testcontainers.utility.DockerImageName;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
 
+@RunWith(Parameterized.class)
 public class SimpleClickhouseTest extends AbstractContainerDatabaseTest {
+
+    private final DockerImageName imageName;
+
+    public SimpleClickhouseTest(DockerImageName imageName) {
+        this.imageName = imageName;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Object[][] data() {
+        return new Object[][] { //
+            { ClickhouseTestImages.CLICKHOUSE_IMAGE },
+            { ClickhouseTestImages.YANDEX_CLICKHOUSE_IMAGE },
+        };
+    }
 
     @Test
     public void testSimple() throws SQLException {
-        try (ClickHouseContainer clickhouse = new ClickHouseContainer(ClickhouseTestImages.CLICKHOUSE_IMAGE)) {
+        try (ClickHouseContainer clickhouse = new ClickHouseContainer(this.imageName)) {
             clickhouse.start();
 
             ResultSet resultSet = performQuery(clickhouse, "SELECT 1");


### PR DESCRIPTION
`clickhouse` was initially developed by Yandex and now it is
OpenSource. See more [here](https://clickhouse.com/blog/yandex-opensources-click-house/)

For backward compatibility, we will be supported the image provided
by Yandex too.
