### PR TITLE
Add test for Confluent platform version 7 to `KafkaContainerTest`

### DIFF
--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -97,6 +97,14 @@ public class KafkaContainerTest {
     }
 
     @Test
+    public void testConfluentPlatformVersion7() throws Exception {
+        try (KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.2.2"))) {
+            kafka.start();
+            testKafkaFunctionality(kafka.getBootstrapServers());
+        }
+    }
+
+    @Test
     public void testConfluentPlatformVersion5() throws Exception {
         try (KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"))) {
             kafka.start();

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -29,10 +29,10 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class KafkaContainerTest {
 
-    private static final DockerImageName KAFKA_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:6.2.1");
+    private static final DockerImageName KAFKA_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:7.2.2");
 
     private static final DockerImageName ZOOKEEPER_TEST_IMAGE = DockerImageName.parse(
-        "confluentinc/cp-zookeeper:4.0.0"
+        "confluentinc/cp-zookeeper:7.2.2"
     );
 
     @Test
@@ -47,7 +47,7 @@ public class KafkaContainerTest {
     public void testUsageWithSpecificImage() throws Exception {
         try (
             // constructorWithVersion {
-            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
+            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.2.2"))
             // }
         ) {
             kafka.start();
@@ -61,7 +61,7 @@ public class KafkaContainerTest {
 
     @Test
     public void testUsageWithVersion() throws Exception {
-        try (KafkaContainer kafka = new KafkaContainer("6.2.1")) {
+        try (KafkaContainer kafka = new KafkaContainer("7.2.2")) {
             kafka.start();
             testKafkaFunctionality(kafka.getBootstrapServers());
         }

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -29,10 +29,10 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class KafkaContainerTest {
 
-    private static final DockerImageName KAFKA_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:7.2.2");
+    private static final DockerImageName KAFKA_TEST_IMAGE = DockerImageName.parse("confluentinc/cp-kafka:6.2.1");
 
     private static final DockerImageName ZOOKEEPER_TEST_IMAGE = DockerImageName.parse(
-        "confluentinc/cp-zookeeper:7.2.2"
+        "confluentinc/cp-zookeeper:4.0.0"
     );
 
     @Test
@@ -47,7 +47,7 @@ public class KafkaContainerTest {
     public void testUsageWithSpecificImage() throws Exception {
         try (
             // constructorWithVersion {
-            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.2.2"))
+            KafkaContainer kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
             // }
         ) {
             kafka.start();
@@ -61,7 +61,7 @@ public class KafkaContainerTest {
 
     @Test
     public void testUsageWithVersion() throws Exception {
-        try (KafkaContainer kafka = new KafkaContainer("7.2.2")) {
+        try (KafkaContainer kafka = new KafkaContainer("6.2.1")) {
             kafka.start();
             testKafkaFunctionality(kafka.getBootstrapServers());
         }


### PR DESCRIPTION
Update Kafka and Zookeeper images to:
- confluentinc/cp-kafka:7.2.2
- confluentinc/cp-zookeeper:7.2.2

This is an attempt to reproduce the error from #4781, but the tests still pass... Feel free to reject this PR if you don't want the image update.