### PR TITLE
[LocalStack] Deprecate methods using aws sdk v1

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -193,7 +193,9 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      *
      * @param service the service that is to be accessed
      * @return an {@link AwsClientBuilder.EndpointConfiguration}
+     * @deprecated {@link LocalStackContainer} will not depend on aws sdk.
      */
+    @Deprecated
     public AwsClientBuilder.EndpointConfiguration getEndpointConfiguration(Service service) {
         return new AwsClientBuilder.EndpointConfiguration(getEndpointOverride(service).toString(), getRegion());
     }
@@ -257,7 +259,9 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
              .build()
      </code></pre>
      * @return an {@link AWSCredentialsProvider}
+     * @deprecated {@link LocalStackContainer} will not depend on aws sdk.
      */
+    @Deprecated
     public AWSCredentialsProvider getDefaultCredentialsProvider() {
         return new AWSStaticCredentialsProvider(new BasicAWSCredentials(getAccessKey(), getSecretKey()));
     }


### PR DESCRIPTION
Currently, `LocalStackContainer` depends on aws sdk v1. We have received
feedback about moving to aws sdk v2. However, we think that the
class already provides the enough information to be used such as
`getEndpointOverride()`, `getRegion()`, `getAccessKey()` and `getSecretKey`.
So, we are deprecating `getDefaultCredentialsProvider()` and `getEndpointConfiguration`
which are going to be removed in the feature and `LocalStack` module will
not depend on any aws sdk.
