### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.11
         continue-on-error: true
         with:
           path: ~/.gradle/caches
@@ -53,7 +53,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.11
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.11
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
@@ -51,7 +51,7 @@ jobs:
           java-version: '8.0.302'
           distribution: temurin
       - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.9
+        uses: actions/cache@v3.0.11
         continue-on-error: true
         with:
           path: ~/.gradle/caches

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@df69d584deac33d8569990cb6413f82447181076 # v5.19.0
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -23,4 +23,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies
 
-      - uses: gradle/wrapper-validation-action@e6e38bacfdf1a337459f332974bb2327a31aaf4b # v1.0.3
+      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1.0.3

--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ subprojects {
     }
 
     dependencies {
-        testImplementation 'ch.qos.logback:logback-classic:1.3.3'
+        testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     }
 
     checkstyle {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testCompileOnly 'org.jetbrains:annotations:23.0.0'
-    api 'org.apache.commons:commons-compress:1.21'
+    api 'org.apache.commons:commons-compress:1.22'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
-    testImplementation ('org.mockito:mockito-core:4.8.0') {
+    testImplementation ('org.mockito:mockito-core:4.8.1') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation project(":selenium")
     testImplementation project(":mysql")
 
-    testImplementation 'mysql:mysql-connector-java:8.0.21'
+    testImplementation 'mysql:mysql-connector-java:8.0.31'
     testImplementation "org.seleniumhq.selenium:selenium-api:3.141.59"
     testImplementation 'org.assertj:assertj-core:3.15.0'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api "io.lettuce:lettuce-core:5.1.1.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.2"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.4.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.4.2"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -7,5 +7,5 @@ dependencies {
     api "io.lettuce:lettuce-core:5.2.0.RELEASE"
     testImplementation 'org.spockframework:spock-core:1.2-groovy-2.5'
     testImplementation project(":spock")
-    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
 }

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:7.8.0'
+    testImplementation 'io.cucumber:cucumber-java:7.9.0'
     testImplementation 'io.cucumber:cucumber-junit:7.8.0'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.24"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.24"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
     testImplementation 'org.postgresql:postgresql:42.5.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     testImplementation 'org.testng:testng:7.5'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.3.3'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.24"
     annotationProcessor "org.projectlombok:lombok:1.18.24"
 
-    implementation 'org.apache.solr:solr-solrj:8.11.1'
+    implementation 'org.apache.solr:solr-solrj:8.11.2'
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.3.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.2.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.37.0'
+    testImplementation 'com.azure:azure-cosmos:4.38.1'
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: Cassandra"
 
 configurations.all {
     resolutionStrategy {
-        force 'io.dropwizard.metrics:metrics-core:3.2.4'
+        force 'io.dropwizard.metrics:metrics-core:3.2.6'
     }
 }
 

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.ibm.db2:jcc:11.5.7.0'
+    testImplementation 'com.ibm.db2:jcc:11.5.8.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.314'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.333'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.314'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.4.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.0"
     testImplementation "org.elasticsearch.client:transport:7.17.6"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.5.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.18'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.31.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.13.0'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.15.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.11.4'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.12.3'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.5.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.18'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.31.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.3'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.5.0'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.18'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.24'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.31.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.15.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.9.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
-    testImplementation("ch.qos.logback:logback-classic:1.4.3")
+    testImplementation("ch.qos.logback:logback-classic:1.4.4")
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     shaded("org.apache.commons:commons-lang3:3.12.0")
     shaded("commons-io:commons-io:2.11.0")
-    shaded("org.javassist:javassist:3.29.0-GA")
+    shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.2")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     api 'org.assertj:assertj-core:3.23.1'
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.23'
+    api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.30'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.0'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation ('org.mockito:mockito-core:4.8.0') {
+    testImplementation ('org.mockito:mockito-core:4.8.1') {
         exclude(module: 'hamcrest-core')
     }
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.0'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.1'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation ('org.mockito:mockito-core:4.8.1') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
 }
 

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.2.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.8.0') {
+    testImplementation ('org.mockito:mockito-core:4.8.1') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.2.3'
+    testImplementation 'redis.clients:jedis:4.3.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     testImplementation ('org.mockito:mockito-core:4.8.1') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.1.1'
-    testImplementation 'io.kubernetes:client-java:16.0.0'
+    testImplementation 'io.kubernetes:client-java:16.0.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.314'
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.313'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.333'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.333'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.314'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.314'
     testImplementation 'software.amazon.awssdk:s3:2.17.285'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.333'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.314'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.314'
-    testImplementation 'software.amazon.awssdk:s3:2.17.285'
+    testImplementation 'software.amazon.awssdk:s3:2.18.7'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.7.1")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.7.2")
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.30'
+    testImplementation 'mysql:mysql-connector-java:8.0.31'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.10.1'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.10.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.1'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.5.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.questdb:questdb:6.4.3-jdk8'
+    testImplementation 'org.questdb:questdb:6.5.4-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.23'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.24'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'org.apache.solr:solr-solrj:8.11.1'
+    testImplementation 'org.apache.solr:solr-solrj:8.11.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.30'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'
 
     testCompileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.30'
