### PR TITLE
Accept `hashicorp/vault` image

### DIFF
--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -24,7 +24,9 @@ import java.util.stream.Collectors;
  */
 public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericContainer<SELF> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("vault");
+    private static final DockerImageName DEFAULT_OLD_IMAGE_NAME = DockerImageName.parse("vault");
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("hashicorp/vault");
 
     private static final String DEFAULT_TAG = "1.1.3";
 
@@ -50,7 +52,7 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
 
     public VaultContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_OLD_IMAGE_NAME, DEFAULT_IMAGE_NAME);
 
         // Use the vault healthcheck endpoint to check for readiness, per https://www.vaultproject.io/api/system/health.html
         setWaitStrategy(Wait.forHttp("/v1/sys/health").forStatusCode(200));

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
@@ -24,7 +24,7 @@ public class VaultContainerTest {
 
     @ClassRule
     // vaultContainer {
-    public static VaultContainer<?> vaultContainer = new VaultContainer<>("vault:1.6.1")
+    public static VaultContainer<?> vaultContainer = new VaultContainer<>("hashicorp/vault:1.13")
         .withVaultToken(VAULT_TOKEN)
         .withSecretInVault("secret/testing1", "top_secret=password123")
         .withSecretInVault(


### PR DESCRIPTION
Currently, `VaultContainer` accepts `vault` from Docker Official
Image. But, there is a deprecation notice and recommend to use
`hashicorp/vault` instead.

In order to keep backward compatibility, both `vault` and
`hashicorp/vault` are valid images.
