### PR TITLE
doc: Update logback-test.xml example to show how to enable DEBUG only for Testcontainers

### DIFF
--- a/docs/supported_docker_environment/logging_config.md
+++ b/docs/supported_docker_environment/logging_config.md
@@ -21,3 +21,11 @@ should be included in your classpath to show a reasonable level of log output:
     <logger name="org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>
 ```
+
+In order to troubleshoot issues with Testcontainers, increase the logging level of `org.testcontainers` to `DEBUG`:
+
+```xml
+<logger name="org.testcontainers" level="DEBUG"/>
+```
+
+Avoid changing the root logger's level to `DEBUG`, because this turns on debug logging for every package whose level isn't explicitly configured here, resulting in a large amount of log data.

--- a/docs/supported_docker_environment/logging_config.md
+++ b/docs/supported_docker_environment/logging_config.md
@@ -18,5 +18,6 @@ should be included in your classpath to show a reasonable level of log output:
 
     <logger name="org.testcontainers" level="INFO"/>
     <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>
 ```

--- a/docs/supported_docker_environment/logging_config.md
+++ b/docs/supported_docker_environment/logging_config.md
@@ -18,7 +18,7 @@ should be included in your classpath to show a reasonable level of log output:
 
     <logger name="org.testcontainers" level="INFO"/>
     <logger name="com.github.dockerjava" level="WARN"/>
-    <logger name="org.apache.hc.client5.http.wire" level="OFF"/>
+    <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
 </configuration>
 ```
 


### PR DESCRIPTION
Update the recommended logging configuration to reduce the risk of people enabling DEBUG level on the root logger, thereby potentially exposing secrets in HTTP traffic, and being swamped by log data. The example `logback-test.xml` now disables Apache HTTP client wire logging and shows how to enable debug logging only for Testcontainers.

Fixes testcontainers/testcontainers-java#4913