### PR TITLE
Exclude guava, jackson-core, jackson-databind from jib-core

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,7 +76,11 @@ dependencies {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
 
-    provided 'com.google.cloud.tools:jib-core:0.22.0'
+    provided('com.google.cloud.tools:jib-core:0.22.0') {
+        exclude group: 'com.google.guava', module: 'guava'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    }
 
     shaded 'org.awaitility:awaitility:4.2.0'
 


### PR DESCRIPTION
Previous to introduce support for Jib in f78c0c32. The dependencies
mentioned were shaded. However, after introducing Jib, those
dependencies became part of the API. For that reason, currently,
those are not shaded.
