### PR TITLE
[CockroachDB] Support setting a username/password/database

### DIFF
--- a/modules/cockroachdb/src/test/java/org/testcontainers/CockroachDBTestImages.java
+++ b/modules/cockroachdb/src/test/java/org/testcontainers/CockroachDBTestImages.java
@@ -3,5 +3,12 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface CockroachDBTestImages {
-    DockerImageName COCKROACHDB_IMAGE = DockerImageName.parse("cockroachdb/cockroach:v19.2.11");
+    DockerImageName COCKROACHDB_IMAGE = DockerImageName.parse("cockroachdb/cockroach:v22.2.3");
+    DockerImageName FIRST_COCKROACHDB_IMAGE_WITH_ENV_VARS_SUPPORT = DockerImageName.parse(
+        "cockroachdb/cockroach:v22.1.0"
+    );
+
+    DockerImageName COCKROACHDB_IMAGE_WITH_ENV_VARS_UNSUPPORTED = DockerImageName.parse(
+        "cockroachdb/cockroach:v21.2.17"
+    );
 }

--- a/modules/cockroachdb/src/test/java/org/testcontainers/junit/cockroachdb/SimpleCockroachDBTest.java
+++ b/modules/cockroachdb/src/test/java/org/testcontainers/junit/cockroachdb/SimpleCockroachDBTest.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class SimpleCockroachDBTest extends AbstractContainerDatabaseTest {
     static {
@@ -61,5 +62,46 @@ public class SimpleCockroachDBTest extends AbstractContainerDatabaseTest {
         } finally {
             cockroach.stop();
         }
+    }
+
+    @Test
+    public void testWithUsernamePasswordDatabase() throws SQLException {
+        try (
+            CockroachContainer cockroach = new CockroachContainer(
+                CockroachDBTestImages.FIRST_COCKROACHDB_IMAGE_WITH_ENV_VARS_SUPPORT
+            )
+                .withUsername("test_user")
+                .withPassword("test_password")
+                .withDatabaseName("test_database")
+        ) {
+            cockroach.start();
+
+            ResultSet resultSet = performQuery(cockroach, "SELECT 1");
+
+            int resultSetInt = resultSet.getInt(1);
+            assertThat(resultSetInt).as("A basic SELECT query succeeds").isEqualTo(1);
+
+            String jdbcUrl = cockroach.getJdbcUrl();
+            assertThat(jdbcUrl).contains("/" + "test_database");
+        }
+    }
+
+    @Test
+    public void testAnExceptionIsThrownWhenImageDoesNotSupportEnvVars() {
+        CockroachContainer cockroachContainer = new CockroachContainer(
+            CockroachDBTestImages.COCKROACHDB_IMAGE_WITH_ENV_VARS_UNSUPPORTED
+        );
+
+        assertThatThrownBy(() -> cockroachContainer.withUsername("test_user"))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .withFailMessage("Setting a username in not supported in the versions below 22.1.0");
+
+        assertThatThrownBy(() -> cockroachContainer.withPassword("test_password"))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .withFailMessage("Setting a password in not supported in the versions below 22.1.0");
+
+        assertThatThrownBy(() -> cockroachContainer.withDatabaseName("test_database"))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .withFailMessage("Setting a databaseName in not supported in the versions below 22.1.0");
     }
 }

--- a/modules/cockroachdb/src/test/java/org/testcontainers/junit/cockroachdb/SimpleCockroachDBTest.java
+++ b/modules/cockroachdb/src/test/java/org/testcontainers/junit/cockroachdb/SimpleCockroachDBTest.java
@@ -55,10 +55,11 @@ public class SimpleCockroachDBTest extends AbstractContainerDatabaseTest {
         try {
             cockroach.start();
             String jdbcUrl = cockroach.getJdbcUrl();
-            assertThat(jdbcUrl).contains("?");
-            assertThat(jdbcUrl).contains("&");
-            assertThat(jdbcUrl).contains("sslmode=disable");
-            assertThat(jdbcUrl).contains("application_name=cockroach");
+            assertThat(jdbcUrl)
+                .contains("?")
+                .contains("&")
+                .contains("sslmode=disable")
+                .contains("application_name=cockroach");
         } finally {
             cockroach.stop();
         }


### PR DESCRIPTION
Fixes #6299 

**Documentation**

No new documentation was added.

**Functionality**

CockroachDB container now supports setting a username/password/database like:
```
CockroachContainer cockroach = new CockroachContainer(
                CockroachDBTestImages.FIRST_COCKROACHDB_IMAGE_WITH_ENV_VARS_SUPPORT
            )
                .withUsername("test_user")
                .withPassword("test_password")
                .withDatabaseName("test_database")
```