### PR TITLE
Use existing rootless-docker GHA for rootless CI

### DIFF
--- a/.github/workflows/ci-docker-wormhole.yml
+++ b/.github/workflows/ci-docker-wormhole.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   in-docker_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Build with Gradle

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   find_gradle_jobs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Setup rootless Docker

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -14,29 +14,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - { XDG_RUNTIME_DIR: "" }
-          - { XDG_RUNTIME_DIR: "/tmp/docker-testcontainers/" }
-    env:
-      XDG_RUNTIME_DIR: ${{ matrix.XDG_RUNTIME_DIR }}
     steps:
       - uses: actions/checkout@v3
-      - name: debug
-        run: id -u; whoami
-      - name: uninstall rootful Docker
-        run: sudo apt-get -q -y --purge remove moby-engine moby-buildx && sudo rm -rf /var/run/docker.sock
-      - name: install rootless Docker
-        run: |
-          mkdir -p $XDG_RUNTIME_DIR || true
-          curl -fsSL https://get.docker.com/rootless | sh > init.sh
-          cat init.sh
-          source <(grep '^export' init.sh)
-          PATH=$HOME/bin:$PATH dockerd-rootless.sh --experimental --storage-driver vfs &
-          sleep 1
-          DOCKER_HOST=unix://$XDG_RUNTIME_DIR/docker.sock docker info || ls -la $XDG_RUNTIME_DIR
+      - name: Setup rootless Docker
+        uses: ScribeMD/rootless-docker@0.2.2
+      - name: Remove Docket root socket
+        run: sudo rm -rf /var/run/docker.sock
       - name: Setup Gradle Build Action
         uses: gradle/gradle-build-action@v2
       - name: Build with Gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   find_gradle_jobs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3


### PR DESCRIPTION
The existing method of installing rootless Docker does not work in newer versions of Ubuntu.

I am using https://github.com/ScribeMD/rootless-docker in tc-node and it works with the newer version of Ubuntu.

The existing workflow set up `XDG_RUNTIME_DIR` as a matrix for the tests. This was to test various permutations of the `RootlessDockerClientProviderStrategy`. This GHA configures its own `XDG_RUNTIME_DIR` which the strategy will use. I think that a workflow testing a single permutation of `XDG_RUNTIME_DIR` should be enough, and permutations can be unit tested if necessary.

---

This PR additionally updates all CI runners from ubuntu 20.04 to 22.04.