### PR TITLE
Add documentation to reusable containers

### DIFF
--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -10,9 +10,9 @@ and should be enabled by environment. In order to reuse a container, the
 configuration *must not change*.
 
 !!! note
-    Reusable containers doesn't suit for CI usage and as an experimental feature
-    not all Testcontainers features are working such as resources cleanup
-    or networking.
+    Reusable containers are not suited for CI usage and as an experimental feature
+    not all Testcontainers features are fully working (e.g., resource cleanup
+    or networking).
 
 ## How to use it
 

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -4,7 +4,7 @@
     Reusable containers is still an experimental feature and the behavior can change.
     Those containers won't stop after all tests are finished.
 
-Reusable containers enables to keep containers running. In order
+Reusable containers feature keeps the containers running between the test sessions. In order
 to achieve it, manual initialization should be used by calling `start()`
 and should be enabled by environment. In order to reuse a container, the
 configuration *must not change*.

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -16,7 +16,7 @@ configuration of the container *must not change*.
 
 ## How to use it
 
-* Define container with `withReuse(true)`
+* Define a container with `withReuse(true)`
 
 ```java
 GenericContainer container = new GenericContainer("redis:6-alpine")

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -19,7 +19,7 @@ configuration *must not change*.
 * Define container with `withReuse(true)`
 
 ```java
-GenericContainer container = new GenericContainer("redis:2.6.17")
+GenericContainer container = new GenericContainer("redis:6-alpine")
     .withExposedPorts(6379)
     .withReuse(true)
 ```

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -4,10 +4,10 @@
     Reusable containers is still an experimental feature and the behavior can change.
     Those containers won't stop after all tests are finished.
 
-Reusable containers feature keeps the containers running between the test sessions. In order
-to achieve it, manual initialization should be used by calling `start()`
-and should be enabled by environment. In order to reuse a container, the
-configuration *must not change*.
+The *Reusable Containers* feature keeps the containers running between test sessions. In order
+to use it, manual container lifecycle instrumentation should be used by calling the `start()` method
+and it needs to be manually enabled through an opt-in mechanism. In order to reuse a container, the
+configuration of the container *must not change*.
 
 !!! note
     Reusable containers are not suited for CI usage and as an experimental feature

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -11,7 +11,7 @@ configuration *must not change*.
 
 !!! note
     Reusable containers doesn't suit for CI usage and as an experimental feature
-    not all Testcontainers features are working such as cleanup, parallelization
+    not all Testcontainers features are working such as resources cleanup
     or networking.
 
 ## How to use it
@@ -24,6 +24,11 @@ GenericContainer container = new GenericContainer("redis:6-alpine")
     .withReuse(true)
 ```
 
-* If using Testcontainers JDBC URL support *should* pass `TC_REUSABLE=true`  parameter. E.g `jdbc:tc:mysql:5.7.34:///databasename?TC_REUSABLE=true`
 * Opt-in to reuse in `~/.testcontainers.properties`, adding `testcontainers.reuse.enable=true`
