### PR TITLE
Revert "Update GHA runner image to latest Ubuntu"

### DIFF
--- a/.github/workflows/ci-docker-wormhole.yml
+++ b/.github/workflows/ci-docker-wormhole.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   in-docker_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - name: Build with Gradle

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   find_gradle_jobs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - id: thundra_test_initializer
         uses: thundra-io/thundra-test-init-action@v1
   find_gradle_jobs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: github.repository == 'testcontainers/testcontainers-java'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Reverts testcontainers/testcontainers-java#5761.

Since our Azure module currently fails on CI with any other runner image besides Ubuntu 18.04, we temporarily roll back to the former state. This is only a short-term temporary solution since Ubuntu 18.04 is now deprecated and CIs using it will sporadically suffer from planned brownouts. 

We need to follow up with someone from Azure, to learn how to mitigate the issues with the `mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator` image on newer versions of Ubuntu.