### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
 
-    testImplementation ('org.mockito:mockito-core:4.9.0') {
+    testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation project(":mysql")
 
     testImplementation 'mysql:mysql-connector-java:8.0.31'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.7.0"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.7.2"
     testImplementation 'org.assertj:assertj-core:3.15.0'
 }

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.2.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.2.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.2.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-remote-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
-    testImplementation 'io.cucumber:cucumber-java:7.9.0'
+    testImplementation 'io.cucumber:cucumber-java:7.10.1'
     testImplementation 'io.cucumber:cucumber-junit:7.9.0'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.9'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.0'
+    testImplementation 'com.couchbase.client:java-client:3.4.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "TestContainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.2"
-    testImplementation "org.elasticsearch.client:transport:7.17.7"
+    testImplementation "org.elasticsearch.client:transport:7.17.8"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.4'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.121.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.33.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.16.0'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.17.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.5'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.7.3'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.7.4'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.121.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.33.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.16.0'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: HiveMQ"
 
 dependencies {
     api(project(":testcontainers"))
-    api("org.jetbrains:annotations:23.0.0")
+    api("org.jetbrains:annotations:23.1.0")
 
     shaded("org.apache.commons:commons-lang3:3.12.0")
     shaded("commons-io:commons-io:2.11.0")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.9.1")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.10.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.5")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.9.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
-    testImplementation("org.apache.httpcomponents:httpclient:4.5.13")
+    testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.5")
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:23.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.2'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.4'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.2'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation ('org.mockito:mockito-core:4.9.0') {
+    testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':database-commons')
     testImplementation project(':test-support')
 
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.4'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.3.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    testImplementation ('org.mockito:mockito-core:4.9.0') {
+    testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.2.0'
-    testImplementation 'io.kubernetes:client-java:16.0.2'
+    testImplementation 'io.kubernetes:client-java:17.0.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.356'
+    compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.376'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.356'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.376'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.356'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.356'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.356'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.356'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.376'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.356'
     testImplementation 'software.amazon.awssdk:s3:2.18.29'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.356'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.376'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.356'
-    testImplementation 'software.amazon.awssdk:s3:2.18.29'
+    testImplementation 'software.amazon.awssdk:s3:2.19.8'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.9'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -2,6 +2,6 @@ description = "Testcontainers :: Nginx"
 
 dependencies {
     api project(':testcontainers')
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.ojdbc:ojdbc8:19.3.0.0'
 
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.1'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.13"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.14"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "TestContainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.13"
+    api "com.orientechnologies:orientdb-client:3.2.14"
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.1'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/presto/build.gradle
+++ b/modules/presto/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'io.prestosql:presto-jdbc:350'
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -9,5 +9,5 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.questdb:questdb:6.6.1-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
-    testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.0'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.1'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.1'
 
-    testCompileOnly 'org.jetbrains:annotations:23.0.0'
+    testCompileOnly 'org.jetbrains:annotations:23.1.0'
 }
 
 sourceJar {

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation project(':postgresql')
 
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'mysql:mysql-connector-java:8.0.31'
 
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'io.trino:trino-jdbc:403'
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump httpclient from 4.5.13 to 4.5.14 in /modules/questdb (#6380) @app/dependabot
* Bump neo4j-java-driver from 4.4.9 to 4.4.11 in /examples (#6379) @app/dependabot
* Bump selenium-api from 4.7.0 to 4.7.2 in /examples (#6378) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/tidb (#6377) @app/dependabot
* Bump cucumber-java from 7.9.0 to 7.10.1 in /examples (#6373) @app/dependabot
* Bump google-cloud-firestore from 3.7.3 to 3.7.4 in /modules/gcloud (#6371) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/hivemq (#6368) @app/dependabot
* Bump orientdb-gremlin from 3.2.13 to 3.2.14 in /modules/orientdb (#6369) @app/dependabot
* Bump lettuce-core from 6.2.1.RELEASE to 6.2.2.RELEASE in /examples (#6367) @app/dependabot
* Bump client-java from 16.0.2 to 17.0.0 in /modules/k3s (#6365) @app/dependabot
* Bump google-cloud-bigtable from 2.16.0 to 2.17.1 in /modules/gcloud (#6366) @app/dependabot
* Bump httpclient from 4.5.13 to 4.5.14 in /modules/hivemq (#6364) @app/dependabot
* Bump orientdb-client from 3.2.13 to 3.2.14 in /modules/orientdb (#6363) @app/dependabot
* Bump hivemq-extension-sdk from 4.9.1 to 4.10.0 in /modules/hivemq (#6362) @app/dependabot
* Bump reactor-core from 3.5.0 to 3.5.1 in /modules/r2dbc (#6361) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/trino (#6359) @app/dependabot
* Bump kubernetes-client from 6.2.0 to 6.3.1 in /modules/k3s (#6358) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/presto (#6355) @app/dependabot
* Bump trino-jdbc from 403 to 405 in /modules/trino (#6356) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/rabbitmq (#6353) @app/dependabot
* Bump google-cloud-datastore from 2.12.5 to 2.13.0 in /modules/gcloud (#6352) @app/dependabot
* Bump mockito-core from 4.9.0 to 4.11.0 in /modules/jdbc (#6350) @app/dependabot
* Bump aws-java-sdk-sqs from 1.12.356 to 1.12.376 in /modules/localstack (#6348) @app/dependabot
* Bump transport from 7.17.7 to 7.17.8 in /modules/elasticsearch (#6349) @app/dependabot
* Bump cucumber-junit from 7.9.0 to 7.10.1 in /examples (#6347) @app/dependabot
* Bump mockito-core from 4.9.0 to 4.11.0 in /core (#6345) @app/dependabot
* Bump mockito-core from 4.9.0 to 4.11.0 in /modules/junit-jupiter (#6344) @app/dependabot
* Bump tomcat-jdbc from 10.1.2 to 10.1.4 in /modules/jdbc (#6340) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/spock (#6342) @app/dependabot
* Bump java-client from 3.4.0 to 3.4.1 in /modules/couchbase (#6343) @app/dependabot
* Bump aws-java-sdk-s3 from 1.12.356 to 1.12.376 in /modules/localstack (#6341) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/mysql (#6334) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/jdbc (#6336) @app/dependabot
* Bump neo4j-java-driver from 4.4.9 to 4.4.11 in /modules/neo4j (#6339) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/postgresql (#6335) @app/dependabot
* Bump elasticsearch-rest-client from 8.5.2 to 8.5.3 in /modules/elasticsearch (#6337) @app/dependabot
* Bump httpclient from 4.5.13 to 4.5.14 in /modules/junit-jupiter (#6332) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/nginx (#6333) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/oracle-xe (#6329) @app/dependabot
* Bump httpclient from 4.5.13 to 4.5.14 in /modules/spock (#6330) @app/dependabot
* Bump s3 from 2.18.29 to 2.19.8 in /modules/localstack (#6328) @app/dependabot
