### PR TITLE
Add workflow to update base version used by japicmp

### DIFF
--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -1,0 +1,32 @@
+name: Update testcontainers version
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
+    if: github.repository == 'testcontainers/testcontainers-java'
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Update testcontainers.version property in gradle.properties
+        run: |
+          sed -ie "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
+          git diff
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v3.10.1
+        with:
+          title: [japicmp] Update testcontainers version to ${GITHUB_REF##*/}
+          body: |
+            Update testcontainers version to ${GITHUB_REF##*/}
+          branch: update-tc-version
+          delete-branch: true

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -20,12 +20,12 @@ jobs:
           ref: main
       - name: Update testcontainers.version property in gradle.properties
         run: |
-          sed -ie "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
+          sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v3.10.1
         with:
-          title: [japicmp] Update testcontainers version to ${GITHUB_REF##*/}
+          title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |
             Update testcontainers version to ${GITHUB_REF##*/}
           branch: update-tc-version

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ Testcontainers' release process is semi-automated through GitHub Actions. This d
 9. Handcraft and polish some of the release notes (e.g. substitute combinded dependency PRs and highlight certain features).
 10. Rename existing milestone corresponding to new release and close it. Then create a new `next` milstestone.
 11. When available through Maven Central, poke [Richard North](https://github.com/rnorth) to announce the release on Twitter!
-12. Merge PRs in order to update version in mkdocs.yml and gradle.properties
+12. Merge automated version update PRs in order to update the reference version in `mkdocs.yml` and `gradle.properties`.
 
 ## Internal details
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,6 +18,7 @@ Testcontainers' release process is semi-automated through GitHub Actions. This d
 9. Handcraft and polish some of the release notes (e.g. substitute combinded dependency PRs and highlight certain features).
 10. Rename existing milestone corresponding to new release and close it. Then create a new `next` milstestone.
 11. When available through Maven Central, poke [Richard North](https://github.com/rnorth) to announce the release on Twitter!
+12. Merge PRs in order to update version in mkdocs.yml and gradle.properties
 
 ## Internal details
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.parallel=false
 org.gradle.caching=true
 org.gradle.configureondemand=true
+testcontainers.version=1.17.6

--- a/gradle/japicmp.gradle
+++ b/gradle/japicmp.gradle
@@ -3,7 +3,7 @@ configurations {
 }
 
 dependencies {
-    baseline "org.testcontainers:${project.name}:1.17.6", {
+    baseline "org.testcontainers:${project.name}:${project['testcontainers.version']}", {
         exclude group: "*", module: "*"
     }
 }


### PR DESCRIPTION
Previously, this step was done manually. In order to promote
automation `testcontainers.version` has been added to `gradle.properties`
in order to be updated every time there is a new release.

A PR will be created after the release is done.
