### PR TITLE
Add checkstyle rule to avoid author tag in javadoc

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -58,4 +58,8 @@
         </module>
         <module name="OneStatementPerLineCheck"/>
     </module>
+    <module name="RegexpSingleline">
+        <property name="format" value="^\s*\*\s*@author"/>
+        <property name="message" value="Remove author tags from source files."/>
+    </module>
 </module>

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
@@ -22,8 +22,6 @@ import java.util.stream.Collectors;
 
 /**
  * Waits until a socket connection can be established on a port exposed or mapped by the container.
- *
- * @author richardnorth
  */
 @Slf4j
 public class HostPortWaitStrategy extends AbstractWaitStrategy {

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/AbstractWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/AbstractWaitStrategyTest.java
@@ -16,8 +16,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Common test methods for {@link WaitStrategy} implementations.
- *
- * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 public abstract class AbstractWaitStrategyTest<W extends WaitStrategy> {
 

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
@@ -17,8 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link HttpWaitStrategy}.
- *
- * @author Pete Cornish {@literal <outofcoffee@gmail.com>}
  */
 public class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrategy> {
 

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -22,8 +22,6 @@ import javax.script.ScriptException;
  * Cassandra container
  *
  * Supports 2.x and 3.x Cassandra versions
- *
- * @author Eugeny Karpov
  */
 public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends GenericContainer<SELF> {
 

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/delegate/CassandraDatabaseDelegate.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/delegate/CassandraDatabaseDelegate.java
@@ -13,8 +13,6 @@ import org.testcontainers.ext.ScriptUtils.ScriptStatementFailedException;
 
 /**
  * Cassandra database delegate
- *
- * @author Eugeny Karpov
  */
 @Slf4j
 @RequiredArgsConstructor

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/wait/CassandraQueryWaitStrategy.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/wait/CassandraQueryWaitStrategy.java
@@ -12,8 +12,6 @@ import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
 
 /**
  * Waits until Cassandra returns its version
- *
- * @author Eugeny Karpov
  */
 public class CassandraQueryWaitStrategy extends AbstractWaitStrategy {
 

--- a/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
+++ b/modules/cassandra/src/test/java/org/testcontainers/containers/CassandraContainerTest.java
@@ -11,9 +11,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Eugeny Karpov
- */
 @Slf4j
 public class CassandraContainerTest {
 

--- a/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/delegate/AbstractDatabaseDelegate.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 
 /**
  * @param <CONNECTION> connection to the database
- * @author Eugeny Karpov
  */
 public abstract class AbstractDatabaseDelegate<CONNECTION> implements DatabaseDelegate {
 

--- a/modules/database-commons/src/main/java/org/testcontainers/delegate/DatabaseDelegate.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/delegate/DatabaseDelegate.java
@@ -6,8 +6,6 @@ import java.util.Collection;
  * Database delegate
  *
  * Gives an abstraction from concrete database
- *
- * @author Eugeny Karpov
  */
 public interface DatabaseDelegate extends AutoCloseable {
     /**

--- a/modules/database-commons/src/main/java/org/testcontainers/exception/ConnectionCreationException.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/exception/ConnectionCreationException.java
@@ -2,8 +2,6 @@ package org.testcontainers.exception;
 
 /**
  * Inability to create connection to the database
- *
- * @author Eugeny Karpov
  */
 public class ConnectionCreationException extends RuntimeException {
 

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptUtils.java
@@ -36,16 +36,6 @@ import javax.script.ScriptException;
  *
  * Generic utility methods for working with SQL scripts. Mainly for internal use
  * within the framework.
- *
- * @author Thomas Risberg
- * @author Sam Brannen
- * @author Juergen Hoeller
- * @author Keith Donald
- * @author Dave Syer
- * @author Chris Beams
- * @author Oliver Gierke
- * @author Chris Baldwin
- * @since 4.0.3
  */
 public abstract class ScriptUtils {
 

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/BigtableEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/BigtableEmulatorContainer.java
@@ -7,9 +7,6 @@ import org.testcontainers.utility.DockerImageName;
  * A Bigtable container that relies in google cloud sdk.
  *
  * Default port is 9000.
- *
- * @author Eddú Meléndez
- * @author Ray Tsang
  */
 public class BigtableEmulatorContainer extends GenericContainer<BigtableEmulatorContainer> {
 

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/DatastoreEmulatorContainer.java
@@ -7,8 +7,6 @@ import org.testcontainers.utility.DockerImageName;
  * A Datastore container that relies in google cloud sdk.
  *
  * Default port is 8081.
- *
- * @author Eddú Meléndez
  */
 public class DatastoreEmulatorContainer extends GenericContainer<DatastoreEmulatorContainer> {
 

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/FirestoreEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/FirestoreEmulatorContainer.java
@@ -7,8 +7,6 @@ import org.testcontainers.utility.DockerImageName;
  * A Firestore container that relies in google cloud sdk.
  *
  * Default port is 8080.
- *
- * @author Eddú Meléndez
  */
 public class FirestoreEmulatorContainer extends GenericContainer<FirestoreEmulatorContainer> {
 

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/PubSubEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/PubSubEmulatorContainer.java
@@ -7,8 +7,6 @@ import org.testcontainers.utility.DockerImageName;
  * A PubSub container that relies in google cloud sdk.
  *
  * Default port is 8085.
- *
- * @author Eddú Meléndez
  */
 public class PubSubEmulatorContainer extends GenericContainer<PubSubEmulatorContainer> {
 

--- a/modules/gcloud/src/main/java/org/testcontainers/containers/SpannerEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/SpannerEmulatorContainer.java
@@ -5,8 +5,6 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * A Spanner container. Default ports: 9010 for GRPC and 9020 for HTTP.
- *
- * @author Eddú Meléndez
  */
 public class SpannerEmulatorContainer extends GenericContainer<SpannerEmulatorContainer> {
 

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 
 /**
  * Base class for containers that expose a JDBC connection
- *
- * @author richardnorth
  */
 public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<SELF>>
     extends GenericContainer<SELF>

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ConnectionUrl.java
@@ -19,8 +19,6 @@ import java.util.stream.Stream;
  * This is an Immutable class holding JDBC Connection Url and its parsed components, used by {@link ContainerDatabaseDriver}.
  * <p>
  * {@link ConnectionUrl#parseUrl()} method must be called after instantiating this class.
- *
- * @author manikmagar
  */
 @EqualsAndHashCode(of = "url")
 @Getter
@@ -203,8 +201,6 @@ public class ConnectionUrl {
 
     /**
      * This interface defines the Regex Patterns used by {@link ConnectionUrl}.
-     *
-     * @author manikmagar
      */
     public interface Patterns {
         Pattern URL_MATCHING_PATTERN = Pattern.compile(

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/JdbcDatabaseDelegate.java
@@ -11,8 +11,6 @@ import java.sql.Statement;
 
 /**
  * JDBC database delegate
- *
- * @author Eugeny Karpov
  */
 @Slf4j
 public class JdbcDatabaseDelegate extends AbstractDatabaseDelegate<Statement> {

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -12,8 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This Test class validates that all supported JDBC URL's can be parsed by ConnectionUrl class.
- *
- * @author ManikMagar
  */
 @RunWith(Parameterized.class)
 public class ConnectionUrlDriversTests {

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -7,8 +7,6 @@ import java.util.Set;
 
 /**
  * Container implementation for the MariaDB project.
- *
- * @author Miguel Gonzalez Sanchez
  */
 public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -7,9 +7,6 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-/**
- * @author Stefan Hufschmidt
- */
 public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server");

--- a/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomPasswordMSSQLServerTest.java
+++ b/modules/mssqlserver/src/test/java/org/testcontainers/junit/mssqlserver/CustomPasswordMSSQLServerTest.java
@@ -15,8 +15,6 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * Tests if the password passed to the container satisfied the password policy described at
  * https://docs.microsoft.com/en-us/sql/relational-databases/security/password-policy?view=sql-server-2017
- *
- * @author Enrico Costanzi
  */
 @RunWith(Parameterized.class)
 public class CustomPasswordMSSQLServerTest {

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -5,9 +5,6 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.Set;
 
-/**
- * @author richardnorth
- */
 public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
     public static final String NAME = "mysql";

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -23,7 +23,6 @@ import java.util.stream.Stream;
  * Testcontainer for Neo4j.
  *
  * @param <S> "SELF" to be used in the <code>withXXX</code> methods.
- * @author Michael J. Simons
  */
 public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContainer<S> {
 

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerJUnitIntegrationTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerJUnitIntegrationTest.java
@@ -14,8 +14,6 @@ import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Test for basic functionality when used as a <code>@ClassRule</code>.
- *
- * @author Michael J. Simons
  */
 public class Neo4jContainerJUnitIntegrationTest {
 

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -28,8 +28,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Tests of functionality special to the Neo4jContainer.
- *
- * @author Michael J. Simons
  */
 public class Neo4jContainerTest {
 

--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -8,9 +8,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
 
-/**
- * @author richardnorth
- */
 public class NginxContainer<SELF extends NginxContainer<SELF>>
     extends GenericContainer<SELF>
     implements LinkableContainer {

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -20,9 +20,6 @@ import java.net.URLConnection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author richardnorth
- */
 public class SimpleNginxTest {
 
     private static final DockerImageName NGINX_IMAGE = DockerImageName.parse("nginx:1.9.4");

--- a/modules/orientdb/src/main/java/org/testcontainers/containers/OrientDBContainer.java
+++ b/modules/orientdb/src/main/java/org/testcontainers/containers/OrientDBContainer.java
@@ -19,9 +19,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
-/**
- * @author robfrank
- */
 public class OrientDBContainer extends GenericContainer<OrientDBContainer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OrientDBContainer.class);

--- a/modules/orientdb/src/test/java/org/testcontainers/containers/OrientDBContainerTest.java
+++ b/modules/orientdb/src/test/java/org/testcontainers/containers/OrientDBContainerTest.java
@@ -7,9 +7,6 @@ import org.testcontainers.utility.MountableFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author robfrank
- */
 public class OrientDBContainerTest {
 
     private static final DockerImageName ORIENTDB_IMAGE = DockerImageName.parse("orientdb:3.2.0-tp3");

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -8,9 +8,6 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 
-/**
- * @author richardnorth
- */
 public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
     public static final String NAME = "postgresql";

--- a/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/CustomizablePostgreSQLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/CustomizablePostgreSQLTest.java
@@ -10,9 +10,6 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author richardnorth
- */
 public class CustomizablePostgreSQLTest extends AbstractContainerDatabaseTest {
 
     private static final String DB_NAME = "foo";

--- a/modules/presto/src/test/java/org/testcontainers/containers/PrestoContainerTest.java
+++ b/modules/presto/src/test/java/org/testcontainers/containers/PrestoContainerTest.java
@@ -14,9 +14,6 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author findepi
- */
 public class PrestoContainerTest {
 
     @Test

--- a/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
+++ b/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
@@ -6,9 +6,6 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Testcontainers implementation for QuestDB.
- *
- * @author vangreen
- * @author jerrinot
  */
 public class QuestDBContainer extends JdbcDatabaseContainer<QuestDBContainer> {
 

--- a/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
+++ b/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
@@ -18,8 +18,6 @@ import java.util.Set;
 
 /**
  * Testcontainer for RabbitMQ.
- *
- * @author Martin Greber
  */
 public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
 

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerJUnitIntegrationTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerJUnitIntegrationTest.java
@@ -7,8 +7,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for basic functionality when used as a <code>@ClassRule</code>.
- *
- * @author Mrtin Greber
  */
 public class RabbitMQContainerJUnitIntegrationTest {
 

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
@@ -27,9 +27,6 @@ import javax.net.ssl.TrustManagerFactory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-/**
- * @author Martin Greber
- */
 public class RabbitMQContainerTest {
 
     public static final int DEFAULT_AMQPS_PORT = 5671;

--- a/modules/solr/src/main/java/org/testcontainers/containers/SolrClientUtils.java
+++ b/modules/solr/src/main/java/org/testcontainers/containers/SolrClientUtils.java
@@ -21,8 +21,6 @@ import java.util.zip.ZipOutputStream;
 
 /**
  * Utils class which can create collections and configurations.
- *
- * @author Simon Schneider
  */
 public class SolrClientUtils {
 

--- a/modules/solr/src/main/java/org/testcontainers/containers/SolrContainerConfiguration.java
+++ b/modules/solr/src/main/java/org/testcontainers/containers/SolrContainerConfiguration.java
@@ -4,9 +4,6 @@ import lombok.Data;
 
 import java.net.URL;
 
-/**
- * @author Simon Schneider
- */
 @Data
 public class SolrContainerConfiguration {
 

--- a/modules/solr/src/test/java/org/testcontainers/containers/SolrContainerTest.java
+++ b/modules/solr/src/test/java/org/testcontainers/containers/SolrContainerTest.java
@@ -12,9 +12,6 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author Simon Schneider
- */
 public class SolrContainerTest {
 
     private static final DockerImageName SOLR_IMAGE = DockerImageName.parse("solr:8.3.0");

--- a/modules/tidb/src/main/java/org/testcontainers/tidb/TiDBContainer.java
+++ b/modules/tidb/src/main/java/org/testcontainers/tidb/TiDBContainer.java
@@ -10,8 +10,6 @@ import java.util.Set;
 
 /**
  * Testcontainers implementation for TiDB.
- *
- * @author Icemap
  */
 public class TiDBContainer extends JdbcDatabaseContainer<TiDBContainer> {
 

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYCQLContainer.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYCQLContainer.java
@@ -14,7 +14,6 @@ import java.util.Set;
 /**
  * Testcontainers implementation for YugabyteDB YCQL API.
  *
- * @author srinivasa-vasu
  * @see <a href="https://docs.yugabyte.com/stable/api/ycql/">YCQL API</a>
  */
 public class YugabyteDBYCQLContainer extends GenericContainer<YugabyteDBYCQLContainer> {

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
@@ -10,7 +10,6 @@ import java.util.Set;
 /**
  * Testcontainers implementation for YugabyteDB YSQL API.
  *
- * @author srinivasa-vasu
  * @see <a href="https://docs.yugabyte.com/stable/api/ysql/">YSQL API</a>
  */
 

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainerProvider.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainerProvider.java
@@ -5,8 +5,6 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * YugabyteDB YSQL (Structured Query Language) JDBC container provider
- *
- * @author srinivasa-vasu
  */
 public class YugabyteDBYSQLContainerProvider extends JdbcDatabaseContainerProvider {
 

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/delegate/AbstractYCQLDelegate.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/delegate/AbstractYCQLDelegate.java
@@ -4,8 +4,6 @@ import org.testcontainers.delegate.DatabaseDelegate;
 
 /**
  * An abstract delegate do-nothing class
- *
- * @author srinivasa-vasu
  */
 public abstract class AbstractYCQLDelegate implements DatabaseDelegate {
 

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/delegate/YugabyteDBYCQLDelegate.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/delegate/YugabyteDBYCQLDelegate.java
@@ -16,7 +16,6 @@ import java.util.Collection;
  * this requirement. This functionality is kept to address the initialization requirements
  * from standalone services that can't leverage liquibase or something similar.
  *
- * @author srinivasa-vasu
  * @see YugabyteDBYCQLContainer
  */
 @RequiredArgsConstructor

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYCQLWaitStrategy.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYCQLWaitStrategy.java
@@ -22,8 +22,6 @@ import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
  * check the DB status with this way with a smoke test query that uses the underlying
  * custom objects and wait for the operation to complete.
  * </p>
- *
- * @author srinivasa-vasu
  */
 @RequiredArgsConstructor
 @Slf4j

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYSQLWaitStrategy.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYSQLWaitStrategy.java
@@ -22,8 +22,6 @@ import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
  * check the DB status with this way with a smoke test query that uses the underlying
  * custom objects and wait for the operation to complete.
  * </p>
- *
- * @author srinivasa-vasu
  */
 @RequiredArgsConstructor
 @Slf4j

--- a/modules/yugabytedb/src/test/java/org/testcontainers/jdbc/yugabytedb/YugabyteDBYSQLJDBCDriverTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/jdbc/yugabytedb/YugabyteDBYSQLJDBCDriverTest.java
@@ -9,8 +9,6 @@ import java.util.EnumSet;
 
 /**
  * YugabyteDB YSQL API JDBC connectivity driver test class
- *
- * @author srinivasa-vasu
  */
 @RunWith(Parameterized.class)
 public class YugabyteDBYSQLJDBCDriverTest extends AbstractJDBCDriverTest {

--- a/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
@@ -10,8 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * YugabyteDB YCQL API unit test class
- *
- * @author srinivasa-vasu
  */
 public class YugabyteDBYCQLTest {
 

--- a/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYSQLTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYSQLTest.java
@@ -11,8 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * YugabyteDB YSQL API unit test class
- *
- * @author srinivasa-vasu
  */
 public class YugabyteDBYSQLTest extends AbstractContainerDatabaseTest {
 


### PR DESCRIPTION
Also, all author tag references have been removed.
