### PR TITLE
chore: refactor JDBC tests to avoid leaking DataSource & friends

### DIFF
--- a/modules/clickhouse/src/test/java/org/testcontainers/junit/clickhouse/SimpleClickhouseTest.java
+++ b/modules/clickhouse/src/test/java/org/testcontainers/junit/clickhouse/SimpleClickhouseTest.java
@@ -8,7 +8,6 @@ import org.testcontainers.containers.ClickHouseContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 import org.testcontainers.utility.DockerImageName;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
@@ -34,11 +33,14 @@ public class SimpleClickhouseTest extends AbstractContainerDatabaseTest {
     public void testSimple() throws SQLException {
         try (ClickHouseContainer clickhouse = new ClickHouseContainer(this.imageName)) {
             clickhouse.start();
-
-            ResultSet resultSet = performQuery(clickhouse, "SELECT 1");
-
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                clickhouse,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 }

--- a/modules/cockroachdb/src/test/java/org/testcontainers/junit/cockroachdb/SimpleCockroachDBTest.java
+++ b/modules/cockroachdb/src/test/java/org/testcontainers/junit/cockroachdb/SimpleCockroachDBTest.java
@@ -5,7 +5,6 @@ import org.testcontainers.CockroachDBTestImages;
 import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -24,11 +23,14 @@ public class SimpleCockroachDBTest extends AbstractContainerDatabaseTest {
     public void testSimple() throws SQLException {
         try (CockroachContainer cockroach = new CockroachContainer(CockroachDBTestImages.COCKROACHDB_IMAGE)) {
             cockroach.start();
-
-            ResultSet resultSet = performQuery(cockroach, "SELECT 1");
-
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                cockroach,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 
@@ -40,10 +42,14 @@ public class SimpleCockroachDBTest extends AbstractContainerDatabaseTest {
         ) { // CockroachDB is expected to be compatible with Postgres
             cockroach.start();
 
-            ResultSet resultSet = performQuery(cockroach, "SELECT foo FROM bar");
-
-            String firstColumnValue = resultSet.getString(1);
-            assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+            assertQuery(
+                cockroach,
+                "SELECT foo FROM bar",
+                rs -> {
+                    String firstColumnValue = rs.getString(1);
+                    assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+                }
+            );
         }
     }
 

--- a/modules/db2/src/test/java/org/testcontainers/junit/db2/SimpleDb2Test.java
+++ b/modules/db2/src/test/java/org/testcontainers/junit/db2/SimpleDb2Test.java
@@ -5,7 +5,6 @@ import org.testcontainers.Db2TestImages;
 import org.testcontainers.containers.Db2Container;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.hamcrest.Matchers.containsString;
@@ -18,11 +17,14 @@ public class SimpleDb2Test extends AbstractContainerDatabaseTest {
     public void testSimple() throws SQLException {
         try (Db2Container db2 = new Db2Container(Db2TestImages.DB2_IMAGE).acceptLicense()) {
             db2.start();
-
-            ResultSet resultSet = performQuery(db2, "SELECT 1 FROM SYSIBM.SYSDUMMY1");
-
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                db2,
+                "SELECT 1 FROM SYSIBM.SYSDUMMY1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 

--- a/modules/jdbc-test/src/main/java/org/testcontainers/db/AbstractContainerDatabaseTest.java
+++ b/modules/jdbc-test/src/main/java/org/testcontainers/db/AbstractContainerDatabaseTest.java
@@ -4,14 +4,25 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 
+import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
 import javax.sql.DataSource;
 
+import static org.junit.Assert.assertTrue;
+
 public abstract class AbstractContainerDatabaseTest {
 
+    /**
+     *
+     * @param container
+     * @param sql
+     * @return
+     * @throws SQLException
+     * @deprecated use {@link #assertQuery(JdbcDatabaseContainer, String, ResultSetConsumer)} instead.
+     */
     protected ResultSet performQuery(JdbcDatabaseContainer<?> container, String sql) throws SQLException {
         DataSource ds = getDataSource(container);
         Statement statement = ds.getConnection().createStatement();
@@ -22,12 +33,34 @@ public abstract class AbstractContainerDatabaseTest {
         return resultSet;
     }
 
+    protected void assertQuery(JdbcDatabaseContainer<?> container, String sql, ResultSetConsumer assertion)
+        throws SQLException {
+        try (
+            HikariDataSource ds = getDataSource0(container);
+            Connection conn = ds.getConnection();
+            Statement stmt = conn.createStatement();
+            ResultSet rs = stmt.executeQuery(sql)
+        ) {
+            assertTrue(rs.next());
+            assertion.accept(rs);
+        }
+    }
+
     protected DataSource getDataSource(JdbcDatabaseContainer<?> container) {
+        return getDataSource0(container);
+    }
+
+    private HikariDataSource getDataSource0(JdbcDatabaseContainer<?> container) {
         HikariConfig hikariConfig = new HikariConfig();
         hikariConfig.setJdbcUrl(container.getJdbcUrl());
         hikariConfig.setUsername(container.getUsername());
         hikariConfig.setPassword(container.getPassword());
         hikariConfig.setDriverClassName(container.getDriverClassName());
         return new HikariDataSource(hikariConfig);
+    }
+
+    @FunctionalInterface
+    public interface ResultSetConsumer {
+        void accept(ResultSet resultSet) throws SQLException;
     }
 }

--- a/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
@@ -6,7 +6,6 @@ import org.testcontainers.MariaDBTestImages;
 import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.hamcrest.Matchers.containsString;
@@ -22,10 +21,14 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
         try (MariaDBContainer<?> mariadb = new MariaDBContainer<>(MariaDBTestImages.MARIADB_IMAGE)) {
             mariadb.start();
 
-            ResultSet resultSet = performQuery(mariadb, "SELECT 1");
-            int resultSetInt = resultSet.getInt(1);
-
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                mariadb,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 
@@ -37,13 +40,16 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
             )
         ) {
             mariadbOldVersion.start();
-
-            ResultSet resultSet = performQuery(mariadbOldVersion, "SELECT VERSION()");
-            String resultSetString = resultSet.getString(1);
-
-            assertTrue(
-                "The database version can be set using a container rule parameter",
-                resultSetString.startsWith("5.5.51")
+            assertQuery(
+                mariadbOldVersion,
+                "SELECT VERSION()",
+                rs -> {
+                    String resultSetString = rs.getString(1);
+                    assertTrue(
+                        "The database version can be set using a container rule parameter",
+                        resultSetString.startsWith("5.5.51")
+                    );
+                }
             );
         }
     }
@@ -60,10 +66,14 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
         ) {
             mariadbCustomConfig.start();
 
-            ResultSet resultSet = performQuery(mariadbCustomConfig, "SELECT @@GLOBAL.innodb_file_format");
-            String result = resultSet.getString(1);
-
-            assertEquals("The InnoDB file format has been set by the ini file content", "Barracuda", result);
+            assertQuery(
+                mariadbCustomConfig,
+                "SELECT @@GLOBAL.innodb_file_format",
+                rs -> {
+                    String result = rs.getString(1);
+                    assertEquals("The InnoDB file format has been set by the ini file content", "Barracuda", result);
+                }
+            );
         }
     }
 
@@ -74,10 +84,14 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
                 .withCommand("mysqld --auto_increment_increment=10")
         ) {
             mariadbCustomConfig.start();
-            ResultSet resultSet = performQuery(mariadbCustomConfig, "show variables like 'auto_increment_increment'");
-            String result = resultSet.getString("Value");
-
-            assertEquals("Auto increment increment should be overriden by command line", "10", result);
+            assertQuery(
+                mariadbCustomConfig,
+                "show variables like 'auto_increment_increment'",
+                rs -> {
+                    String result = rs.getString("Value");
+                    assertEquals("Auto increment increment should be overriden by command line", "10", result);
+                }
+            );
         }
     }
 

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomizableMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomizableMSSQLServerTest.java
@@ -5,7 +5,6 @@ import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 import org.testcontainers.utility.DockerImageName;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
@@ -24,9 +23,14 @@ public class CustomizableMSSQLServerTest extends AbstractContainerDatabaseTest {
         ) {
             mssqlServerContainer.start();
 
-            ResultSet resultSet = performQuery(mssqlServerContainer, mssqlServerContainer.getTestQueryString());
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                mssqlServerContainer,
+                mssqlServerContainer.getTestQueryString(),
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 }

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
@@ -23,10 +23,14 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
             MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE)
         ) {
             mssqlServer.start();
-            ResultSet resultSet = performQuery(mssqlServer, "SELECT 1");
-
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                mssqlServer,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
@@ -5,7 +5,6 @@ import org.testcontainers.MySQLTestImages;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
@@ -30,10 +29,14 @@ public class CustomizableMysqlTest extends AbstractContainerDatabaseTest {
         ) {
             mysql.start();
 
-            ResultSet resultSet = performQuery(mysql, "SELECT 1");
-
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                mysql,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 }

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
@@ -8,7 +8,6 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 import org.testcontainers.utility.DockerImageName;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
@@ -32,13 +31,17 @@ public class MultiVersionMySQLTest extends AbstractContainerDatabaseTest {
     public void versionCheckTest() throws SQLException {
         try (MySQLContainer<?> mysql = new MySQLContainer<>(dockerImageName)) {
             mysql.start();
-            final ResultSet resultSet = performQuery(mysql, "SELECT VERSION()");
-            final String resultSetString = resultSet.getString(1);
-
-            assertEquals(
-                "The database version can be set using a container rule parameter",
-                dockerImageName.getVersionPart(),
-                resultSetString
+            assertQuery(
+                mysql,
+                "SELECT VERSION()",
+                rs -> {
+                    final String resultSetString = rs.getString(1);
+                    assertEquals(
+                        "The database version can be set using a container rule parameter",
+                        dockerImageName.getVersionPart(),
+                        resultSetString
+                    );
+                }
             );
         }
     }

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
@@ -56,10 +56,14 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
         ) {
             mysql.start();
 
-            ResultSet resultSet = performQuery(mysql, "SELECT 1");
-            int resultSetInt = resultSet.getInt(1);
-
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                mysql,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 
@@ -72,12 +76,16 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
         ) {
             mysqlOldVersion.start();
 
-            ResultSet resultSet = performQuery(mysqlOldVersion, "SELECT VERSION()");
-            String resultSetString = resultSet.getString(1);
-
-            assertTrue(
-                "The database version can be set using a container rule parameter",
-                resultSetString.startsWith("5.6")
+            assertQuery(
+                mysqlOldVersion,
+                "SELECT VERSION()",
+                rs -> {
+                    String resultSetString = rs.getString(1);
+                    assertTrue(
+                        "The database version can be set using a container rule parameter",
+                        resultSetString.startsWith("5.6")
+                    );
+                }
             );
         }
     }
@@ -92,10 +100,14 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
         ) {
             mysqlCustomConfig.start();
 
-            ResultSet resultSet = performQuery(mysqlCustomConfig, "SELECT @@GLOBAL.innodb_file_format");
-            String result = resultSet.getString(1);
-
-            assertEquals("The InnoDB file format has been set by the ini file content", "Barracuda", result);
+            assertQuery(
+                mysqlCustomConfig,
+                "SELECT @@GLOBAL.innodb_file_format",
+                rs -> {
+                    String result = rs.getString(1);
+                    assertEquals("The InnoDB file format has been set by the ini file content", "Barracuda", result);
+                }
+            );
         }
     }
 
@@ -106,11 +118,14 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
                 .withCommand("mysqld --auto_increment_increment=42")
         ) {
             mysqlCustomConfig.start();
-
-            ResultSet resultSet = performQuery(mysqlCustomConfig, "show variables like 'auto_increment_increment'");
-            String result = resultSet.getString("Value");
-
-            assertEquals("Auto increment increment should be overriden by command line", "42", result);
+            assertQuery(
+                mysqlCustomConfig,
+                "show variables like 'auto_increment_increment'",
+                rs -> {
+                    String result = rs.getString("Value");
+                    assertEquals("Auto increment increment should be overriden by command line", "42", result);
+                }
+            );
         }
     }
 
