### PR TITLE
Bump kotlin plugins version to 1.7.20

### DIFF
--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.7.4"
-    id("org.jetbrains.kotlin.jvm") version "1.7.10"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.7.10"
+    id("org.jetbrains.kotlin.jvm") version "1.7.20"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.7.20"
 }
 
 apply plugin: 'io.spring.dependency-management'


### PR DESCRIPTION
Individual bumps fails. See #5941 and #5916
