### PR TITLE
Improve ToxiProxyContainer test and docs

### DIFF
--- a/docs/modules/toxiproxy.md
+++ b/docs/modules/toxiproxy.md
@@ -32,16 +32,13 @@ We do this as follows:
 To establish a connection from the test code (on the host machine) to the target container via Toxiproxy, we obtain **Toxiproxy's** proxy host IP and port:
 
 <!--codeinclude-->
-[Obtaining proxied host and port for connections from the host machine](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForHostMachine
+[Obtaining proxied host and port](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForHostMachine
 <!--/codeinclude-->
 
 Code under test should connect to this proxied host IP and port.
 
-To establish a connection from a different container on the same network to the target container via Toxiproxy, we use **Toxiproxy's** network alias and original port:
-
-<!--codeinclude-->
-[Obtaining proxied host and port for connections from a different container](../../modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java) inside_block:obtainProxiedHostAndPortForDifferentContainer
-<!--/codeinclude-->
+!!! note
+    Currently, `ToxiProxyContainer` will reserve 31 ports, starting at 8666.
 
 Other containers should connect to this proxied host and port.
 

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -86,6 +86,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
      * @param port port number on the target service that should be proxied
      * @return a {@link ContainerProxy} instance
      */
+    @Deprecated
     public ContainerProxy getProxy(GenericContainer<?> container, int port) {
         return this.getProxy(container.getNetworkAliases().get(0), port);
     }
@@ -103,6 +104,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
      * @param port port number on the target server that should be proxied
      * @return a {@link ContainerProxy} instance
      */
+    @Deprecated
     public ContainerProxy getProxy(String hostname, int port) {
         String upstream = hostname + ":" + port;
 
@@ -126,6 +128,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
     }
 
     @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+    @Deprecated
     public static class ContainerProxy {
 
         private static final String CUT_CONNECTION_DOWNSTREAM = "CUT_CONNECTION_DOWNSTREAM";

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -85,6 +85,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
      * @param container target container
      * @param port port number on the target service that should be proxied
      * @return a {@link ContainerProxy} instance
+     * @deprecated {@link ToxiproxyContainer} will not build the client. Proxies should be provided manually.
      */
     @Deprecated
     public ContainerProxy getProxy(GenericContainer<?> container, int port) {
@@ -103,6 +104,7 @@ public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
      * @param hostname hostname of target server to be proxied
      * @param port port number on the target server that should be proxied
      * @return a {@link ContainerProxy} instance
+     * @deprecated {@link ToxiproxyContainer} will not build the client. Proxies should be provided manually.
      */
     @Deprecated
     public ContainerProxy getProxy(String hostname, int port) {


### PR DESCRIPTION
Current implementation exposed utilities to handle ToxiProxyClient
and proxies. However, there are some issues which demonstrate that
the container class is coupled to the client. Tests and docs have
been updated in order to promote the usage of its own ToxiProxyClient.
Also, a note about the number of ports reserved by Testcontainers
is added.
