### PR TITLE
Fix missing link color in docs

### DIFF
--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -5,6 +5,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 [data-md-color-scheme="testcontainers"] {
-    --md-primary-fg-color:        #291A3F;
+    --md-primary-fg-color:       #291A3F;
     --md-accent-fg-color:        #291A3F;
+    --md-typeset-a-color:        #0C94AA;
 }


### PR DESCRIPTION
The rebranding of the docs removed any special rendering of links, so they became invisible to users. This change adds an explicit color for links (with the color taken from the TC logo).

It also implicitly highlights the currently selected page in the side-navigation panel.
