### PR TITLE
Update localstack images in tests

### DIFF
--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Enclosed.class)
 public class LegacyModeTest {
 
-    private static DockerImageName LOCALSTACK_CUSTOM_TAG = LocalstackTestImages.LOCALSTACK_IMAGE.withTag("custom");
+    private static DockerImageName LOCALSTACK_CUSTOM_TAG = LocalstackTestImages.LOCALSTACK_0_12_IMAGE.withTag("custom");
 
     @RunWith(Parameterized.class)
     @AllArgsConstructor

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(Enclosed.class)
 public class LegacyModeTest {
 
-    private static DockerImageName LOCALSTACK_CUSTOM_TAG = LocalstackTestImages.LOCALSTACK_0_12_IMAGE.withTag("custom");
+    private static DockerImageName LOCALSTACK_CUSTOM_TAG = LocalstackTestImages.LOCALSTACK_IMAGE.withTag("custom");
 
     @RunWith(Parameterized.class)
     @AllArgsConstructor

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -265,14 +265,17 @@ public class LocalstackContainerTest {
             LocalstackTestImages.AWS_CLI_IMAGE
         )
             .withNetwork(network)
-            .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("top"))
+            .withCreateContainerCmdModifier(cmd -> cmd.withEntrypoint("tail"))
+            .withCommand(" -f /dev/null")
             .withEnv("AWS_ACCESS_KEY_ID", "accesskey")
             .withEnv("AWS_SECRET_ACCESS_KEY", "secretkey")
             .withEnv("AWS_REGION", "eu-west-1");
 
         @Test
         public void s3TestOverDockerNetwork() throws Exception {
-            runAwsCliAgainstDockerNetworkContainer("s3api create-bucket --bucket foo");
+            runAwsCliAgainstDockerNetworkContainer(
+                "s3api create-bucket --bucket foo --create-bucket-configuration LocationConstraint=eu-west-1"
+            );
             runAwsCliAgainstDockerNetworkContainer("s3api list-buckets");
             runAwsCliAgainstDockerNetworkContainer("s3 ls s3://foo");
         }
@@ -313,7 +316,7 @@ public class LocalstackContainerTest {
         private String runAwsCliAgainstDockerNetworkContainer(String command) throws Exception {
             final String[] commandParts = String
                 .format(
-                    "/usr/bin/aws --region eu-west-1 %s --endpoint-url http://localstack:%d --no-verify-ssl",
+                    "/usr/local/bin/aws --region eu-west-1 %s --endpoint-url http://localstack:%d --no-verify-ssl",
                     command,
                     LocalStackContainer.PORT
                 )

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -26,7 +26,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -153,12 +152,7 @@ public class LocalstackContainerTest {
             String fooQueueUrl = queueResult.getQueueUrl();
             assertThat(fooQueueUrl)
                 .as("Created queue has external hostname URL")
-                .contains(
-                    "http://" +
-                    DockerClientFactory.instance().dockerHostIpAddress() +
-                    ":" +
-                    localstack.getMappedPort(LocalStackContainer.PORT)
-                );
+                .contains("http://" + localstack.getHost() + ":" + localstack.getMappedPort(LocalStackContainer.PORT));
 
             sqs.sendMessage(fooQueueUrl, "test");
             final long messageCount = sqs

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
@@ -3,10 +3,10 @@ package org.testcontainers.containers.localstack;
 import org.testcontainers.utility.DockerImageName;
 
 public interface LocalstackTestImages {
-    DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:0.12.8");
+    DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:1.0.4");
     DockerImageName LOCALSTACK_0_7_IMAGE = LOCALSTACK_IMAGE.withTag("0.7.0");
     DockerImageName LOCALSTACK_0_10_IMAGE = LOCALSTACK_IMAGE.withTag("0.10.7");
     DockerImageName LOCALSTACK_0_11_IMAGE = LOCALSTACK_IMAGE.withTag("0.11.3");
     DockerImageName LOCALSTACK_0_12_IMAGE = LOCALSTACK_IMAGE.withTag("0.12.8");
-    DockerImageName AWS_CLI_IMAGE = DockerImageName.parse("atlassian/pipelines-awscli:1.16.302");
+    DockerImageName AWS_CLI_IMAGE = DockerImageName.parse("amazon/aws-cli:2.7.27");
 }

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
@@ -3,7 +3,7 @@ package org.testcontainers.containers.localstack;
 import org.testcontainers.utility.DockerImageName;
 
 public interface LocalstackTestImages {
-    DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:1.0.4");
+    DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:0.12.8");
     DockerImageName LOCALSTACK_0_7_IMAGE = LOCALSTACK_IMAGE.withTag("0.7.0");
     DockerImageName LOCALSTACK_0_10_IMAGE = LOCALSTACK_IMAGE.withTag("0.10.7");
     DockerImageName LOCALSTACK_0_11_IMAGE = LOCALSTACK_IMAGE.withTag("0.11.3");


### PR DESCRIPTION
`atlassian/pipelines-awscli` is deprecated and it recommends to use
`amazon/aws-cli`.
