### PR TITLE
Fix dependabot.yml ignore section

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -118,7 +118,7 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-        update-types: [ "version-update:semver-minor" ]
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   - package-ecosystem: "gradle"
     directory: "/modules/kafka"
     schedule:
@@ -202,7 +202,7 @@ updates:
     open-pull-requests-limit: 10
     ignore:
       - dependency-name: "io.r2dbc:r2dbc-spi"
-        versions: ["0.8.x"]
+        update-types: [ "version-update:semver-major", "version-update:semver-minor" ]
   - package-ecosystem: "gradle"
     directory: "/modules/rabbitmq"
     schedule:


### PR DESCRIPTION
Fix `ignore` for `r2dbc` and `k3s` modules.

* `r2dbc` for now should only rely on `0.8.x` due to `0.9.0` introduces
a breaking change.
* `k3s` should keep jackson version 2.8.8
