### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3.0.5
         continue-on-error: true
         with:
           path: ~/.gradle/caches
@@ -53,7 +53,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3.0.5
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3.0.5
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
@@ -59,7 +59,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.4
+        uses: actions/cache@v3.0.5
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.4.1'
-    testImplementation 'io.cucumber:cucumber-junit:7.4.1'
+    testImplementation 'io.cucumber:cucumber-junit:7.5.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/disque-job-queue/build.gradle
+++ b/examples/disque-job-queue/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.24"
     annotationProcessor "org.projectlombok:lombok:1.18.24"
     implementation 'biz.paluch.redis:spinach:0.3'
-    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.mockito:mockito-all:1.10.19'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.24"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.24"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.2.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.2.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.6'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.9'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.2.3'
-    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.2.3'
-    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.2"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.3"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
     }
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:4.2.3'
-    implementation 'com.google.code.gson:gson:2.9.0'
+    implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.6.4"
     id("org.jetbrains.kotlin.jvm") version "1.7.0"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.7.0"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.7.10"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.32.1'
+    testImplementation 'com.azure:azure-cosmos:4.33.1'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
-    testImplementation 'com.couchbase.client:java-client:3.3.1'
+    testImplementation 'com.couchbase.client:java-client:3.3.2'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.253'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.253'
 
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.3.1"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.3.3"
     testImplementation "org.elasticsearch.client:transport:7.17.5"
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.10.0'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.10.1'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.2.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.6'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.25.7'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.10.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.2.0'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.0'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.6'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.25.7'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.9.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.2.11")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
 }
 
 test {

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.10.0")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.8.2")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: InfluxDB"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'org.influxdb:influxdb-java:2.22'
-    testImplementation 'org.influxdb:influxdb-java:2.21'
+    compileOnly 'org.influxdb:influxdb-java:2.23'
+    testImplementation 'org.influxdb:influxdb-java:2.23'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -14,7 +14,7 @@ dependencies {
         exclude(group: "net.java.dev.jna", module: "jna")
     }
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.22'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.23'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.29'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -16,5 +16,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.23'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.29'
+    api 'mysql:mysql-connector-java:8.0.30'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.22'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.23'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    api 'org.junit.jupiter:junit-jupiter-api:5.8.2'
+    api 'org.junit.jupiter:junit-jupiter-api:5.9.0'
 
     testImplementation project(':mysql')
     testImplementation project(':postgresql')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.29'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }
 
 test {

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.2.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.2.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.253'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.253'
-    testImplementation 'software.amazon.awssdk:s3:2.17.224'
+    testImplementation 'software.amazon.awssdk:s3:2.17.244'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.6.1")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.7.1")
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.29'
+    testImplementation 'mysql:mysql-connector-java:8.0.30'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.6'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.9'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.19'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.21'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.29'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
 
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:388'
+    testImplementation 'io.trino:trino-jdbc:391'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump google-cloud-pubsub from 1.120.0 to 1.120.6 in /modules/gcloud (#5665) @dependabot
* Bump google-cloud-spanner from 6.25.7 to 6.27.0 in /modules/gcloud (#5664) @dependabot
* Bump google-cloud-datastore from 2.10.0 to 2.10.1 in /modules/gcloud (#5662) @dependabot
* Bump google-cloud-firestore from 3.2.0 to 3.3.0 in /modules/gcloud (#5661) @dependabot
* Bump junit-jupiter-api from 5.8.2 to 5.9.0 in /modules/hivemq (#5659) @dependabot
* Bump junit-jupiter-engine from 5.8.2 to 5.9.0 in /modules/hivemq (#5658) @dependabot
* Bump azure-cosmos from 4.32.1 to 4.33.1 in /modules/azure (#5656) @dependabot
* Bump reactor-core from 3.4.19 to 3.4.21 in /modules/r2dbc (#5654) @dependabot
* Bump mongodb-driver-sync from 4.6.1 to 4.7.1 in /modules/mongodb (#5653) @dependabot
* Bump trino-jdbc from 388 to 391 in /modules/trino (#5652) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.7.0 to 1.7.10 in /examples (#5650) @dependabot
* Bump gson from 2.9.0 to 2.9.1 in /examples (#5649) @dependabot
* Bump cucumber-junit from 7.4.1 to 7.5.0 in /examples (#5648) @dependabot
* Bump kafka-clients from 3.2.0 to 3.2.1 in /examples (#5647) @dependabot
* Bump neo4j-java-driver from 4.4.6 to 4.4.9 in /examples (#5645) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.10.2 to 3.10.3 in /examples (#5646) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.7.0 to 1.7.10 in /examples (#5644) @dependabot
* Bump s3 from 2.17.224 to 2.17.244 in /modules/localstack (#5642) @dependabot
* Bump aws-java-sdk-logs from 1.12.253 to 1.12.273 in /modules/localstack (#5641) @dependabot
* Bump influxdb-java from 2.22 to 2.23 in /modules/influxdb (#5639) @dependabot
* Bump actions/cache from 3.0.4 to 3.0.5 (#5638) @dependabot
* Bump junit-jupiter-engine from 5.8.2 to 5.9.0 in /modules/junit-jupiter (#5637) @dependabot
* Bump mysql-connector-java from 8.0.29 to 8.0.30 in /modules/junit-jupiter (#5636) @dependabot
* Bump junit-jupiter-api from 5.8.2 to 5.9.0 in /modules/junit-jupiter (#5634) @dependabot
* Bump elasticsearch-rest-client from 8.3.1 to 8.3.3 in /modules/elasticsearch (#5633) @dependabot
* Bump mysql-connector-java from 8.0.29 to 8.0.30 in /modules/spock (#5632) @dependabot
* Bump mysql-connector-java from 8.0.29 to 8.0.30 in /modules/mysql (#5631) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.253 to 1.12.273 in /modules/dynalite (#5630) @dependabot
* Bump tomcat-jdbc from 10.0.22 to 10.0.23 in /modules/jdbc-test (#5629) @dependabot
* Bump java-client from 3.3.1 to 3.3.2 in /modules/couchbase (#5627) @dependabot
* Bump mysql-connector-java from 8.0.29 to 8.0.30 in /modules/jdbc-test (#5628) @dependabot
* Bump neo4j-java-driver from 4.4.6 to 4.4.9 in /modules/neo4j (#5626) @dependabot
* Bump tomcat-jdbc from 10.0.22 to 10.0.23 in /modules/jdbc (#5625) @dependabot
* Bump kafka-clients from 3.2.0 to 3.2.1 in /modules/kafka (#5624) @dependabot
