### PR TITLE
[doc] Fix HiveMQ EE image name and tag

### DIFF
--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoHiveMQContainerIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoHiveMQContainerIT.java
@@ -25,7 +25,7 @@ public class DemoHiveMQContainerIT {
 
     // hiveEEVersion {
     @Container
-    final HiveMQContainer hivemqEe = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3"))
+    final HiveMQContainer hivemqEe = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq4").withTag("4.7.4"))
         .withLogLevel(Level.DEBUG);
 
     // }
@@ -33,7 +33,7 @@ public class DemoHiveMQContainerIT {
     // eeVersionWithControlCenter {
     @Container
     final HiveMQContainer hivemqEeWithControlCenter = new HiveMQContainer(
-        DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+        DockerImageName.parse("hivemq/hivemq4").withTag("4.7.4")
     )
         .withLogLevel(Level.DEBUG)
         .withHiveMQConfig(MountableFile.forClasspathResource("/inMemoryConfig.xml"))


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Currently, [this](https://www.testcontainers.org/modules/hivemq/) page's HiveMQ EE code example uses the `hivemq-ce` image instead of the `hivemq4` image. I've changed the image and used a tag that can be found in other parts of the documentation, but please note there is a newer one (4.9.1) that could be used.