### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
-    testImplementation ('org.mockito:mockito-core:4.8.1') {
+    testImplementation ('org.mockito:mockito-core:4.9.0') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:5.1.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.1.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:5.1.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.1.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:5.2.0.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.1.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'com.hazelcast:hazelcast:5.2.0'
+    testImplementation 'com.hazelcast:hazelcast:5.2.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.7.5"
     id("org.jetbrains.kotlin.jvm") version "1.7.20"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.7.20"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.7.21"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.apache.curator:curator-framework:5.3.0'
+    testImplementation 'org.apache.curator:curator-framework:5.4.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.0"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.1"
     testImplementation "org.elasticsearch.client:transport:7.17.7"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.4'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.0'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.24'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.25'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.16.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.12.4'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.12.5'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.25'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.24'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.15.0'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.16.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.9.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.9.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
     testImplementation("ch.qos.logback:logback-classic:1.4.4")

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.influxdb:influxdb-java:2.23'
-    testImplementation "com.influxdb:influxdb-client-java:6.4.0"
+    testImplementation "com.influxdb:influxdb-client-java:6.7.0"
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.1'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation ('org.mockito:mockito-core:4.8.1') {
+    testImplementation ('org.mockito:mockito-core:4.9.0') {
         exclude(module: 'hamcrest-core')
     }
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.1'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.2'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation ('org.mockito:mockito-core:4.9.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.3.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.8.1') {
+    testImplementation ('org.mockito:mockito-core:4.9.0') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.337'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.333'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.336'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.342'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.337'
     testImplementation 'software.amazon.awssdk:s3:2.18.11'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.8'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.9'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.7.2")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.8.0")
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-mssql:0.9.0.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.1.0.jre8-preview'
 
     testImplementation project(':r2dbc')
-    testImplementation 'io.r2dbc:r2dbc-mssql:0.8.7.RELEASE'
+    testImplementation 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':r2dbc'))

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.4.24'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.0'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // YCQL driver
     testImplementation 'com.yugabyte:java-driver-core:4.6.0-yb-11'
     // YSQL driver
-    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.4'
+    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-1'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump hazelcast from 5.2.0 to 5.2.1 in /examples (#6203) @dependabot
* Bump lettuce-core from 5.1.1.RELEASE to 6.2.1.RELEASE in /examples (#6201) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.7.20 to 1.7.21 in /examples (#6200) @dependabot
* Bump curator-framework from 5.3.0 to 5.4.0 in /examples (#6199) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.7.20 to 1.7.21 in /examples (#6198) @dependabot
* Bump google-cloud-bigtable from 2.15.0 to 2.16.0 in /modules/gcloud (#6196) @dependabot
* Bump aws-java-sdk-sqs from 1.12.336 to 1.12.342 in /modules/localstack (#6195) @dependabot
* Bump google-cloud-pubsub from 1.120.24 to 1.120.25 in /modules/gcloud (#6194) @dependabot
* Bump google-cloud-firestore from 3.7.0 to 3.7.1 in /modules/gcloud (#6191) @dependabot
* Bump jdbc-yugabytedb from 42.3.4 to 42.3.5-yb-1 in /modules/yugabytedb (#6192) @dependabot
* Bump reactor-core from 3.4.24 to 3.5.0 in /modules/r2dbc (#6190) @dependabot
* Bump mockito-core from 4.8.1 to 4.9.0 in /modules/junit-jupiter (#6183) @dependabot
* Bump hivemq-extension-sdk from 4.9.0 to 4.9.1 in /modules/hivemq (#6187) @dependabot
* Bump mongodb-driver-sync from 4.7.2 to 4.8.0 in /modules/mongodb (#6189) @dependabot
* Bump aws-java-sdk-logs from 1.12.337 to 1.12.342 in /modules/localstack (#6188) @dependabot
* Bump elasticsearch-rest-client from 8.5.0 to 8.5.1 in /modules/elasticsearch (#6185) @dependabot
* Bump mockito-core from 4.8.1 to 4.9.0 in /modules/jdbc (#6184) @dependabot
* Bump google-cloud-datastore from 2.12.4 to 2.12.5 in /modules/gcloud (#6182) @dependabot
* Bump r2dbc-mssql from 0.9.0.RELEASE to 1.0.0.RELEASE in /modules/mssqlserver (#6180) @dependabot
* Bump mariadb-java-client from 3.0.8 to 3.0.9 in /modules/mariadb (#6181) @dependabot
* Bump influxdb-client-java from 6.4.0 to 6.7.0 in /modules/influxdb (#6179) @dependabot
* Bump tomcat-jdbc from 10.1.1 to 10.1.2 in /modules/jdbc (#6178) @dependabot
* Bump mockito-core from 4.8.1 to 4.9.0 in /core (#6176) @dependabot
