### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7 # v3.10.1
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.2.0'
 
-    api platform('com.github.docker-java:docker-java-bom:3.2.13')
+    api platform('com.github.docker-java:docker-java-bom:3.2.14')
     shaded platform('com.github.docker-java:docker-java-bom:3.2.13')
 
     api "com.github.docker-java:docker-java-api"

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
-    testImplementation 'org.postgresql:postgresql:42.5.0'
+    testImplementation 'org.postgresql:postgresql:42.5.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.4'
+    testImplementation 'io.nats:jnats:2.16.5'
     testImplementation 'ch.qos.logback:logback-classic:1.3.4'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("org.springframework.boot") version "2.7.5"
-    id("org.jetbrains.kotlin.jvm") version "1.7.21"
+    id("org.jetbrains.kotlin.jvm") version "1.7.22"
     id("org.jetbrains.kotlin.plugin.spring") version "1.7.21"
 }
 

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.0'
+    testImplementation 'org.postgresql:postgresql:42.5.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
-    testImplementation 'io.rest-assured:rest-assured:5.2.0'
+    testImplementation 'io.rest-assured:rest-assured:5.3.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.342'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.336'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.353'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.353'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.1"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.2"
     testImplementation "org.elasticsearch.client:transport:7.17.7"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.5'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.1'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.120.25'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.121.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.16.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.9.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
-    testImplementation("ch.qos.logback:logback-classic:1.4.4")
+    testImplementation("ch.qos.logback:logback-classic:1.4.5")
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.343'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.343'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.342'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.343'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.353'
     testImplementation 'software.amazon.awssdk:s3:2.18.18'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.343'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.353'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.343'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.342'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.353'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.0.9'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.1'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.12"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.13"
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.5.0'
+    testImplementation 'org.postgresql:postgresql:42.5.1'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':jdbc')
 
-    testImplementation 'org.postgresql:postgresql:42.5.0'
+    testImplementation 'org.postgresql:postgresql:42.5.1'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.questdb:questdb:6.6.1-jdk8'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.5.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.questdb:questdb:6.5.5-jdk8'
+    testImplementation 'org.questdb:questdb:6.6.1-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'io.rest-assured:rest-assured:5.2.0'
+    testImplementation 'io.rest-assured:rest-assured:5.3.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.2.0'
+    testImplementation 'io.rest-assured:rest-assured:5.3.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump jnats from 2.16.4 to 2.16.5 in /examples (#6274) @dependabot
* Bump org.jetbrains.kotlin.jvm from 1.7.21 to 1.7.22 in /examples (#6273) @dependabot
* Bump questdb from 6.5.5-jdk8 to 6.6.1-jdk8 in /modules/questdb (#6272) @dependabot
* Bump postgresql from 42.5.0 to 42.5.1 in /modules/questdb (#6271) @dependabot
* Bump rest-assured from 5.2.0 to 5.3.0 in /modules/redpanda (#6270) @dependabot
* Bump rest-assured from 5.2.0 to 5.3.0 in /modules/consul (#6269) @dependabot
* Bump postgresql from 42.5.0 to 42.5.1 in /examples (#6268) @dependabot
* Bump logback-classic from 1.3.4 to 1.3.5 in /examples (#6267) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.7.21 to 1.7.22 in /examples (#6264) @dependabot
* Bump logback-classic from 1.4.4 to 1.4.5 in /modules/hivemq (#6261) @dependabot
* Bump google-cloud-pubsub from 1.120.25 to 1.121.1 in /modules/gcloud (#6262) @dependabot
* Bump google-cloud-firestore from 3.7.1 to 3.7.3 in /modules/gcloud (#6260) @dependabot
* Bump google-cloud-spanner from 6.32.0 to 6.33.0 in /modules/gcloud (#6258) @dependabot
* Bump postgresql from 42.5.0 to 42.5.1 in /modules/cockroachdb (#6257) @dependabot
* Bump orientdb-gremlin from 3.2.12 to 3.2.13 in /modules/orientdb (#6256) @dependabot
* Bump aws-java-sdk-logs from 1.12.343 to 1.12.353 in /modules/localstack (#6254) @dependabot
* Bump aws-java-sdk-s3 from 1.12.343 to 1.12.353 in /modules/localstack (#6253) @dependabot
* Bump peter-evans/create-pull-request from 4.2.0 to 4.2.3 (#6252) @dependabot
* Bump docker-java-bom from 3.2.13 to 3.2.14 in /core (#6251) @dependabot
* Bump elasticsearch-rest-client from 8.5.1 to 8.5.2 in /modules/elasticsearch (#6248) @dependabot
* Bump s3 from 2.18.18 to 2.18.29 in /modules/localstack (#6250) @dependabot
* Bump aws-java-sdk-dynamodb from 1.12.342 to 1.12.353 in /modules/dynalite (#6246) @dependabot
* Bump aws-java-sdk-sqs from 1.12.342 to 1.12.353 in /modules/localstack (#6247) @dependabot
* Bump mariadb-java-client from 3.0.9 to 3.1.0 in /modules/mariadb (#6243) @dependabot
* Bump rest-assured from 5.2.0 to 5.3.0 in /modules/vault (#6241) @dependabot
* Bump postgresql from 42.5.0 to 42.5.1 in /modules/junit-jupiter (#6242) @dependabot
* Bump postgresql from 42.5.0 to 42.5.1 in /modules/postgresql (#6244) @dependabot
