### PR TITLE
fix: Don't return JSON auth config for partial registry name match

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -229,7 +229,7 @@ public class RegistryAuthLocator {
             final Iterator<Map.Entry<String, JsonNode>> fields = auths.fields();
             while (fields.hasNext()) {
                 final Map.Entry<String, JsonNode> entry = fields.next();
-                if (entry.getKey().contains("://" + reposName) || entry.getKey().equals(reposName)) {
+                if (entry.getKey().endsWith("://" + reposName) || entry.getKey().equals(reposName)) {
                     return entry;
                 }
             }

--- a/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/RegistryAuthLocatorTest.java
@@ -64,6 +64,20 @@ public class RegistryAuthLocatorTest {
     }
 
     @Test
+    public void lookupAuthConfigWithJsonKeyCredentialsPartialMatchShouldGiveNoResult() throws URISyntaxException {
+        // contains entry for registry.example.com
+        final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-json-key.json");
+
+        final AuthConfig authConfig = authLocator.lookupAuthConfig(
+            DockerImageName.parse("registry.example.co/org/repo"), // partial match of registry name
+            new AuthConfig()
+        );
+
+        assertThat(authConfig.getUsername()).as("auth config username").isNull();
+        assertThat(authConfig.getPassword()).as("auth config password").isNull();
+    }
+
+    @Test
     public void lookupAuthConfigUsingStore() throws URISyntaxException {
         final RegistryAuthLocator authLocator = createTestAuthLocator("config-with-store.json");
 


### PR DESCRIPTION
With the current implementation, looking up the JSON file based auth config for an image `registry.example.co/org/repo` would return the auth config for `https://registry.example.com` (note the missing `m` from the TLD of the image name). 

I can not think of a case where this is a desired behavior and in addition, this _could_  be a potential part in a more sophisticated exploit chain (although I don't expect this to be likely for Testcontainers usage scenarios).

This implementation mitigates this issue by ensuring that the parsed repository name has to exactly match the string of the registry following the protocol (`http(s)://`).