### PR TITLE
Add withDockerfileFromClasspath method to ImageFromDockerfile

### DIFF
--- a/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/builder/ImageFromDockerfile.java
@@ -24,12 +24,14 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.ImageNameSubstitutor;
 import org.testcontainers.utility.LazyFuture;
+import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.ResourceReaper;
 
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -236,6 +238,16 @@ public class ImageFromDockerfile
     public ImageFromDockerfile withDockerfilePath(String relativePathFromBuildContextDirectory) {
         this.dockerFilePath = Optional.of(relativePathFromBuildContextDirectory);
         return this;
+    }
+
+    /**
+     * Sets the Dockerfile to be used for this image, from a resource
+     *
+     * @param resourceName resource name for the dockerfile
+     */
+    public ImageFromDockerfile withDockerfileFromClasspath(String resourceName) {
+        final MountableFile mountableFile = MountableFile.forClasspathResource(resourceName);
+        return withDockerfile(Paths.get(mountableFile.getResolvedPath()));
     }
 
     /**

--- a/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
@@ -31,6 +31,16 @@ public class DockerfileTest {
     }
 
     @Test
+    public void withDockerfileFromClassPathWorks() {
+        ImageFromDockerfile image = new ImageFromDockerfile()
+            .withFileFromString("folder/someFile.txt", "hello")
+            .withFileFromClasspath("test.txt", "mappable-resource/test-resource.txt")
+            .withDockerfileFromClasspath("mappable-dockerfile/Dockerfile");
+
+        verifyImage(image);
+    }
+
+    @Test
     public void customizableImage() {
         ImageFromDockerfile image = new ImageFromDockerfile() {
             @Override


### PR DESCRIPTION
Per https://github.com/testcontainers/testcontainers-java/issues/5354#issuecomment-1370750252 using Dockerfiles from the classpath doesn't trigger the pull of dependant images, so when the build happens we get problems if the images need authentication to pull

The withDockerfileFromClasspath method should set things up so that the dockerfile is scanned for dependent images correctly

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
