### PR TITLE
Ignore updates for org.neo4j:neo4j

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -165,6 +165,8 @@ updates:
     ignore:
       - dependency-name: "org.neo4j.driver:neo4j-java-driver"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "org.neo4j:neo4j"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "gradle"
     directory: "/modules/nginx"
     schedule:


### PR DESCRIPTION
`org.neo4j:neo4j` requires JDK 17. For that reason, we are skipping
major version updates.
