### PR TITLE
Elasticsearch: Fix startup check for 8.3 and above

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -102,10 +102,11 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         this.isAtLeastMajorVersion8 =
             new ComparableVersion(dockerImageName.getVersionPart()).isGreaterThanOrEqualTo("8.0.0");
         // regex that
+        //   matches 8.3 JSON logging with started message and some follow up content within the message field
         //   matches 8.0 JSON logging with no whitespace between message field and content
         //   matches 7.x JSON logging with whitespace between message field and content
         //   matches 6.x text logging with node name in brackets and just a 'started' message till the end of the line
-        String regex = ".*(\"message\":\\s?\"started\".*|] started\n$)";
+        String regex = ".*(\"message\":\\s?\"started[\\s?|\"].*|] started\n$)";
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx(regex));
         if (isAtLeastMajorVersion8) {
             withPassword(ELASTICSEARCH_DEFAULT_PASSWORD);

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -25,8 +25,9 @@ import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
+
+import javax.net.ssl.SSLHandshakeException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -151,9 +152,11 @@ public class ElasticsearchContainerTest {
 
     @Test
     public void elasticsearchVersion83() throws IOException {
-        try (ElasticsearchContainer container = new ElasticsearchContainer(
-            "docker.elastic.co/elasticsearch/elasticsearch:8.3.0"
-        )) {
+        try (
+            ElasticsearchContainer container = new ElasticsearchContainer(
+                "docker.elastic.co/elasticsearch/elasticsearch:8.3.0"
+            )
+        ) {
             container.start();
             Response response = getClient(container).performRequest(new Request("GET", "/"));
             assertThat(response.getStatusLine().getStatusCode(), is(200));

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -25,9 +25,8 @@ import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-import java.io.IOException;
-
 import javax.net.ssl.SSLHandshakeException;
+import java.io.IOException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -418,10 +417,11 @@ public class ElasticsearchContainerTest {
                 new UsernamePasswordCredentials(ELASTICSEARCH_USERNAME, ELASTICSEARCH_PASSWORD)
             );
 
+            String protocol = container.caCertAsBytes().isPresent() ? "https://" : "http://";
+
             client =
                 RestClient
-                    .builder(HttpHost.create(container.caCertAsBytes().isEmpty() ? "http://" : "https://" +
-                        container.getHttpHostAddress()))
+                    .builder(HttpHost.create(protocol + container.getHttpHostAddress()))
                     .setHttpClientConfigCallback(httpClientBuilder -> {
                         if (container.caCertAsBytes().isPresent()) {
                             httpClientBuilder.setSSLContext(container.createSslContextFromCa());


### PR DESCRIPTION
With the release of 8.3 the logging changed slightly and thus the log message strategy regex needs to be changed. This adds a test for the check in 8.3.0.