### PR TITLE
Update set-output command in workflows

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           TASKS=$(./gradlew --no-daemon --parallel -q testMatrix)
           echo $TASKS
-          echo "::set-output name=matrix::{\"gradle_args\":$TASKS}"
+          echo "matrix::{\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
   check:
     needs: find_gradle_jobs
     strategy:

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           TASKS=$(./gradlew --no-daemon --parallel -q testMatrix)
           echo $TASKS
-          echo "matrix::{\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
+          echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
   check:
     needs: find_gradle_jobs
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           TASKS=$(./gradlew --no-daemon --parallel -q testMatrix)
           echo $TASKS
-          echo "::set-output name=matrix::{\"gradle_args\":$TASKS}"
+          echo "name=matrix::{\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
   check:
     needs: [find_gradle_jobs]
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           TASKS=$(./gradlew --no-daemon --parallel -q testMatrix)
           echo $TASKS
-          echo "name=matrix::{\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
+          echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
   check:
     needs: [find_gradle_jobs]
     strategy:


### PR DESCRIPTION
`set-output` command has been deprecated and warning messages are
printed within the logs. See more [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
