### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@06a49bf28488e030d35ca2ac6dbf7f408a481779 # v5.19.0
+      - uses: release-drafter/release-drafter@df69d584deac33d8569990cb6413f82447181076 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@18f90432bedd2afd6a825469ffd38aa24712a91d # v3.10.1
+        uses: peter-evans/create-pull-request@671dc9c9e0c2d73f07fa45a3eb0220e1622f0c5f # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,7 +61,7 @@ configurations.all {
 
 dependencies {
     api 'junit:junit:4.13.2'
-    api 'org.slf4j:slf4j-api:2.0.0'
+    api 'org.slf4j:slf4j-api:2.0.3'
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testCompileOnly 'org.jetbrains:annotations:23.0.0'
     api 'org.apache.commons:commons-compress:1.21'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -80,7 +80,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded "org.yaml:snakeyaml:1.31"
+    shaded "org.yaml:snakeyaml:1.33"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -88,7 +88,7 @@ dependencies {
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.2.3'
-    testImplementation 'com.rabbitmq:amqp-client:5.15.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
     testImplementation ('org.mockito:mockito-core:4.7.0') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
-    testImplementation ('org.mockito:mockito-core:4.7.0') {
+    testImplementation ('org.mockito:mockito-core:4.8.0') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.6.0'
-    testImplementation 'io.cucumber:cucumber-junit:7.6.0'
+    testImplementation 'io.cucumber:cucumber-junit:7.8.0'
     testImplementation 'org.testcontainers:selenium'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.24"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.24"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.2.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:2.0.0'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    implementation 'org.json:json:20220320'
+    implementation 'org.json:json:20220924'
     testImplementation 'org.postgresql:postgresql:42.5.0'
     testImplementation 'ch.qos.logback:logback-classic:1.2.11'
     testImplementation 'org.testcontainers:postgresql'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.3'
+    id 'org.springframework.boot' version '2.7.4'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.1"
     }
 }
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.7.3"
+    id("org.springframework.boot") version "2.7.4"
     id("org.jetbrains.kotlin.jvm") version "1.7.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.7.10"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.3'
+    id 'org.springframework.boot' version '2.7.4'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.35.1'
+    testImplementation 'com.azure:azure-cosmos:4.36.0'
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     api project(":database-commons")
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
-    testImplementation 'com.datastax.oss:java-driver-core:4.14.1'
+    testImplementation 'com.datastax.oss:java-driver-core:4.15.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
-    testImplementation 'io.rest-assured:rest-assured:5.1.1'
+    testImplementation 'io.rest-assured:rest-assured:5.2.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.3.3'
+    testImplementation 'com.couchbase.client:java-client:3.3.4'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.295'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.313'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.295'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.4.1"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.4.2"
     testImplementation "org.elasticsearch.client:transport:7.17.6"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.11.0'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.11.4'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.2'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.13'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.29.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.11.4'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.4.2'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.13'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.18'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.29.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.11.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.4.0")
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }
 
 test {

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     shaded("org.javassist:javassist:3.29.0-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
-    shaded("net.lingala.zip4j:zip4j:2.11.1")
+    shaded("net.lingala.zip4j:zip4j:2.11.2")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
     testImplementation(project(":junit-jupiter"))

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.8.3")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.9.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.4.0")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.9.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
-    testImplementation("ch.qos.logback:logback-classic:1.4.0")
+    testImplementation("ch.qos.logback:logback-classic:1.4.1")
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.2")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.8.3")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.23'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation ('org.mockito:mockito-core:4.7.0') {
+    testImplementation ('org.mockito:mockito-core:4.8.0') {
         exclude(module: 'hamcrest-core')
     }
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.0.23'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.0'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation ('org.mockito:mockito-core:4.8.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.2.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.7.0') {
+    testImplementation ('org.mockito:mockito-core:4.8.0') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    api 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    api 'org.junit.jupiter:junit-jupiter-api:5.9.1'
 
     testImplementation project(':mysql')
     testImplementation project(':postgresql')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
 }
 
 test {

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.295'
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.313'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.313'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.295'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.313'
     testImplementation 'software.amazon.awssdk:s3:2.17.266'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.295'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.285'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.295'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.295'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.313'
     testImplementation 'software.amazon.awssdk:s3:2.17.266'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.7'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.8'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:0.9.0.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:11.2.0.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:11.2.1.jre8'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:0.8.7.RELEASE'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.22'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.23'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.15.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Redpanda"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.2.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.1.1'
+    testImplementation 'io.rest-assured:rest-assured:5.2.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.1"
     }
 }
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump cucumber-junit from 7.6.0 to 7.8.0 in /examples (#5926) @dependabot
* Bump zip4j from 2.11.1 to 2.11.2 in /modules/hivemq (#5925) @dependabot
* Bump junit-jupiter-engine from 5.9.0 to 5.9.1 in /modules/hivemq (#5924) @dependabot
* Bump kafka-clients from 3.2.1 to 3.3.0 in /examples (#5923) @dependabot
* Bump org.springframework.boot from 2.7.3 to 2.7.4 in /examples (#5922) @dependabot
* Bump junit-jupiter-api from 5.9.0 to 5.9.1 in /modules/hivemq (#5921) @dependabot
* Bump hivemq-extension-sdk from 4.8.3 to 4.9.0 in /modules/hivemq (#5920) @dependabot
* Bump json from 20220320 to 20220924 in /examples (#5919) @dependabot
* Bump logback-classic from 1.4.0 to 1.4.1 in /modules/hivemq (#5917) @dependabot
* Bump rest-assured from 5.1.1 to 5.2.0 in /modules/vault (#5914) @dependabot
* Bump rest-assured from 5.1.1 to 5.2.0 in /modules/consul (#5913) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.8 to 1.8.1 (#5912) @dependabot
* Bump elasticsearch-rest-client from 8.4.1 to 8.4.2 in /modules/elasticsearch (#5909) @dependabot
* Bump kafka-clients from 3.2.1 to 3.3.0 in /modules/redpanda (#5910) @dependabot
* Bump amqp-client from 5.15.0 to 5.16.0 in /modules/rabbitmq (#5908) @dependabot
* Bump reactor-core from 3.4.22 to 3.4.23 in /modules/r2dbc (#5907) @dependabot
* Bump azure-cosmos from 4.35.1 to 4.36.0 in /modules/azure (#5906) @dependabot
* Bump google-cloud-datastore from 2.11.0 to 2.11.4 in /modules/gcloud (#5905) @dependabot
* Bump mariadb-java-client from 3.0.7 to 3.0.8 in /modules/mariadb (#5903) @dependabot
* Bump google-cloud-firestore from 3.4.2 to 3.5.0 in /modules/gcloud (#5904) @dependabot
* Bump mssql-jdbc from 11.2.0.jre8 to 11.2.1.jre8 in /modules/mssqlserver (#5901) @dependabot
* Bump google-cloud-pubsub from 1.120.13 to 1.120.18 in /modules/gcloud (#5900) @dependabot
* Bump google-cloud-spanner from 6.29.0 to 6.30.2 in /modules/gcloud (#5897) @dependabot
* Bump cucumber-java from 7.6.0 to 7.8.0 in /examples (#5896) @dependabot
* Bump mockito-core from 4.7.0 to 4.8.0 in /modules/jdbc (#5894) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.8 to 1.8.1 in /examples (#5892) @dependabot
* Bump aws-java-sdk-logs from 1.12.295 to 1.12.313 in /modules/localstack (#5890) @dependabot
* Bump tomcat-jdbc from 10.0.23 to 10.1.0 in /modules/jdbc (#5889) @dependabot
* Bump s3 from 2.17.266 to 2.17.284 in /modules/localstack (#5888) @dependabot
* Bump java-client from 3.3.3 to 3.3.4 in /modules/couchbase (#5887) @dependabot
* Bump junit-jupiter-api from 5.9.0 to 5.9.1 in /modules/junit-jupiter (#5885) @dependabot
* Bump amqp-client from 5.15.0 to 5.16.0 in /core (#5884) @dependabot
* Bump peter-evans/create-pull-request from 4.1.1 to 4.1.3 (#5883) @dependabot
* Bump junit-jupiter-engine from 5.9.0 to 5.9.1 in /modules/junit-jupiter (#5881) @dependabot
* Bump aws-java-sdk-s3 from 1.12.295 to 1.12.313 in /modules/localstack (#5880) @dependabot
* Bump mockito-core from 4.7.0 to 4.8.0 in /core (#5879) @dependabot
* Bump release-drafter/release-drafter from 5.20.1 to 5.21.0 (#5878) @dependabot
* Bump mockito-core from 4.7.0 to 4.8.0 in /modules/junit-jupiter (#5877) @dependabot
* Bump junit-jupiter-params from 5.9.0 to 5.9.1 in /modules/junit-jupiter (#5876) @dependabot
* Bump slf4j-api from 2.0.0 to 2.0.3 in /core (#5875) @dependabot
* Bump java-driver-core from 4.14.1 to 4.15.0 in /modules/cassandra (#5874) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.295 to 1.12.313 in /modules/dynalite (#5872) @dependabot
* Bump snakeyaml from 1.31 to 1.33 in /core (#5873) @dependabot
