### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.5
+        uses: actions/cache@v3.0.7
         continue-on-error: true
         with:
           path: ~/.gradle/caches
@@ -53,7 +53,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.5
+        uses: actions/cache@v3.0.7
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.5
+        uses: actions/cache@v3.0.7
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
@@ -59,7 +59,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.5
+        uses: actions/cache@v3.0.7
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.15.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
-    testImplementation ('org.mockito:mockito-core:4.6.1') {
+    testImplementation ('org.mockito:mockito-core:4.7.0') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:7.5.0'
+    testImplementation 'io.cucumber:cucumber-java:7.6.0'
     testImplementation 'io.cucumber:cucumber-junit:7.5.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.3"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
     }
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.33.1'
+    testImplementation 'com.azure:azure-cosmos:4.34.0'
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -9,5 +9,5 @@ configurations.all {
 dependencies {
     api project(":database-commons")
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
-    testImplementation 'com.datastax.oss:java-driver-core:4.8.0'
+    testImplementation 'com.datastax.oss:java-driver-core:4.14.1'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.4.0'
+    testImplementation 'org.postgresql:postgresql:42.4.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
     testImplementation 'io.rest-assured:rest-assured:4.4.0'
-    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.10.1'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.3.0'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.4.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.6'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.27.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.1'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.10.1'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.6'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.27.0'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.28.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.8.2")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.8.3")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.2.11")

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.2.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.6.1') {
+    testImplementation ('org.mockito:mockito-core:4.7.0') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.4.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.273'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.273'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.281'
     testImplementation 'software.amazon.awssdk:s3:2.17.244'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.273'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.281'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.281'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -29,7 +29,7 @@ task customNeo4jPluginJar(type: Jar) {
 processTestResources.dependsOn customNeo4jPluginJar
 
 dependencies {
-    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.34"
+    customNeo4jPluginCompileOnly "org.neo4j:neo4j:3.5.35"
 
     api project(":testcontainers")
 

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.4.0'
+    testImplementation 'org.postgresql:postgresql:42.4.1'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.4.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.4.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
 
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.29'
+    testImplementation 'mysql:mysql-connector-java:8.0.30'
 
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:391'
+    testImplementation 'io.trino:trino-jdbc:392'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.10.3"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump assertj-core from 3.21.0 to 3.23.1 in /modules/consul (#5727) @dependabot
* Bump rest-assured from 4.4.0 to 5.1.1 in /modules/consul (#5726) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.10.3 to 3.11.1 in /examples (#5724) @dependabot
* Bump google-cloud-firestore from 3.3.0 to 3.4.0 in /modules/gcloud (#5723) @dependabot
* Bump cucumber-java from 7.5.0 to 7.6.0 in /examples (#5722) @dependabot
* Bump aws-java-sdk-logs from 1.12.273 to 1.12.281 in /modules/localstack (#5721) @dependabot
* Bump google-cloud-spanner from 6.27.0 to 6.28.0 in /modules/gcloud (#5719) @dependabot
* Bump actions/cache from 3.0.5 to 3.0.7 (#5720) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.7.2 to 1.8.0 in /examples (#5718) @dependabot
* Bump mysql-connector-java from 8.0.29 to 8.0.30 in /modules/tidb (#5717) @dependabot
* Bump google-cloud-datastore from 2.10.1 to 2.11.0 in /modules/gcloud (#5713) @dependabot
* Bump aws-java-sdk-s3 from 1.12.273 to 1.12.281 in /modules/localstack (#5711) @dependabot
* Bump postgresql from 42.4.0 to 42.4.1 in /modules/spock (#5712) @dependabot
* Bump postgresql from 42.4.0 to 42.4.1 in /modules/postgresql (#5708) @dependabot
* Bump trino-jdbc from 391 to 392 in /modules/trino (#5707) @dependabot
* Bump neo4j from 3.5.34 to 3.5.35 in /modules/neo4j (#5709) @dependabot
* Bump mockito-core from 4.6.1 to 4.7.0 in /modules/junit-jupiter (#5706) @dependabot
* Bump google-cloud-pubsub from 1.120.6 to 1.120.11 in /modules/gcloud (#5705) @dependabot
* Bump postgresql from 42.4.0 to 42.4.1 in /modules/junit-jupiter (#5702) @dependabot
* Bump hivemq-extension-sdk from 4.8.2 to 4.8.3 in /modules/hivemq (#5704) @dependabot
* Bump s3 from 2.17.244 to 2.17.252 in /modules/localstack (#5700) @dependabot
* Bump aws-java-sdk-sqs from 1.12.273 to 1.12.281 in /modules/localstack (#5697) @dependabot
* Bump google-cloud-bigtable from 2.10.1 to 2.10.3 in /modules/gcloud (#5699) @dependabot
* Bump azure-cosmos from 4.33.1 to 4.34.0 in /modules/azure (#5694) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.10.3 to 3.11.1 (#5693) @dependabot
* Bump postgresql from 42.4.0 to 42.4.1 in /modules/cockroachdb (#5691) @dependabot
* Bump java-driver-core from 4.8.0 to 4.14.1 in /modules/cassandra (#5692) @dependabot
* Bump mockito-core from 4.6.1 to 4.7.0 in /core (#5688) @dependabot
