### PR TITLE
Solves #3016: custom docker logger name prefix via System property

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerLoggerFactory.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerLoggerFactory.java
@@ -8,6 +8,8 @@ import org.slf4j.LoggerFactory;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class DockerLoggerFactory {
 
+    private static final String loggerNamePrefix = System.getProperty("testcontainers.logger.prefix", "");
+
     public static Logger getLogger(String dockerImageName) {
         final String abbreviatedName;
         if (dockerImageName.contains("@sha256")) {
@@ -17,9 +19,9 @@ public final class DockerLoggerFactory {
         }
 
         if ("UTF-8".equals(System.getProperty("file.encoding"))) {
-            return LoggerFactory.getLogger("\uD83D\uDC33 [" + abbreviatedName + "]");
+            return LoggerFactory.getLogger(loggerNamePrefix + "\uD83D\uDC33 [" + abbreviatedName + "]");
         } else {
-            return LoggerFactory.getLogger("docker[" + abbreviatedName + "]");
+            return LoggerFactory.getLogger(loggerNamePrefix + "docker[" + abbreviatedName + "]");
         }
     }
 }


### PR DESCRIPTION
https://github.com/testcontainers/testcontainers-java/issues/3016

Allows to customize Logger name with prefix via System property - this way the logback hierarchial configuration can be applied. This PR is a separate of #6772 just as a minimal PoC that solved the problem with minimal side effects.