### PR TITLE
Remove "Starting an elasticsearch container" message in constructor

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -96,7 +96,6 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DEFAULT_OSS_IMAGE_NAME);
         this.isOss = dockerImageName.isCompatibleWith(DEFAULT_OSS_IMAGE_NAME);
 
-        logger().info("Starting an elasticsearch container using [{}]", dockerImageName);
         withNetworkAliases("elasticsearch-" + Base58.randomString(6));
         withEnv("discovery.type", "single-node");
         // Sets default memory of elasticsearch instance to 2GB


### PR DESCRIPTION
At this point in the constructor, we are not actually starting Elasticsearch, so this message can lead to confusion (it did for me, leading me to dig into it). I didn't find any of the other org.testcontainers container classes that output a message like this in their constructor.

When the container is actually started, we still get a log message from GenericContainer, anyway, so I think we can just safely delete this log line, which is what this PR does.

Notice line 8 where we have `Starting an elasticsearch container`:
```
...
20:37:40.568 [main] INFO  🐳 [testcontainers/ryuk:0.3.4] - Creating container for image: testcontainers/ryuk:0.3.4
20:37:41.040 [main] INFO  org.testcontainers.utility.RegistryAuthLocator - Credential helper/store (docker-credential-desktop) does not have credentials for https://index.docker.io/v1/
20:37:49.798 [main] INFO  🐳 [testcontainers/ryuk:0.3.4] - Container testcontainers/ryuk:0.3.4 is starting: 7201de8310b1f5870622b4070203ccf609a9a6a550ab3bfb682193c9f1fe7424
20:38:08.714 [main] INFO  🐳 [testcontainers/ryuk:0.3.4] - Container testcontainers/ryuk:0.3.4 started in PT28.516627S
20:38:08.729 [main] INFO  org.testcontainers.utility.RyukResourceReaper - Ryuk started - will monitor and terminate Testcontainers containers on JVM exit
20:38:08.730 [main] INFO  org.testcontainers.DockerClientFactory - Checking the system...
20:38:08.732 [main] INFO  org.testcontainers.DockerClientFactory - ✔︎ Docker server version should be at least 1.6.0
20:38:08.732 [main] INFO  🐳 [docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2] - Starting an elasticsearch container using [docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.2]
20:38:08.824 [main] INFO  🐳 [postgres:10.7-alpine] - Creating container for image: postgres:10.7-alpine
20:38:12.712 [main] INFO  🐳 [postgres:10.7-alpine] - Container postgres:10.7-alpine is starting: f1a9cd20285eea9cc684b76a44916a35e5c9715e787773895f49c164b1a1baa2
20:38:43.861 [main] INFO  🐳 [postgres:10.7-alpine] - Container postgres:10.7-alpine started in PT35.03724S
20:38:44.015 [main] INFO  🐳 [horizon:latest] - Creating container for image: horizon:latest
20:39:44.261 [main] INFO  🐳 [horizon:latest] - Container horizon:latest is starting: 73913f424c20e78c297033c9674286f9659ea87ce124ee08e2c29a9e7cb49a9f
20:39:55.601 [main] INFO  org.opennms.smoketest.containers.OpenNMSContainer - Waiting for startup to begin.
...
```

I can confirm that no Elasticsearch container has been created f I look at recently-created containers while the test is running. I don't see Elasticsearch, but I do see the other containers listed in the output above (and that I expect to see in this case): `ryuk`, `postgres`, and OpenNMS `horizon`.
```
CONTAINER ID   IMAGE                                 COMMAND                  CREATED
73913f424c20   horizon:latest                        "/entrypoint.sh -s"      6 minutes ago
f1a9cd20285e   postgres:10.7-alpine                  "docker-entrypoint.s…"   8 minutes ago
7201de8310b1   testcontainers/ryuk:0.3.4             "/app"                   8 minutes ago
```

In our case, this happens because of the log message in the `ElasticsearchContainer` constructor, and also our smoke test `OpenNMSStack` infrastructure that pre-defines a number of container stacks that we use in tests, one of which called `ALEC` includes Elasticsearch ([code](https://github.com/OpenNMS/opennms/blob/develop/smoke-test/src/main/java/org/opennms/smoketest/stacks/OpenNMSStack.java#L86)). However in the test output I showed above, it wasn't the `ALEC` stack that was being used--an `ElasticsearchContainer` object was instantiated, but the container was never actually created or started in this case.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
