### PR TITLE
Add support for flags in DatastoreEmulatorContainer

### DIFF
--- a/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
@@ -21,13 +21,32 @@ public class DatastoreEmulatorContainer extends GenericContainer<DatastoreEmulat
 
     private static final int HTTP_PORT = 8081;
 
+    private String additionalFlags;
+
+    public DatastoreEmulatorContainer(final String image) {
+        this(DockerImageName.parse(image));
+    }
+
     public DatastoreEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
         withExposedPorts(HTTP_PORT);
         setWaitStrategy(Wait.forHttp("/").forStatusCode(200));
-        withCommand("/bin/sh", "-c", CMD);
+    }
+
+    @Override
+    protected void configure() {
+        String command = CMD;
+        if (this.additionalFlags != null && !this.additionalFlags.isEmpty()) {
+            command += " " + this.additionalFlags;
+        }
+        withCommand("/bin/sh", "-c", command);
+    }
+
+    public DatastoreEmulatorContainer withAdditionalFlags(String flags) {
+        this.additionalFlags = flags;
+        return this;
     }
 
     /**
@@ -36,6 +55,6 @@ public class DatastoreEmulatorContainer extends GenericContainer<DatastoreEmulat
      * com.google.cloud.ServiceOptions.Builder#setHost(java.lang.String) method.
      */
     public String getEmulatorEndpoint() {
-        return getHost() + ":" + getMappedPort(8081);
+        return getHost() + ":" + getMappedPort(HTTP_PORT);
     }
 }

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
@@ -40,6 +40,20 @@ public class DatastoreEmulatorContainerTest {
 
         assertThat(datastore.get(key).getString("description")).isEqualTo("my description");
     }
+
     // }
 
+    @Test
+    public void testWithFlags() {
+        try (
+            DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
+                "gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators"
+            )
+                .withAdditionalFlags("--consistency 1.0")
+        ) {
+            emulator.start();
+
+            assertThat(emulator.getContainerInfo().getConfig().getCmd()).anyMatch(e -> e.contains("--consistency 1.0"));
+        }
+    }
 }


### PR DESCRIPTION
Datastore can start with additional flags such as `--consistency 1.0`
which is recommended for testing.
