### PR TITLE
added new postgres constructor to allow additional wait strategies

### DIFF
--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/PostgresContainerTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/PostgresContainerTests.java
@@ -4,6 +4,7 @@ import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.sql.ResultSet;
 import java.sql.Statement;
@@ -21,10 +22,37 @@ class PostgresContainerTests {
         .withUsername("foo")
         .withPassword("secret");
 
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER_WITH_WAIT = new PostgreSQLContainer<>(
+        JUnitJupiterTestImages.POSTGRES_IMAGE,
+        Wait.forListeningPort()
+    )
+        .withDatabaseName("foo")
+        .withUsername("foo")
+        .withPassword("secret");
+
     @Test
     void waits_until_postgres_accepts_jdbc_connections() throws Exception {
         HikariConfig hikariConfig = new HikariConfig();
         hikariConfig.setJdbcUrl(POSTGRE_SQL_CONTAINER.getJdbcUrl());
+        hikariConfig.setUsername("foo");
+        hikariConfig.setPassword("secret");
+
+        try (HikariDataSource ds = new HikariDataSource(hikariConfig)) {
+            Statement statement = ds.getConnection().createStatement();
+            statement.execute("SELECT 1");
+            ResultSet resultSet = statement.getResultSet();
+            resultSet.next();
+
+            int resultSetInt = resultSet.getInt(1);
+            assertThat(resultSetInt).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void with_custom_waits_until_postgres_accepts_jdbc_connections() throws Exception {
+        HikariConfig hikariConfig = new HikariConfig();
+        hikariConfig.setJdbcUrl(POSTGRE_SQL_CONTAINER_WITH_WAIT.getJdbcUrl());
         hikariConfig.setUsername("foo");
         hikariConfig.setPassword("secret");
 


### PR DESCRIPTION
We ran into this issue with migrating off docker desktop and using rancher desktop, colima, and podman.

https://github.com/rancher-sandbox/rancher-desktop/issues/2609
https://github.com/quarkusio/quarkus/issues/25682

We found the fix would be to wait for ports to become available, however, that overrides the existing wait strategy. Ideally, a new constructor would be available that joins a custom wait strategy with the existing wait strategy.

The unit test demonstrates what basically works, adding an additional wait for exposed ports. I have verified adding that wait with the existing wait fixes this issue.

Also, as more devs migrate off docker desktop, this issue will likely impair devs so getting a convenient fix is prudent.
