### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@cfc5540ebc9d65a8731f02032e3d44db5e449fb6 # v5.19.0
+      - uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -24,4 +24,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies
 
-      - uses: gradle/wrapper-validation-action@55e685c48d84285a5b0418cd094606e199cca3b6 # v1.0.3
+      - uses: gradle/wrapper-validation-action@8d49e559aae34d3e0eb16cde532684bc9702762b # v1.0.3

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.github.johnrengelman.shadow' version '7.1.2'
+    id 'com.github.johnrengelman.shadow' version '8.1.0'
     id 'me.champeau.gradle.japicmp' version '0.4.1' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
 }

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.2.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.3.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.2.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.3.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.2"

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.2.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.3.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'com.hazelcast:hazelcast:5.2.1'
+    testImplementation 'com.hazelcast:hazelcast:5.2.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20220924'
-    testImplementation 'org.postgresql:postgresql:42.5.3'
+    testImplementation 'org.postgresql:postgresql:42.5.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 }

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.8'
+    id 'org.springframework.boot' version '2.7.9'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.7.8"
+    id("org.springframework.boot") version "2.7.9"
     id("org.jetbrains.kotlin.jvm") version "1.8.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.8.10"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.8'
+    id 'org.springframework.boot' version '2.7.9'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.3'
+    testImplementation 'org.postgresql:postgresql:42.5.4'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.406'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.406'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.418'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.418'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.6.1"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.6.2"
     testImplementation "org.elasticsearch.client:transport:7.17.9"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.4'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.5'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.10'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.36.0'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.13.5'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.10'
-    testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.2'
+    testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.4'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.36.0'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.19.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-firestore:3.7.10'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.2'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.36.0'
-    testImplementation 'com.google.cloud:google-cloud-bigtable:2.19.0'
+    testImplementation 'com.google.cloud:google-cloud-bigtable:2.19.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
-    shaded("net.lingala.zip4j:zip4j:2.11.4")
+    shaded("net.lingala.zip4j:zip4j:2.11.5")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.5'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.6'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.4'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
 }
 

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.405'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.405'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.418'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.406'
     testImplementation 'software.amazon.awssdk:s3:2.20.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.405'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.418'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.406'
-    testImplementation 'software.amazon.awssdk:s3:2.20.2'
+    testImplementation 'software.amazon.awssdk:s3:2.20.15'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.2'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'org.mariadb:r2dbc-mariadb:1.0.2'
+    testImplementation 'org.mariadb:r2dbc-mariadb:1.0.3'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JDBC :: MariaDB"
 
 dependencies {
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.0.1'
 
     api project(':jdbc')
 

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: MS SQL Server"
 
 dependencies {
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.0.1'
 
     api project(':jdbc')
 

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JDBC :: MySQL"
 
 dependencies {
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.0.1'
 
     api project(':jdbc')
 

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.3'
+    testImplementation 'org.postgresql:postgresql:42.5.4'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JDBC :: PostgreSQL"
 
 dependencies {
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.0.1'
 
     api project(':jdbc')
 

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.5.3'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.0.0-jdk8'
+    testImplementation 'org.questdb:questdb:7.0.1-jdk8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':jdbc')
 
-    testImplementation 'org.postgresql:postgresql:42.5.3'
+    testImplementation 'org.postgresql:postgresql:42.5.4'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.questdb:questdb:7.0.1-jdk8'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -6,7 +6,7 @@ description = "Testcontainers :: R2DBC"
 
 dependencies {
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0-rc6'
+    compileOnly 'com.google.auto.service:auto-service:1.0.1'
 
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.8.1.RELEASE'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.5.2'
-    testFixturesImplementation 'org.assertj:assertj-core:3.23.1'
+    testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     provided 'org.seleniumhq.selenium:selenium-remote-driver:4.6.0'
     provided 'org.seleniumhq.selenium:selenium-chrome-driver:4.6.0'
     testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.6.0'
-    testImplementation 'org.seleniumhq.selenium:selenium-edge-driver:4.8.0'
+    testImplementation 'org.seleniumhq.selenium:selenium-edge-driver:4.8.1'
     testImplementation 'org.seleniumhq.selenium:selenium-support:4.6.0'
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.2.0'
 
-    testImplementation 'org.assertj:assertj-core:3.23.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.solacesystems:sol-jcsmp:10.18.0'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.5.4'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.questdb:questdb from 7.0.0-jdk8 to 7.0.1-jdk8 in /modules/questdb (#6720) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.3 to 42.5.4 in /modules/questdb (#6719) @app/dependabot
* Bump net.lingala.zip4j:zip4j from 2.11.4 to 2.11.5 in /modules/hivemq (#6718) @app/dependabot
* Bump com.google.cloud:google-cloud-bigtable from 2.19.0 to 2.19.2 in /modules/gcloud (#6717) @app/dependabot
* Bump com.google.cloud:google-cloud-datastore from 2.13.4 to 2.13.5 in /modules/gcloud (#6716) @app/dependabot
* Bump com.google.cloud:google-cloud-firestore from 3.7.10 to 3.8.1 in /modules/gcloud (#6715) @app/dependabot
* Bump com.google.cloud:google-cloud-spanner from 6.36.0 to 6.36.1 in /modules/gcloud (#6713) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.3 to 42.5.4 in /modules/cockroachdb (#6711) @app/dependabot
* Bump com.google.cloud:google-cloud-pubsub from 1.123.2 to 1.123.4 in /modules/gcloud (#6710) @app/dependabot
* Bump com.hazelcast:hazelcast from 5.2.1 to 5.2.2 in /examples (#6708) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/r2dbc (#6707) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.9.1 to 5.9.2 in /examples (#6706) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.3 to 42.5.4 in /examples (#6705) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-sqs from 1.12.405 to 1.12.418 in /modules/localstack (#6704) @app/dependabot
* Bump org.springframework.boot from 2.7.8 to 2.7.9 in /examples (#6703) @app/dependabot
* Bump release-drafter/release-drafter from 5.22.0 to 5.23.0 (#6702) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.2 to 2.20.15 in /modules/localstack (#6700) @app/dependabot
* Bump com.github.johnrengelman.shadow from 7.1.2 to 8.1.0 in /examples (#6701) @app/dependabot
* Bump gradle/wrapper-validation-action from 1.0.5 to 1.0.6 (#6699) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-logs from 1.12.406 to 1.12.418 in /modules/localstack (#6698) @app/dependabot
* Bump io.lettuce:lettuce-core from 6.2.2.RELEASE to 6.2.3.RELEASE in /examples (#6696) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-s3 from 1.12.405 to 1.12.418 in /modules/localstack (#6695) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.6.1 to 8.6.2 in /modules/elasticsearch (#6692) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.3 to 42.5.4 in /modules/junit-jupiter (#6690) @app/dependabot
* Bump org.mariadb:r2dbc-mariadb from 1.0.2 to 1.0.3 in /modules/mariadb (#6691) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.406 to 1.12.418 in /modules/dynalite (#6688) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.5 to 10.1.6 in /modules/jdbc (#6689) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-edge-driver from 4.8.0 to 4.8.1 in /modules/selenium (#6687) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.3 to 42.5.4 in /modules/spock (#6683) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.3 to 42.5.4 in /modules/postgresql (#6682) @app/dependabot
* Bump org.assertj:assertj-core from 3.23.1 to 3.24.2 in /modules/solace (#6630) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.2 to 3.5.3 in /modules/r2dbc (#6629) @app/dependabot
