### PR TITLE
Update Javadoc to highlight the potentially stale behavior of `getMappedPort`

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -152,7 +152,7 @@ public interface ContainerState {
         );
 
         Ports.Binding[] binding = new Ports.Binding[0];
-        final InspectContainerResponse containerInfo = this.getContainerInfo();
+        final InspectContainerResponse containerInfo = this.getCurrentContainerInfo();
         if (containerInfo != null) {
             binding = containerInfo.getNetworkSettings().getPorts().getBindings().get(new ExposedPort(originalPort));
         }

--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -119,6 +119,12 @@ public interface ContainerState {
         }
     }
 
+    /**
+     * Inspects the container and returns up-to-date inspection response.
+     *
+     * @return up-to-date container inspect response
+     * @see #getContainerInfo()
+     */
     default InspectContainerResponse getCurrentContainerInfo() {
         return getDockerClient().inspectContainerCmd(getContainerId()).exec();
     }
@@ -140,10 +146,16 @@ public interface ContainerState {
 
     /**
      * Get the actual mapped port for a given port exposed by the container.
-     * Should be used in conjunction with {@link #getHost()}.
+     * It should be used in conjunction with {@link #getHost()}.
+     * <p>
+     * Note: The returned port number might be outdated (for instance, after disconnecting from a network and reconnecting
+     * again). If you always need up-to-date value, override the {@link #getContainerInfo()} to return the
+     * {@link #getCurrentContainerInfo()}.
      *
      * @param originalPort the original TCP port that is exposed
      * @return the port that the exposed port is mapped to, or null if it is not exposed
+     * @see #getContainerInfo()
+     * @see #getCurrentContainerInfo()
      */
     default Integer getMappedPort(int originalPort) {
         Preconditions.checkState(
@@ -152,7 +164,7 @@ public interface ContainerState {
         );
 
         Ports.Binding[] binding = new Ports.Binding[0];
-        final InspectContainerResponse containerInfo = this.getCurrentContainerInfo();
+        final InspectContainerResponse containerInfo = this.getContainerInfo();
         if (containerInfo != null) {
             binding = containerInfo.getNetworkSettings().getPorts().getBindings().get(new ExposedPort(originalPort));
         }
@@ -222,7 +234,10 @@ public interface ContainerState {
     }
 
     /**
+     * Returns the container inspect response. The response might be cached/outdated.
+     *
      * @return the container info
+     * @see #getCurrentContainerInfo()
      */
     InspectContainerResponse getContainerInfo();
 

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -6,7 +6,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse.ContainerState
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.api.model.Ports;
-
 import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
@@ -27,7 +26,6 @@ import org.testcontainers.utility.MountableFile;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.URL;
 import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.List;
@@ -184,22 +182,22 @@ public class GenericContainerTest {
                 .withNetwork(network)
                 .withNetworkAliases("foo")
                 .withExposedPorts(8080)
-                .withCommand(
-                    "/bin/sh",
-                    "-c",
-                    "while true ; do printf 'HTTP/1.1 200 OK\\n\\nyay' | nc -l -p 8080; done"
-                )
+                .withCommand("/bin/sh", "-c", "while true ; do printf 'HTTP/1.1 200 OK\\n\\nyay' | nc -l -p 8080; done")
         ) {
             container.start();
             assertYayHttpResponseFrom(container.getHost(), container.getMappedPort(8080));
 
             // disconnect container from the network
-            container.getDockerClient().disconnectFromNetworkCmd()
+            container
+                .getDockerClient()
+                .disconnectFromNetworkCmd()
                 .withContainerId(container.getContainerId())
                 .withNetworkId(network.getId())
                 .exec();
             // reconnect container to the network
-            container.getDockerClient().connectToNetworkCmd()
+            container
+                .getDockerClient()
+                .connectToNetworkCmd()
                 .withContainerId(container.getContainerId())
                 .withNetworkId(network.getId())
                 .exec();

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -6,7 +6,6 @@ import com.github.dockerjava.api.command.InspectContainerResponse.ContainerState
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.api.model.Ports;
-import lombok.Cleanup;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.experimental.FieldDefaults;
@@ -23,10 +22,6 @@ import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.MountableFile;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.URLConnection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -175,10 +175,15 @@ public class GenericContainerTest {
     }
 
     @Test
-    public void mappedPortShouldWorkAfterReconnect() throws IOException {
+    public void mappedPortCanBeUpdatedAfterReconnect() throws IOException {
         try (
             Network network = Network.newNetwork();
-            GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)
+            GenericContainer<?> container = new GenericContainer(TestImages.TINY_IMAGE) {
+                @Override
+                public InspectContainerResponse getContainerInfo() {
+                    return getCurrentContainerInfo();
+                }
+            }
                 .withNetwork(network)
                 .withNetworkAliases("foo")
                 .withExposedPorts(8080)


### PR DESCRIPTION
This PR improves the behavior of `ContainerState.getMappedPort(int)` method. Instead of the `getContainerInfo()` it uses `getCurrentContainerInfo()`.

The problem with the original behavior comes when a container is disconnected from a network and then newly connected. The exposed port number will change, but the `GenericContainer.getMappedPort()` returns the old value.

The PR also contains a new test with a simple reproducer.