### PR TITLE
Catch and ignore more errors when reflecting into container subclass

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -360,7 +360,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                     logger().warn("{} can't be reused because it overrides {}", getClass(), method.getName());
                     return false;
                 }
-            } catch (NoSuchMethodException e) {
+            } catch (NoSuchMethodException | NoClassDefFoundError e) {
                 // ignore
             }
         }


### PR DESCRIPTION
With #2830 we added support for 4.x of the Cassandra driver. It was done in a way to allow a user to use either the 3.x or 4.x driver while excluding the other one. However if using 4.x and excluding 3.x, GenericContainer#canBeReused throws an exception during reflection since the Cluster class returned by CassandraContainer#getCluster is missing.

This PR works around that issue by catching and ignoring the thrown NoClassDefFoundError.