### PR TITLE
[junit-jupiter] Add parallel attribute to `@Testcontainers`

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Testcontainers.java
@@ -63,4 +63,9 @@ public @interface Testcontainers {
      * Whether tests should be disabled (rather than failing) when Docker is not available.
      */
     boolean disabledWithoutDocker() default false;
+
+    /**
+     * Whether containers should start in parallel
+     */
+    boolean parallel() default false;
 }

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/JUnitJupiterTestImages.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/JUnitJupiterTestImages.java
@@ -5,4 +5,5 @@ import org.testcontainers.utility.DockerImageName;
 public interface JUnitJupiterTestImages {
     DockerImageName POSTGRES_IMAGE = DockerImageName.parse("postgres:9.6.12");
     DockerImageName HTTPD_IMAGE = DockerImageName.parse("httpd:2.4-alpine");
+    DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0.32");
 }

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelExecutionTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelExecutionTests.java
@@ -10,7 +10,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ParallelExecutionTests {
 
     @Container
-    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(
+    private static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER = new PostgreSQLContainer<>(
         JUnitJupiterTestImages.POSTGRES_IMAGE
     )
         .withDatabaseName("foo")
@@ -18,11 +18,11 @@ public class ParallelExecutionTests {
         .withPassword("secret");
 
     @Container
-    private MySQLContainer mySQLContainer = new MySQLContainer();
+    private MySQLContainer<?> mySQLContainer = new MySQLContainer<>(JUnitJupiterTestImages.MYSQL_IMAGE);
 
     @Test
     void test() {
-        assertThat(POSTGRE_SQL_CONTAINER.isRunning()).isTrue();
+        assertThat(POSTGRESQL_CONTAINER.isRunning()).isTrue();
         assertThat(mySQLContainer.isRunning()).isTrue();
     }
 }

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelExecutionTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelExecutionTests.java
@@ -1,0 +1,28 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers(parallel = true)
+public class ParallelExecutionTests {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(
+        JUnitJupiterTestImages.POSTGRES_IMAGE
+    )
+        .withDatabaseName("foo")
+        .withUsername("foo")
+        .withPassword("secret");
+
+    @Container
+    private MySQLContainer mySQLContainer = new MySQLContainer();
+
+    @Test
+    void test() {
+        assertThat(POSTGRE_SQL_CONTAINER.isRunning()).isTrue();
+        assertThat(mySQLContainer.isRunning()).isTrue();
+    }
+}


### PR DESCRIPTION
#5037 add an option to Testcontainers annotation for JUnit to start containers in parallel