### PR TITLE
Add `Automatic-Module-Name` for JPMS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ subprojects {
         version = '1.18.24'
     }
 
+    jar {
+        manifest {
+            attributes('Automatic-Module-Name': "org.testcontainers.${project.name}")
+        }
+    }
 
     task delombok(type: io.franzbecker.gradle.lombok.task.DelombokTask) {
         outputs.cacheIf {


### PR DESCRIPTION
In order to work with the JPMS and do not conflict with
automatic names, one has been assigned `org.testcontainers.<module-name>`.
