### PR TITLE
docs: clarify usage of `TESTCONTAINERS_HOST_OVERRIDE` for DinD on Docker Desktop

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/dind_patterns.md
+++ b/docs/supported_docker_environment/continuous_integration/dind_patterns.md
@@ -34,7 +34,7 @@ Where:
 
 
 !!! note
-    If you are using Docker Desktop, you need to configure `TESTCONTAINERS_HOST_OVERRIDE` to use the special DNS name 
+    If you are using Docker Desktop, you need to configure the `TESTCONTAINERS_HOST_OVERRIDE` environment variable to use the special DNS name
     `host.docker.internal` for accessing the host from within a container, which is provided by Docker Desktop:
     `-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`
 

--- a/docs/supported_docker_environment/continuous_integration/dind_patterns.md
+++ b/docs/supported_docker_environment/continuous_integration/dind_patterns.md
@@ -34,8 +34,9 @@ Where:
 
 
 !!! note
-    If you are using Docker Desktop, you need to mount the Docker socket that bypasses the API proxy (see [this comment](https://github.com/docker/for-mac/issues/5588#issuecomment-934600089) for more details):
-    `-v /var/run/docker.sock.raw:/var/run/docker.sock`
+    If you are using Docker Desktop, you need to configure `TESTCONTAINERS_HOST_OVERRIDE` to use the special DNS name 
+    `host.docker.internal` for accessing the host from within a container, which is provided by Docker Desktop:
+    `-e TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`
 
 ### Docker Compose example
 The same can be achieved with Docker Compose:


### PR DESCRIPTION
While #6282 tried to clarify the usage of Testcontainers in DinD setups on Docker Desktop (based and what we learned about using `docker.sock.raw` from [this comment](https://github.com/docker/for-mac/issues/5588#issuecomment-934600089) in Docker Desktop), we actually learned that this won't work when running a DinD setup on Docker Desktop using Docker Compose V2 (this holds true on Mac and on Windows). While we are not sure about the root cause that makes sibling containers inaccessible using the default gateway, we suspect that is can be related to the default Docker Compose network.

However, we identified that configuring `TESTCONTAINERS_HOST_OVERRIDE` to use `docker.host.internal` provides a stable experience in all scenarios. Since using DinD requires some manual configuration in the first place, it does not really matter if we have to manually touch the config to use the raw socket or instead use the override, so we can document the widely stable approach instead.

This means, we can also close #4396 now, since this behavior for host ort 0 was an accidental background as outlined by Docker in the comment mentioned above and we now have a good workaround for Docker Desktop. 