### PR TITLE
Use shared selinux context for mounts

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -79,7 +79,7 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      * @param mode          the bind mode
      */
     default void addFileSystemBind(final String hostPath, final String containerPath, final BindMode mode) {
-        addFileSystemBind(hostPath, containerPath, mode, SelinuxContext.NONE);
+        addFileSystemBind(hostPath, containerPath, mode, SelinuxContext.SHARED);
     }
 
     /**
@@ -303,7 +303,7 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
         final String containerPath,
         final BindMode mode
     ) {
-        withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.NONE);
+        withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.SHARED);
         return self();
     }
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1253,7 +1253,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         final String containerPath,
         final BindMode mode
     ) {
-        return withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.NONE);
+        return withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.SHARED);
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1274,7 +1274,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     ) {
         final MountableFile mountableFile = MountableFile.forClasspathResource(resourcePath);
 
-        if (mode == BindMode.READ_ONLY && selinuxContext == SelinuxContext.NONE) {
+        if (mode == BindMode.READ_ONLY && selinuxContext == SelinuxContext.SHARED) {
             withCopyFileToContainer(mountableFile, containerPath);
         } else {
             addFileSystemBind(mountableFile.getResolvedPath(), containerPath, mode, selinuxContext);

--- a/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
@@ -48,16 +48,16 @@ public class CopyFileToContainerTest {
     public void shouldUseCopyOnlyWithReadOnlyClasspathResources() {
         String resource = "/test_copy_to_container.txt";
         GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)
-            .withClasspathResourceMapping(resource, "/readOnlyNoSelinux", BindMode.READ_ONLY, SelinuxContext.NONE)
-            .withClasspathResourceMapping(resource, "/readOnly", BindMode.READ_ONLY)
             .withClasspathResourceMapping(resource, "/readOnlyShared", BindMode.READ_ONLY, SelinuxContext.SHARED)
+            .withClasspathResourceMapping(resource, "/readOnly", BindMode.READ_ONLY)
+            .withClasspathResourceMapping(resource, "/readOnlyNoSelinux", BindMode.READ_ONLY, SelinuxContext.NONE)
             .withClasspathResourceMapping(resource, "/readWrite", BindMode.READ_WRITE);
 
         Map<MountableFile, String> copyMap = container.getCopyToFileContainerPathMap();
-        assertThat(copyMap).as("uses copy for read-only and no Selinux").containsValue("/readOnlyNoSelinux");
+        assertThat(copyMap).as("uses copy for read-only with Selinux").containsValue("/readOnlyShared");
+        assertThat(copyMap).as("uses copy for read-only").containsValue("/readOnly");
 
-        assertThat(copyMap).as("uses mount for read-only").doesNotContainValue("/readOnly");
-        assertThat(copyMap).as("uses mount for read-only with Selinux").doesNotContainValue("/readOnlyShared");
+        assertThat(copyMap).as("uses mount for read-only and no Selinux").doesNotContainValue("/readOnlyNoSelinux");
         assertThat(copyMap).as("uses mount for read-write").doesNotContainValue("/readWrite");
     }
 

--- a/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
@@ -48,15 +48,15 @@ public class CopyFileToContainerTest {
     public void shouldUseCopyOnlyWithReadOnlyClasspathResources() {
         String resource = "/test_copy_to_container.txt";
         GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)
+            .withClasspathResourceMapping(resource, "/readOnlyNoSelinux", BindMode.READ_ONLY, SelinuxContext.NONE)
             .withClasspathResourceMapping(resource, "/readOnly", BindMode.READ_ONLY)
-            .withClasspathResourceMapping(resource, "/readOnlyNoSelinux", BindMode.READ_ONLY)
             .withClasspathResourceMapping(resource, "/readOnlyShared", BindMode.READ_ONLY, SelinuxContext.SHARED)
             .withClasspathResourceMapping(resource, "/readWrite", BindMode.READ_WRITE);
 
         Map<MountableFile, String> copyMap = container.getCopyToFileContainerPathMap();
-        assertThat(copyMap).as("uses copy for read-only").containsValue("/readOnly");
         assertThat(copyMap).as("uses copy for read-only and no Selinux").containsValue("/readOnlyNoSelinux");
 
+        assertThat(copyMap).as("uses mount for read-only").doesNotContainValue("/readOnly");
         assertThat(copyMap).as("uses mount for read-only with Selinux").doesNotContainValue("/readOnlyShared");
         assertThat(copyMap).as("uses mount for read-write").doesNotContainValue("/readWrite");
     }

--- a/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/CopyFileToContainerTest.java
@@ -48,14 +48,14 @@ public class CopyFileToContainerTest {
     public void shouldUseCopyOnlyWithReadOnlyClasspathResources() {
         String resource = "/test_copy_to_container.txt";
         GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)
-            .withClasspathResourceMapping(resource, "/readOnlyShared", BindMode.READ_ONLY, SelinuxContext.SHARED)
             .withClasspathResourceMapping(resource, "/readOnly", BindMode.READ_ONLY)
+            .withClasspathResourceMapping(resource, "/readOnlyShared", BindMode.READ_ONLY, SelinuxContext.SHARED)
             .withClasspathResourceMapping(resource, "/readOnlyNoSelinux", BindMode.READ_ONLY, SelinuxContext.NONE)
             .withClasspathResourceMapping(resource, "/readWrite", BindMode.READ_WRITE);
 
         Map<MountableFile, String> copyMap = container.getCopyToFileContainerPathMap();
-        assertThat(copyMap).as("uses copy for read-only with Selinux").containsValue("/readOnlyShared");
         assertThat(copyMap).as("uses copy for read-only").containsValue("/readOnly");
+        assertThat(copyMap).as("uses copy for read-only with Selinux").containsValue("/readOnlyShared");
 
         assertThat(copyMap).as("uses mount for read-only and no Selinux").doesNotContainValue("/readOnlyNoSelinux");
         assertThat(copyMap).as("uses mount for read-write").doesNotContainValue("/readWrite");


### PR DESCRIPTION
On systems with SElinux enforcing trying to bind a path without a context will result in an error. Using shared context by default will make `withFileSystemBind(String hostPath, String containerPath)` method work for all systems. On Windows, Mac OS and Linux systems without SElinux it will have no effect. On systems with SElinux enforcing it will make the path accessible to the container.