### PR TITLE
Update permission in update-gradle-wrapper workflow

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   update-gradle-wrapper:
     permissions:
+      contents: write # for gradle-update/update-gradle-wrapper-action
       pull-requests: write # for gradle-update/update-gradle-wrapper-action
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, the workflow has been failing. See [workflow runs](https://github.com/testcontainers/testcontainers-java/actions/workflows/update-gradle-wrapper.yml)
This is due to a missing permission which is unable to push the branch
to the repository.
