### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.3
+        uses: actions/cache@v3.0.4
         continue-on-error: true
         with:
           path: ~/.gradle/caches
@@ -50,7 +50,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.3
+        uses: actions/cache@v3.0.4
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.3
+        uses: actions/cache@v3.0.4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
@@ -56,7 +56,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.3
+        uses: actions/cache@v3.0.4
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -17,7 +17,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@f094b77505fb89581e68a1163fbd2fffece39da1 # v3.10.1
+        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@5b865a8b4d09fdf6afaaa20397ba68455bb48f0d # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@981c551b17dbcf1940b1b4435afdb79babb7c13a # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.2.3'
-    testImplementation 'com.rabbitmq:amqp-client:5.14.2'
+    testImplementation 'com.rabbitmq:amqp-client:5.15.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
     testImplementation ('org.mockito:mockito-core:4.6.0') {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:7.2.3'
+    testImplementation 'io.cucumber:cucumber-java:7.4.1'
     testImplementation 'io.cucumber:cucumber-junit:7.3.4'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.24"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.1.0'
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'org.json:json:20220320'
-    testImplementation 'org.postgresql:postgresql:42.3.6'
+    testImplementation 'org.postgresql:postgresql:42.4.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.22.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.6'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.2"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
     }
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.30.0'
+    testImplementation 'com.azure:azure-cosmos:4.32.1'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.3.6'
+    testImplementation 'org.postgresql:postgresql:42.4.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.2.2"
-    testImplementation "org.elasticsearch.client:transport:7.17.4"
+    testImplementation "org.elasticsearch.client:transport:7.17.5"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.7.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.2.0'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.119.0'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.0'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.25.5'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.8.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.2.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.0'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.25.5'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.8.0'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.9.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.7.0'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.10.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.2.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.0'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.25.5'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.8.1")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.8.2")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.2.11")

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.21'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.22'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:5.12.2'
-    testImplementation 'io.kubernetes:client-java:15.0.1'
+    testImplementation 'io.kubernetes:client-java:16.0.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.233'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.253'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'
     testImplementation 'software.amazon.awssdk:s3:2.17.224'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.233'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'
-    testImplementation 'software.amazon.awssdk:s3:2.17.204'
+    testImplementation 'software.amazon.awssdk:s3:2.17.224'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -7,11 +7,11 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
+    compileOnly 'org.mariadb:r2dbc-mariadb:1.1.2'
 
     testImplementation project(':jdbc-test')
     testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.5'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'
+    testImplementation 'org.mariadb:r2dbc-mariadb:1.1.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.6.0")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.6.1")
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.18'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.19'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.14.2'
+    testImplementation 'com.rabbitmq:amqp-client:5.15.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.1.0'
+    testImplementation 'io.rest-assured:rest-assured:5.1.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.1"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.2"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.gradle.enterprise.gradle.plugin from 3.10.1 to 3.10.2 (#5578) @dependabot
* Bump postgresql from 42.3.6 to 42.4.0 in /modules/cockroachdb (#5575) @dependabot
* Bump azure-cosmos from 4.30.0 to 4.32.1 in /modules/azure (#5574) @dependabot
* Bump mongodb-driver-sync from 4.6.0 to 4.6.1 in /modules/mongodb (#5573) @dependabot
* Bump amqp-client from 5.14.2 to 5.15.0 in /modules/rabbitmq (#5572) @dependabot
* Bump google-cloud-pubsub from 1.119.0 to 1.120.0 in /modules/gcloud (#5571) @dependabot
* Bump google-cloud-bigtable from 2.8.0 to 2.9.0 in /modules/gcloud (#5570) @dependabot
* Bump client-java from 15.0.1 to 16.0.0 in /modules/k3s (#5569) @dependabot
* Bump google-cloud-datastore from 2.7.0 to 2.10.0 in /modules/gcloud (#5568) @dependabot
* Bump google-cloud-spanner from 6.25.5 to 6.25.7 in /modules/gcloud (#5567) @dependabot
* Bump hivemq-extension-sdk from 4.8.1 to 4.8.2 in /modules/hivemq (#5565) @dependabot
* Bump reactor-core from 3.4.18 to 3.4.19 in /modules/r2dbc (#5563) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.10 to 3.10.2 in /examples (#5559) @dependabot
* Bump postgresql from 42.3.6 to 42.4.0 in /examples (#5558) @dependabot
* Bump assertj-core from 3.22.0 to 3.23.1 in /examples (#5556) @dependabot
* Bump cucumber-java from 7.2.3 to 7.4.1 in /examples (#5554) @dependabot
* Bump actions/cache from 3.0.3 to 3.0.4 (#5552) @dependabot
* Bump gradle-update/update-gradle-wrapper-action from 1.0.17 to 1.0.18 (#5551) @dependabot
* Bump peter-evans/create-pull-request from 4.0.3 to 4.0.4 (#5550) @dependabot
* Bump s3 from 2.17.204 to 2.17.224 in /modules/localstack (#5547) @dependabot
* Bump amqp-client from 5.14.2 to 5.15.0 in /core (#5546) @dependabot
* Bump aws-java-sdk-sqs from 1.12.233 to 1.12.253 in /modules/localstack (#5545) @dependabot
* Bump cucumber-junit from 7.3.4 to 7.4.1 in /examples (#5544) @dependabot
* Bump tomcat-jdbc from 10.0.21 to 10.0.22 in /modules/jdbc (#5538) @dependabot
* Bump rest-assured from 5.1.0 to 5.1.1 in /modules/vault (#5537) @dependabot
* Bump transport from 7.17.4 to 7.17.5 in /modules/elasticsearch (#5535) @dependabot
* Bump r2dbc-mariadb from 1.0.3 to 1.1.2 in /modules/mariadb (#5534) @dependabot
* Bump elasticsearch-rest-client from 8.2.2 to 8.3.1 in /modules/elasticsearch (#5533) @dependabot
