### PR TITLE
Deprecate VaultContainer#withLogLevel

### DIFF
--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -154,7 +154,9 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      *
      * @param level the logging level to set for Vault.
      * @return this
+     * @deprecated use {@link #withEnv(String, String)} instead
      */
+    @Deprecated
     public SELF withLogLevel(VaultLogLevel level) {
         return withEnv("VAULT_LOG_LEVEL", level.config);
     }


### PR DESCRIPTION
Log level can be configured using env vars. E.g

```java
VaultContainer<?> vault = new VaultContainer<>("vault:1.6.1")
    .withEnv("VAULT_LOG_LEVEL", "info")
```
