### PR TITLE
Replace deprecated RabbitMQ SSL environment variables with configuration file (#5599)

### DIFF
--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQTestImages.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQTestImages.java
@@ -3,5 +3,5 @@ package org.testcontainers.containers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface RabbitMQTestImages {
-    DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.7.25-management-alpine");
+    DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.10.6-management");
 }


### PR DESCRIPTION
This PR enables configuring RabbitMQ SSL for RabbitMQ 3.9+ versions. Until 3.9, SSL could be configured by environment variables. These variables were deprecated in RabbitMQ 3.9 version. If defined, the broker is generating an error on startup.

We solved this issue by adding an additional advanced configuration file that is merged with the [default configuration file included in the Docker image](https://github.com/docker-library/rabbitmq/blob/master/3.10/ubuntu/10-defaults.conf). We chose this solution because the advanced configuration is not configured using Testcontainers DSL and it doesn't interfere with the optional configuration added with `withRabbitMQConfig` method.

Co-authored-by: Joan Fisbein joan@fisbein.com
Co-authored-by: Marcin Gryszko mgryszko@gmail.com

On-behalf-of: @clarityai-eng tech@clarity.ai

Fixes #5599 