### PR TITLE
Use `gradle/gradle-build-action`

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -52,6 +52,8 @@ jobs:
         run: docker image prune -af
       - name: Setup Gradle Build Action
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-cleanup: true
       - name: Build and test Examples with Gradle (${{matrix.gradle_args}})
         working-directory: ./examples/
         run: |

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -24,12 +24,8 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.11
-        continue-on-error: true
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-testmatrix-examples-${{ hashFiles('**/*.gradle') }}
+      - name: Setup Gradle Build Action
+        uses: gradle/gradle-build-action@v2
       - id: set-matrix
         working-directory: ./examples/
         env:
@@ -52,14 +48,10 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.11
-        continue-on-error: true
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-examples-${{matrix.gradle_args}}_check-${{ hashFiles('**/*.gradle') }}
       - name: Clear existing docker image cache
         run: docker image prune -af
+      - name: Setup Gradle Build Action
+        uses: gradle/gradle-build-action@v2
       - name: Build and test Examples with Gradle (${{matrix.gradle_args}})
         working-directory: ./examples/
         run: |

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -33,5 +33,7 @@ jobs:
           PATH=$HOME/bin:$PATH dockerd-rootless.sh --experimental --storage-driver vfs &
           sleep 1
           DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock docker info || ls -la $XDG_RUNTIME_DIR
+      - name: Setup Gradle Build Action
+        uses: gradle/gradle-build-action@v2
       - name: Build with Gradle
         run: ./gradlew --no-daemon --scan testcontainers:test --tests '*GenericContainerRuleTest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,8 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.11
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-testmatrix-${{ hashFiles('**/*.gradle') }}
+      - name: Setup Gradle Build Action
+        uses: gradle/gradle-build-action@v2
       - id: set-matrix
         env:
           # Since we override the tests executor,
@@ -50,14 +47,16 @@ jobs:
         with:
           java-version: '8.0.302'
           distribution: temurin
-      - name: Cache Gradle Home files
-        uses: actions/cache@v3.0.11
-        continue-on-error: true
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-home-${{matrix.gradle_args}}_check-${{ hashFiles('**/*.gradle') }}
       - name: Clear existing docker image cache
         run: docker image prune -af
+      - name: Setup Gradle Build Action
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-home-cache-includes: |
+            caches
+            notifications
+            jdks
+          gradle-home-cache-cleanup: true
       - name: Build and test with Gradle (${{matrix.gradle_args}})
         run: |
           ./gradlew --no-daemon --continue --scan ${{matrix.gradle_args}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Clear existing docker image cache
         run: docker image prune -af
 
+      - name: Setup Gradle Build Action
+        uses: gradle/gradle-build-action@v2
+
       - name: Run Gradle Build
         run: ./gradlew build --scan --no-daemon -i -x test
 


### PR DESCRIPTION
Those are the enefits we can get from the action and our current usage:
* Efficient cache
* Summary report
* Capture of build scan links