@@ -123,10 +138,14 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
         ) {
             container.start();
 
-            ResultSet resultSet = performQuery(container, "SELECT foo FROM bar");
-            String firstColumnValue = resultSet.getString(1);
-
-            assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+            assertQuery(
+                container,
+                "SELECT foo FROM bar",
+                rs -> {
+                    String firstColumnValue = rs.getString(1);
+                    assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+                }
+            );
         }
     }
 
@@ -156,10 +175,14 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
         ) {
             mysql.start();
 
-            ResultSet resultSet = performQuery(mysql, "SELECT 1");
-            int resultSetInt = resultSet.getInt(1);
-
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                mysql,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 

--- a/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
+++ b/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
@@ -5,7 +5,6 @@ import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 import org.testcontainers.utility.DockerImageName;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.junit.Assert.assertEquals;
@@ -26,9 +25,14 @@ public class SimpleOracleTest extends AbstractContainerDatabaseTest {
 
         //Test we can get a connection
         container.start();
-        ResultSet resultSet = performQuery(container, "SELECT 1 FROM dual");
-        int resultSetInt = resultSet.getInt(1);
-        assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+        assertQuery(
+            container,
+            "SELECT 1 FROM dual",
+            rs -> {
+                int resultSetInt = rs.getInt(1);
+                assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            }
+        );
     }
 
     @Test

--- a/modules/postgresql/src/test/java/org/testcontainers/containers/TimescaleDBContainerTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/containers/TimescaleDBContainerTest.java
@@ -3,7 +3,6 @@ package org.testcontainers.containers;
 import org.junit.Test;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
@@ -15,10 +14,14 @@ public class TimescaleDBContainerTest extends AbstractContainerDatabaseTest {
     public void testSimple() throws SQLException {
         try (JdbcDatabaseContainer<?> postgres = new TimescaleDBContainerProvider().newInstance()) {
             postgres.start();
-
-            ResultSet resultSet = performQuery(postgres, "SELECT 1");
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                postgres,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 
@@ -31,12 +34,14 @@ public class TimescaleDBContainerTest extends AbstractContainerDatabaseTest {
         ) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(
+            assertQuery(
                 (JdbcDatabaseContainer<?>) postgres,
-                "SELECT current_setting('max_connections')"
+                "SELECT current_setting('max_connections')",
+                rs -> {
+                    String result = rs.getString(1);
+                    assertEquals("max_connections should be overriden", "42", result);
+                }
             );
-            String result = resultSet.getString(1);
-            assertEquals("max_connections should be overriden", "42", result);
         }
     }
 
@@ -50,12 +55,14 @@ public class TimescaleDBContainerTest extends AbstractContainerDatabaseTest {
         ) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(
+            assertQuery(
                 (JdbcDatabaseContainer<?>) postgres,
-                "SELECT current_setting('max_connections')"
+                "SELECT current_setting('max_connections')",
+                rs -> {
+                    String result = rs.getString(1);
+                    assertNotEquals("max_connections should not be overriden", "42", result);
+                }
             );
-            String result = resultSet.getString(1);
-            assertNotEquals("max_connections should not be overriden", "42", result);
         }
     }
 
@@ -68,10 +75,14 @@ public class TimescaleDBContainerTest extends AbstractContainerDatabaseTest {
         ) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(postgres, "SELECT foo FROM bar");
-
-            String firstColumnValue = resultSet.getString(1);
-            assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+            assertQuery(
+                postgres,
+                "SELECT foo FROM bar",
+                rs -> {
+                    String firstColumnValue = rs.getString(1);
+                    assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+                }
+            );
         }
     }
 }

