### PR TITLE
Link to the docs on environment discovery failure

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -247,11 +247,9 @@ public abstract class DockerClientProviderStrategy {
             .orElseThrow(() -> {
                 log.error(
                     "Could not find a valid Docker environment. Please check configuration. Attempted configurations were:\n" +
-                        configurationFailures.stream()
-                            .map(it -> "\t" + it)
-                            .collect(Collectors.joining("\n")) +
-                        "As no valid configuration was found, execution cannot continue.\n" +
-                        "See https://www.testcontainers.org/on_failure.html for more details."
+                    configurationFailures.stream().map(it -> "\t" + it).collect(Collectors.joining("\n")) +
+                    "As no valid configuration was found, execution cannot continue.\n" +
+                    "See https://www.testcontainers.org/on_failure.html for more details."
                 );
 
                 FAIL_FAST_ALWAYS.set(true);

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -246,12 +246,13 @@ public abstract class DockerClientProviderStrategy {
             .findFirst()
             .orElseThrow(() -> {
                 log.error(
-                    "Could not find a valid Docker environment. Please check configuration. Attempted configurations were:"
+                    "Could not find a valid Docker environment. Please check configuration. Attempted configurations were:\n" +
+                        configurationFailures.stream()
+                            .map(it -> "\t" + it)
+                            .collect(Collectors.joining("\n")) +
+                        "As no valid configuration was found, execution cannot continue.\n" +
+                        "See https://www.testcontainers.org/on_failure.html for more details."
                 );
-                for (String failureMessage : configurationFailures) {
-                    log.error("    " + failureMessage);
-                }
-                log.error("As no valid configuration was found, execution cannot continue");
 
                 FAIL_FAST_ALWAYS.set(true);
                 return new IllegalStateException(

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -12,6 +12,7 @@
 /usage/database_containers.html         /modules/databases/
 /usage/neo4j_container.html             /modules/databases/neo4j/
 /compatibility.html                     /supported_docker_environment/
+/on_failure.html                        /supported_docker_environment/
 
 # No great 1:1 mapping exists for the following, so redirect to somewhere where at least a sensible sidebar will be shown
 


### PR DESCRIPTION
Link to the docs when the environment discovery fails. Currently redirects to https://www.testcontainers.org/supported_docker_environment/