### PR TITLE
Do not trigger CI workflows when docs are modified

### DIFF
--- a/.github/workflows/ci-docker-wormhole.yml
+++ b/.github/workflows/ci-docker-wormhole.yml
@@ -1,8 +1,19 @@
 name: CI-Docker-Wormhole
 
 on:
-  pull_request: {}
-  push: { branches: [ main ] }
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -1,8 +1,19 @@
 name: CI-Examples
 
 on:
-  pull_request: {}
-  push: { branches: [ main ] }
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -1,8 +1,19 @@
 name: CI-Docker-Rootless
 
 on:
-  pull_request: {}
-  push: { branches: [ main ] }
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,19 @@
 name: CI
 
 on:
-  pull_request: {}
-  push: { branches: [ main ] }
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - 'README.md'
+      - 'RELEASING.md'
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"


### PR DESCRIPTION
Add `paths-ignore` to do not run CI when certain files are modified.
