### PR TITLE
Update GHA runner image to latest Ubuntu

### DIFF
--- a/.github/workflows/ci-docker-wormhole.yml
+++ b/.github/workflows/ci-docker-wormhole.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   in-docker_test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Build with Gradle

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   find_gradle_jobs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - id: thundra_test_initializer
         uses: thundra-io/thundra-test-init-action@v1
   find_gradle_jobs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository == 'testcontainers/testcontainers-java'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Our GHA workflows were using `ubuntu-18.04` in most of the places. This image has just been [deprecated](https://github.com/actions/runner-images/issues/6002) (8/8/22) and will be completely unsupported end of 2022. 

This PR changes all workflows to use `ubuntu-latest` instead (which currently means `ubuntu-20.04` as per [GHA docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)).

There is some more information in [this blog post](https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/) by GH. We currently experience a planned brownout from using `ubuntu-18.04`.

As an alternative, we could also specify `ubuntu-20.04` or `ubuntu-22.04`. However, I thought `ubuntu-latest` is a reasonable choice for our use case.