### PR TITLE
MS SQL Server container - support for MSSQL_PID env variable

### DIFF
--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -134,7 +134,6 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
         return self();
     }
 
-    @Override
     public SELF withPid(@NonNull final ProductId productId) {
         this.pid = productId;
         return self();

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -13,24 +13,35 @@ import java.util.stream.Stream;
  */
 public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server");
+
     @Deprecated
     public static final String DEFAULT_TAG = "2017-CU12";
+
     public static final String NAME = "sqlserver";
-    public static final Integer MS_SQL_SERVER_PORT = 1433;
-    static final String DEFAULT_USER = "SA";
-    static final String DEFAULT_PASSWORD = "A_Str0ng_Required_Password";
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server");
+
     public static final String IMAGE = DEFAULT_IMAGE_NAME.getUnversionedPart();
+
+    public static final Integer MS_SQL_SERVER_PORT = 1433;
+
+    static final String DEFAULT_USER = "SA";
+
+    static final String DEFAULT_PASSWORD = "A_Str0ng_Required_Password";
+
+    private String password = DEFAULT_PASSWORD;
+
+    private ProductId pid = ProductId.DEVELOPER;
+
     private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 240;
+
     private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 240;
-    private static final Pattern[] PASSWORD_CATEGORY_VALIDATION_PATTERNS = new Pattern[]{
+
+    private static final Pattern[] PASSWORD_CATEGORY_VALIDATION_PATTERNS = new Pattern[] {
         Pattern.compile("[A-Z]+"),
         Pattern.compile("[a-z]+"),
         Pattern.compile("[0-9]+"),
         Pattern.compile("[^a-zA-Z0-9]+", Pattern.CASE_INSENSITIVE),
     };
-    private String password = DEFAULT_PASSWORD;
-    private ProductId pid = ProductId.DEVELOPER;
 
     /**
      * @deprecated use {@link MSSQLServerContainer(DockerImageName)} instead

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -1,6 +1,5 @@
 package org.testcontainers.containers;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.LicenseAcceptance;
 
@@ -134,7 +133,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
         return self();
     }
 
-    public SELF withPid(@NonNull final ProductId productId) {
+    public SELF withPid(final ProductId productId) {
         this.pid = productId;
         return self();
     }

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
@@ -12,6 +12,7 @@ import java.sql.Statement;
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.containers.MSSQLServerContainer.ProductId.*;
 
 public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
 
@@ -44,9 +45,37 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
     }
 
     @Test
+    public void testWithDefaultPid() throws SQLException {
+        try (
+            MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE)
+        ) {
+            mssqlServer.start();
+            ResultSet resultSet = performQuery(mssqlServer, "SELECT @@VERSION;");
+
+            String versionResultSet = resultSet.getString(1);
+            assertThat(versionResultSet).contains("Developer Edition");
+        }
+    }
+
+    @Test
+    public void testWithCustomPid() throws SQLException {
+        try (
+            MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE)
+                .withPid(WEB)
+        ) {
+            mssqlServer.start();
+            ResultSet resultSet = performQuery(mssqlServer, "SELECT @@VERSION;");
+
+            String versionResultSet = resultSet.getString(1);
+            assertThat(versionResultSet).contains("Web Edition");
+        }
+    }
+
+    @Test
     public void testSetupDatabase() throws SQLException {
         try (
             MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE)
+                .withPid(ENTERPRISE);
         ) {
             mssqlServer.start();
             DataSource ds = getDataSource(mssqlServer);

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
@@ -12,7 +12,6 @@ import java.sql.Statement;
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testcontainers.containers.MSSQLServerContainer.ProductId.WEB;
 
 public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
 
@@ -61,7 +60,7 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
     public void testWithCustomPid() throws SQLException {
         try (
             MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE)
-                .withPid(WEB)
+                .withPid(MSSQLServerContainer.ProductId.WEB)
         ) {
             mssqlServer.start();
             ResultSet resultSet = performQuery(mssqlServer, "SELECT @@VERSION;");

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/SimpleMSSQLServerTest.java
@@ -12,7 +12,7 @@ import java.sql.Statement;
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.testcontainers.containers.MSSQLServerContainer.ProductId.*;
+import static org.testcontainers.containers.MSSQLServerContainer.ProductId.WEB;
 
 public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
 
@@ -74,8 +74,7 @@ public class SimpleMSSQLServerTest extends AbstractContainerDatabaseTest {
     @Test
     public void testSetupDatabase() throws SQLException {
         try (
-            MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE)
-                .withPid(ENTERPRISE);
+            MSSQLServerContainer<?> mssqlServer = new MSSQLServerContainer<>(MSSQLServerTestImages.MSSQL_SERVER_IMAGE);
         ) {
             mssqlServer.start();
             DataSource ds = getDataSource(mssqlServer);


### PR DESCRIPTION
Added support for `MSSQL_PID` variable of MS SQL Server container.
This change allows users to run tests against specific SQL Server editions ex. Developer (default), Express, Web etc. 

Description of `MSSQL_PID` is available on [DockerHub](https://hub.docker.com/_/microsoft-mssql-server#:~:text=non%2Dalphanumeric%20symbols.-,MSSQL_PID,-is%20the%20Product) and [Learn Microsoft](https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-configure-environment-variables?view=sql-server-2017#:~:text=use%20MSSQL_SA_PASSWORD%20instead.-,MSSQL_PID,-Set%20the%20SQL)