### PR TITLE
Added override for startupTimeout

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -6,6 +6,7 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.JdbcDatabaseContainerProvider;
 import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.ext.ScriptUtils;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -107,6 +108,12 @@ public class ContainerDatabaseDriver implements Driver {
                 for (JdbcDatabaseContainerProvider candidateContainerType : databaseContainers) {
                     if (candidateContainerType.supports(connectionUrl.getDatabaseType())) {
                         container = candidateContainerType.newInstance(connectionUrl);
+
+                        int startupTimeout = Integer.parseInt(TestcontainersConfiguration.getInstance().getEnvVarOrProperty("tc.jdbc.startuptimeout", "120"));
+                        int connectionTimeout = Integer.parseInt(TestcontainersConfiguration.getInstance().getEnvVarOrProperty("tc.jdbc.connectiontimeout", "120"));
+                        container.withStartupTimeoutSeconds(startupTimeout);
+                        container.withConnectTimeoutSeconds(connectionTimeout);
+
                         container.withTmpFs(connectionUrl.getTmpfsOptions());
                         delegate = container.getJdbcDriverInstance();
                     }


### PR DESCRIPTION
Added provision to override jdbc container's startup timeout. 120 second is not enough when working on HDD instead of SDD.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
In this commit I have added two new overridable properties:
tc.jdbc.startuptimeout=120
tc.jdbc.connectiontimeout=120
Using these two properties user can increase container startup timeout and connection timeout. I my case I had to set these variables to 600 to make my application work.