### PR TITLE
Feature/neo4j defaults

### DIFF
--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -159,7 +159,7 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
 
     /**
      * Update the default Neo4jContainer wait strategy based on the exposed ports.
-     * Still possible to override the startup timeout later via {@link WaitStrategy#withStartupTimeout(Duration)}.
+     * Still possible to override the startup timeout before starting the container via {@link WaitStrategy#withStartupTimeout(Duration)}.
      */
     private void configureWaitStrategy() {
         List<Integer> exposedPorts = getExposedPorts();

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -94,7 +94,6 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
         this.standardImage = dockerImageName.getUnversionedPart().equals(DEFAULT_IMAGE_NAME.getUnversionedPart());
 
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-
     }
 
     @Override
@@ -107,7 +106,6 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
 
     @Override
     protected void configure() {
-
         configureAuth();
         configureLabsPlugins();
         configureExposedPorts();
@@ -161,18 +159,17 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
         // because we already checked if nothing was manually exposed in the configureExposedPorts method,
         // we can be sure that either both or one of those ports are exposed.
         if (boltExposed && httpExposed) {
-            this.waitStrategy = new WaitAllStrategy()
-                .withStrategy(waitForBolt)
-                .withStrategy(waitForHttp)
-                .withStartupTimeout(Duration.ofMinutes(2));
+            this.waitStrategy =
+                new WaitAllStrategy()
+                    .withStrategy(waitForBolt)
+                    .withStrategy(waitForHttp)
+                    .withStartupTimeout(Duration.ofMinutes(2));
         } else if (boltExposed) {
-            this.waitStrategy = new WaitAllStrategy()
-                .withStrategy(waitForBolt)
-                .withStartupTimeout(Duration.ofMinutes(2));
+            this.waitStrategy =
+                new WaitAllStrategy().withStrategy(waitForBolt).withStartupTimeout(Duration.ofMinutes(2));
         } else if (httpExposed) {
-            this.waitStrategy = new WaitAllStrategy()
-                .withStrategy(waitForHttp)
-                .withStartupTimeout(Duration.ofMinutes(2));
+            this.waitStrategy =
+                new WaitAllStrategy().withStrategy(waitForHttp).withStartupTimeout(Duration.ofMinutes(2));
         }
     }
 

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -209,7 +209,7 @@ public class Neo4jContainerTest {
 
         neo4jContainer.configure();
 
-        assertThat(neo4jContainer.getExposedPorts()).containsExactlyInAnyOrder(7687);
+        assertThat(neo4jContainer.getExposedPorts()).containsExactly(7687);
     }
 
     @Test
@@ -218,7 +218,7 @@ public class Neo4jContainerTest {
 
         neo4jContainer.configure();
 
-        assertThat(neo4jContainer.getExposedPorts()).containsExactlyInAnyOrder(7474);
+        assertThat(neo4jContainer.getExposedPorts()).containsExactly(7474);
     }
 
     @Test

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -9,6 +9,7 @@ import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 import org.testcontainers.utility.MountableFile;
 
 import java.util.Collections;
@@ -240,6 +241,15 @@ public class Neo4jContainerTest {
     }
 
     @Test
+    public void shouldRespectCustomWaitStrategy() {
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").waitingFor(new CustomDummyWaitStrategy());
+
+        neo4jContainer.configure();
+
+        assertThat(neo4jContainer.getWaitStrategy()).isInstanceOf(CustomDummyWaitStrategy.class);
+    }
+
+    @Test
     public void shouldConfigureSingleLabsPlugin() {
         try (
             Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withLabsPlugins(Neo4jLabsPlugin.APOC)
@@ -287,6 +297,14 @@ public class Neo4jContainerTest {
 
             assertThat(neo4jContainer.getEnvMap().get("NEO4JLABS_PLUGINS"))
                 .containsAnyOf("[\"myApoc\",\"myBloom\"]", "[\"myBloom\",\"myApoc\"]");
+        }
+    }
+
+    private static class CustomDummyWaitStrategy extends AbstractWaitStrategy {
+
+        @Override
+        protected void waitUntilReady() {
+            // ehm...ready
         }
     }
 

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -174,13 +174,11 @@ public class Neo4jContainerTest {
 
     @Test
     public void shouldRespectEnvironmentAuth() {
-        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
-            .withEnv("NEO4J_AUTH", "neo4j/secret");
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withEnv("NEO4J_AUTH", "neo4j/secret");
 
         neo4jContainer.configure();
 
-        assertThat(neo4jContainer.getEnvMap())
-            .containsEntry("NEO4J_AUTH", "neo4j/secret");
+        assertThat(neo4jContainer.getEnvMap()).containsEntry("NEO4J_AUTH", "neo4j/secret");
     }
 
     @Test
@@ -191,8 +189,7 @@ public class Neo4jContainerTest {
 
         neo4jContainer.configure();
 
-        assertThat(neo4jContainer.getEnvMap())
-            .containsEntry("NEO4J_AUTH", "neo4j/anotherSecret");
+        assertThat(neo4jContainer.getEnvMap()).containsEntry("NEO4J_AUTH", "neo4j/anotherSecret");
     }
 
     @Test
@@ -203,14 +200,12 @@ public class Neo4jContainerTest {
 
         neo4jContainer.configure();
 
-        assertThat(neo4jContainer.getEnvMap())
-            .containsEntry("NEO4J_AUTH", "none");
+        assertThat(neo4jContainer.getEnvMap()).containsEntry("NEO4J_AUTH", "none");
     }
 
     @Test
     public void shouldRespectAlreadyDefinedPortMappingsBolt() {
-        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
-            .withExposedPorts(7687);
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withExposedPorts(7687);
 
         neo4jContainer.configure();
 
@@ -219,8 +214,7 @@ public class Neo4jContainerTest {
 
     @Test
     public void shouldRespectAlreadyDefinedPortMappingsHttp() {
-        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
-            .withExposedPorts(7474);
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withExposedPorts(7474);
 
         neo4jContainer.configure();
 
@@ -229,8 +223,7 @@ public class Neo4jContainerTest {
 
     @Test
     public void shouldRespectAlreadyDefinedPortMappingsWithoutHttps() {
-        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
-            .withExposedPorts(7687, 7474);
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withExposedPorts(7687, 7474);
 
         neo4jContainer.configure();
 


### PR DESCRIPTION
Coming from a GenericContainer, the Neo4j module overrules
the authentication.
Also, it will eagerly require its waitStrategy.
This leads into problems with custom port exposure because sometimes
it is not wanted to expose both ports (HTTP/Bolt).

As something outside of this PR, I can think of offering the explicit HTTP(s), Bolt port exposing as something that we might add to the API explicitly. But I am not yet sure if this should be a `without` or `with` API.