### PR TITLE
Add link to CircleCI article to docs

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -14,3 +14,5 @@ jobs:
       - checkout
       - run: mvn -B clean install
 ```
+
+You can learn more about the best practices of using Testcontainers together with CircleCI in [this article](https://www.atomicjar.com/2022/12/testcontainers-with-circleci/).


### PR DESCRIPTION
Adds a link to [this article](https://www.atomicjar.com/2022/12/testcontainers-with-circleci/) regarding CircleCI usage best practices to our CircleCI docs. 