### PR TITLE
less dependency to junit4

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/FailureDetectingExternalResource.java
+++ b/core/src/main/java/org/testcontainers/containers/FailureDetectingExternalResource.java
@@ -2,11 +2,7 @@ package org.testcontainers.containers;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * {@link TestRule} which is called before and after each test, and also is notified on success/failure.
@@ -22,20 +18,22 @@ public class FailureDetectingExternalResource implements TestRule {
         return new Statement() {
             @Override
             public void evaluate() throws Throwable {
-                List<Throwable> errors = new ArrayList<Throwable>();
+                Throwable error = null;
 
                 try {
                     starting(description);
                     base.evaluate();
                     succeeded(description);
                 } catch (Throwable e) {
-                    errors.add(e);
+                    error = e;
                     failed(e, description);
                 } finally {
                     finished(description);
                 }
 
-                MultipleFailureException.assertEmpty(errors);
+                if (error != null) {
+                    throw error;
+                }
             }
         };
     }

--- a/test-support/src/main/java/org/testcontainers/testsupport/FlakyTestException.java
+++ b/test-support/src/main/java/org/testcontainers/testsupport/FlakyTestException.java
@@ -1,0 +1,50 @@
+package org.testcontainers.testsupport;
+
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Inspired by {@link org.junit.runners.model.MultipleFailureException}
+ */
+public class FlakyTestException extends IllegalStateException {
+    
+    private static final long serialVersionUID = 1L;
+
+    private final List<Throwable> errors;
+
+    public FlakyTestException(String message, List<Throwable> errors) {
+        this.errors = new ArrayList<>(errors);
+    }
+    
+    @Override
+    public String getMessage() {
+        StringBuilder sb = new StringBuilder(String.format("There were %d errors:", errors.size()));
+        for (Throwable e : errors) {
+            sb.append(String.format("%n  %s(%s)", e.getClass().getName(), e.getMessage()));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public void printStackTrace() {
+        for (Throwable e: errors) {
+            e.printStackTrace();
+        }
+    }
+    
+    @Override
+    public void printStackTrace(PrintStream s) {
+        for (Throwable e: errors) {
+            e.printStackTrace(s);
+        }
+    }
+    
+    @Override
+    public void printStackTrace(PrintWriter s) {
+        for (Throwable e: errors) {
+            e.printStackTrace(s);
+        }
+    }
+}

--- a/test-support/src/main/java/org/testcontainers/testsupport/FlakyTestJUnit4RetryRule.java
+++ b/test-support/src/main/java/org/testcontainers/testsupport/FlakyTestJUnit4RetryRule.java
@@ -3,7 +3,6 @@ package org.testcontainers.testsupport;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
-import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 import java.time.LocalDate;
@@ -94,9 +93,9 @@ public class FlakyTestJUnit4RetryRule implements TestRule {
                 }
             }
 
-            throw new IllegalStateException(
+            throw new FlakyTestException(
                 "@Flaky-annotated test failed despite retries.",
-                new MultipleFailureException(causes)
+                causes
             );
         }
     }


### PR DESCRIPTION
Problem: I want to include testcontainers without also including entire JUnit4 dependency (by manually excluding JUnit4).

With this change, the dependency to JUnit4 classes is reduced, specifically below classes are no longer used:
```
org.junit.rules.ExternalResource
org.junit.runners.model.MultipleFailureException
```

It is then possible to manually exclude JUnit4 dependency from testcontainers, and only have to manually include below small independent classes:
```
org.junit.rules.TestRule
org.junit.runner.Description
org.junit.runners.model.Statement
```