### PR TITLE
Add edge support to browser web driver container

### DIFF
--- a/docs/modules/webdriver_containers.md
+++ b/docs/modules/webdriver_containers.md
@@ -5,7 +5,7 @@ from SeleniumHQ's [docker-selenium](https://github.com/SeleniumHQ/docker-seleniu
 
 ## Benefits
 
-* Fully compatible with Selenium 3 & 4 tests, by providing a `RemoteWebDriver` instance
+* Fully compatible with Selenium 3 & 4 tests for Chrome and Firefox and Selenium 4 tests for Edge, by providing a `RemoteWebDriver` instance
 * No need to have specific web browsers, or even a desktop environment, installed on test servers. The only dependency
   is a working Docker installation and your Java JUnit test suite.
 * Browsers are always launched from a fixed, clean image. This means no configuration drift from user changes or
@@ -46,10 +46,11 @@ running on - which is quite likely), you'll need to use [the host exposing](../f
 
 ### Other browsers
 
-At the moment, Chrome and Firefox are supported. To switch, simply change the first parameter to the rule constructor:
+At the moment, Chrome, Firefox and Edge are supported. To switch, simply change the first parameter to the rule constructor:
 <!--codeinclude-->
 [Chrome](../../modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java) inside_block:junitRule
 [Firefox](../../modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java) inside_block:junitRule
+[Edge](../../modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java) inside_block:junitRule
 <!--/codeinclude-->
 
 ### Recording videos

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     provided 'org.seleniumhq.selenium:selenium-remote-driver:4.6.0'
     provided 'org.seleniumhq.selenium:selenium-chrome-driver:4.6.0'
     testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.6.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-edge-driver:4.6.0'
     testImplementation 'org.seleniumhq.selenium:selenium-support:4.6.0'
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -275,13 +275,17 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
                 }
                 throw new UnsupportedOperationException(
                     "For browser 'MicrosoftEdge' selenium version must be 4 or higher;" +
-                        "docker images are available from there upwards;" +
-                        "provided version: '" + seleniumVersion + "'"
+                    "docker images are available from there upwards;" +
+                    "provided version: '" +
+                    seleniumVersion +
+                    "'"
                 );
             default:
                 throw new UnsupportedOperationException(
                     "Browser name must be 'chrome', 'firefox' or 'MicrosoftEdge';" +
-                        "provided '" + browserName + "' is not supported"
+                    "provided '" +
+                    browserName +
+                    "' is not supported"
                 );
         }
     }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -52,6 +52,8 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
     private static final DockerImageName FIREFOX_IMAGE = DockerImageName.parse("selenium/standalone-firefox");
 
+    private static final DockerImageName EDGE_IMAGE = DockerImageName.parse("selenium/standalone-edge");
+
     private static final DockerImageName CHROME_DEBUG_IMAGE = DockerImageName.parse("selenium/standalone-chrome-debug");
 
     private static final DockerImageName FIREFOX_DEBUG_IMAGE = DockerImageName.parse(
@@ -61,6 +63,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     private static final DockerImageName[] COMPATIBLE_IMAGES = new DockerImageName[] {
         CHROME_IMAGE,
         FIREFOX_IMAGE,
+        EDGE_IMAGE,
         CHROME_DEBUG_IMAGE,
         FIREFOX_DEBUG_IMAGE,
     };
@@ -126,7 +129,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
      */
     public BrowserWebDriverContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
-        // we assert compatibility with the chrome/firefox image later, after capabilities are processed
+        // we assert compatibility with the chrome/firefox/edge image later, after capabilities are processed
 
         final WaitStrategy logWaitStrategy = new LogMessageWaitStrategy()
             .withRegEx(
@@ -266,9 +269,18 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
                 return (supportsVncWithoutDebugImage ? CHROME_IMAGE : CHROME_DEBUG_IMAGE).withTag(seleniumVersion);
             case BrowserType.FIREFOX:
                 return (supportsVncWithoutDebugImage ? FIREFOX_IMAGE : FIREFOX_DEBUG_IMAGE).withTag(seleniumVersion);
+            case BrowserType.EDGE:
+                if (supportsVncWithoutDebugImage)
+                    return EDGE_IMAGE.withTag(seleniumVersion);
+                throw new UnsupportedOperationException(
+                    "For browser 'MicrosoftEdge' selenium version must be 4 or higher;" +
+                        "docker images are available from there upwards;" +
+                        "provided version: '" + seleniumVersion + "'"
+                );
             default:
                 throw new UnsupportedOperationException(
-                    "Browser name must be 'chrome' or 'firefox'; provided '" + browserName + "' is not supported"
+                    "Browser name must be 'chrome', 'firefox' or 'MicrosoftEdge';" +
+                        "provided '" + browserName + "' is not supported"
                 );
         }
     }
