### PR TITLE
Add section about MySQL root user password to docs

### DIFF
--- a/docs/modules/databases/mysql.md
+++ b/docs/modules/databases/mysql.md
@@ -12,6 +12,11 @@ is a directory on the classpath containing .cnf files, the following URL can be 
 Any .cnf files in this classpath directory will be mapped into the database container's /etc/mysql/conf.d directory,
 and will be able to override server settings when the container starts.
 
+## MySQL `root` user password
+
+If no custom password is specified, the container will use the default user password `test` for the `root` user as well.
+When you specify a custom password for the database user,
+this will also act as the password of the MySQL root user automatically. 
 
 ## Adding this module to your project dependencies
 


### PR DESCRIPTION
Our MySQL module has some implicit behavior around the password for the `root` user. 
This PR adds a section to the `MySQLContainer` docs.