### PR TITLE
Add `Transferable.of(String, int)`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -113,3 +113,9 @@ tasks.generatePomFileForMavenJavaPublication.finalizedBy(
         ]
     }
 )
+
+tasks.japicmp {
+    methodExcludes = [
+        "org.testcontainers.images.builder.Transferable#of(java.lang.String,int)"
+    ]
+}

--- a/core/src/main/java/org/testcontainers/images/builder/Transferable.java
+++ b/core/src/main/java/org/testcontainers/images/builder/Transferable.java
@@ -16,6 +16,10 @@ public interface Transferable {
         return of(string.getBytes(StandardCharsets.UTF_8));
     }
 
+    static Transferable of(String string, int fileMode) {
+        return of(string.getBytes(StandardCharsets.UTF_8), fileMode);
+    }
+
     static Transferable of(byte[] bytes) {
         return of(bytes, DEFAULT_FILE_MODE);
     }

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -85,6 +85,19 @@ public class GenericContainerTest {
     }
 
     @Test
+    public void shouldCopyTransferableAsFileWithFileMode() {
+        try (
+            GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withStartupCheckStrategy(new NoopStartupCheckStrategy())
+                .withCopyToContainer(Transferable.of("test", 0777), "/tmp/test")
+                .waitingFor(new WaitForExitedState(state -> state.getExitCodeLong() > 0))
+                .withCommand("sh", "-c", "ls -ll /tmp | grep '\\-rwxrwxrwx\\|test' && exit 100")
+        ) {
+            assertThatThrownBy(container::start).hasStackTraceContaining("Container exited with code 100");
+        }
+    }
+
+    @Test
     public void shouldCopyTransferableAfterMountableFile() {
         try (
             GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)


### PR DESCRIPTION
The new method adds similar capability of `Transferable.of(byte[], int)`
but for `String`.