@@ -444,5 +456,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         private static final String CHROME = "chrome";
 
         private static final String FIREFOX = "firefox";
+
+        private static final String EDGE = "MicrosoftEdge";
     }
 }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -270,8 +270,9 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
             case BrowserType.FIREFOX:
                 return (supportsVncWithoutDebugImage ? FIREFOX_IMAGE : FIREFOX_DEBUG_IMAGE).withTag(seleniumVersion);
             case BrowserType.EDGE:
-                if (supportsVncWithoutDebugImage)
+                if (supportsVncWithoutDebugImage) {
                     return EDGE_IMAGE.withTag(seleniumVersion);
+                }
                 throw new UnsupportedOperationException(
                     "For browser 'MicrosoftEdge' selenium version must be 4 or higher;" +
                         "docker images are available from there upwards;" +

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -274,14 +274,18 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
                     return EDGE_IMAGE.withTag(seleniumVersion);
                 }
                 throw new UnsupportedOperationException(
-                    "For browser 'MicrosoftEdge' selenium version must be 4 or higher;" +
-                        "docker images are available from there upwards;" +
-                        "provided version: '" + seleniumVersion + "'"
+                    "For browser 'msedge' selenium version must be 4 or higher;" +
+                    "docker images are available from there upwards;" +
+                    "provided version: '" +
+                    seleniumVersion +
+                    "'"
                 );
             default:
                 throw new UnsupportedOperationException(
-                    "Browser name must be 'chrome', 'firefox' or 'MicrosoftEdge';" +
-                        "provided '" + browserName + "' is not supported"
+                    "Browser name must be 'chrome', 'firefox' or 'msedge';" +
+                    "provided '" +
+                    browserName +
+                    "' is not supported"
                 );
         }
     }
@@ -458,6 +462,6 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
         private static final String FIREFOX = "firefox";
 
-        private static final String EDGE = "MicrosoftEdge";
+        private static final String EDGE = "msedge";
     }
 }

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -274,18 +274,14 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
                     return EDGE_IMAGE.withTag(seleniumVersion);
                 }
                 throw new UnsupportedOperationException(
-                    "For browser 'msedge' selenium version must be 4 or higher;" +
-                    "docker images are available from there upwards;" +
-                    "provided version: '" +
-                    seleniumVersion +
-                    "'"
+                    "For browser 'MicrosoftEdge' selenium version must be 4 or higher;" +
+                        "docker images are available from there upwards;" +
+                        "provided version: '" + seleniumVersion + "'"
                 );
             default:
                 throw new UnsupportedOperationException(
-                    "Browser name must be 'chrome', 'firefox' or 'msedge';" +
-                    "provided '" +
-                    browserName +
-                    "' is not supported"
+                    "Browser name must be 'chrome', 'firefox' or 'MicrosoftEdge';" +
+                        "provided '" + browserName + "' is not supported"
                 );
         }
     }
@@ -462,6 +458,6 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
 
         private static final String FIREFOX = "firefox";
 
-        private static final String EDGE = "msedge";
+        private static final String EDGE = "MicrosoftEdge";
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -4,8 +4,6 @@ import org.junit.ClassRule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.GenericContainer;
@@ -49,7 +47,11 @@ public class BaseWebDriverContainerTest {
         driver.quit();
     }
 
