### PR TITLE
Update spring boot version to 2.7.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -281,6 +281,8 @@ updates:
         update-types: [ "version-update:semver-minor" ]
       - dependency-name: "org.slf4j:slf4j-api"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "org.springframework.boot:spring-boot-gradle-plugin"
+        update-types: [ "version-update:semver-major" ]
 
 # GitHub Actions
   - package-ecosystem: "github-actions"

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.5'
+    id 'org.springframework.boot' version '2.7.6'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.5'
+    id 'org.springframework.boot' version '2.7.6'
 }
 apply plugin: 'io.spring.dependency-management'
 


### PR DESCRIPTION
2.7.x is compatible with Java 8. For that reason, we are skipping
major versions upgraded due to 3.0.0 needs Java 17.