### PR TITLE
Fix image tag command in test

### DIFF
--- a/core/src/test/java/org/testcontainers/DockerRegistryContainer.java
+++ b/core/src/test/java/org/testcontainers/DockerRegistryContainer.java
@@ -100,7 +100,7 @@ public class DockerRegistryContainer extends GenericContainer<DockerRegistryCont
             .withTag(tag);
 
         // push the image to the registry
-        client.tagImageCmd(dummyImageId, imageName.asCanonicalNameString(), tag).exec();
+        client.tagImageCmd(dummyImageId, imageName.getUnversionedPart(), tag).exec();
 
         client
             .pushImageCmd(imageName.asCanonicalNameString())


### PR DESCRIPTION
`imageName.asCanonicalNameString()` returns the image name with the tag, so for example `localhost:123/my-image:1.0.0`, but `tagImageCmd` takes the image tag as a separate parameter, so the end result would be `localhost:123/my-image:1.0.0:1.0.0`. 

According to the [docker API spec](https://docs.docker.com/engine/api/v1.41/#tag/Image/operation/ImageTag), the repo parameter should not contain a tag.

This is a blocker for #6158 
