### PR TITLE
Remove Transferable#of(java.lang.String,int) for japicmp

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -113,9 +113,3 @@ tasks.generatePomFileForMavenJavaPublication.finalizedBy(
         ]
     }
 )
-
-tasks.japicmp {
-    methodExcludes = [
-        "org.testcontainers.images.builder.Transferable#of(java.lang.String,int)"
-    ]
-}


### PR DESCRIPTION
`Transferable#of(java.lang.String,int)` was introduced in version
1.17.4. Current builds will check against 1.17.5 and binary
compatibility will be fine.
