### PR TITLE
Add paragraph about Docker requirements to docs

### DIFF
--- a/docs/supported_docker_environment/index.md
+++ b/docs/supported_docker_environment/index.md
@@ -2,6 +2,16 @@
 
 ## Overview
 
+Testcontainers requires a Docker-API compatible container runtime. 
+During development, Testcontainers is actively tested against recent versions of Docker on Linux, as well as against Docker Desktop on Mac and Windows. 
+These Docker environments are automatically detected and used by Testcontainers without any additional configuration being necessary.
+
+It is possible to configure Testcontainers to work for other Docker setups, such as a remote Docker host or Docker alternatives. 
+However, these are not actively tested in the main development workflow, so not all Testcontainers features might be available and additional manual configuration might be necessary. 
+If you have further questions about configuration details for your setup or whether it supports running Testcontainers-based tests, 
+please contact the Testcontainers team and other users from the Testcontainers community on [Slack](https://slack.testcontainers.org/).
+
+
 | Host Operating System / Environment | Minimum recommended docker versions | Known issues / tips                                                                                                                                                                                 |
 |-------------------------------------|-----------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Linux - general                     | Docker v17.09              | After docker installation, follow [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/).                                                                             |


### PR DESCRIPTION
Adds a paragraph about the Docker requirements to our docs. 

Highlights the challenges of different custom Docker environments and specifies which variants are actively tested for compatibility by the maintainers. 