### PR TITLE
Proxy subscripts

### DIFF
--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -77,7 +77,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
 
     /**
      * Obtain a {@link ContainerProxy} instance for target container that is managed by Testcontainers. The target
-     * container should be routable from this <b>from this {@link ToxiproxyContainer} instance</b> (e.g. on the same
+     * container should be routable <b>from this {@link ToxiproxyContainer} instance</b> (e.g. on the same
      * Docker {@link Network}).
      *
      * @param container target container

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -122,10 +122,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
     public ContainerProxy getProxy(String hostname, int port) {
         String upstream = hostname + ":" + port;
 
-        return proxies.computeIfAbsent(
-            upstream,
-            __ -> createProxy(upstream, upstream)
-        );
+        return proxies.computeIfAbsent(upstream, __ -> createProxy(upstream, upstream));
     }
 
     /**
@@ -150,10 +147,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
         String upstream = hostname + ":" + port;
         String name = upstream + ":" + subscript;
 
-        return proxies.computeIfAbsent(
-            name,
-            __ -> createProxy(name, upstream)
-        );
+        return proxies.computeIfAbsent(name, __ -> createProxy(name, upstream));
     }
 
     private ContainerProxy createProxy(String name, String upstream) {

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -12,8 +12,8 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -33,7 +33,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
 
     private ToxiproxyClient client;
 
-    private final Map<String, ContainerProxy> proxies = new HashMap<>();
+    private final Map<String, ContainerProxy> proxies = new ConcurrentHashMap<>();
 
     private final AtomicInteger nextPort = new AtomicInteger(FIRST_PROXIED_PORT);
 

--- a/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
+++ b/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
@@ -157,27 +157,13 @@ public class ToxiproxyTest {
         final ToxiproxyContainer.ContainerProxy firstProxy = toxiproxy.getProxy(redis, 6379);
         final ToxiproxyContainer.ContainerProxy proxyA = toxiproxy.getProxy(redis, 6379, "A");
 
-        assertSame(
-            "no subscript, same proxy",
-            firstProxy,
-            toxiproxy.getProxy(redis, 6379)
-        );
+        assertSame("no subscript, same proxy", firstProxy, toxiproxy.getProxy(redis, 6379));
 
-        assertSame(
-            "same subscript, same proxy",
-            proxyA,
-            toxiproxy.getProxy(redis, 6379, "A")
-        );
+        assertSame("same subscript, same proxy", proxyA, toxiproxy.getProxy(redis, 6379, "A"));
 
-        assertTrue(
-            "subscript, different proxy",
-            firstProxy != proxyA
-        );
+        assertTrue("subscript, different proxy", firstProxy != proxyA);
 
-        assertTrue(
-            "different subscripts, different proxies",
-            proxyA != toxiproxy.getProxy(redis, 6379, "B")
-        );
+        assertTrue("different subscripts, different proxies", proxyA != toxiproxy.getProxy(redis, 6379, "B"));
 
         final Jedis firstJedis = createJedis(firstProxy.getContainerIpAddress(), firstProxy.getProxyPort());
         final Jedis secondJedis = createJedis(proxyA.getContainerIpAddress(), proxyA.getProxyPort());


### PR DESCRIPTION
## Abstract

Allows multiple proxies to be created for the same target `host:port` so parallel tests can test different toxics on the same container at the same time.

## Rationale

Toxiproxy itself allows proxies to be assigned arbitrary names, but `ToxiproxyContainer` simplifies this a bit by auto-generating the names in the form `host:port`. This allows you to do `getProxy` multiple times for the same `host:port` and get back the same proxy. Handy.

To maintain this functionality, I added `getProxy` variants that allow you to supply a so-called "subscript". Then, the auto-generated name takes the form `host:port:subscript`. This way, you can have mutliple proxies for the same `host:port` but also don't need to manage name strings, or worry about having two proxies with the same name.

## Use case

For my use, in unit tests, I intend to use a counter as the subscript, giving each test class its own separate proxy, so that toxics in one class won't affect the others, allowing the classes to run in parallel.