+    testImplementation 'mysql:mysql-connector-java:8.0.31'
 
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:398'
+    testImplementation 'io.trino:trino-jdbc:401'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.3"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.1"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump questdb from 6.4.3-jdk8 to 6.5.4-jdk8 in /modules/questdb (#6111) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.11.1 to 3.11.3 (#6110) @dependabot
* Bump google-cloud-datastore from 2.11.4 to 2.12.3 in /modules/gcloud (#6109) @dependabot
* Bump google-cloud-bigtable from 2.13.0 to 2.15.0 in /modules/gcloud (#6108) @dependabot
* Bump google-cloud-spanner from 6.31.0 to 6.32.0 in /modules/gcloud (#6107) @dependabot
* Bump azure-cosmos from 4.37.0 to 4.38.1 in /modules/azure (#6105) @dependabot
* Bump google-cloud-pubsub from 1.120.18 to 1.120.24 in /modules/gcloud (#6104) @dependabot
* Bump jcc from 11.5.7.0 to 11.5.8.0 in /modules/db2 (#6103) @dependabot
* Bump trino-jdbc from 398 to 401 in /modules/trino (#6102) @dependabot
* Bump mockito-core from 4.8.0 to 4.8.1 in /core (#6101) @dependabot
* Bump commons-compress from 1.21 to 1.22 in /core (#6100) @dependabot
* Bump cucumber-java from 7.8.0 to 7.9.0 in /examples (#6099) @dependabot
* Bump cucumber-junit from 7.8.0 to 7.9.0 in /examples (#6098) @dependabot
* Bump gradle/wrapper-validation-action from 1.0.4 to 1.0.5 (#6096) @dependabot
* Bump aws-java-sdk-s3 from 1.12.314 to 1.12.333 in /modules/localstack (#6095) @dependabot
* Bump s3 from 2.17.285 to 2.18.7 in /modules/localstack (#6094) @dependabot
* Bump aws-java-sdk-sqs from 1.12.314 to 1.12.333 in /modules/localstack (#6093) @dependabot
* Bump mockito-core from 4.8.0 to 4.8.1 in /modules/jdbc (#6091) @dependabot
* Bump elasticsearch-rest-client from 8.4.2 to 8.5.0 in /modules/elasticsearch (#6090) @dependabot
* Bump mockito-core from 4.8.0 to 4.8.1 in /modules/junit-jupiter (#6089) @dependabot
* Bump transport from 7.17.6 to 7.17.7 in /modules/elasticsearch (#6087) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.314 to 1.12.333 in /modules/dynalite (#6086) @dependabot
* Bump client-java from 16.0.0 to 16.0.1 in /modules/k3s (#6050) @dependabot
* Bump junit-jupiter-params from 5.4.2 to 5.9.1 in /examples (#6042) @dependabot
* Bump release-drafter/release-drafter from 5.21.0 to 5.21.1 (#6040) @dependabot
* Bump junit-jupiter-engine from 5.4.2 to 5.9.1 in /examples (#6038) @dependabot
* Bump logback-classic from 1.3.3 to 1.3.4 in /examples (#6034) @dependabot
* Bump actions/cache from 3.0.9 to 3.0.11 (#6033) @dependabot
* Bump pulsar-client from 2.10.1 to 2.10.2 in /modules/pulsar (#6032) @dependabot
* Bump mysql-connector-java from 8.0.21 to 8.0.31 in /examples (#6030) @dependabot
* Bump mysql-connector-java from 8.0.30 to 8.0.31 in /modules/tidb (#6025) @dependabot
* Bump logback-classic from 1.4.3 to 1.4.4 in /modules/hivemq (#6022) @dependabot
* Bump kubernetes-client from 6.1.1 to 6.2.0 in /modules/k3s (#6019) @dependabot
* Bump mysql-connector-java from 8.0.30 to 8.0.31 in /modules/junit-jupiter (#6016) @dependabot
* Bump reactor-core from 3.4.23 to 3.4.24 in /modules/r2dbc (#6015) @dependabot
* Bump mysql-connector-java from 8.0.30 to 8.0.31 in /modules/spock (#6014) @dependabot
* Bump jedis from 4.2.3 to 4.3.1 in /modules/junit-jupiter (#6012) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.8.1 to 1.8.2 (#6010) @dependabot
* Bump tomcat-jdbc from 10.0.23 to 10.0.27 in /modules/jdbc-test (#6004) @dependabot
* Bump mysql-connector-java from 8.0.30 to 8.0.31 in /modules/mysql (#6008) @dependabot
* Bump tomcat-jdbc from 10.1.0 to 10.1.1 in /modules/jdbc (#6007) @dependabot
* Bump kafka-clients from 3.3.0 to 3.3.1 in /examples (#5972) @dependabot
* Bump solr-solrj from 8.11.1 to 8.11.2 in /examples (#5969) @dependabot
* Bump solr-solrj from 8.11.1 to 8.11.2 in /modules/solr (#5968) @dependabot
* Bump actions/cache from 3.0.9 to 3.0.10 (#5967) @dependabot
* Bump metrics-core from 3.2.4 to 3.2.6 in /modules/cassandra (#5958) @dependabot
* Bump mongodb-driver-sync from 4.7.1 to 4.7.2 in /modules/mongodb (#5957) @dependabot
* Bump kafka-clients from 3.3.0 to 3.3.1 in /modules/kafka (#5952) @dependabot
* Bump javassist from 3.29.0-GA to 3.29.2-GA in /modules/hivemq (#5947) @dependabot
