### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.11.1'
-    testImplementation 'io.cucumber:cucumber-junit:7.10.1'
+    testImplementation 'io.cucumber:cucumber-junit:7.11.1'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.assertj:assertj-core:3.23.1'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.azure:azure-cosmos:4.40.0'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.13.3'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.7.4'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.7.9'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.122.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.35.2'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.17.1'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.9'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.122.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.35.2'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.17.1'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.18.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.5")
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }
 
 test {

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.4'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.5'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 }
 
 test {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         exclude(module: 'hamcrest-core')
     }
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.5.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.2'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.3.2'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.398'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.376'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.398'
     testImplementation 'software.amazon.awssdk:s3:2.19.8'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.398'
-    testImplementation 'software.amazon.awssdk:s3:2.19.8'
+    testImplementation 'software.amazon.awssdk:s3:2.19.29'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.0'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.2'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.8.1")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.8.2")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -2,6 +2,6 @@ description = "Testcontainers :: Nginx"
 
 dependencies {
     api project(':testcontainers')
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.2.15"
 
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.1'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.15"
 }

--- a/modules/presto/build.gradle
+++ b/modules/presto/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'io.prestosql:presto-jdbc:350'
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '2.11.0'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.23.1'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '2.11.0'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     testImplementation 'org.postgresql:postgresql:42.5.1'
     testImplementation project(':jdbc-test')
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.questdb:questdb:6.7-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Redpanda"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.3.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'io.rest-assured:rest-assured:5.3.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.5.2'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.31'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'
 
     testCompileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.1'
 
-    testCompileOnly 'org.jetbrains:annotations:23.1.0'
+    testCompileOnly 'org.jetbrains:annotations:24.0.0'
 }
 
 sourceJar {

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'mysql:mysql-connector-java:8.0.31'
 
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.31'
+    testImplementation 'mysql:mysql-connector-java:8.0.32'
 
     compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'io.trino:trino-jdbc:406'
-    compileOnly 'org.jetbrains:annotations:23.1.0'
+    compileOnly 'org.jetbrains:annotations:24.0.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.amazonaws:aws-java-sdk-sqs from 1.12.376 to 1.12.398 in /modules/localstack (#6544) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/spock (#6543) @app/dependabot
* Bump io.cucumber:cucumber-junit from 7.10.1 to 7.11.1 in /examples (#6540) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/azure (#6539) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/pulsar (#6533) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/presto (#6531) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.9.1 to 5.9.2 in /modules/junit-jupiter (#6527) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.8.1 to 4.8.2 in /modules/mongodb (#6526) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/questdb (#6520) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/tidb (#6519) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.3.1 to 3.3.2 in /modules/redpanda (#6517) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.31 to 8.0.32 in /modules/tidb (#6516) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.1 to 5.9.2 in /modules/hivemq (#6510) @app/dependabot
* Bump com.google.cloud:google-cloud-firestore from 3.7.4 to 3.7.9 in /modules/gcloud (#6509) @app/dependabot
* Bump com.google.cloud:google-cloud-bigtable from 2.17.1 to 2.18.3 in /modules/gcloud (#6503) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/orientdb (#6502) @app/dependabot
* Bump com.google.cloud:google-cloud-pubsub from 1.122.2 to 1.123.1 in /modules/gcloud (#6499) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/trino (#6495) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.6.1 to 3.6.2 in /modules/orientdb (#6494) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/rabbitmq (#6491) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.1 to 5.9.2 in /modules/junit-jupiter (#6489) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.1 to 42.5.2 in /modules/junit-jupiter (#6469) @app/dependabot
* Bump org.jetbrains:annotations from 23.1.0 to 24.0.0 in /modules/nginx (#6472) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.1.0 to 3.1.2 in /modules/mariadb (#6470) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.9.1 to 1.9.2 in /modules/spock (#6473) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.19.8 to 2.19.29 in /modules/localstack (#6461) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/kafka (#6465) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/mockserver (#6458) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.4 to 10.1.5 in /modules/jdbc (#6453) @app/dependabot
