### PR TITLE
Allow containers to start on host network mode

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -141,6 +141,8 @@ public interface ContainerState {
     /**
      * Get the actual mapped port for a given port exposed by the container.
      * Should be used in conjunction with {@link #getHost()}.
+     * <p>
+     * If network mode "host" is enabled, the original port is returned.
      *
      * @param originalPort the original TCP port that is exposed
      * @return the port that the exposed port is mapped to, or null if it is not exposed
@@ -154,6 +156,9 @@ public interface ContainerState {
         Ports.Binding[] binding = new Ports.Binding[0];
         final InspectContainerResponse containerInfo = this.getContainerInfo();
         if (containerInfo != null) {
+            if (containerInfo.getHostConfig().getNetworkMode().equals("host")) {
+                return originalPort;
+            }
             binding = containerInfo.getNetworkSettings().getPorts().getBindings().get(new ExposedPort(originalPort));
         }
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -132,7 +132,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @NonNull
     private List<String> extraHosts = new ArrayList<>();
 
-    @NonNull
+    @Nullable
     private String networkMode;
 
     @Nullable
@@ -446,29 +446,35 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             // For all registered output consumers, start following as close to container startup as possible
             this.logConsumers.forEach(this::followOutput);
 
-            // Wait until inspect container returns the mapped ports
-            containerInfo =
-                await()
-                    .atMost(5, TimeUnit.SECONDS)
-                    .pollInterval(DynamicPollInterval.ofMillis(50))
-                    .pollInSameThread()
-                    .until(
-                        () -> dockerClient.inspectContainerCmd(containerId).exec(),
-                        inspectContainerResponse -> {
-                            Set<Integer> exposedAndMappedPorts = inspectContainerResponse
-                                .getNetworkSettings()
-                                .getPorts()
-                                .getBindings()
-                                .entrySet()
-                                .stream()
-                                .filter(it -> Objects.nonNull(it.getValue())) // filter out exposed but not yet mapped
-                                .map(Entry::getKey)
-                                .map(ExposedPort::getPort)
-                                .collect(Collectors.toSet());
+            if (networkMode == null || !networkMode.equals("host")) {
+                // Wait until inspect container returns the mapped ports
+                containerInfo =
+                    await()
+                        .atMost(5, TimeUnit.SECONDS)
+                        .pollInterval(DynamicPollInterval.ofMillis(50))
+                        .pollInSameThread()
+                        .until(
+                            () -> dockerClient.inspectContainerCmd(containerId).exec(),
+                            inspectContainerResponse -> {
+                                Set<Integer> exposedAndMappedPorts = inspectContainerResponse
+                                    .getNetworkSettings()
+                                    .getPorts()
+                                    .getBindings()
+                                    .entrySet()
+                                    .stream()
+                                    .filter(it -> Objects.nonNull(it.getValue())) // filter out exposed but not yet mapped
+                                    .map(Entry::getKey)
+                                    .map(ExposedPort::getPort)
+                                    .collect(Collectors.toSet());
 
-                            return exposedAndMappedPorts.containsAll(exposedPorts);
-                        }
-                    );
+                                return exposedAndMappedPorts.containsAll(exposedPorts);
+                            }
+                        );
+            } else {
+                // On host network mode, inspect container does not return any mapped ports.
+                // As ports are directly exposed on the hosts' network.
+                containerInfo = dockerClient.inspectContainerCmd(containerId).exec();
+            }
 
             // Tell subclasses that we're starting
             containerIsStarting(containerInfo, reused);

--- a/core/src/test/java/org/testcontainers/containers/HostNetworkModeTest.java
+++ b/core/src/test/java/org/testcontainers/containers/HostNetworkModeTest.java
@@ -1,0 +1,76 @@
+package org.testcontainers.containers;
+
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Test;
+import org.testcontainers.TestImages;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+public class HostNetworkModeTest {
+    private static final String NGINX_IMAGE = "nginx:1.17.10-alpine";
+
+    @Test
+    public void givenLinuxShouldStart() {
+        assumeThat(SystemUtils.IS_OS_LINUX).isTrue();
+        try (
+            GenericContainer<?> container = new GenericContainer<>(TestImages.REDIS_IMAGE)
+                .withNetworkMode("host")
+                .withExposedPorts(6379)
+        ) {
+            container.start();
+        }
+    }
+//
+//    @Test
+//    public void givenMacOsOrWindowsShouldThrowIllegalArgumentException() {
+//        assumeThat(SystemUtils.IS_OS_MAC || SystemUtils.IS_OS_WINDOWS).isTrue();
+//        assertThatThrownBy(() -> {
+//            new GenericContainer<>(TestImages.REDIS_IMAGE)
+//                .withNetworkMode("host");
+//        }).isInstanceOf(IllegalArgumentException.class);
+//    }
+
+    @Test
+    public void getMappedPortShouldReturnOriginalPort() {
+        assumeThat(SystemUtils.IS_OS_LINUX).isTrue();
+        try (
+            GenericContainer<?> container = new GenericContainer<>(TestImages.REDIS_IMAGE)
+                .withNetworkMode("host")
+                .withExposedPorts(6379)
+        ) {
+            container.start();
+            assertThat(container.getMappedPort(6379)).isEqualTo(6379);
+        }
+    }
+
+    @Test
+    public void getLivenessCheckPortsShouldReturnExposedPortsWhenHostNetworkMode() {
+        assumeThat(SystemUtils.IS_OS_LINUX).isTrue();
+        try (
+            GenericContainer<?> container = new GenericContainer<>(TestImages.REDIS_IMAGE)
+                .withNetworkMode("host")
+                .withExposedPorts(6379);
+        ) {
+            container.start();
+            assertThat(container.getLivenessCheckPortNumbers()).containsExactly(6379);
+            assertThat(container.getLivenessCheckPort()).isEqualTo(6379);
+            assertThat(container.getLivenessCheckPorts()).containsExactly(6379);
+        }
+    }
+
+    @Test
+    public void httpWaitStrategyShouldWorkOnHostNetworkMode() {
+        assumeThat(SystemUtils.IS_OS_LINUX).isTrue();
+        try (
+            GenericContainer<?> container = new GenericContainer<>(NGINX_IMAGE)
+                .withNetworkMode("host")
+                .withExposedPorts(80)
+                .waitingFor(new HttpWaitStrategy().forPort(80))
+        ) {
+            container.start();
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Fixes #5151 

@kiview RE:
> I've been testing locally and I think there's a simple fix we could do. We could add to `ContainerState.getMappedPort` an additional condition:
> 
> ```
>     default Integer getMappedPort(int originalPort) {
>         ...
>         Ports.Binding[] binding = new Ports.Binding[0];
>         final InspectContainerResponse containerInfo = this.getContainerInfo();
>         if (containerInfo != null) {
>             if (containerInfo.getHostConfig().getNetworkMode().equals("host")) {
>                 return originalPort;
>             }
>             binding = containerInfo.getNetworkSettings().getPorts().getBindings().get(new ExposedPort(originalPort));
>         }
>         ...
>     }
> ```
> 
> Which simply returns the original port if the container is in host mode. Though this feels a bit wrong. `host` mode doesn't really have a concept of mapped ports - the ports are simply on the host. It seems like we'd be stretching this method beyond it's original abstraction.
> 
> The more semantically correct alternative would be to throw if getMappedPort is called when container is host mode:
> 
> ```
>     default Integer getMappedPort(int originalPort) {
>         ...
>         Ports.Binding[] binding = new Ports.Binding[0];
>         final InspectContainerResponse containerInfo = this.getContainerInfo();
>         if (containerInfo != null) {
>             if (containerInfo.getHostConfig().getNetworkMode().equals("host")) {
>                 throw new IllegalArgumentException("getMappedPort is not supported for host network mode");
>             }
>             binding = containerInfo.getNetworkSettings().getPorts().getBindings().get(new ExposedPort(originalPort));
>         }
>         ...
>     }
> ```
> 
> We would, however, need to check all references to getMapped port and add in a check for host mode and there's a lot: ![Screenshot from 2022-08-25 20-27-41](https://user-images.githubusercontent.com/43259657/186647517-e42c85a3-fb84-46d6-83aa-006ff13323b5.png)


I tried going down the 2nd approach but I realised it really is not feasible - as you said, the blast radius is too large. Every module container that relies on getMapped port wouldn't work for "host" network mode unless we add a check for every use of getMappedPort.

So I went with the former approach here. I think this is fine. I suspect people don't use "host" network mode much and it doesn't really break the principal of least surprise.