### PR TITLE
Solves #3016: custom docker logger name prefix via config

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerLoggerFactory.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerLoggerFactory.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DockerLoggerFactory {
 
+    private static final String loggerNamePrefix = TestcontainersConfiguration.getInstance().getLoggerNamePrefix();
+
     public static Logger getLogger(String dockerImageName) {
         final String abbreviatedName;
         if (dockerImageName.contains("@sha256")) {
@@ -17,9 +19,9 @@ public final class DockerLoggerFactory {
         }
 
         if ("UTF-8".equals(System.getProperty("file.encoding"))) {
-            return LoggerFactory.getLogger("\uD83D\uDC33 [" + abbreviatedName + "]");
+            return LoggerFactory.getLogger(loggerNamePrefix + "\uD83D\uDC33 [" + abbreviatedName + "]");
         } else {
-            return LoggerFactory.getLogger("docker[" + abbreviatedName + "]");
+            return LoggerFactory.getLogger(loggerNamePrefix + "docker[" + abbreviatedName + "]");
         }
     }
 }

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -217,6 +217,10 @@ public class TestcontainersConfiguration {
         return Integer.parseInt(getEnvVarOrProperty("client.ping.timeout", "10"));
     }
 
+    public String getLoggerNamePrefix() {
+        return getEnvVarOrUserProperty("testcontainers.logger.prefix", "");
+    }
+
     @Nullable
     @Contract("_, !null, _ -> !null")
     private String getConfigurable(


### PR DESCRIPTION
https://github.com/testcontainers/testcontainers-java/issues/3016

Allows to customize Logger name with prefix via `testcontainers.properties` and/or System properties - this way the logback hierarchial configuration can be applied.