### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,7 +68,7 @@ configurations.all {
 dependencies {
     api 'junit:junit:4.13.2'
     api 'org.slf4j:slf4j-api:1.7.36'
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
     testCompileOnly 'org.jetbrains:annotations:23.0.0'
     api 'org.apache.commons:commons-compress:1.22'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.10.1'
-    testImplementation 'io.cucumber:cucumber-junit:7.9.0'
+    testImplementation 'io.cucumber:cucumber-junit:7.10.1'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.356'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.353'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.376'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.376'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.3"
     testImplementation "org.elasticsearch.client:transport:7.17.8"
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.12.5'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.4'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.121.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.34.1'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.12.5'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.4'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.121.1'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.33.0'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.34.1'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.17.1'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'redis.clients:jedis:4.3.1'
-    testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.2.0'
+    testImplementation 'io.fabric8:kubernetes-client:6.3.1'
     testImplementation 'io.kubernetes:client-java:17.0.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.376'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.356'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.376'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.356'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.376'
     testImplementation 'software.amazon.awssdk:s3:2.19.8'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.8.0")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.8.1")
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }
 

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -12,5 +12,5 @@ dependencies {
     testImplementation project(':nginx')
     testImplementation 'org.assertj:assertj-core:3.23.1'
 
-    compileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:403'
+    testImplementation 'io.trino:trino-jdbc:405'
     compileOnly 'org.jetbrains:annotations:23.1.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump kubernetes-client from 6.2.0 to 6.3.1 in /modules/k3s (#6358) @app/dependabot
* Bump google-cloud-spanner from 6.33.0 to 6.34.1 in /modules/gcloud (#6357) @app/dependabot
* Bump trino-jdbc from 403 to 405 in /modules/trino (#6356) @app/dependabot
* Bump mongodb-driver-sync from 4.8.0 to 4.8.1 in /modules/mongodb (#6354) @app/dependabot
* Bump google-cloud-datastore from 2.12.5 to 2.13.0 in /modules/gcloud (#6352) @app/dependabot
* Bump aws-java-sdk-logs from 1.12.356 to 1.12.376 in /modules/localstack (#6351) @app/dependabot
* Bump cucumber-junit from 7.9.0 to 7.10.1 in /examples (#6347) @app/dependabot
* Bump aws-java-sdk-dynamodb from 1.12.356 to 1.12.376 in /modules/dynalite (#6346) @app/dependabot
* Bump elasticsearch-rest-client from 8.5.2 to 8.5.3 in /modules/elasticsearch (#6337) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /modules/selenium (#6338) @app/dependabot
* Bump httpclient from 4.5.13 to 4.5.14 in /modules/junit-jupiter (#6332) @app/dependabot
* Bump annotations from 23.0.0 to 23.1.0 in /core (#6331) @app/dependabot
