### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v2.1.0
+        uses: github/combine-prs@v3.0.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v3.10.1
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@2b011faafdcbc9ceb11414d64d0573f37c774b04 # v3.10.1
+        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v3.10.1
         with:
           title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.github.johnrengelman.shadow' version '8.1.0'
+    id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'me.champeau.gradle.japicmp' version '0.4.1' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -97,7 +97,7 @@ dependencies {
 
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.3.1'
-    testImplementation 'com.rabbitmq:amqp-client:5.16.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.17.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.12'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,8 +69,8 @@ configurations.all {
 dependencies {
     api 'junit:junit:4.13.2'
     api 'org.slf4j:slf4j-api:1.7.36'
-    compileOnly 'org.jetbrains:annotations:24.0.0'
-    testCompileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
+    testCompileOnly 'org.jetbrains:annotations:24.0.1'
     api 'org.apache.commons:commons-compress:1.22'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -76,7 +76,7 @@ dependencies {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
 
-    provided 'com.google.cloud.tools:jib-core:0.22.0'
+    provided 'com.google.cloud.tools:jib-core:0.23.0'
 
     shaded 'org.awaitility:awaitility:4.2.0'
 

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation project(":mysql")
 
     testImplementation 'mysql:mysql-connector-java:8.0.32'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.8.1"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.8.3"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20230227'
-    testImplementation 'org.postgresql:postgresql:42.5.4'
+    testImplementation 'org.postgresql:postgresql:42.6.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.8'
+    testImplementation 'io.nats:jnats:2.16.9'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:4.3.1'
+    implementation 'redis.clients:jedis:4.3.2'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:4.3.1'
+    implementation 'redis.clients:jedis:4.3.2'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.9'
+    id 'org.springframework.boot' version '2.7.10'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.2"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.10"
     }
 }
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:4.3.1'
+    implementation 'redis.clients:jedis:4.3.2'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.7.9"
+    id("org.springframework.boot") version "2.7.10"
     id("org.jetbrains.kotlin.jvm") version "1.8.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.8.10"
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id("org.springframework.boot") version "2.7.10"
     id("org.jetbrains.kotlin.jvm") version "1.8.10"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.8.10"
+    id("org.jetbrains.kotlin.plugin.spring") version "1.8.20"
 }
 
 apply plugin: 'io.spring.dependency-management'

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.9'
+    id 'org.springframework.boot' version '2.7.10'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.azure:azure-cosmos:4.41.0'
+    testImplementation 'com.azure:azure-cosmos:4.42.0'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.4'
+    testImplementation 'org.postgresql:postgresql:42.6.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.3'
+    testImplementation 'com.couchbase.client:java-client:3.4.4'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.4'
+    testImplementation 'org.postgresql:postgresql:42.6.0'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -9,5 +9,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'org.postgresql:postgresql:42.5.4'
 
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.418'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.418'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.440'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.440'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.6.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.7.0"
     testImplementation "org.elasticsearch.client:transport:7.17.9"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.google.cloud:google-cloud-datastore:2.13.5'
+    testImplementation 'com.google.cloud:google-cloud-datastore:2.14.2'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.8.1'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.4'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.38.2'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.13.5'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.8.1'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.4'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.36.1'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.38.2'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.19.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.12.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.13.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: HiveMQ"
 
 dependencies {
     api(project(":testcontainers"))
-    api("org.jetbrains:annotations:24.0.0")
+    api("org.jetbrains:annotations:24.0.1")
 
     shaded("org.apache.commons:commons-lang3:3.12.0")
     shaded("commons-io:commons-io:2.11.0")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.12.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.4.5")
+    testImplementation("ch.qos.logback:logback-classic:1.4.6")
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.influxdb:influxdb-java:2.23'
-    testImplementation "com.influxdb:influxdb-client-java:6.7.0"
+    testImplementation "com.influxdb:influxdb-client-java:6.8.0"
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.6'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.7'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: JDBC"
 dependencies {
     api project(':database-commons')
 
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.7'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.3.1'
+    testImplementation 'redis.clients:jedis:4.3.2'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.5.4'
+    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
 }
 

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.4.1'
+    testImplementation 'io.fabric8:kubernetes-client:6.5.1'
     testImplementation 'io.kubernetes:client-java:17.0.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.418'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.440'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.418'
-    testImplementation 'software.amazon.awssdk:s3:2.20.15'
+    testImplementation 'software.amazon.awssdk:s3:2.20.37'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.418'
-    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.418'
+    testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.440'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.418'
     testImplementation 'software.amazon.awssdk:s3:2.20.15'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.2'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.3'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'dev.miku:r2dbc-mysql:0.8.2.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -2,6 +2,6 @@ description = "Testcontainers :: Nginx"
 
 dependencies {
     api project(':testcontainers')
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: Oracle XE"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0.1.1'
+    compileOnly 'com.google.auto.service:auto-service:1.0.1'
 
     api project(':jdbc')
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
+    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:21.9.0.0'
@@ -15,7 +15,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.0'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
+    testImplementation 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
 }
 
 test {

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:21.9.0.0'
 
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:21.5.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:21.9.0.0'
 
     compileOnly 'org.jetbrains:annotations:24.0.0'
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.16"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.17"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "TestContainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.16"
+    api "com.orientechnologies:orientdb-client:3.2.17"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.postgresql:postgresql:42.5.4'
+    testImplementation 'org.postgresql:postgresql:42.6.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/presto/build.gradle
+++ b/modules/presto/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testImplementation 'io.prestosql:presto-jdbc:350'
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':jdbc')
 
-    testImplementation 'org.postgresql:postgresql:42.5.4'
+    testImplementation 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.questdb:questdb:7.0.1-jdk8'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.3'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.4'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.16.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     provided 'org.seleniumhq.selenium:selenium-remote-driver:4.6.0'
     provided 'org.seleniumhq.selenium:selenium-chrome-driver:4.6.0'
     testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver:4.6.0'
-    testImplementation 'org.seleniumhq.selenium:selenium-edge-driver:4.8.1'
+    testImplementation 'org.seleniumhq.selenium:selenium-edge-driver:4.8.3'
     testImplementation 'org.seleniumhq.selenium:selenium-support:4.6.0'
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation project(':nginx')
     testImplementation 'org.assertj:assertj-core:3.24.2'
 
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     shaded 'org.awaitility:awaitility:4.2.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.solacesystems:sol-jcsmp:10.18.0'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.19.0'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'
 
-    testCompileOnly 'org.jetbrains:annotations:24.0.0'
+    testCompileOnly 'org.jetbrains:annotations:24.0.1'
 }
 
 sourceJar {

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'mysql:mysql-connector-java:8.0.32'
 
-    compileOnly 'org.jetbrains:annotations:24.0.0'
+    compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:408'
+    testImplementation 'io.trino:trino-jdbc:411'
     compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
     testImplementation project(':jdbc-test')
     // YCQL driver
-    testImplementation 'com.yugabyte:java-driver-core:4.6.0-yb-11'
+    testImplementation 'com.yugabyte:java-driver-core:4.6.0-yb-12'
     // YSQL driver
     testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-2'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.8.2"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.10"
         classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump github/combine-prs from 2.1.0 to 3.0.1 (#6886) @app/dependabot
* Bump com.google.cloud:google-cloud-spanner from 6.36.1 to 6.38.2 in /modules/gcloud (#6882) @app/dependabot
* Bump io.nats:jnats from 2.16.8 to 2.16.9 in /examples (#6881) @app/dependabot
* Bump com.github.johnrengelman.shadow from 8.1.0 to 8.1.1 in /examples (#6880) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.8.1 to 4.8.3 in /examples (#6879) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.4 to 42.6.0 in /examples (#6878) @app/dependabot
* Bump org.springframework.boot from 2.7.9 to 2.7.10 in /examples (#6877) @app/dependabot
* Bump org.jetbrains.kotlin.plugin.spring from 1.8.10 to 1.8.20 in /examples (#6876) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.16.0 to 5.17.0 in /core (#6875) @app/dependabot
* Bump com.google.cloud.tools:jib-core from 0.22.0 to 0.23.0 in /core (#6873) @app/dependabot
* Bump redis.clients:jedis from 4.3.1 to 4.3.2 in /core (#6872) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-sqs from 1.12.418 to 1.12.440 in /modules/localstack (#6870) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.4.5 to 1.4.6 in /modules/hivemq (#6869) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-logs from 1.12.418 to 1.12.440 in /modules/localstack (#6868) @app/dependabot
* Bump com.azure:azure-cosmos from 4.41.0 to 4.42.0 in /modules/azure (#6866) @app/dependabot
* Bump peter-evans/create-pull-request from 4.2.3 to 4.2.4 (#6865) @app/dependabot
* Bump redis.clients:jedis from 4.3.1 to 4.3.2 in /examples (#6863) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.4 to 42.6.0 in /modules/junit-jupiter (#6862) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-s3 from 1.12.418 to 1.12.440 in /modules/localstack (#6861) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 21.5.0.0 to 21.9.0.0 in /modules/oracle-xe (#6860) @app/dependabot
* Bump redis.clients:jedis from 4.3.1 to 4.3.2 in /modules/junit-jupiter (#6853) @app/dependabot
* Bump com.yugabyte:java-driver-core from 4.6.0-yb-11 to 4.6.0-yb-12 in /modules/yugabytedb (#6855) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.4 to 42.6.0 in /modules/questdb (#6852) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.418 to 1.12.440 in /modules/dynalite (#6856) @app/dependabot
* Bump com.google.cloud:google-cloud-bigtable from 2.19.2 to 2.20.2 in /modules/gcloud (#6857) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0 to 1.0.1 in /modules/oracle-xe (#6854) @app/dependabot
* Bump io.trino:trino-jdbc from 408 to 411 in /modules/trino (#6848) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-edge-driver from 4.8.1 to 4.8.3 in /modules/selenium (#6850) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.4 to 42.6.0 in /modules/postgresql (#6849) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.3 to 3.5.4 in /modules/r2dbc (#6851) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.1.2 to 3.1.3 in /modules/mariadb (#6845) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/cratedb (#6846) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.4.1 to 6.5.1 in /modules/k3s (#6847) @app/dependabot
* Bump com.oracle.database.r2dbc:oracle-r2dbc from 1.0.0 to 1.1.1 in /modules/oracle-xe (#6844) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.6.2 to 8.7.0 in /modules/elasticsearch (#6840) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.4 to 42.6.0 in /modules/cratedb (#6841) @app/dependabot
* Bump com.google.cloud:google-cloud-datastore from 2.13.5 to 2.14.2 in /modules/gcloud (#6842) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.7.0 to 6.8.0 in /modules/influxdb (#6843) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.15 to 2.20.37 in /modules/localstack (#6839) @app/dependabot
* Bump org.postgresql:postgresql from 42.5.4 to 42.6.0 in /modules/cockroachdb (#6838) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.18.0 to 10.19.0 in /modules/solace (#6837) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.8.2 to 1.10 in /examples (#6820) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.3 to 3.12.6 in /examples (#6818) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.8.2 to 1.10 (#6814) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.3 to 3.12.6 (#6812) @app/dependabot
* Bump io.trino:trino-jdbc from 408 to 409 in /modules/trino (#6769) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.16 to 3.2.17 in /modules/orientdb (#6760) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/hivemq (#6758) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/spock (#6757) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.16 to 3.2.17 in /modules/orientdb (#6756) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.3 to 3.4.4 in /modules/couchbase (#6755) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/postgresql (#6750) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/presto (#6751) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/oracle-xe (#6748) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/tidb (#6752) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/selenium (#6753) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/mysql (#6745) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/rabbitmq (#6747) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/nginx (#6746) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.6 to 10.1.7 in /modules/jdbc (#6743) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/jdbc (#6741) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.12.0 to 4.13.0 in /modules/hivemq (#6742) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /core (#6739) @app/dependabot