-    protected void assertBrowserNameIs(BrowserWebDriverContainer<?> rule, String expectedName, Capabilities capabilities) {
+    protected void assertBrowserNameIs(
+        BrowserWebDriverContainer<?> rule,
+        String expectedName,
+        Capabilities capabilities
+    ) {
         RemoteWebDriver driver = new RemoteWebDriver(rule.getSeleniumAddress(), capabilities);
         driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
         String actual = driver.getCapabilities().getBrowserName();

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -47,8 +47,15 @@ public class BaseWebDriverContainerTest {
         driver.quit();
     }
 
-    protected void assertBrowserNameIs(String expectedName, Capabilities capabilities) {
-        String actual = capabilities.getBrowserName();
+    protected void assertBrowserNameIs(
+        BrowserWebDriverContainer<?> rule,
+        String expectedName,
+        Capabilities capabilities
+    ) {
+        RemoteWebDriver driver = new RemoteWebDriver(rule.getSeleniumAddress(), capabilities);
+        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
+        String actual = driver.getCapabilities().getBrowserName();
         assertThat(actual).as(String.format("actual browser name is %s", actual)).isEqualTo(expectedName);
+        driver.quit();
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -49,8 +49,7 @@ public class BaseWebDriverContainerTest {
         driver.quit();
     }
 
-    protected void assertBrowserNameIs(BrowserWebDriverContainer<?> rule, String expectedName) {
-        Capabilities capabilities = ("chrome".equals(expectedName)) ? new ChromeOptions() : new FirefoxOptions();
+    protected void assertBrowserNameIs(BrowserWebDriverContainer<?> rule, String expectedName, Capabilities capabilities) {
         RemoteWebDriver driver = new RemoteWebDriver(rule.getSeleniumAddress(), capabilities);
         driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
         String actual = driver.getCapabilities().getBrowserName();

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -4,8 +4,6 @@ import org.junit.ClassRule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.GenericContainer;
@@ -49,11 +47,8 @@ public class BaseWebDriverContainerTest {
         driver.quit();
     }
 
-    protected void assertBrowserNameIs(BrowserWebDriverContainer<?> rule, String expectedName, Capabilities capabilities) {
-        RemoteWebDriver driver = new RemoteWebDriver(rule.getSeleniumAddress(), capabilities);
-        driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
-        String actual = driver.getCapabilities().getBrowserName();
+    protected void assertBrowserNameIs(String expectedName, Capabilities capabilities) {
+        String actual = capabilities.getBrowserName();
         assertThat(actual).as(String.format("actual browser name is %s", actual)).isEqualTo(expectedName);
-        driver.quit();
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/BaseWebDriverContainerTest.java
@@ -4,6 +4,8 @@ import org.junit.ClassRule;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxOptions;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 import org.testcontainers.containers.GenericContainer;
@@ -47,11 +49,7 @@ public class BaseWebDriverContainerTest {
         driver.quit();
     }
 
-    protected void assertBrowserNameIs(
-        BrowserWebDriverContainer<?> rule,
-        String expectedName,
-        Capabilities capabilities
-    ) {
+    protected void assertBrowserNameIs(BrowserWebDriverContainer<?> rule, String expectedName, Capabilities capabilities) {
         RemoteWebDriver driver = new RemoteWebDriver(rule.getSeleniumAddress(), capabilities);
         driver.manage().timeouts().implicitlyWait(Duration.ofSeconds(30));
         String actual = driver.getCapabilities().getBrowserName();

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -20,7 +20,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedChrome() {
-        assertBrowserNameIs(chrome, "chrome");
+        assertBrowserNameIs(chrome, "chrome", new ChromeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -20,7 +20,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedChrome() {
-        assertBrowserNameIs("chrome", new ChromeOptions());
+        assertBrowserNameIs(chrome, "chrome", new ChromeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ChromeWebDriverContainerTest.java
@@ -20,7 +20,7 @@ public class ChromeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedChrome() {
-        assertBrowserNameIs(chrome, "chrome", new ChromeOptions());
+        assertBrowserNameIs("chrome", new ChromeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
@@ -12,7 +12,7 @@ public class ContainerWithoutCapabilitiesTest extends BaseWebDriverContainerTest
 
     @Test
     public void chromeIsStartedIfNoCapabilitiesProvided() {
-        assertBrowserNameIs(chrome, "chrome");
+        assertBrowserNameIs(chrome, "chrome", new ChromeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
@@ -12,7 +12,7 @@ public class ContainerWithoutCapabilitiesTest extends BaseWebDriverContainerTest
 
     @Test
     public void chromeIsStartedIfNoCapabilitiesProvided() {
-        assertBrowserNameIs(chrome, "chrome", new ChromeOptions());
+        assertBrowserNameIs("chrome", new ChromeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/ContainerWithoutCapabilitiesTest.java
@@ -12,7 +12,7 @@ public class ContainerWithoutCapabilitiesTest extends BaseWebDriverContainerTest
 
     @Test
     public void chromeIsStartedIfNoCapabilitiesProvided() {
-        assertBrowserNameIs("chrome", new ChromeOptions());
+        assertBrowserNameIs(chrome, "chrome", new ChromeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
@@ -19,8 +19,8 @@ public class EdgeWebDriverContainerTest extends BaseWebDriverContainerTest {
         .withNetwork(NETWORK);
 
     @Before
-    public void checkBrowserIsIndeedMicrosoftEdge() {
-        assertBrowserNameIs(edge, "MicrosoftEdge", new EdgeOptions());
+    public void checkBrowserIsIndeedMSEdge() {
+        assertBrowserNameIs(edge, "msedge", new EdgeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
@@ -19,8 +19,8 @@ public class EdgeWebDriverContainerTest extends BaseWebDriverContainerTest {
         .withNetwork(NETWORK);
 
     @Before
-    public void checkBrowserIsIndeedMicrosoftEdge() {
-        assertBrowserNameIs(edge, "MicrosoftEdge", new EdgeOptions());
+    public void checkBrowserIsIndeedMSEdge() {
+        assertBrowserNameIs("MicrosoftEdge", new EdgeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
@@ -1,0 +1,30 @@
+package org.testcontainers.junit;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.openqa.selenium.edge.EdgeOptions;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+
+/**
+ *
+ */
+public class EdgeWebDriverContainerTest extends BaseWebDriverContainerTest {
+
+    // junitRule {
+    @Rule
+    public BrowserWebDriverContainer<?> edge = new BrowserWebDriverContainer<>()
+        .withCapabilities(new EdgeOptions())
+        // }
+        .withNetwork(NETWORK);
+
+    @Before
+    public void checkBrowserIsIndeedMicrosoftEdge() {
+        assertBrowserNameIs(edge, "MicrosoftEdge", new EdgeOptions());
+    }
+
+    @Test
+    public void simpleExploreTest() {
+        doSimpleExplore(edge, new EdgeOptions());
+    }
+}

--- a/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
@@ -19,8 +19,8 @@ public class EdgeWebDriverContainerTest extends BaseWebDriverContainerTest {
         .withNetwork(NETWORK);
 
     @Before
-    public void checkBrowserIsIndeedMSEdge() {
-        assertBrowserNameIs(edge, "msedge", new EdgeOptions());
+    public void checkBrowserIsIndeedMicrosoftEdge() {
+        assertBrowserNameIs(edge, "MicrosoftEdge", new EdgeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/EdgeWebDriverContainerTest.java
@@ -6,9 +6,6 @@ import org.junit.Test;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.testcontainers.containers.BrowserWebDriverContainer;
 
-/**
- *
- */
 public class EdgeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     // junitRule {
@@ -20,7 +17,7 @@ public class EdgeWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedMSEdge() {
-        assertBrowserNameIs("MicrosoftEdge", new EdgeOptions());
+        assertBrowserNameIs(edge, "msedge", new EdgeOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
@@ -20,7 +20,7 @@ public class FirefoxWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedFirefox() {
-        assertBrowserNameIs(firefox, "firefox");
+        assertBrowserNameIs(firefox, "firefox", new FirefoxOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
@@ -20,7 +20,7 @@ public class FirefoxWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedFirefox() {
-        assertBrowserNameIs(firefox, "firefox", new FirefoxOptions());
+        assertBrowserNameIs("firefox", new FirefoxOptions());
     }
 
     @Test

--- a/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/junit/FirefoxWebDriverContainerTest.java
@@ -20,7 +20,7 @@ public class FirefoxWebDriverContainerTest extends BaseWebDriverContainerTest {
 
     @Before
     public void checkBrowserIsIndeedFirefox() {
-        assertBrowserNameIs("firefox", new FirefoxOptions());
+        assertBrowserNameIs(firefox, "firefox", new FirefoxOptions());
     }
 
     @Test


### PR DESCRIPTION
- add Egde support for BrowserWebDriverContainer
- add/adjust tests
- as the selenium image for edge on docker-hub is only available from version 4 on, an exception is thrown if browser is edge and selenium version < 4