### PR TITLE
Enforce UTF-8 as Javadoc encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ subprojects {
     targetCompatibility = 1.8
     compileJava.options.encoding = 'UTF-8'
     compileTestJava.options.encoding = 'UTF-8'
+    javadoc.options.encoding = 'UTF-8'
 
     repositories {
         mavenCentral()

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.0"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.0"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8"
     }
 }
 


### PR DESCRIPTION
The Javadoc task (or publishing) fails when running on Windows with "unmappable character for encoding Cp1252" at https://github.com/testcontainers/testcontainers-java/blob/29aa84d19739f3d20c485275180e0619dd4145b1/core/src/main/java/org/testcontainers/DockerClientFactory.java#L243

The patch includes a version change for the `com.gradle.common-custom-user-data-gradle-plugin`, too, because _1.8.0_ can't be found.