### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.3.3"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.4.1"
     testImplementation "org.elasticsearch.client:transport:7.17.6"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.11.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.2'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.12'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.13'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.29.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.3'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.2'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.13'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.29.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.10.3'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.11.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.295'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.285'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.295'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.295'
     testImplementation 'software.amazon.awssdk:s3:2.17.256'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.295'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.295'
-    testImplementation 'software.amazon.awssdk:s3:2.17.256'
+    testImplementation 'software.amazon.awssdk:s3:2.17.266'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.4.2'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
 
     testCompileClasspath 'org.jetbrains:annotations:23.0.0'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump google-cloud-pubsub from 1.120.12 to 1.120.13 in /modules/gcloud (#5807) @dependabot
* Bump google-cloud-bigtable from 2.10.3 to 2.11.1 in /modules/gcloud (#5806) @dependabot
* Bump elasticsearch-rest-client from 8.3.3 to 8.4.1 in /modules/elasticsearch (#5803) @dependabot
* Bump postgresql from 42.4.2 to 42.5.0 in /modules/spock (#5801) @dependabot
* Bump aws-java-sdk-sqs from 1.12.285 to 1.12.295 in /modules/localstack (#5790) @dependabot
* Bump s3 from 2.17.256 to 2.17.266 in /modules/localstack (#5788) @dependabot
