### PR TITLE
Add JavaDoc to Spock's Testcontainers annotation

### DIFF
--- a/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
@@ -8,6 +8,47 @@ import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 import java.lang.annotation.Target
 
+/**
+ * {@code @Testcontainers} is a Spock extension to activate automatic
+ * startup and stop of containers used in a test case.
+ *
+ * <p>The test containers extension finds all fields that extend
+ * {@link org.testcontainers.containers.GenericContainer} or
+ * {@link org.testcontainers.containers.DockerComposeContainer} and calls their
+ * container lifecycle methods. Containers annotated with {@link spock.lang.Shared}
+ * will be shared between test methods. They will be
+ * started only once before any test method is executed and stopped after the
+ * last test method has executed. Containers without {@link spock.lang.Shared}
+ * annotation will be started and stopped for every test method.</p>
+ *
+ * <p>The annotation {@code @Testcontainers} can be used on a superclass in
+ * the test hierarchy as well. All subclasses will automatically inherit
+ * support for the extension.</p>
+ *
+ * <p>Example:</p>
+ *
+ * <pre>
+ * &#64;Testcontainers
+ * class MyTestcontainersTests extends Specification {
+ *
+ *     // will be started only once in setupSpec() and stopped after last test method
+ *     &#64;Shared
+ *     MySQLContainer MY_SQL_CONTAINER = new MySQLContainer()
+ *
+ *     // will be started before and stopped after each test method
+ *     PostgreSQLContainer postgresqlContainer = new PostgreSQLContainer()
+ *             .withDatabaseName('foo')
+ *             .withUsername('foo')
+ *             .withPassword('secret')
+ *
+ *     def 'test'() {
+ *         expect:
+ *         MY_SQL_CONTAINER.running
+ *         postgresqlContainer.running
+ *     }
+ * }
+ * </pre>
+ */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target([ElementType.TYPE, ElementType.METHOD])

--- a/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
@@ -12,7 +12,7 @@ import java.lang.annotation.Target
  * {@code @Testcontainers} is a Spock extension to activate automatic
  * startup and stop of containers used in a test case.
  *
- * <p>The test containers extension finds all fields that extend
+ * <p>The Testcontainers extension finds all fields that extend
  * {@link org.testcontainers.containers.GenericContainer} or
  * {@link org.testcontainers.containers.DockerComposeContainer} and calls their
  * container lifecycle methods. Containers annotated with {@link spock.lang.Shared}


### PR DESCRIPTION
The `Testcontainers` annotation in the Spock module did not feature any JavaDoc so developers had to guess or read the source code to know what's happening behind the scenes. As a first suggestion I adapted the comment from JUnit's `Testcontainers` annotation to Spock/Groovy. I did *not* copy the warning

> This extension has only been tested with sequential test execution. Using it with parallel test execution is unsupported and may have unintended side effects.

 as I do not know whether the same applies to the Spock extension.