### PR TITLE
use type long to calculate memory

### DIFF
--- a/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
@@ -25,9 +25,9 @@ public class CmdModifierTest {
 
     // spotless:off
     // memory {
-    private long memoryInBytes = 32 * 1024 * 1024;
+    private long memoryInBytes = 32l * 1024l * 1024l;
 
-    private long memorySwapInBytes = 64 * 1024 * 1024;
+    private long memorySwapInBytes = 64l * 1024l * 1024l;
 
     @Rule
     public GenericContainer memoryLimitedRedis = new GenericContainer<>(DockerImageName.parse("redis:3.0.2"))


### PR DESCRIPTION
if you try to set 3g memory limit container will fail to start with msg 'at least 6m memory minimum', multiplication of those will exceed int and fails

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
