### PR TITLE
Improve JavaDoc on `GenericContainer`

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -627,7 +627,30 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     }
 
     /**
-     * Stops the container.
+     * Kills the container and removes it from Docker.
+     *
+     * <p>In most situations, killing the container is the correct course of action in a test environment.
+     * This is how Ryuk stops containers.
+     *
+     * <p>If a more graceful shutdown is required, interact with the container's docker client directly:
+     *
+     * <pre>
+     * container
+     *     .getDockerClient()
+     *     .stopContainerCmd(container.getContainerId())
+     *     .withTimeout(timeout)
+     *      .exec();
+     * </pre>
+     *
+     * <p>or, if control of the signal sent, consider using the kill command directly:
+     *
+     * <pre>
+     * container
+     *     .getDockerClient()
+     *     .killContainerCmd(container.getContainerId())
+     *     .withSignal("HUP")
+     *     .exec();
+     * </pre>
      */
     @Override
     public void stop() {


### PR DESCRIPTION
Not necessarily a fix for https://github.com/testcontainers/testcontainers-java/issues/1000, but at least make it easier for people to discover how to gracefully stop a container and/or send it different signals.

If/when this is merged, I'll leave it up to the committers to choose if https://github.com/testcontainers/testcontainers-java/issues/1000 should be closed, or if there is still intent to change the API.  If the latter, I'm happy to raise a PR if someone gives brief guidance as to _what_ api would be acceptable...