### PR TITLE
Update docs to better reflect the links to other languages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,7 @@
 <!-- allow aspect ratio computation to reduce layout shift. CSS enforces max-width: 100% -->
 <img src="logo.png" alt="Testcontainers logo" width="1024" height="512"/>
 
-## Test dependencies as code for your entire stack
-Get lightweight and throwaway containers during your tests that let you test against any container image (database, broker, browser, etc..) using one of the several supported languages.
-
-
-<p align=center><strong>Select your language</strong></p>
+<p align=center><strong>Not using Java? Here are other supported languages!</strong></p>
 <div class="card-grid">
     <a class="card-grid-item"><img src="language-logos/java.svg"/>Java</a>
     <a href="https://golang.testcontainers.org/" class="card-grid-item"><img src="language-logos/go.svg"/>Go</a>
@@ -19,7 +15,7 @@ Get lightweight and throwaway containers during your tests that let you test aga
 
 ## About Testcontainers for Java
 
-*Testcontainers for Java* is a Java library that supports the usage in JUnit tests and other popular test frameworks.
+Testcontainers is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 
 Testcontainers make the following kinds of tests easier:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,9 @@ Get lightweight and throwaway containers during your tests that let you test aga
     <a href="https://docs.rs/testcontainers/latest/testcontainers/" class="card-grid-item"><img src="language-logos/rust.svg"/>Rust</a>
 </div>
 
-## About
+## About Testcontainers for Java
 
-Testcontainers is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
+*Testcontainers for Java* is a Java library that supports the usage in JUnit tests and other popular test frameworks.
 
 Testcontainers make the following kinds of tests easier:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,7 +9,7 @@
     <a href="https://golang.testcontainers.org/" class="card-grid-item"><img src="language-logos/go.svg"/>Go</a>
     <a href="https://dotnet.testcontainers.org/" class="card-grid-item"><img src="language-logos/dotnet.svg"/>.NET</a>
     <a href="https://testcontainers-python.readthedocs.io/en/latest/" class="card-grid-item"><img src="language-logos/python.svg"/>Python</a>
-    <a href="https://github.com/testcontainers/testcontainers-node" class="card-grid-item"><img src="language-logos/javascript.svg"/>JavaScript<wbr>/Node.js</a>
+    <a href="https://github.com/testcontainers/testcontainers-node" class="card-grid-item"><img src="language-logos/javascript.svg"/><span>JavaScript<wbr>/Node.js</span></a>
     <a href="https://docs.rs/testcontainers/latest/testcontainers/" class="card-grid-item"><img src="language-logos/rust.svg"/>Rust</a>
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@
 
 ## About Testcontainers for Java
 
-Testcontainers is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
+*Testcontainers for Java* is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 
 Testcontainers make the following kinds of tests easier:
 

--- a/docs/supported_languages.md
+++ b/docs/supported_languages.md
@@ -1,9 +1,0 @@
-# Other Supported Languages
-
-Besides *Testcontainers for Java,* you can find Testcontainers implementations for many other languages.
-Please note that not all features that are available in *Testcontainers for Java* might be available in the implementations for other languages yet.
-
-* [Go](https://golang.testcontainers.org/)
-* [.Net](https://github.com/testcontainers/testcontainers-dotnet)
-* [Python](https://testcontainers-python.readthedocs.io/)
-* [JavaScript/NodeJS](https://github.com/testcontainers/testcontainers-node)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Testcontainers
+site_name: Testcontainers for Java
 plugins:
     - search
     - codeinclude
@@ -104,7 +104,6 @@ nav:
           - supported_docker_environment/windows.md
           - supported_docker_environment/logging_config.md
           - supported_docker_environment/image_registry_rate_limiting.md
-    - Other Supported Languages: supported_languages.md
     - Getting help: getting_help.md
     - Contributing:
           - contributing.md


### PR DESCRIPTION
As a follow-up to #6067, this PR changes the docs to make it more clear when a section references the Testcontainers project in general, and when it references Testcontainers for Java in particular. 

It also removes the `Other Supported Languages` sub-page, since this function is now fulfilled by the logo grid. 