### PR TITLE
Add compatibility with MongoDB 6

### DIFF
--- a/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.ComparableVersion;
 import org.testcontainers.utility.DockerImageName;
 
 import java.io.IOException;
@@ -29,6 +30,8 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
 
     private static final String MONGODB_DATABASE_NAME_DEFAULT = "test";
 
+    private final boolean isAtLeastVersion6;
+
     /**
      * @deprecated use {@link MongoDBContainer(DockerImageName)} instead
      */
@@ -44,6 +47,8 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
     public MongoDBContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        this.isAtLeastVersion6 = new ComparableVersion(dockerImageName.getVersionPart()).isGreaterThanOrEqualTo("6.0");
 
         withExposedPorts(MONGODB_INTERNAL_PORT);
         withCommand("--replSet", "docker-rs");
@@ -87,7 +92,8 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
     }
 
     private String[] buildMongoEvalCommand(final String command) {
-        return new String[] { "mongo", "--eval", command };
+        String cmd = this.isAtLeastVersion6 ? "mongosh" : "mongo";
+        return new String[] { cmd, "--eval", command };
     }
 
     private void checkMongoNodeExitCode(final Container.ExecResult execResult) {

--- a/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
+++ b/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
@@ -98,4 +98,11 @@ public class MongoDBContainerTest {
             assertThat(mongoDBContainer.getReplicaSetUrl(databaseName)).endsWith(databaseName);
         }
     }
+
+    @Test
+    public void supportsMongoDB_6() {
+        try (final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:6.0.1")) {
+            mongoDBContainer.start();
+        }
+    }
 }


### PR DESCRIPTION
MongoDB 6 removed `mongo` shell and `mongosh` is recommended.
See [here](https://www.mongodb.com/docs/manual/release-notes/6.0-compatibility/#legacy-mongo-shell-removed)

Closes #5768
