### PR TITLE
Expand documentation about Singleton Containers and lambdas

### DIFF
--- a/docs/test_framework_integration/manual_lifecycle_control.md
+++ b/docs/test_framework_integration/manual_lifecycle_control.md
@@ -1,6 +1,6 @@
 # Manual container lifecycle control
 
-While Testcontainers was originally built with JUnit 4 integration in mind, it is fully usable with other test 
+While Testcontainers was originally built with JUnit 4 integration in mind, it is fully usable with other test
 frameworks, or with no framework at all.
 
 ## Manually starting/stopping containers
@@ -13,7 +13,7 @@ try (GenericContainer container = new GenericContainer("imagename")) {
     container.start();
     // ... use the container
     // no need to call stop() afterwards
-}
+    }
 ```
 
 ## Singleton containers
@@ -48,3 +48,79 @@ The singleton container is started only once when the base class is loaded.
 The container can then be used by all inheriting test classes.
 At the end of the test suite the [Ryuk container](https://github.com/testcontainers/moby-ryuk)
 that is started by Testcontainers core will take care of stopping the singleton container.
+
+Please keep in mind that putting the container in a static block will influence how to use certain features of the container.
+You will not be able to use methods such as `forResponsePredicate` by just providing a Lambda expression, you will have to use
+anonymous classes, or alternatively provide them from non-abstract class.
+This is not due to the limitation of TestContainers, but because of how they work under the hood, namely that lambdas get compiled
+to static methods on a class level. Since your container is in a static block, the container gets created
+before your parent and children classes get initialized and as such you cannot pass the reference to them.
+
+Therefore, once again - it is advised to use anonymous classes in such case or full predicates coming in from different, non-abstract class.
+
+Instead of:
+
+```java
+abstract class AbstractContainerBaseTest {
+
+    static final GenericContainer GENERIC_CONTAINER;
+
+    static {
+        GENERIC_CONTAINER = new GENERIC_CONTAINER(
+                new ImageFromDockerfile().waitingFor(Wait.forHttp('/path'))
+                                         .forStatusCode(200)
+                                         .forResponsePredicate(yourLambda -> yourLambda(here)) //This is never going to get executed due to NoClassDefFoundError
+        );
+        GENERIC_CONTAINER.start();
+    }
+}
+```
+
+You can do an anonymous class:
+
+```java
+abstract class AbstractContainerBaseTest {
+
+    static final GenericContainer GENERIC_CONTAINER;
+
+    static {
+        GENERIC_CONTAINER = new GENERIC_CONTAINER(
+                new ImageFromDockerfile().waitingFor(Wait.forHttp('/path'))
+                                         .forStatusCode(200)
+                                         .forResponsePredicate(new Predicate<String>() {
+                                             
+                                             @Override
+                                             public boolean test(String s) {
+                                                 return yourConditionHere;
+                                             }
+                                         }) 
+        );
+        
+        GENERIC_CONTAINER.start();
+    }
+}
+```
+Or full predicate coming in from different class:
+
+```java
+abstract class AbstractContainerBaseTest {
+
+    static final GenericContainer GENERIC_CONTAINER;
+
+    static {
+        GENERIC_CONTAINER = new GENERIC_CONTAINER(
+                new ImageFromDockerfile().waitingFor(Wait.forHttp('/path'))
+                                         .forStatusCode(200)
+                                         .forResponsePredicate(PredicateHolder.getPredicate())
+        );
+        GENERIC_CONTAINER.start();
+    }
+}
+
+public class PredicateHolder {
+    
+    public static Predicate<String> getPredicate() {
+        return yourLambda -> yourLambda(here);
+    } 
+}
+```


### PR DESCRIPTION
I have stumbled upon this while using TestContainers for a slow-spinning Docker image. Naturally I wanted to use a singleton container and I tried to make it work using the `withResponsePredicate()` method opposed to sleeping the health check. After some debugging I have found out that the reason it did not work, even though local uses of same predicates worked, was NoClassDefFoundError. It will be visible in HttpWaitStrategy.java, if you put breakpoint in here:

```
if (!responsePredicate.test(responseBody)) {
}
```

You can replicate it creating an abstract base class and trying to use any function derivative.

There are ways to work around it (at least I think so), but I have chosen instead to update documentation to save others time and to not introduce dirty hacks.