### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.6.0'
-    testImplementation 'io.cucumber:cucumber-junit:7.5.0'
+    testImplementation 'io.cucumber:cucumber-junit:7.6.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220320'
-    testImplementation 'org.postgresql:postgresql:42.4.0'
+    testImplementation 'org.postgresql:postgresql:42.4.1'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.0"
     }
 }
 

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
-    testImplementation 'io.rest-assured:rest-assured:4.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.1.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:3.14.9'
 
-    testImplementation 'com.couchbase.client:java-client:3.3.2'
+    testImplementation 'com.couchbase.client:java-client:3.3.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.273'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.253'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.281'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.281'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.10.1'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.11.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.6'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.28.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.11'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.28.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.1'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.3'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.11.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.0'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.6'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.11'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.28.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.23'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation ('org.mockito:mockito-core:4.6.1') {
+    testImplementation ('org.mockito:mockito-core:4.7.0') {
         exclude(module: 'hamcrest-core')
     }
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.273'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.281'
-    testImplementation 'software.amazon.awssdk:s3:2.17.244'
+    testImplementation 'software.amazon.awssdk:s3:2.17.253'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.281'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.273'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.273'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.282'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.281'
     testImplementation 'software.amazon.awssdk:s3:2.17.253'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.6'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.7'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:0.9.0.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:11.1.2.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:11.2.0.jre8'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:0.8.7.RELEASE'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.21'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.22'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.7.2"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.0"
     }
 }
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump s3 from 2.17.244 to 2.17.253 in /modules/localstack (#5732) @dependabot
* Bump aws-java-sdk-sqs from 1.12.273 to 1.12.282 in /modules/localstack (#5731) @dependabot
* Bump rest-assured from 4.4.0 to 5.1.1 in /modules/consul (#5726) @dependabot
* Bump cucumber-junit from 7.5.0 to 7.6.0 in /examples (#5725) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.7.2 to 1.8.0 in /examples (#5718) @dependabot
* Bump postgresql from 42.4.0 to 42.4.1 in /examples (#5714) @dependabot
* Bump google-cloud-datastore from 2.10.1 to 2.11.0 in /modules/gcloud (#5713) @dependabot
* Bump reactor-core from 3.4.21 to 3.4.22 in /modules/r2dbc (#5710) @dependabot
* Bump google-cloud-pubsub from 1.120.6 to 1.120.11 in /modules/gcloud (#5705) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.273 to 1.12.281 in /modules/dynalite (#5703) @dependabot
* Bump mockito-core from 4.6.1 to 4.7.0 in /modules/jdbc (#5701) @dependabot
* Bump google-cloud-bigtable from 2.10.1 to 2.10.3 in /modules/gcloud (#5699) @dependabot
* Bump mssql-jdbc from 11.1.2.jre8-preview to 11.2.0.jre8 in /modules/mssqlserver (#5698) @dependabot
* Bump mariadb-java-client from 3.0.6 to 3.0.7 in /modules/mariadb (#5695) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.7.2 to 1.8.0 (#5690) @dependabot
* Bump java-client from 3.3.2 to 3.3.3 in /modules/couchbase (#5689) @dependabot
