### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,7 +125,7 @@ subprojects {
     }
 
     dependencies {
-        testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+        testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     }
 
     checkstyle {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'me.champeau.gradle.japicmp' version '0.4.1' apply false
     id 'com.diffplug.spotless' version '6.11.0' apply false
-    id 'org.gradle.test-retry' version '1.4.1'
+    id 'org.gradle.test-retry' version '1.5.0'
 }
 
 apply from: "$rootDir/gradle/ci-support.gradle"

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.2.1.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
 }
 
 test {

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -9,6 +9,6 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.2.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
     testImplementation 'org.postgresql:postgresql:42.5.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.16.5'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.testng:testng:7.5'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.7.5"
     id("org.jetbrains.kotlin.jvm") version "1.7.22"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.7.21"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.7.22"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.4.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.4'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.38.1'
+    testImplementation 'com.azure:azure-cosmos:4.39.0'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.5'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.7.1'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.7.3'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.121.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.16.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.5'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.3'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.121.1'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.32.0'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.33.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.16.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.353'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.343'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.342'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.354'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.353'
     testImplementation 'software.amazon.awssdk:s3:2.18.18'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "TestContainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.12"
+    api "com.orientechnologies:orientdb-client:3.2.13"
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.1'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.1'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:402'
+    testImplementation 'io.trino:trino-jdbc:403'
     compileOnly 'org.jetbrains:annotations:23.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump aws-java-sdk-sqs from 1.12.342 to 1.12.354 in /modules/localstack (#6276) @dependabot
* Bump logback-classic from 1.3.4 to 1.3.5 in /examples (#6267) @dependabot
* Bump org.gradle.test-retry from 1.4.1 to 1.5.0 in /examples (#6265) @dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.7.21 to 1.7.22 in /examples (#6264) @dependabot
* Bump azure-cosmos from 4.38.1 to 4.39.0 in /modules/azure (#6263) @dependabot
* Bump google-cloud-firestore from 3.7.1 to 3.7.3 in /modules/gcloud (#6260) @dependabot
* Bump orientdb-client from 3.2.12 to 3.2.13 in /modules/orientdb (#6259) @dependabot
* Bump google-cloud-spanner from 6.32.0 to 6.33.0 in /modules/gcloud (#6258) @dependabot
* Bump trino-jdbc from 402 to 403 in /modules/trino (#6255) @dependabot
* Bump com.diffplug.spotless from 6.11.0 to 6.12.0 in /examples (#6249) @dependabot
* Bump postgresql from 42.5.0 to 42.5.1 in /modules/spock (#6245) @dependabot
