### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.24"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.24"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.1.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.2.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.6.4"
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.6.21"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.7.0"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
-    testImplementation 'com.couchbase.client:java-client:3.3.0'
+    testImplementation 'com.couchbase.client:java-client:3.3.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.232'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.210'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.253'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.253'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.5'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.6'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:0.9.0.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:11.1.1.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:11.1.2.jre8-preview'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:0.8.7.RELEASE'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -29,7 +29,7 @@ task customNeo4jPluginJar(type: Jar) {
 processTestResources.dependsOn customNeo4jPluginJar
 
 dependencies {
-    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.33"
+    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.34"
 
     api project(":testcontainers")
 

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.10.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.0'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.1'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.10.0'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.10.1'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.1'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump kafka-clients from 3.1.0 to 3.2.0 in /examples (#5582) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.6.21 to 1.7.0 in /examples (#5553) @dependabot
* Bump pulsar-client-admin from 2.10.0 to 2.10.1 in /modules/pulsar (#5543) @dependabot
* Bump mssql-jdbc from 11.1.1.jre8-preview to 11.1.2.jre8-preview in /modules/mssqlserver (#5542) @dependabot
* Bump pulsar-client from 2.10.0 to 2.10.1 in /modules/pulsar (#5539) @dependabot
* Bump java-client from 3.3.0 to 3.3.1 in /modules/couchbase (#5536) @dependabot
* Bump mariadb-java-client from 3.0.5 to 3.0.6 in /modules/mariadb (#5532) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.232 to 1.12.253 in /modules/dynalite (#5531) @dependabot
* Bump neo4j from 3.5.33 to 3.5.34 in /modules/neo4j (#5528) @dependabot
