### PR TITLE
Accept `hashicorp/consul` image

### DIFF
--- a/modules/consul/src/main/java/org/testcontainers/consul/ConsulContainer.java
+++ b/modules/consul/src/main/java/org/testcontainers/consul/ConsulContainer.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 public class ConsulContainer extends GenericContainer<ConsulContainer> {
 
     private static final DockerImageName DEFAULT_OLD_IMAGE_NAME = DockerImageName.parse("consul");
+
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("hashicorp/consul");
 
     private static final int CONSUL_HTTP_PORT = 8500;

--- a/modules/consul/src/main/java/org/testcontainers/consul/ConsulContainer.java
+++ b/modules/consul/src/main/java/org/testcontainers/consul/ConsulContainer.java
@@ -17,7 +17,8 @@ import java.util.stream.Collectors;
  */
 public class ConsulContainer extends GenericContainer<ConsulContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("consul");
+    private static final DockerImageName DEFAULT_OLD_IMAGE_NAME = DockerImageName.parse("consul");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("hashicorp/consul");
 
     private static final int CONSUL_HTTP_PORT = 8500;
 
@@ -33,7 +34,7 @@ public class ConsulContainer extends GenericContainer<ConsulContainer> {
 
     public ConsulContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_OLD_IMAGE_NAME, DEFAULT_IMAGE_NAME);
 
         // Use the status leader endpoint to verify if consul is running.
         setWaitStrategy(Wait.forHttp("/v1/status/leader").forPort(CONSUL_HTTP_PORT).forStatusCode(200));

--- a/modules/consul/src/test/java/org/testcontainers/consul/ConsulContainerTest.java
+++ b/modules/consul/src/test/java/org/testcontainers/consul/ConsulContainerTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ConsulContainerTest {
 
     @ClassRule
-    public static ConsulContainer consulContainer = new ConsulContainer(ConsulTestImages.CONSUL_IMAGE)
+    public static ConsulContainer consulContainer = new ConsulContainer("hashicorp/consul:1.15")
         .withConsulCommand("kv put config/testing1 value123");
 
     @Test

--- a/modules/consul/src/test/java/org/testcontainers/consul/ConsulTestImages.java
+++ b/modules/consul/src/test/java/org/testcontainers/consul/ConsulTestImages.java
@@ -1,7 +1,0 @@
-package org.testcontainers.consul;
-
-import org.testcontainers.utility.DockerImageName;
-
-public interface ConsulTestImages {
-    DockerImageName CONSUL_IMAGE = DockerImageName.parse("consul:1.10.12");
-}


### PR DESCRIPTION
Currently, `ConsulContainer` accepts `consul` from Docker Official
Image. But, there is a deprecation notice and recommend to use
`hashicorp/consul` instead.

In order to keep backward compatibility, both `consul` and
`hashicorp/consul` are valid images.
