### PR TITLE
Ensure Elasticsearch can start despite restrictive umask

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -295,16 +295,34 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      *
      * @param resourcePath  path to the resource on the classpath (relative to the classpath root; should not start with a leading slash)
      * @param containerPath path this should be mapped to inside the container
-     * @param mode          access mode for the file
+     * @param bindMode      access mode for the file
      * @return this
      */
     default SELF withClasspathResourceMapping(
         final String resourcePath,
         final String containerPath,
-        final BindMode mode
+        final BindMode bindMode
     ) {
-        withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.NONE);
-        return self();
+        return withClasspathResourceMapping(resourcePath, null, containerPath, bindMode, SelinuxContext.NONE);
+    }
+
+    /**
+     * Map a resource (file or directory) on the classpath to a path inside the container.
+     * This will only work if you are running your tests outside a Docker container.
+     *
+     * @param resourcePath  path to the resource on the classpath (relative to the classpath root; should not start with a leading slash)
+     * @param fileMode      octal value of posix file mode (000..777)
+     * @param containerPath path this should be mapped to inside the container
+     * @param bindMode      access mode for the file
+     * @return this
+     */
+    default SELF withClasspathResourceMapping(
+        final String resourcePath,
+        final Integer fileMode,
+        final String containerPath,
+        final BindMode bindMode
+    ) {
+        return withClasspathResourceMapping(resourcePath, fileMode, containerPath, bindMode, SelinuxContext.NONE);
     }
 
     /**
@@ -313,14 +331,35 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
      *
      * @param resourcePath   path to the resource on the classpath (relative to the classpath root; should not start with a leading slash)
      * @param containerPath  path this should be mapped to inside the container
-     * @param mode           access mode for the file
+     * @param bindMode       access mode for the file
+     * @param selinuxContext selinux context argument to use for this file
+     * @return this
+     */
+    default SELF withClasspathResourceMapping(
+        String resourcePath,
+        String containerPath,
+        BindMode bindMode,
+        SelinuxContext selinuxContext
+    ) {
+        return withClasspathResourceMapping(resourcePath, null, containerPath, bindMode, selinuxContext);
+    }
+
+    /**
+     * Map a resource (file or directory) on the classpath to a path inside the container.
+     * This will only work if you are running your tests outside a Docker container.
+     *
+     * @param resourcePath   path to the resource on the classpath (relative to the classpath root; should not start with a leading slash)
+     * @param fileMode       octal value of posix file mode (000..777)
+     * @param containerPath  path this should be mapped to inside the container
+     * @param bindMode       access mode for the file
      * @param selinuxContext selinux context argument to use for this file
      * @return this
      */
     SELF withClasspathResourceMapping(
         String resourcePath,
+        Integer fileMode,
         String containerPath,
-        BindMode mode,
+        BindMode bindMode,
         SelinuxContext selinuxContext
     );
 

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1256,28 +1256,17 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withClasspathResourceMapping(
         final String resourcePath,
+        final Integer fileMode,
         final String containerPath,
-        final BindMode mode
-    ) {
-        return withClasspathResourceMapping(resourcePath, containerPath, mode, SelinuxContext.NONE);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public SELF withClasspathResourceMapping(
-        final String resourcePath,
-        final String containerPath,
-        final BindMode mode,
+        final BindMode bindMode,
         final SelinuxContext selinuxContext
     ) {
-        final MountableFile mountableFile = MountableFile.forClasspathResource(resourcePath);
+        final MountableFile mountableFile = MountableFile.forClasspathResource(resourcePath, fileMode);
 
-        if (mode == BindMode.READ_ONLY && selinuxContext == SelinuxContext.NONE) {
+        if (bindMode == BindMode.READ_ONLY && selinuxContext == SelinuxContext.NONE) {
             withCopyFileToContainer(mountableFile, containerPath);
         } else {
-            addFileSystemBind(mountableFile.getResolvedPath(), containerPath, mode, selinuxContext);
+            addFileSystemBind(mountableFile.getResolvedPath(), containerPath, bindMode, selinuxContext);
         }
 
         return self();

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -102,6 +102,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         // Spaces are deliberate to allow user to define additional jvm options as elasticsearch resolves option files lexicographically
         withClasspathResourceMapping(
             "elasticsearch-default-memory-vm.options",
+            0664,
             "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-default-memory-vm.options",
             BindMode.READ_ONLY
         );


### PR DESCRIPTION
Ensure the config file copied to the Elasticsearch container is readable, even when the umask something restrictive, like 027 or 077, so that the container can start, instead of failing with an `AccessDeniedException`.

Closes #6444.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
