### PR TITLE
Fix `allowInsecure()` on `HttpWaitStrategy` for non-localhost Docker daemon

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
 import java.security.KeyManagementException;
@@ -29,8 +30,9 @@ import java.util.function.Predicate;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 
 import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
 
@@ -332,7 +334,7 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
                 // Create a trust manager that does not validate certificate chains
                 // and trust all certificates
                 final TrustManager[] trustAllCerts = new TrustManager[] {
-                    new X509TrustManager() {
+                    new X509ExtendedTrustManager() {
                         @Override
                         public X509Certificate[] getAcceptedIssuers() {
                             return new X509Certificate[0];
@@ -343,6 +345,18 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
 
                         @Override
                         public void checkServerTrusted(final X509Certificate[] certs, final String authType) {}
+
+                        @Override
+                        public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+                        @Override
+                        public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {}
+
+                        @Override
+                        public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
+
+                        @Override
+                        public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {}
                     },
                 };
 


### PR DESCRIPTION
We found out that `HttpWaitStrategyTest.testWaitUntilReadyWithTlsAndAllowUnsecure()` will fail with `java.security.cert.CertificateException: No subject alternative names matching IP address 127.0.0.1 found` when used with a Docker daemon that makes containers accessible on `127.0.0.1` rather than on `localhost`.

This seems to be due to our implementation of `allowInsecure` in `HttpWaitStrategy`, where we used a `X509TrustManager`, that only performs part of the certifacte validation.

This PR changes this implementation to now use a [`X509ExtendedTrustManager`](https://docs.oracle.com/javase/7/docs/api/javax/net/ssl/X509ExtendedTrustManager.html), to ignore this check accordingly. We don't consider this a security issue, since this is for the explicit use case, where a user wants the `HttpWaitStrategy` to ignore insecure SSL certificates. 