### PR TITLE
ClickHouse uses new driver if it is available and version is compatible

### DIFF
--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
@@ -25,7 +25,8 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
 
     public static final Integer NATIVE_PORT = 9000;
 
-    private static final String DRIVER_CLASS_NAME = "ru.yandex.clickhouse.ClickHouseDriver";
+    private static final String LEGACY_DRIVER_CLASS_NAME = "ru.yandex.clickhouse.ClickHouseDriver";
+    private static final String DRIVER_CLASS_NAME = "com.clickhouse.jdbc.ClickHouseDriver";
 
     private static final String JDBC_URL_PREFIX = "jdbc:" + NAME + "://";
 
@@ -36,6 +37,8 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
     private String username = "default";
 
     private String password = "";
+
+    private boolean supportsNewDriver;
 
     /**
      * @deprecated use {@link ClickHouseContainer(DockerImageName)} instead
@@ -51,7 +54,9 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
 
     public ClickHouseContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
+
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, CLICKHOUSE_IMAGE_NAME);
+        supportsNewDriver = isNewDriverSupported(dockerImageName);
 
         addExposedPorts(HTTP_PORT, NATIVE_PORT);
         this.waitStrategy =
@@ -69,10 +74,43 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
     @Override
     public String getDriverClassName() {
         try {
-            Class.forName(DRIVER_CLASS_NAME);
-            return DRIVER_CLASS_NAME;
+            if (supportsNewDriver) {
+                Class.forName(DRIVER_CLASS_NAME);
+                return DRIVER_CLASS_NAME;
+            } else {
+                return LEGACY_DRIVER_CLASS_NAME;
+            }
         } catch (ClassNotFoundException e) {
-            return "com.clickhouse.jdbc.ClickHouseDriver";
+            return LEGACY_DRIVER_CLASS_NAME;
+        }
+    }
+
+    private static boolean isNewDriverSupported(DockerImageName dockerImageName) {
+        // New driver supports versions 20.7+. Check the version part of the tag
+        String[] versionParts = dockerImageName.getVersionPart().split(".");
+        // if no version part found (unknown version), return false for compatibility
+        if (versionParts.length == 0) {
+            return false;
+        }
+        try {
+            int major = Integer.parseInt(versionParts[0]);
+            // v21+ support the new driver
+            if (major >= 21) return true;
+            if (major == 20) {
+                if (versionParts.length == 1) {
+                    // tag "20" points to the latest 20.x tag
+                    return true;
+                }
+                int minor = Integer.parseInt(versionParts[1]);
+                // versions 20.7 and beyond support the latest driver
+                return minor >= 7;
+            }
+            // 19.x and older versions do not support
+            return false;
+        }
+        catch (NumberFormatException e) {
+            // non-numbered tags are "head-*", which point to the latest available version
+            return true;
         }
     }
 

--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
@@ -1,8 +1,8 @@
 package org.testcontainers.containers;
 
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.ComparableVersion;
+import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 import java.util.HashSet;


### PR DESCRIPTION
A replacement for #5666 (related to the now-closed #6232). Now, `ClickHouseContainer` picks up the new `com.clickhouse.jdbc.ClickHouseDriver` driver if it is available and the version tag is 20.7 or later (as supported by the driver), otherwise it falls back to the legacy `ru.yandex.clickhouse.ClickHouseDriver` driver.