### PR TITLE
Allow Pulsar default WaitStrategy to honour startup timeout

### DIFF
--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -2,11 +2,7 @@ package org.testcontainers.containers;
 
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
-import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.utility.DockerImageName;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * This container wraps Apache Pulsar running in standalone mode
@@ -36,6 +32,8 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
     @Deprecated
     private static final String DEFAULT_TAG = "2.10.0";
 
+    private final WaitAllStrategy waitAllStrategy = new WaitAllStrategy();
+
     private boolean functionsWorkerEnabled = false;
 
     private boolean transactionsEnabled = false;
@@ -60,6 +58,7 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DockerImageName.parse("apachepulsar/pulsar"));
         withExposedPorts(BROKER_PORT, BROKER_HTTP_PORT);
+        setWaitStrategy(waitAllStrategy);
     }
 
     @Override
@@ -98,21 +97,18 @@ public class PulsarContainer extends GenericContainer<PulsarContainer> {
 
         final String clusterName = getEnvMap().getOrDefault("PULSAR_PREFIX_clusterName", "standalone");
         final String response = String.format("[\"%s\"]", clusterName);
-
-        List<WaitStrategy> waitStrategies = new ArrayList<>();
-        waitStrategies.add(Wait.defaultWaitStrategy());
-        waitStrategies.add(
+        waitAllStrategy.withStrategy(
             Wait.forHttp(ADMIN_CLUSTERS_ENDPOINT).forPort(BROKER_HTTP_PORT).forResponsePredicate(response::equals)
         );
+
         if (transactionsEnabled) {
             withEnv("PULSAR_PREFIX_transactionCoordinatorEnabled", "true");
-            waitStrategies.add(Wait.forHttp(TRANSACTION_TOPIC_ENDPOINT).forStatusCode(200).forPort(BROKER_HTTP_PORT));
+            waitAllStrategy.withStrategy(
+                Wait.forHttp(TRANSACTION_TOPIC_ENDPOINT).forStatusCode(200).forPort(BROKER_HTTP_PORT)
+            );
         }
         if (functionsWorkerEnabled) {
-            waitStrategies.add(Wait.forLogMessage(".*Function worker service started.*", 1));
+            waitAllStrategy.withStrategy(Wait.forLogMessage(".*Function worker service started.*", 1));
         }
-        final WaitAllStrategy compoundedWaitStrategy = new WaitAllStrategy();
-        waitStrategies.forEach(compoundedWaitStrategy::withStrategy);
-        waitingFor(compoundedWaitStrategy);
     }
 }

--- a/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
+++ b/modules/pulsar/src/test/java/org/testcontainers/containers/PulsarContainerTest.java
@@ -12,6 +12,7 @@ import org.apache.pulsar.client.api.transaction.Transaction;
 import org.junit.Test;
 import org.testcontainers.utility.DockerImageName;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -141,6 +142,14 @@ public class PulsarContainerTest {
             try (PulsarAdmin pulsarAdmin = PulsarAdmin.builder().serviceHttpUrl(pulsar.getHttpServiceUrl()).build()) {
                 assertThat(pulsarAdmin.clusters().getClusters()).hasSize(1).contains("standalone");
             }
+        }
+    }
+
+    @Test
+    public void testStartupTimeoutIsHonored() {
+        try (PulsarContainer pulsar = new PulsarContainer(PULSAR_IMAGE).withStartupTimeout(Duration.ZERO)) {
+            assertThatThrownBy(pulsar::start)
+                .hasRootCauseMessage("Precondition failed: timeout must be greater than zero");
         }
     }
 


### PR DESCRIPTION
## Motivation

Currently, the PulsarContainer WaitStrategy is configured after the user
has started the container. This means that any modifications that the
user makes to the WaitStrategy or startupTimeout are discarded.

## Modifications

This change honours the user's modifications to the WaitStrategy or
startupTimeout.