### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,8 +68,8 @@ configurations.all {
 dependencies {
     api 'junit:junit:4.13.2'
     api 'org.slf4j:slf4j-api:1.7.36'
-    compileOnly 'org.jetbrains:annotations:23.1.0'
-    testCompileOnly 'org.jetbrains:annotations:23.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
+    testCompileOnly 'org.jetbrains:annotations:24.0.0'
     api 'org.apache.commons:commons-compress:1.22'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.2.2.RELEASE"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.1"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.1"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.1"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.1"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.2"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
-    testImplementation 'org.postgresql:postgresql:42.5.1'
+    testImplementation 'org.postgresql:postgresql:42.5.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.23.1'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.5'
+    testImplementation 'io.nats:jnats:2.16.7'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.3.1'
-    implementation 'com.google.code.gson:gson:2.10'
+    implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:4.3.1'
-    implementation 'com.google.code.gson:gson:2.10'
+    implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.2"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.2"
     }
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:4.3.1'
-    implementation 'com.google.code.gson:gson:2.10'
+    implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'com.azure:azure-cosmos:4.39.0'
+    testImplementation 'com.azure:azure-cosmos:4.40.0'
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.15.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.2'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.1'
+    testImplementation 'org.postgresql:postgresql:42.5.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
     testImplementation 'io.rest-assured:rest-assured:5.3.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'com.couchbase.client:java-client:3.4.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.1'
