### PR TITLE
Upgrade spring-boot version to 2.7.3 in examples

### DIFF
--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.4'
+    id 'org.springframework.boot' version '2.7.3'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/selenium-container/src/test/java/SeleniumContainerTest.java
+++ b/examples/selenium-container/src/test/java/SeleniumContainerTest.java
@@ -2,12 +2,13 @@ import com.example.DemoApplication;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.context.WebServerInitializedEvent;
-import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -43,7 +44,7 @@ public class SeleniumContainerTest {
         RemoteWebDriver driver = chrome.getWebDriver();
 
         driver.get("http://host.testcontainers.internal:" + port + "/foo.html");
-        List<WebElement> hElement = driver.findElementsByTagName("h");
+        List<WebElement> hElement = driver.findElements(By.tagName("h"));
 
         assertThat(hElement).as("The h element is found").isNotEmpty();
     }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.6.4"
+    id("org.springframework.boot") version "2.7.3"
     id("org.jetbrains.kotlin.jvm") version "1.7.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.7.10"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.6.4'
+    id 'org.springframework.boot' version '2.7.3'
 }
 apply plugin: 'io.spring.dependency-management'
 


### PR DESCRIPTION
Currently, #5755 fails because `driver.findElementsByTagName()` is
not available anymore.
