### PR TITLE
Use slim-faststart images from oracle

### DIFF
--- a/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
+++ b/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.fail;
 public class SimpleOracleTest extends AbstractContainerDatabaseTest {
 
     public static final DockerImageName ORACLE_DOCKER_IMAGE_NAME = DockerImageName.parse(
-        "gvenzl/oracle-xe:21-faststart"
+        "gvenzl/oracle-xe:21-slim-faststart"
     );
 
     private void runTest(OracleContainer container, String databaseName, String username, String password)
@@ -53,7 +53,7 @@ public class SimpleOracleTest extends AbstractContainerDatabaseTest {
     public void testPluggableDatabaseAndCustomUser() throws SQLException {
         try (
             // constructor {
-            OracleContainer oracle = new OracleContainer("gvenzl/oracle-xe:21-faststart")
+            OracleContainer oracle = new OracleContainer("gvenzl/oracle-xe:21-slim-faststart")
                 .withDatabaseName("testDB")
                 .withUsername("testUser")
                 .withPassword("testPassword")


### PR DESCRIPTION
Previously, the `fastart` images were used but those are quite big.
Instead, it was suggested to use `slim-faststart` tags.