+    testImplementation 'com.couchbase.client:java-client:3.4.2'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.ibm.db2:jcc:11.5.8.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.376'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.376'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.376'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.3"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.6.1"
     testImplementation "org.elasticsearch.client:transport:7.17.8"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.5.3"
     testImplementation "org.elasticsearch.client:transport:7.17.8"
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.13.0'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.4'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.122.2'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.34.1'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.35.2'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.17.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.122.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.34.1'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.17.1'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.0'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.3'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.4'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.122.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.35.2'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.10.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.11.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.5")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
-    shaded("net.lingala.zip4j:zip4j:2.11.2")
+    shaded("net.lingala.zip4j:zip4j:2.11.3")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.5")
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
 }
 

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: HiveMQ"
 
 dependencies {
     api(project(":testcontainers"))
-    api("org.jetbrains:annotations:23.1.0")
+    api("org.jetbrains:annotations:24.0.0")
 
     shaded("org.apache.commons:commons-lang3:3.12.0")
     shaded("commons-io:commons-io:2.11.0")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.2")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.10.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'org.influxdb:influxdb-java:2.23'
 
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.influxdb:influxdb-java:2.23'
     testImplementation "com.influxdb:influxdb-client-java:6.7.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -13,5 +13,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.31'
+    api 'mysql:mysql-connector-java:8.0.32'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -9,7 +9,7 @@ dependencies {
 
     api 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
 
-    api 'org.assertj:assertj-core:3.23.1'
+    api 'org.assertj:assertj-core:3.24.2'
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.4'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':database-commons')
     testImplementation project(':test-support')
 
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.4'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    api 'org.junit.jupiter:junit-jupiter-api:5.9.1'
+    api 'org.junit.jupiter:junit-jupiter-api:5.9.2'
 
     testImplementation project(':mysql')
     testImplementation project(':postgresql')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.1'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.3.1'
+    testImplementation 'io.fabric8:kubernetes-client:6.4.1'
     testImplementation 'io.kubernetes:client-java:17.0.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:6.3.1'
     testImplementation 'io.kubernetes:client-java:17.0.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.3.2'
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.376'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.376'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.398'
     testImplementation 'software.amazon.awssdk:s3:2.19.8'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.376'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.376'
     testImplementation 'software.amazon.awssdk:s3:2.19.8'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MockServer"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.mock-server:mockserver-client-java:5.14.0'
+    testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.1.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre8'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.31'
+    testImplementation 'mysql:mysql-connector-java:8.0.32'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Nginx"
 dependencies {
     api project(':testcontainers')
     compileOnly 'org.jetbrains:annotations:23.1.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.ojdbc:ojdbc8:19.3.0.0'
 
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.1'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.14"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.15"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "TestContainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.14"
+    api "com.orientechnologies:orientdb-client:3.2.15"
 
     testImplementation 'org.assertj:assertj-core:3.23.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.1'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.5.1'
+    testImplementation 'org.postgresql:postgresql:42.5.2'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.11.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.2'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.11.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.10.2'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.11.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.10.2'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.5.1'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.23.1'
-    testImplementation 'org.questdb:questdb:6.6.1-jdk8'
+    testImplementation 'org.questdb:questdb:6.7-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.1'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.2'
     testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'io.rest-assured:rest-assured:5.3.0'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     provided 'org.seleniumhq.selenium:selenium-remote-driver:4.6.0'
     provided 'org.seleniumhq.selenium:selenium-chrome-driver:4.6.0'
     testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.6.0'
-    testImplementation 'org.seleniumhq.selenium:selenium-edge-driver:4.6.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-edge-driver:4.8.0'
     testImplementation 'org.seleniumhq.selenium:selenium-support:4.6.0'
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation project(':nginx')
     testImplementation 'org.assertj:assertj-core:3.24.2'
 
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.2'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.2'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.1'
 
     testCompileOnly 'org.jetbrains:annotations:23.1.0'

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.7'
 
     testImplementation 'redis.clients:jedis:3.0.1'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 
     testImplementation project(':test-support')
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:405'
+    testImplementation 'io.trino:trino-jdbc:406'
     compileOnly 'org.jetbrains:annotations:23.1.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:5.3.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // YCQL driver
     testImplementation 'com.yugabyte:java-driver-core:4.6.0-yb-11'
     // YSQL driver
-    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-1'
+    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-2'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.2"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.2"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/selenium (#6562) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /core (#6561) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.3.1 to 3.3.2 in /examples (#6560) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/mongodb (#6559) @app/dependabot
* Bump io.cucumber:cucumber-java from 7.10.1 to 7.11.1 in /examples (#6558) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/rabbitmq (#6557) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-s3 from 1.12.376 to 1.12.398 in /modules/localstack (#6556) @app/dependabot
* Bump release-drafter/release-drafter from 5.21.1 to 5.22.0 (#6555) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.1 to 42.5.2 in /modules/spock (#6554) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/r2dbc (#6553) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.31 to 8.0.32 in /modules/junit-jupiter (#6552) @app/dependabot
* Bump com.google.code.gson:gson from 2.10 to 2.10.1 in /examples (#6551) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.1 to 42.5.2 in /modules/cockroachdb (#6550) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/localstack (#6549) @app/dependabot
* Bump org.apache.pulsar:pulsar-client from 2.10.2 to 2.11.0 in /modules/pulsar (#6548) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-edge-driver from 4.6.0 to 4.8.0 in /modules/selenium (#6546) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /core (#6545) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-sqs from 1.12.376 to 1.12.398 in /modules/localstack (#6544) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.1 to 42.5.2 in /examples (#6542) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/gcloud (#6541) @app/dependabot
* Bump io.cucumber:cucumber-junit from 7.10.1 to 7.11.1 in /examples (#6540) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/junit-jupiter (#6538) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.2 to 3.12.3 in /examples (#6537) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.1 to 5.9.2 in /examples (#6536) @app/dependabot
* Bump io.trino:trino-jdbc from 405 to 406 in /modules/trino (#6535) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.376 to 1.12.398 in /modules/dynalite (#6534) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/pulsar (#6533) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/solr (#6530) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-logs from 1.12.376 to 1.12.398 in /modules/localstack (#6529) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/db2 (#6528) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.9.1 to 5.9.2 in /modules/junit-jupiter (#6527) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.1 to 5.9.2 in /modules/junit-jupiter (#6525) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.1 to 5.9.2 in /examples (#6524) @app/dependabot
* Bump com.yugabyte:jdbc-yugabytedb from 42.3.5-yb-1 to 42.3.5-yb-2 in /modules/yugabytedb (#6523) @app/dependabot
* Bump org.questdb:questdb from 6.6.1-jdk8 to 6.7-jdk8 in /modules/questdb (#6522) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/questdb (#6520) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/redpanda (#6518) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.3.1 to 3.3.2 in /modules/redpanda (#6517) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/consul (#6515) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.2 to 3.12.3 (#6514) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.1 to 5.9.2 in /modules/hivemq (#6513) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/hivemq (#6512) @app/dependabot
* Bump net.lingala.zip4j:zip4j from 2.11.2 to 2.11.3 in /modules/hivemq (#6511) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.1 to 5.9.2 in /modules/hivemq (#6510) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/hivemq (#6508) @app/dependabot
* Bump com.google.cloud:google-cloud-spanner from 6.34.1 to 6.35.2 in /modules/gcloud (#6507) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.10.0 to 4.11.0 in /modules/hivemq (#6506) @app/dependabot
* Bump com.azure:azure-cosmos from 4.39.0 to 4.40.0 in /modules/azure (#6505) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.14 to 3.2.15 in /modules/orientdb (#6504) @app/dependabot
* Bump com.google.cloud:google-cloud-bigtable from 2.17.1 to 2.18.3 in /modules/gcloud (#6503) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.14 to 3.2.15 in /modules/orientdb (#6501) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/k3s (#6500) @app/dependabot
* Bump com.google.cloud:google-cloud-pubsub from 1.122.2 to 1.123.1 in /modules/gcloud (#6499) @app/dependabot
* Bump com.google.cloud:google-cloud-datastore from 2.13.0 to 2.13.3 in /modules/gcloud (#6497) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.1 to 3.5.2 in /modules/r2dbc (#6496) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.6.1 to 3.6.2 in /modules/orientdb (#6494) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.3.1 to 6.4.1 in /modules/k3s (#6493) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/cockroachdb (#6492) @app/dependabot
* Bump io.nats:jnats from 2.16.5 to 2.16.7 in /examples (#6490) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/elasticsearch (#6488) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.1 to 5.9.2 in /modules/junit-jupiter (#6489) @app/dependabot
* Bump org.apache.pulsar:pulsar-client-admin from 2.10.2 to 2.11.0 in /modules/pulsar (#6484) @app/dependabot
* Bump org.mock-server:mockserver-client-java from 5.14.0 to 5.15.0 in /modules/mockserver (#6486) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/postgresql (#6485) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/nginx (#6483) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.5.3 to 8.6.1 in /modules/elasticsearch (#6480) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/mysql (#6481) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.9.1 to 1.9.2 in /modules/spock (#6479) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.1.0.jre8-preview to 12.2.0.jre8 in /modules/mssqlserver (#6474) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/toxiproxy (#6477) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/jdbc (#6475) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/selenium (#6476) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/couchbase (#6478) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.1 to 42.5.2 in /modules/junit-jupiter (#6469) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/oracle-xe (#6471) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.9.1 to 1.9.2 in /modules/spock (#6473) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/database-commons (#6466) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.1 to 42.5.2 in /modules/postgresql (#6467) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.1 to 3.4.2 in /modules/couchbase (#6468) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/cassandra (#6462) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/dynalite (#6463) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/neo4j (#6464) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.31 to 8.0.32 in /modules/mysql (#6459) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/vault (#6460) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.19.8 to 2.19.29 in /modules/localstack (#6461) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/clickhouse (#6456) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/mockserver (#6458) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/jdbc (#6454) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.3.1 to 3.3.2 in /modules/kafka (#6455) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/influxdb (#6457) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.31 to 8.0.32 in /modules/jdbc-test (#6451) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/jdbc-test (#6452) @app/dependabot
