### PR TITLE
#6667: reset network creation state if network creation fails.

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -59,9 +59,16 @@ public interface Network extends AutoCloseable, TestRule {
         @Override
         public synchronized String getId() {
             if (initialized.compareAndSet(false, true)) {
-                id = create();
+                boolean success = false;
+                try {
+                    id = create();
+                    success = true;
+                } finally {
+                    if (!success) {
+                        initialized.set(false);
+                    }
+                }
             }
-
             return id;
         }
 


### PR DESCRIPTION
Reset network creation state if network creation fails.  This allows any `startAttempts` that the user has applied to the container to retry the creation of the network too.


<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->


