### PR TITLE
Removes unused module junit-toolbox

### DIFF
--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -9,7 +9,9 @@ dependencies {
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.23'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
-    testImplementation 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
     testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation ('org.mockito:mockito-core:4.6.1') {
+        exclude(module: 'hamcrest-core')
+    }
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.23'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
-    testImplementation 'org.rnorth.visible-assertions:visible-assertions:2.1.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation ('org.mockito:mockito-core:4.6.1') {
         exclude(module: 'hamcrest-core')


### PR DESCRIPTION
This module is not used since commit ed0143333b386d551ae0fbdf00e11e707e2cf0a1

Module junit-toolbox depends on mockito-core 1.9.5 which makes unit test
JdbcDatabaseContainerTest fail on Java 16 or greater.

Exception on master with Java 16:
```
$ JAVA_HOME=/home/froque/.jdks/adopt-openjdk-16.0.2 ./gradlew :jdbc:test --tests org.testcontainers.containers.JdbcDatabaseContainerTest 
Configuration on demand is an incubating feature.

> Task :jdbc:test FAILED

Gradle Test Executor 1 > org.testcontainers.containers.JdbcDatabaseContainerTest > anExceptionIsThrownIfJdbcIsNotAvailable STARTED

Gradle Test Executor 1 > org.testcontainers.containers.JdbcDatabaseContainerTest > anExceptionIsThrownIfJdbcIsNotAvailable FAILED
    java.lang.AssertionError: 
    Expecting actual throwable to be an instance of:
      java.lang.IllegalStateException
    but was:
      java.lang.ExceptionInInitializerError
        at org.mockito.cglib.core.KeyFactory$Generator.generateClass(KeyFactory.java:167)
        at org.mockito.cglib.core.DefaultGeneratorStrategy.generate(DefaultGeneratorStrategy.java:25)
        at org.mockito.cglib.core.AbstractClassGenerator.create(AbstractClassGenerator.java:217)
        ...(61 remaining lines not displayed - this can be changed with Assertions.setMaxStackTraceElementsDisplayed)
        at org.testcontainers.containers.JdbcDatabaseContainerTest.anExceptionIsThrownIfJdbcIsNotAvailable(JdbcDatabaseContainerTest.java:20)

1 test completed, 1 failed

FAILURE: Build failed with an exception.
```