### PR TITLE
Reuse `BrowserWebDriverContainer`'s network for VNC recorder

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -3,6 +3,7 @@ package org.testcontainers.containers;
 import com.github.dockerjava.api.command.CreateNetworkCmd;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Singular;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
@@ -36,6 +37,21 @@ public interface Network extends AutoCloseable, TestRule {
 
     static NetworkImpl.NetworkImplBuilder builder() {
         return NetworkImpl.builder();
+    }
+
+    static Network ofContainer(@NonNull String containerId) {
+        class ContainerNetwork extends ExternalResource implements Network {
+            @Override
+            public String getId() {
+                return "container:" + containerId;
+            }
+
+            @Override
+            public void close() {
+
+            }
+        }
+        return new ContainerNetwork();
     }
 
     @Builder

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -191,16 +191,6 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
                     throw new ContainerLaunchException("Exception while trying to create temp directory", e);
                 }
             }
-
-            if (getNetwork() == null) {
-                withNetwork(Network.SHARED);
-            }
-
-            vncRecordingContainer =
-                new VncRecordingContainer(this)
-                    .withVncPassword(DEFAULT_PASSWORD)
-                    .withVncPort(VNC_PORT)
-                    .withVideoFormat(recordingFormat);
         }
 
         if (customImageName != null) {
@@ -299,8 +289,14 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
-        if (vncRecordingContainer != null) {
+        if (recordingMode != VncRecordingMode.SKIP) {
             LOGGER.debug("Starting VNC recording");
+            vncRecordingContainer =
+                new VncRecordingContainer(Network.ofContainer(containerInfo.getId()), "localhost")
+                    .withVncPassword(DEFAULT_PASSWORD)
+                    .withVncPort(VNC_PORT)
+                    .withVideoFormat(recordingFormat);
+
             vncRecordingContainer.start();
         }
     }


### PR DESCRIPTION
To avoid creating unnecessary networks, we can reuse browser container's network stack in VNC container.
This is possible because Docker supports `container:$containerId` network mode, where VNC container would see the browser on `localhost`.