### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,7 +61,7 @@ configurations.all {
 
 dependencies {
     api 'junit:junit:4.13.2'
-    api 'org.slf4j:slf4j-api:1.7.35'
+    api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'
     api 'org.apache.commons:commons-compress:1.21'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -89,7 +89,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.2.3'
     testImplementation 'com.rabbitmq:amqp-client:5.14.2'
-    testImplementation 'org.mongodb:mongo-java-driver:3.12.10'
+    testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
     testImplementation ('org.mockito:mockito-core:4.6.0') {
         exclude(module: 'hamcrest-core')

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.2.3'
-    testImplementation 'io.cucumber:cucumber-junit:7.2.3'
+    testImplementation 'io.cucumber:cucumber-junit:7.3.4'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
-    implementation 'org.json:json:20211205'
+    implementation 'org.json:json:20220320'
     testImplementation 'org.postgresql:postgresql:42.3.6'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:4.2.2'
+    implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.32'
-    implementation 'redis.clients:jedis:4.2.2'
+    implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:4.2.2'
+    implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.32'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.6.4"
     id("org.jetbrains.kotlin.jvm") version "1.6.21"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.6.20"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.6.21"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
     testImplementation 'com.couchbase.client:java-client:3.3.0'
-    testImplementation 'org.awaitility:awaitility:4.1.1'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:7.16.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.2.2"
     testImplementation "org.elasticsearch.client:transport:7.17.4"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.4.0'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.7.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.21'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.119.0'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.20.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.119.0'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.25.5'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.8.0'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.7.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.0.21'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.119.0'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.20.0'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.25.5'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.8.0'
     testImplementation 'org.assertj:assertj-core:3.22.0'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.8.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
-    testImplementation("ch.qos.logback:logback-classic:1.2.10")
+    testImplementation("ch.qos.logback:logback-classic:1.2.11")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
 }
 

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.3.6'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.27'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.29'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }
 

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.2.2'
+    testImplementation 'redis.clients:jedis:4.2.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation ('org.mockito:mockito-core:4.6.1') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.2.2'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.4.0') {
+    testImplementation ('org.mockito:mockito-core:4.6.1') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:5.12.2'
-    testImplementation 'io.kubernetes:client-java:15.0.0'
+    testImplementation 'io.kubernetes:client-java:15.0.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.0.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.2.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.210'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.233'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'
     testImplementation 'software.amazon.awssdk:s3:2.17.181'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.233'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'
-    testImplementation 'software.amazon.awssdk:s3:2.17.181'
+    testImplementation 'software.amazon.awssdk:s3:2.17.204'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.5.1")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.6.0")
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,10 +11,10 @@ dependencies {
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.8.1.RELEASE'
 
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.4.18'
-    testFixturesImplementation 'org.assertj:assertj-core:3.14.0'
+    testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.0.1'
+    testImplementation 'io.rest-assured:rest-assured:5.1.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump mockito-core from 4.4.0 to 4.6.1 in /modules/junit-jupiter (#5473) @dependabot
* Bump aws-java-sdk-sqs from 1.12.210 to 1.12.233 in /modules/localstack (#5472) @dependabot
* Bump google-cloud-datastore from 2.4.0 to 2.7.0 in /modules/gcloud (#5471) @dependabot
* Bump s3 from 2.17.181 to 2.17.204 in /modules/localstack (#5470) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.7 to 1.7.1 in /examples (#5469) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.10 to 3.10.1 (#5461) @dependabot
* Bump google-cloud-spanner from 6.20.0 to 6.25.5 in /modules/gcloud (#5455) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/r2dbc (#5454) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /modules/gcloud (#5453) @dependabot
* Bump google-cloud-firestore from 3.0.21 to 3.2.0 in /modules/gcloud (#5444) @dependabot
* Bump elasticsearch-rest-client from 7.16.2 to 8.2.2 in /modules/elasticsearch (#5430) @dependabot
* Bump jedis from 4.2.2 to 4.2.3 in /modules/junit-jupiter (#5426) @dependabot
* Bump rest-assured from 5.0.1 to 5.1.0 in /modules/vault (#5419) @dependabot
* Bump kafka-clients from 3.0.0 to 3.2.0 in /modules/kafka (#5372) @dependabot
* Bump cucumber-junit from 7.2.3 to 7.3.4 in /examples (#5371) @dependabot
* Bump jedis from 4.2.2 to 4.2.3 in /examples (#5369) @dependabot
* Bump client-java from 15.0.0 to 15.0.1 in /modules/k3s (#5329) @dependabot
* Bump mongodb-driver-sync from 4.5.1 to 4.6.0 in /modules/mongodb (#5328) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.6.20 to 1.6.21 in /examples (#5317) @dependabot
* Bump mysql-connector-java from 8.0.27 to 8.0.29 in /modules/junit-jupiter (#5308) @dependabot
* Bump mongo-java-driver from 3.12.10 to 3.12.11 in /core (#5291) @dependabot
* Bump logback-classic from 1.2.10 to 1.2.11 in /modules/hivemq (#5243) @dependabot
* Bump json from 20211205 to 20220320 in /examples (#5217) @dependabot
* Bump r2dbc-postgresql from 0.8.11.RELEASE to 0.8.12.RELEASE in /modules/postgresql (#5201) @dependabot
* Bump awaitility from 4.1.1 to 4.2.0 in /modules/couchbase (#5199) @dependabot
* Bump slf4j-api from 1.7.35 to 1.7.36 in /core (#5085) @dependabot
* Bump slf4j-api from 1.7.32 to 1.7.36 in /examples (#5078) @dependabot
