### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         continue-on-error: true
         with:
           path: ~/.gradle/caches
@@ -53,7 +53,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
@@ -59,7 +59,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.7
+        uses: actions/cache@v3.0.8
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded "org.yaml:snakeyaml:1.30"
+    shaded "org.yaml:snakeyaml:1.31"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,7 +61,7 @@ configurations.all {
 
 dependencies {
     api 'junit:junit:4.13.2'
-    api 'org.slf4j:slf4j-api:1.7.36'
+    api 'org.slf4j:slf4j-api:2.0.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'
     api 'org.apache.commons:commons-compress:1.21'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220320'
-    testImplementation 'org.postgresql:postgresql:42.4.2'
+    testImplementation 'org.postgresql:postgresql:42.5.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -6,7 +6,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:1.7.36'
+    compileOnly 'org.slf4j:slf4j-api:2.0.0'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220320'
     testImplementation 'org.postgresql:postgresql:42.5.0'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:1.7.36'
+    compileOnly 'org.slf4j:slf4j-api:2.0.0'
     implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:1.7.36'
+    compileOnly 'org.slf4j:slf4j-api:2.0.0'
     implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
-    compileOnly 'org.slf4j:slf4j-api:1.7.36'
+    compileOnly 'org.slf4j:slf4j-api:2.0.0'
 
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:testcontainers'

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.34.0'
+    testImplementation 'com.azure:azure-cosmos:4.35.1'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.4.2'
+    testImplementation 'org.postgresql:postgresql:42.5.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.285'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.281'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.295'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.295'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.3.3"
-    testImplementation "org.elasticsearch.client:transport:7.17.5"
+    testImplementation "org.elasticsearch.client:transport:7.17.6"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.11.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.12'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.28.0'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.29.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.3'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.11.0'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.4.0'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.4.2'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.12'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.29.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.3'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.8.3")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
-    testImplementation("ch.qos.logback:logback-classic:1.2.11")
+    testImplementation("ch.qos.logback:logback-classic:1.4.0")
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.4.2'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.0.0'
+    testImplementation 'io.fabric8:kubernetes-client:6.1.1'
     testImplementation 'io.kubernetes:client-java:16.0.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.285'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.285'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.295'
     testImplementation 'software.amazon.awssdk:s3:2.17.256'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.285'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.295'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.295'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -7,14 +7,14 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
     testImplementation 'org.postgresql:postgresql:42.4.2'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.11.RELEASE'
+    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.4.2'
+    testImplementation 'org.postgresql:postgresql:42.5.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     api 'io.r2dbc:r2dbc-spi:0.8.1.RELEASE'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.12.RELEASE'
+    testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.4.22'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:393'
+    testImplementation 'io.trino:trino-jdbc:394'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump azure-cosmos from 4.34.0 to 4.35.1 in /modules/azure (#5815) @dependabot
* Bump postgresql from 42.4.2 to 42.5.0 in /modules/cockroachdb (#5814) @dependabot
* Bump trino-jdbc from 393 to 394 in /modules/trino (#5813) @dependabot
* Bump kubernetes-client from 6.0.0 to 6.1.1 in /modules/k3s (#5812) @dependabot
* Bump logback-classic from 1.2.11 to 1.4.0 in /modules/hivemq (#5811) @dependabot
* Bump google-cloud-spanner from 6.28.0 to 6.29.0 in /modules/gcloud (#5810) @dependabot
* Bump google-cloud-firestore from 3.4.0 to 3.4.2 in /modules/gcloud (#5809) @dependabot
* Bump r2dbc-postgresql from 0.8.12.RELEASE to 0.8.13.RELEASE in /modules/r2dbc (#5808) @dependabot
* Bump google-cloud-pubsub from 1.120.12 to 1.120.13 in /modules/gcloud (#5807) @dependabot
* Bump actions/cache from 3.0.7 to 3.0.8 (#5805) @dependabot
* Bump transport from 7.17.5 to 7.17.6 in /modules/elasticsearch (#5804) @dependabot
* Bump elasticsearch-rest-client from 8.3.3 to 8.4.1 in /modules/elasticsearch (#5803) @dependabot
* Bump postgresql from 42.4.2 to 42.5.0 in /modules/junit-jupiter (#5800) @dependabot
* Bump r2dbc-postgresql from 0.8.12.RELEASE to 0.8.13.RELEASE in /modules/postgresql (#5799) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.285 to 1.12.295 in /modules/dynalite (#5797) @dependabot
* Bump postgresql from 42.4.2 to 42.5.0 in /modules/postgresql (#5798) @dependabot
* Bump aws-java-sdk-logs from 1.12.285 to 1.12.295 in /modules/localstack (#5796) @dependabot
* Bump snakeyaml from 1.30 to 1.31 in /core (#5795) @dependabot
* Bump slf4j-api from 1.7.36 to 2.0.0 in /core (#5794) @dependabot
* Bump aws-java-sdk-s3 from 1.12.285 to 1.12.295 in /modules/localstack (#5793) @dependabot
* Bump postgresql from 42.4.2 to 42.5.0 in /examples (#5792) @dependabot
* Bump slf4j-api from 1.7.36 to 2.0.0 in /examples (#5791) @dependabot
* Bump aws-java-sdk-sqs from 1.12.285 to 1.12.295 in /modules/localstack (#5790) @dependabot
