### PR TITLE
Add lang and version labels to containers

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,6 +10,12 @@ test.maxParallelForks = 4
 
 idea.module.testSourceDirs += sourceSets.jarFileTest.allSource.srcDirs
 
+jar {
+    manifest {
+        attributes('Implementation-Version': project.getProperty("version"))
+    }
+}
+
 shadowJar {
     [
         'META-INF/NOTICE',

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -70,8 +70,8 @@ public class DockerClientFactory {
 
         Map<String, String> labels = new HashMap<>();
         labels.put(TESTCONTAINERS_LABEL, "true");
-        labels.put(DockerClientFactory.TESTCONTAINERS_LANG_LABEL, "java");
-        labels.put(DockerClientFactory.TESTCONTAINERS_VERSION_LABEL, testcontainersVersion);
+        labels.put(TESTCONTAINERS_LANG_LABEL, "java");
+        labels.put(TESTCONTAINERS_VERSION_LABEL, testcontainersVersion);
         return Collections.unmodifiableMap(labels);
     }
 

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -13,7 +13,6 @@ import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.api.model.Version;
 import com.github.dockerjava.api.model.Volume;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import lombok.Synchronized;
@@ -34,6 +33,7 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +62,19 @@ public class DockerClientFactory {
 
     public static final String SESSION_ID = UUID.randomUUID().toString();
 
-    public static final Map<String, String> DEFAULT_LABELS = ImmutableMap.of(TESTCONTAINERS_LABEL, "true");
+    public static final Map<String, String> DEFAULT_LABELS = markerLabels();
+
+    static Map<String, String> markerLabels() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(TESTCONTAINERS_LABEL, "true");
+        labels.put(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL, DockerClientFactory.SESSION_ID);
+        labels.put(DockerClientFactory.TESTCONTAINERS_LANG_LABEL, "java");
+        labels.put(
+            DockerClientFactory.TESTCONTAINERS_VERSION_LABEL,
+            ResourceReaper.class.getPackage().getImplementationVersion()
+        );
+        return Collections.unmodifiableMap(labels);
+    }
 
     private static final DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.16");
 

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -67,7 +67,6 @@ public class DockerClientFactory {
     static Map<String, String> markerLabels() {
         Map<String, String> labels = new HashMap<>();
         labels.put(TESTCONTAINERS_LABEL, "true");
-        labels.put(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL, DockerClientFactory.SESSION_ID);
         labels.put(DockerClientFactory.TESTCONTAINERS_LANG_LABEL, "java");
         labels.put(
             DockerClientFactory.TESTCONTAINERS_VERSION_LABEL,

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -56,6 +56,10 @@ public class DockerClientFactory {
 
     public static final String TESTCONTAINERS_SESSION_ID_LABEL = TESTCONTAINERS_LABEL + ".sessionId";
 
+    public static final String TESTCONTAINERS_LANG_LABEL = TESTCONTAINERS_LABEL + ".lang";
+
+    public static final String TESTCONTAINERS_VERSION_LABEL = TESTCONTAINERS_LABEL + ".version";
+
     public static final String SESSION_ID = UUID.randomUUID().toString();
 
     public static final Map<String, String> DEFAULT_LABELS = ImmutableMap.of(TESTCONTAINERS_LABEL, "true");

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -65,13 +65,13 @@ public class DockerClientFactory {
     public static final Map<String, String> DEFAULT_LABELS = markerLabels();
 
     static Map<String, String> markerLabels() {
+        String implementationVersion = ResourceReaper.class.getPackage().getImplementationVersion();
+        String testcontainersVersion = implementationVersion == null ? "unspecified" : implementationVersion;
+
         Map<String, String> labels = new HashMap<>();
         labels.put(TESTCONTAINERS_LABEL, "true");
         labels.put(DockerClientFactory.TESTCONTAINERS_LANG_LABEL, "java");
-        labels.put(
-            DockerClientFactory.TESTCONTAINERS_VERSION_LABEL,
-            ResourceReaper.class.getPackage().getImplementationVersion()
-        );
+        labels.put(DockerClientFactory.TESTCONTAINERS_VERSION_LABEL, testcontainersVersion);
         return Collections.unmodifiableMap(labels);
     }
 

--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -65,7 +65,7 @@ public class DockerClientFactory {
     public static final Map<String, String> DEFAULT_LABELS = markerLabels();
 
     static Map<String, String> markerLabels() {
-        String implementationVersion = ResourceReaper.class.getPackage().getImplementationVersion();
+        String implementationVersion = DockerClientFactory.class.getPackage().getImplementationVersion();
         String testcontainersVersion = implementationVersion == null ? "unspecified" : implementationVersion;
 
         Map<String, String> labels = new HashMap<>();

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -25,7 +25,6 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,18 +41,10 @@ public class ResourceReaper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceReaper.class);
 
-    private static final Map<String, String> MARKER_LABELS = markerLabels();
-
-    static Map<String, String> markerLabels() {
-        Map<String, String> labels = new HashMap<>();
-        labels.put(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL, DockerClientFactory.SESSION_ID);
-        labels.put(DockerClientFactory.TESTCONTAINERS_LANG_LABEL, "java");
-        labels.put(
-            DockerClientFactory.TESTCONTAINERS_VERSION_LABEL,
-            ResourceReaper.class.getPackage().getImplementationVersion()
-        );
-        return Collections.unmodifiableMap(labels);
-    }
+    private static final Map<String, String> MARKER_LABELS = Collections.singletonMap(
+        DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL,
+        DockerClientFactory.SESSION_ID
+    );
 
     static final List<List<Map.Entry<String, String>>> DEATH_NOTE = new ArrayList<>(
         Arrays.asList(

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -25,6 +25,7 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,10 +42,18 @@ public class ResourceReaper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ResourceReaper.class);
 
-    private static final Map<String, String> MARKER_LABELS = Collections.singletonMap(
-        DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL,
-        DockerClientFactory.SESSION_ID
-    );
+    private static final Map<String, String> MARKER_LABELS = markerLabels();
+
+    static Map<String, String> markerLabels() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL, DockerClientFactory.SESSION_ID);
+        labels.put(DockerClientFactory.TESTCONTAINERS_LANG_LABEL, "java");
+        labels.put(
+            DockerClientFactory.TESTCONTAINERS_VERSION_LABEL,
+            ResourceReaper.class.getPackage().getImplementationVersion()
+        );
+        return Collections.unmodifiableMap(labels);
+    }
 
     static final List<List<Map.Entry<String, String>>> DEATH_NOTE = new ArrayList<>(
         Arrays.asList(

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -269,6 +269,13 @@ public class GenericContainerRuleTest {
 
             Map<String, String> labels = alpineCustomLabel.getCurrentContainerInfo().getConfig().getLabels();
             assertThat(labels).as("org.testcontainers label is present").containsKey("org.testcontainers");
+            assertThat(labels).as("org.testcontainers.lang label is present").containsKey("org.testcontainers.lang");
+            assertThat(labels)
+                .as("org.testcontainers.lang label is present")
+                .containsEntry("org.testcontainers.lang", "java");
+            assertThat(labels)
+                .as("org.testcontainers.version label is present")
+                .containsKey("org.testcontainers.version");
             assertThat(labels).as("our.custom label is present").containsKey("our.custom");
             assertThat(labels).as("our.custom label value is label").containsEntry("our.custom", "label");
         }


### PR DESCRIPTION
The following labels are added `org.testcontainers.lang` and
`org.testcontainers.version`. Those are good identifiers when debugging
and sharing logs.
