### PR TITLE
Update MockServer Image: mockserver/mockserver:5.13.2

### DIFF
--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MockServer"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.mock-server:mockserver-client-java:5.5.4'
+    testImplementation 'org.mock-server:mockserver-client-java:5.13.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -12,8 +12,7 @@ import static org.mockserver.model.HttpResponse.response;
 public class MockServerContainerRuleTest {
 
     public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse(
-        "jamesdbloom/mockserver:mockserver-5.5.4"
-    );
+        "mockserver/mockserver:5.13.2");
 
     // creatingProxy {
     @Rule

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -11,8 +11,7 @@ import static org.mockserver.model.HttpResponse.response;
 public class MockServerContainerTest {
 
     public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse(
-        "jamesdbloom/mockserver:mockserver-5.5.4"
-    );
+        "mockserver/mockserver:5.13.2");
 
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {
@@ -40,7 +39,7 @@ public class MockServerContainerTest {
 
     @Test
     public void newVersionStartsWithDefaultWaitStrategy() {
-        DockerImageName dockerImageName = DockerImageName.parse("mockserver/mockserver:mockserver-5.11.2");
+        DockerImageName dockerImageName = DockerImageName.parse("mockserver/mockserver:5.13.2");
         try (MockServerContainer mockServer = new MockServerContainer(dockerImageName)) {
             mockServer.start();
         }


### PR DESCRIPTION
`jamesdbloom/mockserver` is deprecated and moved to `mockserver/mockserver`.