### PR TITLE
Avoid Pattern recompilation in log output processing

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/output/FrameConsumerResultCallback.java
+++ b/core/src/main/java/org/testcontainers/containers/output/FrameConsumerResultCallback.java
@@ -30,7 +30,9 @@ public class FrameConsumerResultCallback extends ResultCallbackTemplate<FrameCon
 
     private static final String LINE_BREAK_REGEX = "((\\r?\\n)|(\\r))";
 
-    static final String LINE_BREAK_AT_END_REGEX = LINE_BREAK_REGEX + "$";
+    private static final Pattern LINE_BREAK_PATTERN = Pattern.compile(LINE_BREAK_REGEX);
+
+    static final Pattern LINE_BREAK_AT_END_PATTERN = Pattern.compile(LINE_BREAK_REGEX + "$");
 
     private Map<OutputFrame.OutputType, Consumer<OutputFrame>> consumers;
 
@@ -139,7 +141,7 @@ public class FrameConsumerResultCallback extends ResultCallbackTemplate<FrameCon
 
     private void normalizeLogLines(String utf8String, Consumer<OutputFrame> consumer) {
         // Reformat strings to normalize new lines.
-        List<String> lines = new ArrayList<>(Arrays.asList(utf8String.split(LINE_BREAK_REGEX)));
+        List<String> lines = new ArrayList<>(Arrays.asList(LINE_BREAK_PATTERN.split(utf8String)));
         if (lines.isEmpty()) {
             consumer.accept(new OutputFrame(OutputFrame.OutputType.STDOUT, EMPTY_LINE));
             return;

--- a/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
+++ b/core/src/main/java/org/testcontainers/containers/output/Slf4jLogConsumer.java
@@ -53,7 +53,7 @@ public class Slf4jLogConsumer extends BaseConsumer<Slf4jLogConsumer> {
         OutputFrame.OutputType outputType = outputFrame.getType();
 
         String utf8String = outputFrame.getUtf8String();
-        utf8String = utf8String.replaceAll(FrameConsumerResultCallback.LINE_BREAK_AT_END_REGEX, "");
+        utf8String = FrameConsumerResultCallback.LINE_BREAK_AT_END_PATTERN.matcher(utf8String).replaceAll("");
 
         Map<String, String> originalMdc = MDC.getCopyOfContextMap();
         MDC.setContextMap(mdc);


### PR DESCRIPTION
Hi,

I've been doing some profiling and noticed an admittedly small - but avoidable - amount of allocations coming from testcontainers when processing log outputs.

<img width="1014" alt="image" src="https://user-images.githubusercontent.com/6304496/204145239-ab2dc195-f8cf-4af0-a8a8-eaa59ae8c196.png">

This PR avoids recompiling patterns and the corresponding allocations.

Cheers,
Christoph