### PR TITLE
Update CircleCI docs for current Cloud/v2/v3 configuration

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -1,9 +1,9 @@
-# CircleCI 2.0
+# CircleCI (Cloud, Server v2.x, and Server v3.x)
 
-Your CircleCI configuration should use a dedicated VM for testcontainers to work. You can achieve this by specifying the 
-executor type in your `.circleci/config.yml` to be `machine` instead of the default `docker` executor ( see [Choosing an Executor Type](https://circleci.com/docs/2.0/executor-types/) for more info ).  
+Your CircleCI configuration should use a dedicated VM for Testcontainers to work. You can achieve this by specifying the 
+executor type in your `.circleci/config.yml` to be `machine` instead of the default `docker` executor (see [Choosing an Executor Type](https://circleci.com/docs/2.0/executor-types/) for more info).  
 
-Here is a sample CircleCI configuration (applicable for Cloud, Server v2.x, and Server v3.x)  that does a checkout of a project and runs maven:
+Here is a sample CircleCI configuration that does a checkout of a project and runs Maven:
 
 ```yml
 jobs:
@@ -12,6 +12,5 @@ jobs:
     machine: true
     steps:
       - checkout
-
       - run: mvn -B clean install
 ```

--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -3,7 +3,7 @@
 Your CircleCI configuration should use a dedicated VM for testcontainers to work. You can achieve this by specifying the 
 executor type in your `.circleci/config.yml` to be `machine` instead of the default `docker` executor ( see [Choosing an Executor Type](https://circleci.com/docs/2.0/executor-types/) for more info ).  
 
-Here is a sample CircleCI configuration that does a checkout of a project and runs maven:
+Here is a sample CircleCI configuration (applicable for Cloud, Server v2.x, and Server v3.x)  that does a checkout of a project and runs maven:
 
 ```yml
 jobs:

--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -10,7 +10,6 @@ Here is a sample CircleCI configuration that does a checkout of a project and ru
 jobs:
   build:
     # Check https://circleci.com/docs/executor-intro#linux-vm for more details
-    #
     machine: true
 
     steps:

--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -6,12 +6,13 @@ executor type in your `.circleci/config.yml` to be `machine` instead of the defa
 Here is a sample CircleCI configuration that does a checkout of a project and runs maven:
 
 ```yml
-# Check https://circleci.com/docs/2.0/language-java/ for more details
-#
-version: 2
-machine: true
+
 jobs:
   build:
+    # Check https://circleci.com/docs/executor-intro#linux-vm for more details
+    #
+    machine: true
+
     steps:
       - checkout
 

--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -6,7 +6,6 @@ executor type in your `.circleci/config.yml` to be `machine` instead of the defa
 Here is a sample CircleCI configuration that does a checkout of a project and runs maven:
 
 ```yml
-
 jobs:
   build:
     # Check https://circleci.com/docs/executor-intro#linux-vm for more details

--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -11,7 +11,6 @@ jobs:
   build:
     # Check https://circleci.com/docs/executor-intro#linux-vm for more details
     machine: true
-
     steps:
       - checkout
 


### PR DESCRIPTION
Documentation might have changed, but correct setup is as above, as per https://circleci.com/docs/executor-intro#linux-vm