### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:7.4.1'
+    testImplementation 'io.cucumber:cucumber-java:7.5.0'
     testImplementation 'io.cucumber:cucumber-junit:7.5.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("org.springframework.boot") version "2.6.4"
-    id("org.jetbrains.kotlin.jvm") version "1.7.0"
+    id("org.jetbrains.kotlin.jvm") version "1.7.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.7.10"
 }
 

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.10.1'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.2.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.6'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.25.7'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.27.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.9.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.29'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }
 

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.253'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.231'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.253'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.253'
     testImplementation 'software.amazon.awssdk:s3:2.17.244'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.2"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.3"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump cucumber-java from 7.4.1 to 7.5.0 in /examples (#5669) @dependabot
* Bump google-cloud-spanner from 6.25.7 to 6.27.0 in /modules/gcloud (#5664) @dependabot
* Bump google-cloud-bigtable from 2.9.0 to 2.10.1 in /modules/gcloud (#5663) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.10.2 to 3.10.3 (#5660) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.7.0 to 1.7.10 in /examples (#5644) @dependabot
* Bump aws-java-sdk-sqs from 1.12.253 to 1.12.273 in /modules/localstack (#5643) @dependabot
* Bump aws-java-sdk-logs from 1.12.253 to 1.12.273 in /modules/localstack (#5641) @dependabot
* Bump mysql-connector-java from 8.0.29 to 8.0.30 in /modules/junit-jupiter (#5636) @dependabot
* Bump junit-jupiter-params from 5.8.2 to 5.9.0 in /modules/junit-jupiter (#5635) @dependabot