-* Containers should be started manually using `container.start()`. See [docs](https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/)
+* Containers should be started manually using `container.start()`. See [docs](../../test_framework_integration/manual_lifecycle_control)
+
+### Reusable Container with Testcontainers JDBC URL
+
+If using [Testcontainers JDBC URL support](../../modules/databases/jdbc#database-containers-launched-via-jdbc-url-scheme)
+url **must** be like `jdbc:tc:mysql:5.7.34:///databasename?TC_REUSABLE=true`. `TC_REUSABLE=true` parameter is passed to
+the URL.

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -29,6 +29,5 @@ GenericContainer container = new GenericContainer("redis:6-alpine")
 
 ### Reusable Container with Testcontainers JDBC URL
 
-If using [Testcontainers JDBC URL support](../../modules/databases/jdbc#database-containers-launched-via-jdbc-url-scheme)
-url **must** be like `jdbc:tc:mysql:5.7.34:///databasename?TC_REUSABLE=true`. `TC_REUSABLE=true` parameter is passed to
-the URL.
+If using the [Testcontainers JDBC URL support](../../modules/databases/jdbc#database-containers-launched-via-jdbc-url-scheme)
+the URL **must** follow the pattern of `jdbc:tc:mysql:5.7.34:///databasename?TC_REUSABLE=true`. `TC_REUSABLE=true` is set as a parameter of the JDBC URL.

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -24,8 +24,8 @@ GenericContainer container = new GenericContainer("redis:6-alpine")
     .withReuse(true)
 ```
 
-* Opt-in to reuse in `~/.testcontainers.properties`, adding `testcontainers.reuse.enable=true`
-* Containers should be started manually using `container.start()`. See [docs](../../test_framework_integration/manual_lifecycle_control)
+* Opt-in to Reusable Containers in `~/.testcontainers.properties`, by adding `testcontainers.reuse.enable=true`
+* Containers need to be started manually using `container.start()`. See [docs](../../test_framework_integration/manual_lifecycle_control)
 
 ### Reusable Container with Testcontainers JDBC URL
 

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -26,4 +26,4 @@ GenericContainer container = new GenericContainer("redis:6-alpine")
 
 * If using Testcontainers JDBC URL support *should* pass `TC_REUSABLE=true`  parameter
 * Opt-in to reuse in `~/.testcontainers.properties`, adding `testcontainers.reuse.enable=true`
-* Containers should be started manually using container.start(). See [docs](https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/)
+* Containers should be started manually using `container.start()`. See [docs](https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/)

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -1,7 +1,7 @@
 # Reusable Containers (Experimental)
 
 !!! warning 
-    Reusable containers is still an experimental feature and the behavior can change.
+    Reusable Containers is still an experimental feature and the behavior can change.
     Those containers won't stop after all tests are finished.
 
 The *Reusable Containers* feature keeps the containers running between test sessions. In order

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -1,0 +1,29 @@
+# Reusable Containers (Experimental)
+
+!!! warning 
+    Reusable containers is still an experimental feature and the behavior can change.
+    Those containers won't stop after all tests are finished.
+
+Reusable containers enables to keep containers running. In order
+to achieve it, manual initialization should be used by calling `start()`
+and should be enabled by environment. In order to reuse a container, the
+configuration *must not change*.
+
+!!! note
+    Reusable containers doesn't suit for CI usage and as an experimental feature
+    not all Testcontainers features are working such as cleanup, parallelization
+    or networking.
+
+## How to use it
+
+* Define container with `withReuse(true)`
+
+```java
+GenericContainer container = new GenericContainer("redis:2.6.17")
+    .withExposedPorts(6379)
+    .withReuse(true)
+```
+
+* If using Testcontainers JDBC URL support *should* pass `TC_REUSABLE=true`  parameter
+* Opt-in to reuse in `~/.testcontainers.properties`, adding `testcontainers.reuse.enable=true`
+* Containers should be started manually using container.start(). See [docs](https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/)

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -24,6 +24,6 @@ GenericContainer container = new GenericContainer("redis:6-alpine")
     .withReuse(true)
 ```
 
-* If using Testcontainers JDBC URL support *should* pass `TC_REUSABLE=true`  parameter
+* If using Testcontainers JDBC URL support *should* pass `TC_REUSABLE=true`  parameter. E.g `jdbc:tc:mysql:5.7.34:///databasename?TC_REUSABLE=true`
 * Opt-in to reuse in `~/.testcontainers.properties`, adding `testcontainers.reuse.enable=true`
 * Containers should be started manually using `container.start()`. See [docs](https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
           - features/configuration.md
           - features/image_name_substitution.md
           - features/advanced_options.md
+          - features/reuse.md
     - Modules:
           - Databases:
                 - modules/databases/index.md


### PR DESCRIPTION
Reusable containers is an experimental features and docs should
address questions around `what is it?` and `how to enable it?`
