### PR TITLE
Using version discovery for mockserver container image based on client dependency

### DIFF
--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -11,15 +11,13 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class MockServerContainerRuleTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse(
-        "mockserver/mockserver:mockserver-5.14.0"
-    );
 
     // creatingProxy {
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver")
+        .withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion());
+
     @Rule
-    public MockServerContainer mockServer = new MockServerContainer(
-        MOCKSERVER_IMAGE.withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion())
-    );
+    public MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE);
 
     // }
 
@@ -27,19 +25,20 @@ public class MockServerContainerRuleTest {
     public void shouldReturnExpectation() throws Exception {
         // spotless:off
         // testSimpleExpectation {
-        new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
-            .when(request()
+        try(MockServerClient mockServerClient = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())) {
+            mockServerClient.when(request()
                 .withPath("/person")
                 .withQueryStringParameter("name", "peter"))
-            .respond(response()
-                .withBody("Peter the person!"));
+                .respond(response()
+                    .withBody("Peter the person!"));
 
-        // ...a GET request to '/person?name=peter' returns "Peter the person!"
-        // }
-        // spotless:on
+            // ...a GET request to '/person?name=peter' returns "Peter the person!"
+            // }
+            // spotless:on
 
-        assertThat(SimpleHttpClient.responseFromMockserver(mockServer, "/person?name=peter"))
-            .as("Expectation returns expected response body")
-            .contains("Peter the person");
+            assertThat(SimpleHttpClient.responseFromMockserver(mockServer, "/person?name=peter"))
+                .as("Expectation returns expected response body")
+                .contains("Peter the person");
+        }
     }
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -11,9 +11,9 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class MockServerContainerRuleTest {
 
-
     // creatingProxy {
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver")
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName
+        .parse("mockserver/mockserver")
         .withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion());
 
     @Rule

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerRuleTest.java
@@ -23,22 +23,20 @@ public class MockServerContainerRuleTest {
 
     @Test
     public void shouldReturnExpectation() throws Exception {
-        // spotless:off
         // testSimpleExpectation {
-        try(MockServerClient mockServerClient = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())) {
-            mockServerClient.when(request()
-                .withPath("/person")
-                .withQueryStringParameter("name", "peter"))
-                .respond(response()
-                    .withBody("Peter the person!"));
+        try (
+            MockServerClient mockServerClient = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
+        ) {
+            mockServerClient
+                .when(request().withPath("/person").withQueryStringParameter("name", "peter"))
+                .respond(response().withBody("Peter the person!"));
 
             // ...a GET request to '/person?name=peter' returns "Peter the person!"
-            // }
-            // spotless:on
 
             assertThat(SimpleHttpClient.responseFromMockserver(mockServer, "/person?name=peter"))
                 .as("Expectation returns expected response body")
                 .contains("Peter the person");
         }
+        // }
     }
 }

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -10,7 +10,8 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class MockServerContainerTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver")
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName
+        .parse("mockserver/mockserver")
         .withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion());
 
     @Test
@@ -20,7 +21,7 @@ public class MockServerContainerTest {
 
             String expectedBody = "Hello World!";
 
-            try(MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())) {
+            try (MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())) {
                 assertThat(client.hasStarted()).as("Mockserver running").isTrue();
 
                 client.when(request().withPath("/hello")).respond(response().withBody(expectedBody));

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -10,38 +10,31 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class MockServerContainerTest {
 
-    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse(
-        "mockserver/mockserver:mockserver-5.14.0"
-    );
+    public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName.parse("mockserver/mockserver")
+        .withTag("mockserver-" + MockServerClient.class.getPackage().getImplementationVersion());
 
     @Test
     public void shouldCallActualMockserverVersion() throws Exception {
-        String actualVersion = MockServerClient.class.getPackage().getImplementationVersion();
-        try (
-            MockServerContainer mockServer = new MockServerContainer(
-                MOCKSERVER_IMAGE.withTag("mockserver-" + actualVersion)
-            )
-        ) {
+        try (MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE)) {
             mockServer.start();
 
             String expectedBody = "Hello World!";
 
-            MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort());
+            try(MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())) {
+                assertThat(client.hasStarted()).as("Mockserver running").isTrue();
 
-            assertThat(client.isRunning()).as("Mockserver running").isTrue();
+                client.when(request().withPath("/hello")).respond(response().withBody(expectedBody));
 
-            client.when(request().withPath("/hello")).respond(response().withBody(expectedBody));
-
-            assertThat(SimpleHttpClient.responseFromMockserver(mockServer, "/hello"))
-                .as("MockServer returns correct result")
-                .isEqualTo(expectedBody);
+                assertThat(SimpleHttpClient.responseFromMockserver(mockServer, "/hello"))
+                    .as("MockServer returns correct result")
+                    .isEqualTo(expectedBody);
+            }
         }
     }
 
     @Test
     public void newVersionStartsWithDefaultWaitStrategy() {
-        DockerImageName dockerImageName = DockerImageName.parse("mockserver/mockserver:mockserver-5.14.0");
-        try (MockServerContainer mockServer = new MockServerContainer(dockerImageName)) {
+        try (MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE)) {
             mockServer.start();
         }
     }


### PR DESCRIPTION
While looking in the current documentation of the mockserver module I've noticed a constant which was not visible inside the documentation. So I had to take a look into the code. To make it more convenient I've added the complete mockserver version discovery based on client dependency to the documentation.

I've also fixed some places where a hard-coded image version was used. This would have caused problems when updating the mockserver client version inside the Gradle file. Now automatic dependency upgrades for the mockserver module should be possible without having to touch test code.