### PR TITLE
Deprecate `setCustomContent` and `withCustomContent` at `NginxContainer`

### DIFF
--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -56,10 +56,12 @@ public class NginxContainer<SELF extends NginxContainer<SELF>>
         return new URL(scheme + "://" + getHost() + ":" + getMappedPort(port));
     }
 
+    @Deprecated
     public void setCustomContent(String htmlContentPath) {
         addFileSystemBind(htmlContentPath, "/usr/share/nginx/html", BindMode.READ_ONLY);
     }
 
+    @Deprecated
     public SELF withCustomContent(String htmlContentPath) {
         this.setCustomContent(htmlContentPath);
         return self();

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.testcontainers.containers.NginxContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 import java.io.*;
 import java.net.URL;
@@ -26,7 +27,7 @@ public class SimpleNginxTest {
     // creatingContainer {
     @Rule
     public NginxContainer<?> nginx = new NginxContainer<>(NGINX_IMAGE)
-        .withCustomContent(tmpDirectory)
+        .withCopyFileToContainer(MountableFile.forHostPath(tmpDirectory), "/usr/share/nginx/html")
         .waitingFor(new HttpWaitStrategy());
 
     // }


### PR DESCRIPTION
In order to make `NginxContainer` friendly with remote environments,
we should avoid the use of `addFileSystemBind`. Example has been updated
in order to show how to do it.
