### PR TITLE
Log JDBC URL to support TC Port Updater IntelliJ plugin

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -157,7 +157,6 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
                 try (Connection connection = createConnection(""); Statement statement = connection.createStatement()) {
                     boolean testQuerySucceeded = statement.execute(this.getTestQueryString());
                     if (testQuerySucceeded) {
-                        logger().info("Container is started (JDBC URL: {})", this.getJdbcUrl());
                         return;
                     }
                 } catch (NoDriverFoundException e) {
@@ -183,6 +182,7 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
 
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        logger().info("Container is started (JDBC URL: {})", this.getJdbcUrl());
         runInitScriptIfRequired();
     }
 

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -134,8 +134,6 @@ public class ContainerDatabaseDriver implements Driver {
                 container.start();
             }
 
-            LOGGER.debug("Container is started (JDBC URL: {})", container.getJdbcUrl());
-
             /*
               Create a connection using the delegated driver. The container must be ready to accept connections.
              */

--- a/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/jdbc/ContainerDatabaseDriver.java
@@ -134,6 +134,8 @@ public class ContainerDatabaseDriver implements Driver {
                 container.start();
             }
 
+            LOGGER.debug("Container is started (JDBC URL: {})", container.getJdbcUrl());
+
             /*
               Create a connection using the delegated driver. The container must be ready to accept connections.
              */


### PR DESCRIPTION
As a user of Testcontainers, I want to see the JDBC URL on the logs when the container starts.

Currently it is possible to get JDBC URL from the container object. However if I use JDBC support on my Spring Boot application, I don't have a container object. 

I would love to get a log by default from the `ContainerDatabaseDriver`. Then I can easily set my log level to DEBUG for `org.testcontainers.jdbc` and have the JDBC URL from TC.

That would also support [Testcontainers Port Updater IntelliJ plugin](https://github.com/yusufugurozbek/testcontainers-port-updater)