### PR TITLE
Update spock dependencies

### DIFF
--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -5,7 +5,11 @@ plugins {
 
 dependencies {
     api "io.lettuce:lettuce-core:6.2.1.RELEASE"
-    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -6,7 +6,7 @@ description = "Testcontainers :: Spock-Extension"
 
 dependencies {
     api project(':testcontainers')
-    api 'org.spockframework:spock-core:2.1-groovy-3.0'
+    api 'org.spockframework:spock-core:2.3-groovy-3.0'
 
     testImplementation project(':selenium')
     testImplementation project(':mysql')
@@ -17,6 +17,8 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.1'
 
     testCompileOnly 'org.jetbrains:annotations:23.0.0'
 }


### PR DESCRIPTION
Currently, `docs/examples/spock/redis` is not running (since 89a33684).
After the dependency was upgraded, it stopped running unless `useJUnitPlatform()`
is added. Also, `spock` module is adding two additional dependencies
which are required since `spock-core` version `2.2`.
