### PR TITLE
Use an OS-appropriate location for the properties file

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -92,6 +92,8 @@ dependencies {
 
     shaded 'org.zeroturnaround:zt-exec:1.12'
 
+    shaded 'dev.dirs:directories:26'
+
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.3.1'
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -410,7 +410,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                             "" +
                             "Reuse was requested but the environment does not support the reuse of containers\n" +
                             "To enable reuse of containers, you must set 'testcontainers.reuse.enable=true' in a file located at {}",
-                            Paths.get(System.getProperty("user.home"), ".testcontainers.properties")
+                            TestcontainersConfiguration.getUserConfigFile()
                         );
                     reusable = false;
                 }

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -360,8 +360,9 @@ public abstract class DockerClientProviderStrategy {
             .filter(DockerClientProviderStrategy::isPersistable)
             .peek(strategy -> {
                 log.info(
-                    "Loaded {} from ~/.testcontainers.properties, will try it first",
-                    strategy.getClass().getName()
+                    "Loaded {} from {}, will try it first",
+                    strategy.getClass().getName(),
+                    TestcontainersConfiguration.getUserConfigFile()
                 );
             })
             .findFirst();

--- a/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  * Resolution order is:
  * <ol>
  *     <li>DOCKER_HOST env var</li>
- *     <li>docker.host in ~/.testcontainers.properties</li>
+ *     <li>docker.host in {@link TestcontainersConfiguration#getUserConfigFile()}</li>
  * </ol>
  *
  * @deprecated this class is used by the SPI and should not be used directly

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -6,11 +6,13 @@ You can override some default properties if your environment requires that.
 The configuration will be loaded from multiple locations. Properties are considered in the following order:
 
 1. Environment variables
-2. `.testcontainers.properties` in user's home folder. Example locations:  
-**Linux:** `/home/myuser/.testcontainers.properties`  
-**Windows:** `C:/Users/myuser/.testcontainers.properties`  
-**macOS:** `/Users/myuser/.testcontainers.properties`
+2. `testcontainers.properties` in user's configuration folder. Example locations:  
+**Linux:** `/home/myuser/.config/testcontainers/testcontainers.properties`  
+**Windows:** `C:/Users/myuser/AppData/Roaming/testcontainers/config/testcontainers.properties`  
+**macOS:** `/Users/myuser/Library/Application Support/testcontainers/testcontainers.properties`
 3. `testcontainers.properties` on the classpath.
+
+For backwards compatibility, `.testcontainers.properties` in user's home folder will be used if it exists.
 
 Note that when using environment variables, configuration property names should be set in upper 
 case with underscore separators, preceded by `TESTCONTAINERS_` - e.g. `checks.disable` becomes 
@@ -33,7 +35,7 @@ Before running any containers Testcontainers will perform a set of startup check
         ✔ File should be mountable
         ✔ A port exposed by a docker container should be accessible
 ```
-It takes a couple of seconds, but if you want to speed up your tests, you can disable the checks once you have everything configured. Add `checks.disable=true` to your `$HOME/.testcontainers.properties` to completely disable them.
+It takes a couple of seconds, but if you want to speed up your tests, you can disable the checks once you have everything configured. Add `checks.disable=true` to your `testcontainers.properties` in your [configuration directory](#configuration-locations) to completely disable them.
 
 ## Customizing images
 
@@ -115,7 +117,8 @@ However, sometimes customization is required. Testcontainers will respect the fo
 > Docker's host on which ports are exposed.  
 > Example: `docker.svc.local`
 
-For advanced users, the Docker host connection can be configured **via configuration** in `~/.testcontainers.properties`.
+For advanced users, the Docker host connection can be configured **via configuration** in `testcontainers.properties`
+in your [configuration directory](#configuration-locations).
 Note that these settings require use of the `EnvironmentAndSystemPropertyClientProviderStrategy`. The example below 
 illustrates usage:
 

--- a/docs/features/image_name_substitution.md
+++ b/docs/features/image_name_substitution.md
@@ -67,7 +67,7 @@ This can be done in one of two ways:
 
 * Setting environment variables `TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=registry.mycompany.com/mirror/`
 * Via config file, setting `hub.image.name.prefix` in either:
-    * the `~/.testcontainers.properties` file in your user home directory, or
+    * the `testcontainers.properties` file in your [configuration directory](./configuration.md#configuration-locations), or
     * a file named `testcontainers.properties` on the classpath
     
 Testcontainers will automatically apply the prefix to every image that it pulls from Docker Hub - please verify that all [the required images](../supported_docker_environment/image_registry_rate_limiting.md#which-images-are-used-by-testcontainers) exist in your registry.
@@ -119,8 +119,8 @@ For example:
 
 Note that it is also possible to provide this same configuration property:
 
-* in a `testcontainers.properties` file at the root of a library JAR file (useful if you wish to distribute a drop-in image substitutor JAR within an organization) 
-* in a properties file in the user's home directory (`~/.testcontainers.properties`; note the leading `.`)
+* in a `testcontainers.properties` file at the root of a library JAR file (useful if you wish to distribute a drop-in image substitutor JAR within an organization), 
+* in a properties file in the user's [configuration directory](./configuration.md#configuration-locations),
 * or as an environment variable (e.g. `TESTCONTAINERS_IMAGE_SUBSTITUTOR=com.mycompany.testcontainers.ExampleImageNameSubstitutor`).
 
 Please see [the documentation on configuration mechanisms](./configuration.md) for more information.

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -24,7 +24,7 @@ GenericContainer container = new GenericContainer("redis:6-alpine")
     .withReuse(true)
 ```
 
-* Opt-in to Reusable Containers in `~/.testcontainers.properties`, by adding `testcontainers.reuse.enable=true`
+* Opt-in to Reusable Containers in `testcontainers.properties` in your [configuration directory](./configuration.md#configuration-locations), by adding `testcontainers.reuse.enable=true`
 * Containers need to be started manually using `container.start()`. See [docs](../../test_framework_integration/manual_lifecycle_control)
 
 ### Reusable Container with Testcontainers JDBC URL


### PR DESCRIPTION
Uses directories-jvm to resolve the configuration directory location. See: https://github.com/dirs-dev/directories-jvm#introduction

The old `$HOME/.testcontainers.properties` is still preferred if it exists.

New example locations:
- **Linux:** `/home/myuser/.config/testcontainers/testcontainers.properties`  
- **Windows:** `C:/Users/myuser/AppData/Roaming/testcontainers/config/testcontainers.properties`  
- **macOS:** `/Users/myuser/Library/Application Support/testcontainers/testcontainers.properties`
