### PR TITLE
Upgrade mockserver default version from 5.5.4 to 5.14.0

### DIFF
--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -9,7 +9,7 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("jamesdbloom/mockserver");
 
-    private static final String DEFAULT_TAG = "mockserver-5.5.4";
+    private static final String DEFAULT_TAG = "mockserver-5.14.0";
 
     @Deprecated
     public static final String VERSION = DEFAULT_TAG;


### PR DESCRIPTION
Upgrade the default server version of mockserver from 5.5.4 to 5.14.0. It is the first version with multi-architecture (amd64 + arm64).