### PR TITLE
Update toxiproxy image to ghcr.io/shopify/toxiproxy

### DIFF
--- a/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
+++ b/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
@@ -35,7 +35,7 @@ public class ToxiproxyTest {
         .withExposedPorts(6379)
         .withNetwork(network);
 
-    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("shopify/toxiproxy:2.1.0");
+    private static final DockerImageName TOXIPROXY_IMAGE = DockerImageName.parse("ghcr.io/shopify/toxiproxy:2.5.0");
 
     // Toxiproxy container, which will be used as a TCP proxy
     @Rule

--- a/modules/toxiproxy/src/test/resources/logback-test.xml
+++ b/modules/toxiproxy/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+</configuration>


### PR DESCRIPTION
`shopify/toxiproxy` has moved to `ghcr.io/shopify/toxiproxy`. Currently,
our tests are using the prior and is display as part of the documentation.
In order to keep our tests and docs up-to-date with latest images
we are updating the image. Also, we are adding the proper configuration
for logging in this module.
