### PR TITLE
Update gitlab_ci.md with clarifying note about the docker host port number

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
@@ -46,7 +46,7 @@ services:
     command: ["--tls=false"]
 
 variables:
-  # Instruct Testcontainers to use the daemon of DinD.
+  # Instruct Testcontainers to use the daemon of DinD, use port 2735 for non-tls connections.
   DOCKER_HOST: "tcp://docker:2375"
   # Instruct Docker not to start over TLS.
   DOCKER_TLS_CERTDIR: ""


### PR DESCRIPTION
Clarity around the port number for unencrypted docker host connections, as most gitlab DinD examples recommend 2736 without explaining why.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
