### PR TITLE
Add Docker image name to ContainerLaunchException message

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -346,7 +346,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 }
             );
         } catch (Exception e) {
-            throw new ContainerLaunchException("Container startup failed", e);
+            throw new ContainerLaunchException("Container startup failed for image " + getDockerImageName(), e);
         }
     }
 

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -70,6 +70,7 @@ public class GenericContainerTest {
                 .withCommand("sh", "-c", "usleep 100; exit 123")
         ) {
             assertThatThrownBy(container::start)
+                .hasStackTraceContaining("Container startup failed for image " + TestImages.TINY_IMAGE)
                 .hasStackTraceContaining("Wait strategy failed. Container exited with code 123")
                 .hasStackTraceContaining("Nope!");
         }


### PR DESCRIPTION
When using multiple containers in one test and a container startup fails, it's unclear from the `ContainerLaunchException` which container failed.

Adding the Docker image name to the exception message is a simple solution to improve debugging test failures.