### PR TITLE
Exclude `org.testcontainers.shaded.*` package and upgrade deps

### DIFF
--- a/gradle/japicmp.gradle
+++ b/gradle/japicmp.gradle
@@ -25,6 +25,9 @@ tasks.japicmp {
 
     onlyBinaryIncompatibleModified = true
     htmlOutputFile = file("$buildDir/reports/japi.html")
+    packageExcludes = [
+        "org.testcontainers.shaded.*",
+    ]
 }
 // do not run on Windows by default
 // TODO investigate zip issue on Windows

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -1,9 +1,15 @@
 description = "Testcontainers :: Azure"
 
+tasks.japicmp {
+    packageExcludes = [
+        "org.testcontainers.shaded.*",
+    ]
+}
+
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:3.14.9'
+    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.azure:azure-cosmos:4.34.0'

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -1,11 +1,5 @@
 description = "Testcontainers :: Azure"
 
-tasks.japicmp {
-    packageExcludes = [
-        "org.testcontainers.shaded.*",
-    ]
-}
-
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -1,11 +1,5 @@
 description = "Testcontainers :: Couchbase"
 
-tasks.japicmp {
-    packageExcludes = [
-        "org.testcontainers.shaded.*",
-    ]
-}
-
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -1,9 +1,15 @@
 description = "Testcontainers :: Couchbase"
 
+tasks.japicmp {
+    packageExcludes = [
+        "org.testcontainers.shaded.*",
+    ]
+}
+
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:3.14.9'
+    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'com.couchbase.client:java-client:3.3.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -1,15 +1,21 @@
 description = "TestContainers :: HiveMQ"
 
+tasks.japicmp {
+    packageExcludes = [
+        "org.testcontainers.shaded.*",
+    ]
+}
+
 dependencies {
     api(project(":testcontainers"))
     api("org.jetbrains:annotations:23.0.0")
 
     shaded("org.apache.commons:commons-lang3:3.12.0")
     shaded("commons-io:commons-io:2.11.0")
-    shaded("org.javassist:javassist:3.28.0-GA")
+    shaded("org.javassist:javassist:3.29.0-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
-    shaded("net.lingala.zip4j:zip4j:2.10.0")
+    shaded("net.lingala.zip4j:zip4j:2.11.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
     testImplementation(project(":junit-jupiter"))

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -1,11 +1,5 @@
 description = "TestContainers :: HiveMQ"
 
-tasks.japicmp {
-    packageExcludes = [
-        "org.testcontainers.shaded.*",
-    ]
-}
-
 dependencies {
     api(project(":testcontainers"))
     api("org.jetbrains:annotations:23.0.0")

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:5.12.2'
+    testImplementation 'io.fabric8:kubernetes-client:6.0.0'
     testImplementation 'io.kubernetes:client-java:16.0.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.dsl.Readiable;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -55,7 +55,7 @@ public class Fabric8K3sContainerTest {
             client.pods().inNamespace("default").withName("helloworld").waitUntilReady(30, TimeUnit.SECONDS);
 
             assertThat(client.pods().inNamespace("default").withName("helloworld"))
-                .extracting(Readiable::isReady)
+                .extracting(Resource::isReady)
                 .isEqualTo(true);
         }
     }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MockServer"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.mock-server:mockserver-client-java:5.5.4'
+    testImplementation 'org.mock-server:mockserver-client-java:5.13.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -12,7 +12,7 @@ import static org.mockserver.model.HttpResponse.response;
 public class MockServerContainerRuleTest {
 
     public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse(
-        "jamesdbloom/mockserver:mockserver-5.5.4"
+        "jamesdbloom/mockserver:mockserver-5.13.2"
     );
 
     // creatingProxy {

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -1,9 +1,15 @@
 description = "Testcontainers :: Solr"
 
+tasks.japicmp {
+    packageExcludes = [
+        "org.testcontainers.shaded.*",
+    ]
+}
+
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.9.3'
+    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -1,11 +1,5 @@
 description = "Testcontainers :: Solr"
 
-tasks.japicmp {
-    packageExcludes = [
-        "org.testcontainers.shaded.*",
-    ]
-}
-
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5


### PR DESCRIPTION
Add general japicmp's package exclusion.

Also, shadow and test dependencies below are upgraded:
* Upgrade okhttp version to 4.10.0
* Upgrade javassist version to 3.29.0-GA
* Upgrade zip4j version to 2.11.1
* Upgrade kubernetes-client version to 6.0.0
