### PR TITLE
Fixes wrong timestamp calculation

### DIFF
--- a/core/src/main/java/org/testcontainers/images/ImageData.java
+++ b/core/src/main/java/org/testcontainers/images/ImageData.java
@@ -24,6 +24,6 @@ public class ImageData {
     }
 
     static ImageData from(Image image) {
-        return ImageData.builder().createdAt(Instant.ofEpochMilli(image.getCreated())).build();
+        return ImageData.builder().createdAt(Instant.ofEpochSecond(image.getCreated())).build();
     }
 }


### PR DESCRIPTION
As already noted in https://github.com/testcontainers/testcontainers-java/issues/4275

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
The docker api returns the created date in epoch seconds, not in epoch millis. This caused the max age pull policy to always pull the image, as the calculated date ended up in the 1970ies. This fixes that by parsing the date as seconds, rather than millis.
See documentation here: https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageList

```
Created | required | integerDate and time at which the image was created as a Unix timestamp (number of seconds sinds EPOCH).
-- | --
```
