### PR TITLE
getWebDriver timeout is too low

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -310,10 +310,28 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      * <p>
      * All containers and drivers will be automatically shut down after the test method finishes (if used as a @Rule) or the test
      * class (if used as a @ClassRule)
+     * <p>
+     * Note that {@link RemoteWebDriver} does not initialize immediately thus this method will wait until it is initialized.
+     * This method will time out in 20 seconds. If you need to increase this timeout see {@link #getWebDriver(int)}
      *
      * @return a new Remote Web Driver instance
      */
     public synchronized RemoteWebDriver getWebDriver() {
+        return getWebDriver(20);
+    }
+
+    /**
+     * Obtain a {@link RemoteWebDriver} instance that is bound to an instance of the browser running inside a new container.
+     * <p>
+     * All containers and drivers will be automatically shut down after the test method finishes (if used as a @Rule) or the test
+     * class (if used as a @ClassRule)
+     * <p>
+     * Note that {@link RemoteWebDriver} does not initialize immediately, so this method will accept a timeout in seconds to wait.
+     *
+     * @param timeoutInSeconds the timeout in seconds to wait for the initialization of the remote web driver
+     * @return a new Remote Web Driver instance
+     */
+    public synchronized RemoteWebDriver getWebDriver(int timeoutInSeconds) {
         if (driver == null) {
             if (capabilities == null) {
                 logger()
@@ -325,11 +343,11 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
             driver =
                 Unreliables.retryUntilSuccess(
-                    30,
+                    timeoutInSeconds * 2,
                     TimeUnit.SECONDS,
                     () -> {
                         return Timeouts.getWithTimeout(
-                            10,
+                            timeoutInSeconds,
                             TimeUnit.SECONDS,
                             () -> {
                                 return new RemoteWebDriver(getSeleniumAddress(), capabilities);

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BrowserWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BrowserWebDriverContainerTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.util.Collections;
 import java.util.List;
@@ -79,6 +80,25 @@ public class BrowserWebDriverContainerTest {
                 .isEqualTo(512 * FileUtils.ONE_MB);
 
             assertThat(shmVolumes(webDriverContainer)).as("No shm mounts present").isEqualTo(Collections.emptyList());
+        }
+    }
+
+    /**
+     * Test that getWebDriver has a sufficient default timeout on the latest images.
+     * If this test fails occasionally, this may indicate that the default timeout specified in getWebDriver is too low.
+     * This may occur on new versions of selenium which have been shown to be slower
+     */
+    @Test
+    public void getWebDriverShouldNotTimeout() {
+        try (
+            BrowserWebDriverContainer webDriverContainer = new BrowserWebDriverContainer<>(
+                DockerImageName.parse("selenium/standalone-firefox:latest")
+            )
+                .withCapabilities(new FirefoxOptions())
+        ) {
+            webDriverContainer.start();
+            // Should not throw a timeout exception
+            webDriverContainer.getWebDriver();
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Fixes https://github.com/testcontainers/testcontainers-java/issues/5833

I've found that a default timeout of 20, passes a sample of 10 of `getWebDriver` calls (whereas a timeout of 15 or 10 does not). That being said, `getWebDriver` could run slower in different environments, thus I've introduced a new method `public RemoteWebDriver getWebDriver(int timeoutInSeconds)` that allows users to specify the timeout.