### PR TITLE
[gcloud] Accept gcr.io/google.com/cloudsdktool/google-cloud-cli as a valid image

### DIFF
--- a/modules/gcloud/src/main/java/org/testcontainers/containers/BigtableEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/BigtableEmulatorContainer.java
@@ -14,6 +14,10 @@ import org.testcontainers.utility.DockerImageName;
 public class BigtableEmulatorContainer extends GenericContainer<BigtableEmulatorContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse(
+        "gcr.io/google.com/cloudsdktool/google-cloud-cli"
+    );
+
+    private static final DockerImageName CLOUD_SDK_IMAGE_NAME = DockerImageName.parse(
         "gcr.io/google.com/cloudsdktool/cloud-sdk"
     );
 
@@ -23,7 +27,7 @@ public class BigtableEmulatorContainer extends GenericContainer<BigtableEmulator
 
     public BigtableEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, CLOUD_SDK_IMAGE_NAME);
 
         withExposedPorts(PORT);
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx("(?s).*running.*$"));

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
@@ -13,6 +13,10 @@ import org.testcontainers.utility.DockerImageName;
 public class DatastoreEmulatorContainer extends GenericContainer<DatastoreEmulatorContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse(
+        "gcr.io/google.com/cloudsdktool/google-cloud-cli"
+    );
+
+    private static final DockerImageName CLOUD_SDK_IMAGE_NAME = DockerImageName.parse(
         "gcr.io/google.com/cloudsdktool/cloud-sdk"
     );
 
@@ -29,7 +33,7 @@ public class DatastoreEmulatorContainer extends GenericContainer<DatastoreEmulat
 
     public DatastoreEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, CLOUD_SDK_IMAGE_NAME);
 
         withExposedPorts(HTTP_PORT);
         setWaitStrategy(Wait.forHttp("/").forStatusCode(200));

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/FirestoreEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/FirestoreEmulatorContainer.java
@@ -13,6 +13,10 @@ import org.testcontainers.utility.DockerImageName;
 public class FirestoreEmulatorContainer extends GenericContainer<FirestoreEmulatorContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse(
+        "gcr.io/google.com/cloudsdktool/google-cloud-cli"
+    );
+
+    private static final DockerImageName CLOUD_SDK_IMAGE_NAME = DockerImageName.parse(
         "gcr.io/google.com/cloudsdktool/cloud-sdk"
     );
 
@@ -22,7 +26,7 @@ public class FirestoreEmulatorContainer extends GenericContainer<FirestoreEmulat
 
     public FirestoreEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, CLOUD_SDK_IMAGE_NAME);
 
         withExposedPorts(PORT);
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx("(?s).*running.*$"));

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/PubSubEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/PubSubEmulatorContainer.java
@@ -13,6 +13,10 @@ import org.testcontainers.utility.DockerImageName;
 public class PubSubEmulatorContainer extends GenericContainer<PubSubEmulatorContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse(
+        "gcr.io/google.com/cloudsdktool/google-cloud-cli"
+    );
+
+    private static final DockerImageName CLOUD_SDK_IMAGE_NAME = DockerImageName.parse(
         "gcr.io/google.com/cloudsdktool/cloud-sdk"
     );
 
@@ -22,7 +26,7 @@ public class PubSubEmulatorContainer extends GenericContainer<PubSubEmulatorCont
 
     public PubSubEmulatorContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, CLOUD_SDK_IMAGE_NAME);
 
         withExposedPorts(8085);
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx("(?s).*started.*$"));

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/BigtableEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/BigtableEmulatorContainerTest.java
@@ -36,7 +36,7 @@ public class BigtableEmulatorContainerTest {
     @Rule
     // emulatorContainer {
     public BigtableEmulatorContainer emulator = new BigtableEmulatorContainer(
-        DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators")
+        DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators")
     );
 
     // }

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/DatastoreEmulatorContainerTest.java
@@ -19,7 +19,7 @@ public class DatastoreEmulatorContainerTest {
     @Rule
     // creatingDatastoreEmulatorContainer {
     public DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
-        DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators")
+        DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators")
     );
 
     // }
@@ -49,7 +49,7 @@ public class DatastoreEmulatorContainerTest {
     public void testWithFlags() throws IOException, InterruptedException {
         try (
             DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
-                "gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators"
+                "gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators"
             )
                 .withFlags("--consistency 1.0")
         ) {
@@ -64,7 +64,7 @@ public class DatastoreEmulatorContainerTest {
     public void testWithMultipleFlags() throws IOException, InterruptedException {
         try (
             DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
-                "gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators"
+                "gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators"
             )
                 .withFlags("--consistency 1.0 --data-dir /root/.config/test-gcloud")
         ) {

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/FirestoreEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/FirestoreEmulatorContainerTest.java
@@ -23,7 +23,7 @@ public class FirestoreEmulatorContainerTest {
     @Rule
     // emulatorContainer {
     public FirestoreEmulatorContainer emulator = new FirestoreEmulatorContainer(
-        DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators")
+        DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators")
     );
 
     // }

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/PubSubEmulatorContainerTest.java
@@ -37,7 +37,7 @@ public class PubSubEmulatorContainerTest {
     @Rule
     // emulatorContainer {
     public PubSubEmulatorContainer emulator = new PubSubEmulatorContainer(
-        DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:367.0.0-emulators")
+        DockerImageName.parse("gcr.io/google.com/cloudsdktool/google-cloud-cli:380.0.0-emulators")
     );
 
     // }


### PR DESCRIPTION
Also, use the new image in tests with a new tag which provides
`amd` and `arm` support. For backward compatibility, previous
image `gcr.io/google.com/cloudsdktool/cloud-sdk` is still valid.

Closes gh-6421
