### PR TITLE
[Neo4j] Add random password function and warn on too short passwords.

### DIFF
--- a/docs/modules/databases/neo4j.md
+++ b/docs/modules/databases/neo4j.md
@@ -21,12 +21,28 @@ You are not limited to Unit tests and can of course use an instance of the Neo4j
 
 ## Additional features
 
+### Custom password
+
+A custom password can be provided:
+
+<!--codeinclude-->
+[Custom password](../../../modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java) inside_block:withAdminPassword
+<!--/codeinclude-->
+
 ### Disable authentication
 
 Authentication can be disabled:
 
 <!--codeinclude-->
 [Disable authentication](../../../modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java) inside_block:withoutAuthentication
+<!--/codeinclude-->
+
+### Random password
+
+A random (`UUID`-random based) password can be set:
+
+<!--codeinclude-->
+[Random password](../../../modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java) inside_block:withRandomPassword
 <!--/codeinclude-->
 
 ### Neo4j-Configuration

--- a/examples/neo4j-container/src/test/java/org/testcontainers/containers/Neo4jExampleTest.java
+++ b/examples/neo4j-container/src/test/java/org/testcontainers/containers/Neo4jExampleTest.java
@@ -28,7 +28,7 @@ class Neo4jExampleTest {
 
     @Container
     private static Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>(DockerImageName.parse("neo4j:4.4"))
-        .withAdminPassword(null); // Disable password
+        .withoutAuthentication(); // Disable password
 
     @Test
     void testSomethingUsingBolt() {

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -15,6 +15,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -230,6 +231,9 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
      * @return This container.
      */
     public S withAdminPassword(final String adminPassword) {
+        if (adminPassword != null && adminPassword.length() < 8) {
+            logger().warn("Your provided admin password is too short and will not work with Neo4j 5.3+.");
+        }
         this.adminPassword = adminPassword;
         return self();
     }
@@ -359,5 +363,9 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
         }
 
         return false;
+    }
+
+    public S withRandomPassword() {
+        return withAdminPassword(UUID.randomUUID().toString());
     }
 }

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -1,5 +1,9 @@
 package org.testcontainers.containers;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
 import org.junit.Test;
 import org.neo4j.driver.AuthToken;
 import org.neo4j.driver.AuthTokens;
@@ -10,13 +14,16 @@ import org.neo4j.driver.Result;
 import org.neo4j.driver.Session;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.MountableFile;
 
 import java.util.Collections;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
@@ -185,6 +192,17 @@ public class Neo4jContainerTest {
     }
 
     @Test
+    public void shouldSetCustomPasswordCorrectly() {
+        // withoutAuthentication {
+        Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withAdminPassword("verySecret");
+        // }
+
+        neo4jContainer.configure();
+
+        assertThat(neo4jContainer.getEnvMap()).containsEntry("NEO4J_AUTH", "neo4j/verySecret");
+    }
+
+    @Test
     public void containerAdminPasswordOverrulesEnvironmentAuth() {
         Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
             .withEnv("NEO4J_AUTH", "neo4j/secret")
@@ -302,11 +320,60 @@ public class Neo4jContainerTest {
         }
     }
 
+    @Test
+    public void shouldCreateRandomUuidBasedPasswords() {
+        try (
+            // withRandomPassword {
+            Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withRandomPassword();
+            // }
+        ) {
+            // It will throw an exception if it's not UUID parsable.
+            assertThatNoException().isThrownBy(neo4jContainer::configure);
+            // This basically is always true at if the random password is UUID-like.
+            assertThat(neo4jContainer.getAdminPassword())
+                .satisfies(password -> assertThat(UUID.fromString(password).toString()).isEqualTo(password));
+        }
+    }
+
+    @Test
+    public void shouldWarnOnPasswordTooShort() {
+        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4");) {
+            Logger logger = (Logger) DockerLoggerFactory.getLogger("neo4j:4.4");
+            TestLogAppender testLogAppender = new TestLogAppender();
+            logger.addAppender(testLogAppender);
+            testLogAppender.start();
+
+            neo4jContainer.withAdminPassword("short");
+
+            testLogAppender.stop();
+
+            assertThat(testLogAppender.passwordTooShortWarningAppeared).isTrue();
+        }
+    }
+
     private static class CustomDummyWaitStrategy extends AbstractWaitStrategy {
 
         @Override
         protected void waitUntilReady() {
             // ehm...ready
+        }
+    }
+
+    private static class TestLogAppender extends AppenderBase<ILoggingEvent> {
+
+        boolean passwordTooShortWarningAppeared = false;
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            if (eventObject.getLevel().equals(Level.WARN)) {
+                if (
+                    eventObject
+                        .getMessage()
+                        .equals("Your provided admin password is too short and will not work with Neo4j 5.3+.")
+                ) {
+                    passwordTooShortWarningAppeared = true;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Even though it seems a lot by the following list, the change(s) are pretty atomic and -from my point of view- fit nicely in one "password-themed" PR.

### Documentation
* Use best-practice method (`withoutAuthentication`) instead of `withAdminPassword(null)` in example.
* Explicitly mention custom password (`withAdminPassword`) and the new `withRandomPassword` method in the feature section

### Logging
* Add log message if password is shorter than 8 characters.
Intentionally chose to not throw an exception because this strict requirement is just valid for Neo4j 5.3+
* Add test for new log message.

### Functionality
* Add `withRandomPassword` function. Something that people guarantee to have a password set but don't need to care about length, lifetime or accidentally (publicly) shared credentials.