### PR TITLE
Update gradle enterprise plugin version to 3.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.1.2'
     id 'me.champeau.gradle.japicmp' version '0.4.1' apply false
     id 'com.diffplug.spotless' version '6.12.0' apply false
-    id 'org.gradle.test-retry' version '1.5.0'
 }
 
 apply from: "$rootDir/gradle/ci-support.gradle"
@@ -34,7 +33,6 @@ subprojects {
     apply from: "$rootDir/gradle/shading.gradle"
     apply from: "$rootDir/gradle/spotless.gradle"
     apply plugin: 'checkstyle'
-    apply plugin: 'org.gradle.test-retry'
 
     group = "org.testcontainers"
 

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.4"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.2"
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.11.4"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.2"
     }
 }


### PR DESCRIPTION
Latest version of Gradle Enterprise Plugin offers Test Retry plugin
and the build fails when both are in place. Gradle recommends to
use Gradle Enterprise Plugin so Test Retry is removed in order to
make the build pass.
