### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.3.1'
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
-    testImplementation 'org.mongodb:mongo-java-driver:3.12.11'
+    testImplementation 'org.mongodb:mongo-java-driver:3.12.12'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.24"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.24"
+    testCompileOnly "org.projectlombok:lombok:1.18.26"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.26"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.24"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.24"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.2'
+    testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
-    testImplementation 'org.postgresql:postgresql:42.5.2'
+    testImplementation 'org.postgresql:postgresql:42.5.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.7'
+    testImplementation 'io.nats:jnats:2.16.8'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '2.7.8'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.24"
-    annotationProcessor "org.projectlombok:lombok:1.18.24"
+    compileOnly "org.projectlombok:lombok:1.18.26"
+    annotationProcessor "org.projectlombok:lombok:1.18.26"
 
     implementation 'org.apache.solr:solr-solrj:8.11.2'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.7.6"
+    id("org.springframework.boot") version "2.7.8"
     id("org.jetbrains.kotlin.jvm") version "1.8.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.8.10"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.6'
+    id 'org.springframework.boot' version '2.7.8'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.2'
+    testImplementation 'org.postgresql:postgresql:42.5.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.2'
+    testImplementation 'com.couchbase.client:java-client:3.4.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.398'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.376'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.405'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.405'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.3'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.4'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.9'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.35.2'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.9'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.1'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.35.2'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.18.3'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.19.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.13.3'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.9'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.1'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.35.2'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.19.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
-    shaded("net.lingala.zip4j:zip4j:2.11.3")
+    shaded("net.lingala.zip4j:zip4j:2.11.4")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.2'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.2'
+    testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'com.amazonaws:aws-java-sdk-s3:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.398'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.398'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.398'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.405'
     testImplementation 'software.amazon.awssdk:s3:2.19.29'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.8.2")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.9.0")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "TestContainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.15"
+    api "com.orientechnologies:orientdb-client:3.2.16"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.15"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.16"
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -11,7 +11,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation project(':test-support')
-    testImplementation 'org.postgresql:postgresql:42.5.2'
+    testImplementation 'org.postgresql:postgresql:42.5.3'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':jdbc')
 
-    testImplementation 'org.postgresql:postgresql:42.5.1'
+    testImplementation 'org.postgresql:postgresql:42.5.3'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.questdb:questdb:7.0.0-jdk8'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.5.1'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:6.7-jdk8'
+    testImplementation 'org.questdb:questdb:7.0.0-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Redpanda"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.3.2'
+    testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'io.rest-assured:rest-assured:5.3.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.2'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.springframework.boot from 2.7.6 to 2.7.8 in /examples (#6619) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-logs from 1.12.398 to 1.12.405 in /modules/localstack (#6618) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.3.2 to 3.4.0 in /examples (#6617) @app/dependabot
* Bump org.projectlombok:lombok from 1.18.24 to 1.18.26 in /examples (#6616) @app/dependabot
* Bump com.google.cloud:google-cloud-bigtable from 2.18.3 to 2.19.0 in /modules/gcloud (#6615) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-sqs from 1.12.398 to 1.12.405 in /modules/localstack (#6614) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.2 to 42.5.3 in /examples (#6612) @app/dependabot
* Bump io.nats:jnats from 2.16.7 to 2.16.8 in /examples (#6611) @app/dependabot
* Bump com.google.cloud:google-cloud-pubsub from 1.123.1 to 1.123.2 in /modules/gcloud (#6610) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.19.29 to 2.20.2 in /modules/localstack (#6609) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.15 to 3.2.16 in /modules/orientdb (#6607) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.2 to 42.5.3 in /modules/spock (#6603) @app/dependabot
* Bump com.google.cloud:google-cloud-datastore from 2.13.3 to 2.13.4 in /modules/gcloud (#6606) @app/dependabot
* Bump org.questdb:questdb from 6.7-jdk8 to 7.0.0-jdk8 in /modules/questdb (#6605) @app/dependabot
* Bump net.lingala.zip4j:zip4j from 2.11.3 to 2.11.4 in /modules/hivemq (#6604) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.398 to 1.12.405 in /modules/dynalite (#6601) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.2 to 42.5.3 in /modules/postgresql (#6602) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.15 to 3.2.16 in /modules/orientdb (#6600) @app/dependabot
* Bump org.mongodb:mongo-java-driver from 3.12.11 to 3.12.12 in /core (#6599) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.2 to 42.5.3 in /modules/junit-jupiter (#6598) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.8.2 to 4.9.0 in /modules/mongodb (#6596) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.1 to 42.5.3 in /modules/questdb (#6597) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.2 to 42.5.3 in /modules/cockroachdb (#6595) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.2 to 3.4.3 in /modules/couchbase (#6593) @app/dependabot
* Bump com.google.cloud:google-cloud-spanner from 6.35.2 to 6.36.0 in /modules/gcloud (#6594) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.3.2 to 3.4.0 in /modules/redpanda (#6591) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.3.2 to 3.4.0 in /modules/kafka (#6590) @app/dependabot
