### PR TITLE
Allow jib-core dependency in checkPOMdependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -118,6 +118,7 @@ dependencies {
 tasks.generatePomFileForMavenJavaPublication.finalizedBy(
     tasks.register('checkPOMdependencies', org.testcontainers.build.ComparePOMWithLatestReleasedTask) {
         ignore = [
+            "com.google.cloud.tools:jib-core"
         ]
     }
 )


### PR DESCRIPTION
`jib-core` was added and when `publishToMavenLocal` is performed
`checkPOMdependencies` dependencies failed because of it.
