### PR TITLE
Update Redpanda image

### DIFF
--- a/docs/modules/redpanda.md
+++ b/docs/modules/redpanda.md
@@ -1,10 +1,10 @@
 # Redpanda
 
 Testcontainers can be used to automatically instantiate and manage [Redpanda](https://redpanda.com/) containers.
-More precisely Testcontainers uses the official Docker images for [Redpanda](https://hub.docker.com/r/vectorized/redpanda/)
+More precisely Testcontainers uses the official Docker images for [Redpanda](https://hub.docker.com/r/redpandadata/redpanda)
 
 !!! note
-    This module uses features provided in `docker.redpanda.com/vectorized/redpanda`.
+    This module uses features provided in `docker.redpanda.com/redpandadata/redpanda`.
 
 ## Example
 

--- a/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
+++ b/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
@@ -12,9 +12,15 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
 
-    private static final String REDPANDA_FULL_IMAGE_NAME = "docker.redpanda.com/vectorized/redpanda";
+    private static final String REDPANDA_FULL_IMAGE_NAME = "docker.redpanda.com/redpandadata/redpanda";
+
+    @Deprecated
+    private static final String REDPANDA_OLD_FULL_IMAGE_NAME = "docker.redpanda.com/vectorized/redpanda";
 
     private static final DockerImageName REDPANDA_IMAGE = DockerImageName.parse(REDPANDA_FULL_IMAGE_NAME);
+
+    @Deprecated
+    private static final DockerImageName REDPANDA_OLD_IMAGE = DockerImageName.parse(REDPANDA_OLD_FULL_IMAGE_NAME);
 
     private static final int REDPANDA_PORT = 9092;
 
@@ -28,7 +34,7 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
 
     public RedpandaContainer(DockerImageName imageName) {
         super(imageName);
-        imageName.assertCompatibleWith(REDPANDA_IMAGE);
+        imageName.assertCompatibleWith(REDPANDA_OLD_IMAGE, REDPANDA_IMAGE);
 
         boolean isLessThanBaseVersion = new ComparableVersion(imageName.getVersionPart()).isLessThan("v22.2.1");
         if (REDPANDA_FULL_IMAGE_NAME.equals(imageName.getUnversionedPart()) && isLessThanBaseVersion) {

--- a/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
+++ b/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.tuple;
 
 public class RedpandaContainerTest {
 
-    private static final String REDPANDA_IMAGE = "docker.redpanda.com/vectorized/redpanda:v22.2.1";
+    private static final String REDPANDA_IMAGE = "docker.redpanda.com/redpandadata/redpanda:v22.2.1";
 
     private static final DockerImageName REDPANDA_DOCKER_IMAGE = DockerImageName.parse(REDPANDA_IMAGE);
 
@@ -47,7 +47,7 @@ public class RedpandaContainerTest {
     public void testUsageWithStringImage() throws Exception {
         try (
             // constructorWithVersion {
-            RedpandaContainer container = new RedpandaContainer("docker.redpanda.com/vectorized/redpanda:v22.2.1")
+            RedpandaContainer container = new RedpandaContainer("docker.redpanda.com/redpandadata/redpanda:v22.2.1")
             // }
         ) {
             container.start();
@@ -61,7 +61,7 @@ public class RedpandaContainerTest {
 
     @Test
     public void testNotCompatibleVersion() {
-        assertThatThrownBy(() -> new RedpandaContainer("docker.redpanda.com/vectorized/redpanda:v21.11.19"))
+        assertThatThrownBy(() -> new RedpandaContainer("docker.redpanda.com/redpandadata/redpanda:v21.11.19"))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessageContaining("Redpanda version must be >= v22.2.1");
     }


### PR DESCRIPTION
Currently, `RedpandaContainer` uses `docker.redpanda.com/vectorized/redpanda`
but must use `docker.redpanda.com/redpandadata/redpanda` instead.
