### PR TITLE
Fix type/docs label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -85,4 +85,5 @@
   - modules/trino/*
 "modules/vault":
   - modules/vault/*
-"type/docs": docs/**/*
+"type/docs":
+  - docs/**/*.md


### PR DESCRIPTION
Only consider files with `.md` extension.
