### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.15.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
-    testImplementation ('org.mockito:mockito-core:4.6.0') {
+    testImplementation ('org.mockito:mockito-core:4.6.1') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.4.1'
-    testImplementation 'io.cucumber:cucumber-junit:7.3.4'
+    testImplementation 'io.cucumber:cucumber-junit:7.4.1'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220320'
     testImplementation 'org.postgresql:postgresql:42.4.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("org.springframework.boot") version "2.6.4"
-    id("org.jetbrains.kotlin.jvm") version "1.6.21"
+    id("org.jetbrains.kotlin.jvm") version "1.7.0"
     id("org.jetbrains.kotlin.plugin.spring") version "1.6.21"
 }
 

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.2.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.3.1"
     testImplementation "org.elasticsearch.client:transport:7.17.5"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.10.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.2.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.0'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.25.5'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.25.7'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.9.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.21'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.22'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.29'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.3.6'
+    testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.29'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.231'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.253'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.253'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.253'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.253'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.232'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.253'
     testImplementation 'software.amazon.awssdk:s3:2.17.224'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.3.6'
+    testImplementation 'org.postgresql:postgresql:42.4.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.3.6'
+    testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.29'
 
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:382'
+    testImplementation 'io.trino:trino-jdbc:388'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.2"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
     }
 }
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.jetbrains.kotlin.jvm from 1.6.21 to 1.7.0 in /examples (#5581) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.7 to 1.7.2 (#5577) @dependabot
* Bump google-cloud-spanner from 6.25.5 to 6.25.7 in /modules/gcloud (#5567) @dependabot
* Bump trino-jdbc from 382 to 388 in /modules/trino (#5566) @dependabot
* Bump okhttp from 4.9.3 to 4.10.0 in /examples (#5557) @dependabot
* Bump aws-java-sdk-s3 from 1.12.231 to 1.12.253 in /modules/localstack (#5549) @dependabot
* Bump aws-java-sdk-logs from 1.12.232 to 1.12.253 in /modules/localstack (#5548) @dependabot
* Bump cucumber-junit from 7.3.4 to 7.4.1 in /examples (#5544) @dependabot
* Bump tomcat-jdbc from 10.0.21 to 10.0.22 in /modules/jdbc-test (#5540) @dependabot
* Bump mockito-core from 4.6.0 to 4.6.1 in /core (#5541) @dependabot
* Bump elasticsearch-rest-client from 8.2.2 to 8.3.1 in /modules/elasticsearch (#5533) @dependabot
* Bump postgresql from 42.3.6 to 42.4.0 in /modules/junit-jupiter (#5530) @dependabot
* Bump postgresql from 42.3.6 to 42.4.0 in /modules/spock (#5529) @dependabot
* Bump postgresql from 42.3.6 to 42.4.0 in /modules/postgresql (#5527) @dependabot
