### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@671dc9c9e0c2d73f07fa45a3eb0220e1622f0c5f # v3.10.1
+        uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     shaded 'org.zeroturnaround:zt-exec:1.12'
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:4.2.3'
+    testImplementation 'redis.clients:jedis:4.3.1'
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.4.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.1"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 dependencies {
     api "io.lettuce:lettuce-core:5.2.0.RELEASE"
-    testImplementation 'org.spockframework:spock-core:1.2-groovy-2.5'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.1"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.3"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.1"
     }
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.3.4'
+    testImplementation 'com.couchbase.client:java-client:3.4.0'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.3'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.5.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.24'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.31.0'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.15.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -13,5 +13,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.30'
+    api 'mysql:mysql-connector-java:8.0.31'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.1.1'
+    testImplementation 'io.fabric8:kubernetes-client:6.2.0'
     testImplementation 'io.kubernetes:client-java:16.0.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.333'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.333'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.314'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.333'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.314'
     testImplementation 'software.amazon.awssdk:s3:2.18.7'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.10.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.1'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.2'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Redpanda"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'io.rest-assured:rest-assured:5.2.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.3"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.1"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.2"
     }
 }
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump google-cloud-spanner from 6.31.0 to 6.32.0 in /modules/gcloud (#6107) @dependabot
* Bump google-cloud-firestore from 3.5.0 to 3.7.0 in /modules/gcloud (#6106) @dependabot
* Bump com.gradle.enterprise.gradle.plugin from 3.11.1 to 3.11.3 in /examples (#6097) @dependabot
* Bump aws-java-sdk-sqs from 1.12.314 to 1.12.333 in /modules/localstack (#6093) @dependabot
* Bump aws-java-sdk-logs from 1.12.314 to 1.12.333 in /modules/localstack (#6092) @dependabot
* Bump java-client from 3.3.4 to 3.4.0 in /modules/couchbase (#6088) @dependabot
* Bump spock-core from 1.2-groovy-2.5 to 2.3-groovy-4.0 in /examples (#6043) @dependabot
* Bump junit-jupiter-engine from 5.4.2 to 5.9.1 in /examples (#6038) @dependabot
* Bump peter-evans/create-pull-request from 4.1.3 to 4.2.0 (#6035) @dependabot
* Bump pulsar-client-admin from 2.10.1 to 2.10.2 in /modules/pulsar (#6020) @dependabot
* Bump kubernetes-client from 6.1.1 to 6.2.0 in /modules/k3s (#6019) @dependabot
* Bump jedis from 4.2.3 to 4.3.1 in /core (#6009) @dependabot
* Bump common-custom-user-data-gradle-plugin from 1.8.1 to 1.8.2 (#6010) @dependabot
* Bump mysql-connector-java from 8.0.30 to 8.0.31 in /modules/jdbc-test (#6003) @dependabot
* Bump kafka-clients from 3.3.0 to 3.3.1 in /modules/redpanda (#5965) @dependabot
