### PR TITLE
Clarify docker-socket mounting workaround for Docker Desktop

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/dind_patterns.md
+++ b/docs/supported_docker_environment/continuous_integration/dind_patterns.md
@@ -32,6 +32,11 @@ Where:
 * `-w $PWD` will set the current directory to this volume
 * `-v /var/run/docker.sock:/var/run/docker.sock` will map the Docker socket
 
+
+!!! note
+    If you are using Docker Dekstop, you need to mount the Docker socket that bypasses the API proxy (see [this comment](https://github.com/docker/for-mac/issues/5588#issuecomment-934600089) for more details):
+    `-v /var/run/docker.sock.raw:/var/run/docker.sock`
+
 ### Docker Compose example
 The same can be achieved with Docker Compose:
 ```yaml


### PR DESCRIPTION
Docker Desktop changed some internal network details regarding quite some time ago (see [this comment](https://github.com/docker/for-mac/issues/5588#issuecomment-934600089)). We raised the issue in the upstream, since Testcontainers users were discovering this in Docker-Wormhole setups, but the workaround used to fail on WSL2 back in the day.

Nowadays, the workaround also works fine on WSL2 and since this implementation works as intended by the upstream and we used to rely on undefined behavior before, I'd say the workaround is the actual correct approach how to do. Hence this PR adds it to our documentation.

Closes #4395.