### PR TITLE
Rollback back to slf4j-api 1.7.36

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -61,7 +61,7 @@ configurations.all {
 
 dependencies {
     api 'junit:junit:4.13.2'
-    api 'org.slf4j:slf4j-api:2.0.3'
+    api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testCompileOnly 'org.jetbrains:annotations:23.0.0'
     api 'org.apache.commons:commons-compress:1.21'

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:2.0.3'
+    compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'io.codenotary:immudb4j:0.9.10.2'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -6,7 +6,7 @@ repositories {
     mavenCentral()
 }
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:2.0.3'
+    compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
     testImplementation 'org.postgresql:postgresql:42.5.0'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:2.0.3'
+    compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.slf4j:slf4j-api:2.0.3'
+    compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'redis.clients:jedis:4.2.3'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
-    compileOnly 'org.slf4j:slf4j-api:2.0.3'
+    compileOnly 'org.slf4j:slf4j-api:1.7.36'
 
     testImplementation 'ch.qos.logback:logback-classic:1.3.3'
     testImplementation 'org.testcontainers:testcontainers'

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
-    implementation 'org.slf4j:slf4j-api:2.0.0'
+    implementation 'org.slf4j:slf4j-api:1.7.36'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }


### PR DESCRIPTION
As reported in #5950, the upgrade to slf4j-api 2.x in release `1.17.4` was a breaking change. This PR does a rollback to the previous slf4j-api version `1.17.36`.

Reverts the following PRs: 
#5794, #5942, #5875, #5848, #5794, #5791

We can keep #5948, since it is unrelated to users and logback-classic 1.3.x is still compatible with slf4j 1.x.