### PR TITLE
Fail on nonexistent MountableFile

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -17,6 +17,7 @@ import org.testcontainers.UnstableAPI;
 import org.testcontainers.images.builder.Transferable;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -352,6 +353,9 @@ public class MountableFile implements Transferable {
                 tarEntryFilename = entryFilename + "/" + relativePathToSourceFile; // entry filename e.g. /xyz/bar/baz => /foo/bar/baz
             }
 
+            if (!sourceFile.exists()) {
+                throw new UncheckedIOException(new FileNotFoundException("File not found: " + sourceFile));
+            }
             final TarArchiveEntry tarEntry = new TarArchiveEntry(sourceFile, tarEntryFilename.replaceAll("^/", ""));
 
             // TarArchiveEntry automatically sets the mode for file/directory, but we can update to ensure that the mode is set exactly (inc executable bits)

--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -10,12 +10,14 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatRuntimeException;
 
 public class MountableFileTest {
 
@@ -85,6 +87,16 @@ public class MountableFileTest {
         assertThat(mountableFile.getResolvedPath())
             .as("The resolved path does not contain an escaped space")
             .doesNotContain(" ");
+    }
+
+    @Test
+    public void forHostPathWithNonexistentFile() throws Exception {
+        final MountableFile mountableFile = MountableFile.forHostPath("does-not-exist.txt");
+
+        assertThatRuntimeException()
+            .isThrownBy(() -> intoTarArchive(taos -> mountableFile.transferTo(taos, "path.txt")))
+            .withRootCauseInstanceOf(FileNotFoundException.class)
+            .withMessageContaining("does-not-exist.txt");
     }
 
     @Test


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

`MountableFile.transferTo` creates an empty file in the container when the source file doesn't
exist. This change fixes that.
