### PR TITLE
feat: enable reuse for mongodb

### DIFF
--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -6,3 +6,9 @@ dependencies {
     testImplementation("org.mongodb:mongodb-driver-sync:4.8.0")
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }
+
+tasks.japicmp {
+    methodExcludes = [
+        "org.testcontainers.containers.MongoDBContainer#containerIsStarted(com.github.dockerjava.api.command.InspectContainerResponse)"
+    ]
+}

--- a/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
@@ -83,12 +83,8 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
 
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo, boolean reused) {
-        if(reused) {
-            if (isReplicationSetAlreadyInitialized()) {
-                log.debug("Replica set already initialized.");
-            } else {
-                initReplicaSet();
-            }
+        if (reused && isReplicationSetAlreadyInitialized()) {
+            log.debug("Replica set already initialized.");
         } else {
             initReplicaSet();
         }
@@ -160,9 +156,12 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
         }
     }
 
+    @SneakyThrows
     private boolean isReplicationSetAlreadyInitialized() {
         // since we are creating a replica set with one node, this node must be primary (state = 1)
-        final ExecResult execCheckRsInit = execInContainer(buildMongoEvalCommand("if(db.adminCommand({replSetGetStatus: 1})['myState'] != 1) quit(900)"));
+        final ExecResult execCheckRsInit = execInContainer(
+            buildMongoEvalCommand("if(db.adminCommand({replSetGetStatus: 1})['myState'] != 1) quit(900)")
+        );
         return execCheckRsInit.getExitCode() == CONTAINER_EXIT_CODE_OK;
     }
 }


### PR DESCRIPTION
When we reuse container with mongodb images, it fails the first time we reuse it because the replica is already set, hence the exit code of the replica set is 1 and not 0.

In order to avoid that, a check is made on the state of the current node.
If the command fails because there is no replica, it will fallback to the initialisation of the replica set like today.
Otherwise, it will skip.

In order to know if a replica is set or not, since we are working with one node, it must be a primary one.
We use [replSetGetStatus](https://www.mongodb.com/docs/manual/reference/command/replSetGetStatus/#mongodb-data-replSetGetStatus.myState) to check its "[myState](https://www.mongodb.com/docs/manual/reference/replica-states/)" attribute.