### PR TITLE
make postgres wait for both log message and port

### DIFF
--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -1,7 +1,8 @@
 package org.testcontainers.containers;
 
 import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
@@ -52,9 +53,9 @@ public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
         this.waitStrategy =
-            new LogMessageWaitStrategy()
-                .withRegEx(".*database system is ready to accept connections.*\\s")
-                .withTimes(2)
+            new WaitAllStrategy()
+                .withStrategy(Wait.forListeningPort())
+                .withStrategy(Wait.forLogMessage(".*database system is ready to accept connections.*\\s", 2))
                 .withStartupTimeout(Duration.of(60, ChronoUnit.SECONDS));
         this.setCommand("postgres", "-c", FSYNC_OFF_OPTION);
 


### PR DESCRIPTION
When using the postgres container with colima I can reproduce that the first test fails to connect to the database. Additionally waiting for the port fixed the issue for me.

My environment:
M1 MacBook Pro
macOS Monterey 12.6.1
❯ colima version
colima version 0.4.6
git commit: 10377f3a20c2b0f7196ad5944264b69f048a3d40

runtime: docker
arch: aarch64
client: v20.10.21
server: v20.10.18