### PR TITLE
[Core] use TestcontainersConfiguration#getEnvVarOrProperty to disable ryuk instead of System#getenv only

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -94,6 +94,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.6.0') {
         exclude(module: 'hamcrest-core')
     }
+    testImplementation ('org.mockito:mockito-inline:4.6.0')
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -55,6 +55,9 @@ public class ResourceReaper {
         )
     );
 
+    @VisibleForTesting
+    static final String RYUK_DISABLED_PROPERTY_KEY = "ryuk.disabled";
+
     private static ResourceReaper instance;
 
     final DockerClient dockerClient = DockerClientFactory.lazyClient();
@@ -74,7 +77,11 @@ public class ResourceReaper {
 
     public static synchronized ResourceReaper instance() {
         if (instance == null) {
-            boolean useRyuk = !Boolean.parseBoolean(System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
+            TestcontainersConfiguration configuration = TestcontainersConfiguration.getInstance();
+
+            boolean useRyuk = !Boolean.parseBoolean(
+                configuration.getEnvVarOrProperty(RYUK_DISABLED_PROPERTY_KEY, "false")
+            );
             if (useRyuk) {
                 //noinspection deprecation
                 instance = new RyukResourceReaper();


### PR DESCRIPTION
Hello, 

This is a simple change to allow disabling of ryuk from both env & properties.

This is more of a QoL change as I've had issues getting env variables to work with maven in a CI environment. Setting them elsewhere does work(i.e. on the CI level), but I'd rather set such a property in the testcontainers.properties file and maintain it with all the other testcontainers properties.

I'm not sure about the usefulness of the added unit test though as configuration.getEnvVarOrProperty is already a tested behaviour and it requires a new dependency to mockito-inline.