### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'me.champeau.gradle.japicmp' version '0.2.9' apply false
     id 'com.diffplug.spotless' version '6.8.0' apply false
-    id 'org.gradle.test-retry' version '1.4.0'
+    id 'org.gradle.test-retry' version '1.4.1'
 }
 
 apply from: "$rootDir/gradle/ci-support.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.github.johnrengelman.shadow' version '7.0.0'
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'me.champeau.gradle.japicmp' version '0.2.9' apply false
     id 'com.diffplug.spotless' version '6.8.0' apply false
     id 'org.gradle.test-retry' version '1.4.0'

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:5.1.1.RELEASE"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.4.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.1"
     testImplementation project(":testcontainers")

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.2.3'
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.2.3'
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.4'
+    id 'org.springframework.boot' version '2.7.5'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:4.2.3'
-    implementation 'com.google.code.gson:gson:2.9.1'
+    implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.7.4"
+    id("org.springframework.boot") version "2.7.5"
     id("org.jetbrains.kotlin.jvm") version "1.7.20"
     id("org.jetbrains.kotlin.plugin.spring") version "1.7.20"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.4'
+    id 'org.springframework.boot' version '2.7.5'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.333'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.314'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.336'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.336'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.12.3'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.12.4'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.24'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.333'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.336'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.334'
-    testImplementation 'software.amazon.awssdk:s3:2.18.7'
+    testImplementation 'software.amazon.awssdk:s3:2.18.11'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.333'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.333'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.333'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.336'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.334'
     testImplementation 'software.amazon.awssdk:s3:2.18.7'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:0.9.0.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:11.2.1.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.1.0.jre8-preview'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:0.8.7.RELEASE'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.5.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.questdb:questdb:6.5.4-jdk8'
+    testImplementation 'org.questdb:questdb:6.5.5-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:401'
+    testImplementation 'io.trino:trino-jdbc:402'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump google-cloud-datastore from 2.12.3 to 2.12.4 in /modules/gcloud (#6149) @dependabot
* Bump aws-java-sdk-sqs from 1.12.333 to 1.12.336 in /modules/localstack (#6147) @dependabot
* Bump org.springframework.boot from 2.7.4 to 2.7.5 in /examples (#6146) @dependabot
* Bump s3 from 2.18.7 to 2.18.11 in /modules/localstack (#6144) @dependabot
* Bump gson from 2.9.1 to 2.10 in /examples (#6145) @dependabot
* Bump aws-java-sdk-logs from 1.12.334 to 1.12.336 in /modules/localstack (#6143) @dependabot
* Bump jedis from 4.2.3 to 4.3.1 in /examples (#6141) @dependabot
* Bump com.github.johnrengelman.shadow from 7.0.0 to 7.1.2 in /examples (#6139) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.333 to 1.12.336 in /modules/dynalite (#6138) @dependabot
* Bump org.gradle.test-retry from 1.4.0 to 1.4.1 in /examples (#6137) @dependabot
* Bump junit-jupiter-api from 5.4.2 to 5.9.1 in /examples (#6136) @dependabot
* Bump mssql-jdbc from 11.2.1.jre8 to 12.1.0.jre8-preview in /modules/mssqlserver (#6135) @dependabot
* Bump trino-jdbc from 401 to 402 in /modules/trino (#6132) @dependabot
* Bump com.diffplug.spotless from 6.8.0 to 6.11.0 in /examples (#6134) @dependabot
* Bump questdb from 6.5.4-jdk8 to 6.5.5-jdk8 in /modules/questdb (#6130) @dependabot
