### PR TITLE
Fix typo in docs - Streamlio description

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -187,7 +187,7 @@ A huge thank you to our sponsors:
 * [Playtika](https://github.com/Playtika/testcontainers-spring-boot) - Kafka, Couchbase, MariaDB, Redis, Neo4j, Aerospike, MemSQL
 * [JetBrains](https://www.jetbrains.com/) - Testing of the TeamCity plugin for HashiCorp Vault
 * [Plumbr](https://plumbr.io) - Integration testing of data processing pipeline micro-services
-* [Streamlio](https://streaml.io/) - Integration and Chaos Testing of our fast data platform based on Apache Puslar, Apache Bookeeper and Apache Heron.
+* [Streamlio](https://streaml.io/) - Integration and Chaos Testing of our fast data platform based on Apache Pulsar, Apache BookKeeper and Apache Heron.
 * [Spring Session](https://projects.spring.io/spring-session/) - Redis, PostgreSQL, MySQL and MariaDB integration testing
 * [Apache Camel](https://camel.apache.org) - Testing Camel against native services such as Consul, Etcd and so on
 * [Infinispan](https://infinispan.org) - Testing the Infinispan Server as well as integration tests with databases, LDAP and KeyCloak


### PR DESCRIPTION
Hi, 
Browsing documentation I noticed that there are a couple of typos at https://github.com/testcontainers/testcontainers-java/blob/main/docs/index.md in the section “Who is using Testcontainers?”.

When describing Streamlio project , it says “Integration and Chaos Testing of our fast data platform based on **Apache Puslar**, **Apache Bookeeper** and Apache Heron”.

Following modifications were applied.

Change “Apache Puslar”  to “Apache Pulsar” [https://pulsar.apache.org/]
Change “Apache Bookeeper” to “Apache BookKeeper” [https://bookkeeper.apache.org/]