--- a/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/CustomizablePostgreSQLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/CustomizablePostgreSQLTest.java
@@ -5,7 +5,6 @@ import org.testcontainers.PostgreSQLTestImages;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import static org.rnorth.visibleassertions.VisibleAssertions.assertEquals;
@@ -31,10 +30,14 @@ public class CustomizablePostgreSQLTest extends AbstractContainerDatabaseTest {
         ) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(postgres, "SELECT 1");
-
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                postgres,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 }

--- a/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
@@ -5,7 +5,6 @@ import org.testcontainers.PostgreSQLTestImages;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.logging.Level;
 import java.util.logging.LogManager;
@@ -26,9 +25,14 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
         try (PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(PostgreSQLTestImages.POSTGRES_TEST_IMAGE)) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(postgres, "SELECT 1");
-            int resultSetInt = resultSet.getInt(1);
-            assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+            assertQuery(
+                postgres,
+                "SELECT 1",
+                rs -> {
+                    int resultSetInt = rs.getInt(1);
+                    assertEquals("A basic SELECT query succeeds", 1, resultSetInt);
+                }
+            );
         }
     }
 
@@ -40,9 +44,14 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
         ) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
-            String result = resultSet.getString(1);
-            assertEquals("max_connections should be overriden", "42", result);
+            assertQuery(
+                postgres,
+                "SELECT current_setting('max_connections')",
+                rs -> {
+                    String result = rs.getString(1);
+                    assertEquals("max_connections should be overriden", "42", result);
+                }
+            );
         }
     }
 
@@ -55,9 +64,14 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
         ) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
-            String result = resultSet.getString(1);
-            assertNotEquals("max_connections should not be overriden", "42", result);
+            assertQuery(
+                postgres,
+                "SELECT current_setting('max_connections')",
+                rs -> {
+                    String result = rs.getString(1);
+                    assertNotEquals("max_connections should not be overriden", "42", result);
+                }
+            );
         }
     }
 
@@ -69,10 +83,14 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
         ) {
             postgres.start();
 
-            ResultSet resultSet = performQuery(postgres, "SELECT foo FROM bar");
-
-            String firstColumnValue = resultSet.getString(1);
-            assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+            assertQuery(
+                postgres,
+                "SELECT foo FROM bar",
+                rs -> {
+                    String firstColumnValue = rs.getString(1);
+                    assertEquals("Value from init script should equal real value", "hello world", firstColumnValue);
+                }
+            );
         }
     }
 


### PR DESCRIPTION
`performQuery()` is leaking DataSources, Connections and Statements. 
Chances are it's also leaking ResutSets, unless a caller closes it. This is an attempt to fix it.

I kept the leaky method as there can be users outside the main repo. 

 I stumbled upon this while working on https://github.com/testcontainers/testcontainers-java/pull/5606