### PR TITLE
Expose Redpanda schema registry

### DIFF
--- a/docs/modules/redpanda.md
+++ b/docs/modules/redpanda.md
@@ -19,6 +19,12 @@ Now your tests or any other process running on your machine can get access to ru
 [Bootstrap Servers](../../modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java) inside_block:getBootstrapServers
 <!--/codeinclude-->
 
+Redpanda also provides a schema registry implementation. Like the Redpanda broker, you can access by using the following schema registry location:
+
+<!--codeinclude-->
+[Schema Registry](../../modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java) inside_block:getSchemaRegistryAddress
+<!--/codeinclude-->
+
 ## Adding this module to your project dependencies
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -5,4 +5,5 @@ dependencies {
 
     testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'io.rest-assured:rest-assured:5.2.0'
 }

--- a/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
+++ b/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
@@ -18,6 +18,8 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
 
     private static final int REDPANDA_PORT = 9092;
 
+    private static final int SCHEMA_REGISTRY_PORT = 8081;
+
     private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
     public RedpandaContainer(String image) {
@@ -33,7 +35,7 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
             throw new IllegalArgumentException("Redpanda version must be >= v22.2.1");
         }
 
-        withExposedPorts(REDPANDA_PORT);
+        withExposedPorts(REDPANDA_PORT, SCHEMA_REGISTRY_PORT);
         withCreateContainerCmdModifier(cmd -> {
             cmd.withEntrypoint("sh");
         });
@@ -49,12 +51,17 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
 
         command += "/usr/bin/rpk redpanda start --mode dev-container ";
         command += "--kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 ";
-        command += "--advertise-kafka-addr PLAINTEXT://kafka:29092,OUTSIDE://" + getHost() + ":" + getMappedPort(9092);
+        command +=
+            "--advertise-kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://" + getHost() + ":" + getMappedPort(9092);
 
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
     }
 
     public String getBootstrapServers() {
         return String.format("PLAINTEXT://%s:%s", getHost(), getMappedPort(REDPANDA_PORT));
+    }
+
+    public String getSchemaRegistryAddress() {
+        return String.format("http://%s:%s", getHost(), getMappedPort(SCHEMA_REGISTRY_PORT));
     }
 }

--- a/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
+++ b/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
@@ -1,6 +1,7 @@
 package org.testcontainers.redpanda;
 
 import com.google.common.collect.ImmutableMap;
+import io.restassured.RestAssured;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -62,6 +63,21 @@ public class RedpandaContainerTest {
         assertThatThrownBy(() -> new RedpandaContainer("docker.redpanda.com/vectorized/redpanda:v21.11.19"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Redpanda version must be >= v22.2.1");
+    }
+
+    @Test
+    public void testSchemaRegistry() {
+        try (RedpandaContainer container = new RedpandaContainer(REDPANDA_DOCKER_IMAGE)) {
+            container.start();
+
+            io.restassured.response.Response response = RestAssured
+                .given()
+                .when()
+                .get(container.getSchemaRegistryAddress() + "/subjects")
+                .andReturn();
+
+            assertThat(response.getStatusCode()).isEqualTo(200);
+        }
     }
 
     private void testKafkaFunctionality(String bootstrapServers) throws Exception {

--- a/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
+++ b/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
@@ -80,7 +80,6 @@ public class RedpandaContainerTest {
 
             String subjectName = String.format("test-%s-value", UUID.randomUUID());
 
-            // register the new subject
             RestAssured
                 .given()
                 .contentType("application/vnd.schemaregistry.v1+json")
@@ -91,7 +90,6 @@ public class RedpandaContainerTest {
                 .then()
                 .statusCode(200);
 
-            // list all the registered subjects
             RestAssured.given().when().get(subjectsEndpoint).then().statusCode(200).body("$", hasItems(subjectName));
         }
     }

--- a/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
+++ b/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
@@ -70,13 +70,16 @@ public class RedpandaContainerTest {
         try (RedpandaContainer container = new RedpandaContainer(REDPANDA_DOCKER_IMAGE)) {
             container.start();
 
-            io.restassured.response.Response response = RestAssured
-                .given()
-                .when()
-                .get(container.getSchemaRegistryAddress() + "/subjects")
-                .andReturn();
+            String subjectsEndpoint = String.format(
+                "%s/subjects",
+                // getSchemaRegistryAddress {
+                container.getSchemaRegistryAddress()
+                // }
+            );
 
-            assertThat(response.getStatusCode()).isEqualTo(200);
+            io.restassured.response.Response subjects = RestAssured.given().when().get(subjectsEndpoint).andReturn();
+
+            assertThat(subjects.getStatusCode()).isEqualTo(200);
         }
     }
 


### PR DESCRIPTION
This change is intended to make the redpanda implementation of the schema registry easily available on test containers.

The schema registry port `8081` was added to the list of exposed ports and a supporting method `getSchemaRegistryAddress` was added to easily use for configuring `schema.registry.url` serializer configuration.

A minor change on the internal advertised address was made as the previous `kafka` alias was not available within the container and the panda proxy would get lost with the following message:
```
WARN  2022-10-17 19:08:37,176 [shard 0] kafka/client - broker.cc:52 - std::system_error: kafka: Not found
ERROR 2022-10-17 19:08:37,177 [shard 0] pandaproxy - service.cc:137 - Schema registry failed to initialize internal topic: kafka::client::broker_error ({ node: -1 }, { error_code: broker_not_available [8] })
```

Since this is only an internal advertised address and the `dev-container` is an alias to only one node, using 127.0.0.1 should not be an issue. An alternative approach for configuring the `kafka` alias within the container should work, any suggestion on configuring the internal container address lookup?

Also, a simple test to check if the registry is available is made. Please let me know if you feel like we should actually perform some schema registration.