### PR TITLE
Bump logback-classic versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ subprojects {
     }
 
     dependencies {
-        testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+        testImplementation 'ch.qos.logback:logback-classic:1.3.3'
     }
 
     spotless {

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -7,5 +7,5 @@ dependencies {
     api "io.lettuce:lettuce-core:5.2.0.RELEASE"
     testImplementation 'org.spockframework:spock-core:1.2-groovy-2.5'
     testImplementation project(":spock")
-    testImplementation 'ch.qos.logback:logback-classic:1.2.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
     testImplementation 'org.postgresql:postgresql:42.5.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
     testImplementation 'org.testng:testng:7.5'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:2.0.3'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.9.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
-    testImplementation("ch.qos.logback:logback-classic:1.4.1")
+    testImplementation("ch.qos.logback:logback-classic:1.4.3")
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }


### PR DESCRIPTION
`ch.qos.logback:logback-classic` 1.3.x is compatible with slf4j 2.x.
Currently, logs are not displayed.
