### PR TITLE
Update slf4j in test-support to 2.0.0

### DIFF
--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
-    implementation 'org.slf4j:slf4j-api:1.7.30'
+    implementation 'org.slf4j:slf4j-api:2.0.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }


### PR DESCRIPTION
Dependabot did update our use of `org.slf4j:slf4j-api` in other modules to version `2.0.0` already. However, it missed out our internal `test-support` module, so this is a manual follow-up PR.