### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@ac463ffd9cc4c6ad5682af93dc3e3591c4657ee3 # v5.19.0
+      - uses: release-drafter/release-drafter@06a49bf28488e030d35ca2ac6dbf7f408a481779 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@923ad837f191474af6b1721408744feb989a4c27 # v3.10.1
+        uses: peter-evans/create-pull-request@18f90432bedd2afd6a825469ffd38aa24712a91d # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220320'
-    testImplementation 'org.postgresql:postgresql:42.4.1'
+    testImplementation 'org.postgresql:postgresql:42.4.2'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.4.1'
+    testImplementation 'org.postgresql:postgresql:42.4.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.281'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.281'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.4.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.4.2'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.282'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.281'
-    testImplementation 'software.amazon.awssdk:s3:2.17.253'
+    testImplementation 'software.amazon.awssdk:s3:2.17.256'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.281'
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.273'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.285'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.282'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.281'
     testImplementation 'software.amazon.awssdk:s3:2.17.253'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.4.1'
+    testImplementation 'org.postgresql:postgresql:42.4.2'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:392'
+    testImplementation 'io.trino:trino-jdbc:393'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump postgresql from 42.4.1 to 42.4.2 in /examples (#5756) @dependabot
* Bump peter-evans/create-pull-request from 4.0.4 to 4.1.1 (#5754) @dependabot
* Bump aws-java-sdk-s3 from 1.12.281 to 1.12.285 in /modules/localstack (#5753) @dependabot
* Bump release-drafter/release-drafter from 5.20.0 to 5.20.1 (#5752) @dependabot
* Bump s3 from 2.17.253 to 2.17.256 in /modules/localstack (#5751) @dependabot
* Bump aws-java-sdk-logs from 1.12.281 to 1.12.285 in /modules/localstack (#5750) @dependabot
* Bump postgresql from 42.4.1 to 42.4.2 in /modules/postgresql (#5748) @dependabot
* Bump trino-jdbc from 392 to 393 in /modules/trino (#5747) @dependabot
* Bump aws-java-sdk-sqs from 1.12.282 to 1.12.285 in /modules/localstack (#5746) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.281 to 1.12.285 in /modules/dynalite (#5745) @dependabot
* Bump postgresql from 42.4.1 to 42.4.2 in /modules/junit-jupiter (#5743) @dependabot
* Bump postgresql from 42.4.1 to 42.4.2 in /modules/cockroachdb (#5742) @dependabot
