### PR TITLE
Improve Pulsar's wait strategy to rely on clusterName

### DIFF
--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -96,13 +96,13 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
 
         withCommand("/bin/bash", "-c", standaloneBaseCommand);
 
+        final String clusterName = getEnvMap().getOrDefault("PULSAR_PREFIX_clusterName", "standalone");
+        final String response = String.format("[\"%s\"]", clusterName);
+
         List<WaitStrategy> waitStrategies = new ArrayList<>();
         waitStrategies.add(Wait.defaultWaitStrategy());
         waitStrategies.add(
-            Wait
-                .forHttp(ADMIN_CLUSTERS_ENDPOINT)
-                .forPort(BROKER_HTTP_PORT)
-                .forResponsePredicate("[\"standalone\"]"::equals)
+            Wait.forHttp(ADMIN_CLUSTERS_ENDPOINT).forPort(BROKER_HTTP_PORT).forResponsePredicate(response::equals)
         );
         if (transactionsEnabled) {
             withEnv("PULSAR_PREFIX_transactionCoordinatorEnabled", "true");

--- a/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
+++ b/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
@@ -55,6 +55,17 @@ public class PulsarContainerTest {
     }
 
     @Test
+    public void customClusterName() throws Exception {
+        try (
+            PulsarContainer pulsar = new PulsarContainer(PULSAR_IMAGE)
+                .withEnv("PULSAR_PREFIX_clusterName", "tc-cluster");
+        ) {
+            pulsar.start();
+            testPulsarFunctionality(pulsar.getPulsarBrokerUrl());
+        }
+    }
+
+    @Test
     public void shouldNotEnableFunctionsWorkerByDefault() throws Exception {
         try (PulsarContainer pulsar = new PulsarContainer(PULSAR_IMAGE)) {
             pulsar.start();


### PR DESCRIPTION
`PulsarContainer` allow to override configuration using env vars,
using `PULSAR_PREFIX_clusterName" will override the default's value
"standalone". The endpoint response should adapt accordingly.
