### PR TITLE
[HiveMQ] do not delete /opt/hivemq/temp-extensions in startup command

### DIFF
--- a/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
+++ b/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
@@ -123,7 +123,7 @@ public class HiveMQContainer extends GenericContainer<HiveMQContainer> {
             "-c",
             removeCommand +
             "cp -r '/opt/hivemq/temp-extensions/'* /opt/hivemq/extensions/ " +
-            "&& chmod -R 777 /opt/hivemq/extensions " +
+            "; chmod -R 777 /opt/hivemq/extensions " +
             "&& /opt/docker-entrypoint.sh /opt/hivemq/bin/run.sh"
         );
     }

--- a/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
+++ b/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
@@ -123,7 +123,6 @@ public class HiveMQContainer extends GenericContainer<HiveMQContainer> {
             "-c",
             removeCommand +
             "cp -r '/opt/hivemq/temp-extensions/'* /opt/hivemq/extensions/ " +
-            "; rm -rf /opt/hivemq/temp-extensions/** " +
             "&& chmod -R 777 /opt/hivemq/extensions " +
             "&& /opt/docker-entrypoint.sh /opt/hivemq/bin/run.sh"
         );


### PR DESCRIPTION
Removed the deletion of `/opt/hivemq/temp-extensions` because it causes trouble with some test scenarios.