### PR TITLE
Use `testCompileOnly` instead of `testCompileClasspath`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     api 'junit:junit:4.13.2'
     api 'org.slf4j:slf4j-api:2.0.0'
     compileOnly 'org.jetbrains:annotations:23.0.0'
-    testCompileClasspath 'org.jetbrains:annotations:23.0.0'
+    testCompileOnly 'org.jetbrains:annotations:23.0.0'
     api 'org.apache.commons:commons-compress:1.21'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -13,5 +13,4 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
 
     compileOnly 'org.jetbrains:annotations:23.0.0'
-    testCompileClasspath 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -1,6 +1,5 @@
 package org.testcontainers.junit;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.ClassRule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -51,7 +50,6 @@ public class BaseWebDriverContainerTest {
         assertThat(actual).as(String.format("actual browser name is %s", actual)).isEqualTo(expectedName);
     }
 
-    @NotNull
     private static RemoteWebDriver setupDriverFromRule(BrowserWebDriverContainer<?> rule) {
         RemoteWebDriver driver = rule.getWebDriver();
         driver.manage().timeouts().implicitlyWait(30, TimeUnit.SECONDS);

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,8 +17,6 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
-
-    testCompileClasspath 'org.jetbrains:annotations:23.0.0'
 }
 
 sourceJar {

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,6 +17,8 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
+
+    testCompileOnly 'org.jetbrains:annotations:23.0.0'
 }
 
 sourceJar {


### PR DESCRIPTION
`testCompileClasspath` is deprecated. Also, removing `org.jetbrains:annotations`
from `selenium` module.
