### PR TITLE
Improve consistency of Testcontainers name in docs

### DIFF
--- a/docs/contributing_docs.md
+++ b/docs/contributing_docs.md
@@ -1,6 +1,6 @@
 # Contributing to documentation
 
-The testcontainers-java documentation is a static site built with [MkDocs](https://www.mkdocs.org/).
+The Testcontainers-java documentation is a static site built with [MkDocs](https://www.mkdocs.org/).
 We use the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme, which offers a number of useful extensions to MkDocs.
 
 In addition we use a [custom plugin](https://github.com/rnorth/mkdocs-codeinclude-plugin) for inclusion of code snippets.

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ Using Gradle 5.0 or higher, you can add the following to the `dependencies` sect
     Testcontainers depends on other libraries (like docker-java) for it to work.  
     Some of them (JUnit, docker-java-{api,transport} and its transitive dependencies, JNA, visible-assertions and others) are part of our public API.  
     But there are also "private", implementation detail dependencies (e.g., docker-java-core, Guava, OkHttp, etc.) that are not exposed to public API but prone to conflicts with test code/application under test code. 
-    As such, **these libraries are 'shaded' into the core testcontainers JAR** and relocated under `org.testcontainers.shaded` to prevent class conflicts.
+    As such, **these libraries are 'shaded' into the core Testcontainers JAR** and relocated under `org.testcontainers.shaded` to prevent class conflicts.
 
 ## Sponsors
 

--- a/docs/modules/databases/orientdb.md
+++ b/docs/modules/databases/orientdb.md
@@ -10,7 +10,7 @@ Note that it's based on the [official Docker image](https://hub.docker.com/_/ori
 
 ## Usage example
 
-Declare your Testcontainer as a `@ClassRule` or `@Rule` in a JUnit 4 test or as static or member attribute of a JUnit 5 test annotated with `@Container` as you would with other Testcontainers.
+Declare your Testcontainers instance as a `@ClassRule` or `@Rule` in a JUnit 4 test or as static or member attribute of a JUnit 5 test annotated with `@Container` as you would with other Testcontainers.
 You can call `getDbUrl()` OrientDB container and build the `ODatabaseSession` by your own, but a more useful `getSession()` method is provided.
 On the JVM you would most likely use the [Java driver](https://github.com/).
 
@@ -39,7 +39,7 @@ The following example uses the JUnit 5 extension `@Testcontainers` and demonstra
     }
     ```
 
-You are not limited to Unit tests and can of course use an instance of the OrientDB Testcontainer in vanilla Java code as well.
+You are not limited to Unit tests and can of course use an instance of the OrientDB Testcontainers implementation in vanilla Java code as well.
 
 
 ## Adding this module to your project dependencies


### PR DESCRIPTION
In light of the discussion found in [this](https://github.com/testcontainers/testcontainers-go/pull/534#discussion_r979193706) Testcontainers-go PR, I checked for consistent writing of the Testcontainers name in the Testcontainers-java docs as well.

What is still pending is to decide if all references of `Testcontainers` in the Testcontainers-java docs should be replaced with `Testcontainers-java` as well (similar to what is done for Go). Accordingly I can edit the other Testcontainers libraries.