### PR TITLE
Add docker rootless support for macOS and desktop for Linux

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/RootlessDockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/RootlessDockerClientProviderStrategy.java
@@ -34,8 +34,15 @@ public final class RootlessDockerClientProviderStrategy extends DockerClientProv
                 Path homePath = Paths.get(System.getProperty("user.home")).resolve(".docker").resolve("run");
                 return tryFolder(homePath)
                     .orElseGet(() -> {
-                        Path implicitPath = Paths.get("/run/user/" + LibC.INSTANCE.getuid());
-                        return tryFolder(implicitPath).orElse(null);
+                        Path dockerDesktopPath = Paths
+                            .get(System.getProperty("user.home"))
+                            .resolve(".docker")
+                            .resolve("desktop");
+                        return tryFolder(dockerDesktopPath)
+                            .orElseGet(() -> {
+                                Path implicitPath = Paths.get("/run/user/" + LibC.INSTANCE.getuid());
+                                return tryFolder(implicitPath).orElse(null);
+                            });
                     });
             });
     }
@@ -79,7 +86,11 @@ public final class RootlessDockerClientProviderStrategy extends DockerClientProv
 
     @Override
     protected boolean isApplicable() {
-        return SystemUtils.IS_OS_LINUX && getSocketPath() != null && Files.exists(getSocketPath());
+        return (
+            (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) &&
+            getSocketPath() != null &&
+            Files.exists(getSocketPath())
+        );
     }
 
     @Override


### PR DESCRIPTION
Docker Desktop for Linux installs the socket path at
`/home/username/.docker/desktop/docker.sock`. In Docker Desktop
for Mac 4.18, there is an option to disable the default Docker socket
(/var/run/docker.sock) and rely on `/home/username/.docker/run/docker.sock`
instead.

Fixes #6426
