### PR TITLE
Fix link for Selenium examples

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,7 +6,7 @@ Examples of different use cases provided by Testcontainers can be found below:
 - [Linked containers](https://github.com/testcontainers/testcontainers-java/tree/master/examples/linked-container)
 - [Neo4j](https://github.com/testcontainers/testcontainers-java/tree/master/examples/neo4j-container)
 - [Redis](https://github.com/testcontainers/testcontainers-java/tree/master/examples/redis-backed-cache)
-- [Selenium](https://github.com/testcontainers/testcontainers-java/tree/master/examples/cucumber)
+- [Selenium](https://github.com/testcontainers/testcontainers-java/tree/master/examples/selenium-container)
 - [Selenium Module with Cucumber](https://github.com/testcontainers/testcontainers-java/tree/master/examples/cucumber)
 - [Singleton Container Pattern](https://github.com/testcontainers/testcontainers-java/tree/master/examples/singleton-container)
 - [Solr](https://github.com/testcontainers/testcontainers-java/tree/master/examples/solr-container)


### PR DESCRIPTION
The Selenium examples currently link to the Cucumber Selenium examples. This PR fixes the link.
