### PR TITLE
Solve #6678 (sleep in RemoteDockerImage retries)

### DIFF
--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -107,6 +107,12 @@ public class RemoteDockerImage extends LazyFuture<String> {
                         imageName,
                         Duration.between(Instant.now(), lastRetryAllowed).getSeconds()
                     );
+                    // to avoid busy wait if docker repository returns 5xx
+                    try {
+                        Thread.sleep(1000L);
+                    } catch (InterruptedException interruptedException) {
+                        Thread.currentThread().interrupt();
+                    }
                 }
             }
             logger.error(


### PR DESCRIPTION
Solves #6678
There is retry cycle in `RemoteDockerImage.resolve` in case if Docker repository responds 5xx code. This cycle has the limit on time execution, but once the situation can happen, the log is just fully of garbage messages of failed attempt to make an HTTP call. Also it makes the redundant load on a docker repo.
In our case it was a wrong configured Artifactory for Docker images, the authentication token was missing. In the log there were thousands of failure messages done while timeout did not happen.

The proposal is pretty simple: add the sleep between retries in this cycle - either constant or logarithmic.