### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testCompileOnly 'org.jetbrains:annotations:24.0.1'
-    api 'org.apache.commons:commons-compress:1.22'
+    api 'org.apache.commons:commons-compress:1.23.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -103,7 +103,7 @@ dependencies {
 
     testImplementation 'com.google.cloud.tools:jib-core:0.23.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:4.3.1'
+    testImplementation 'redis.clients:jedis:4.3.2'
     testImplementation 'com.rabbitmq:amqp-client:5.17.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.12'
 

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.8'
+    testImplementation 'io.nats:jnats:2.16.10'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.10"
     }
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.14.2'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.8.1'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.8'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.36.1'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.38.2'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.20.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.14.2'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.8.1'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.9.3'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.8'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.38.2'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.20.3'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.5.1'
-    testImplementation 'io.kubernetes:client-java:17.0.1'
+    testImplementation 'io.kubernetes:client-java:18.0.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.446'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.441'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.418'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.446'
     testImplementation 'software.amazon.awssdk:s3:2.20.38'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.418'
+    testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.446'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.441'
     testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.418'
     testImplementation 'software.amazon.awssdk:s3:2.20.38'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.16"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.17"
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.3"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.10"
         classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
     }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.amazonaws:aws-java-sdk-s3 from 1.12.418 to 1.12.446 in /modules/localstack (#6911) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-logs from 1.12.418 to 1.12.446 in /modules/localstack (#6910) @app/dependabot
* Bump io.nats:jnats from 2.16.8 to 2.16.10 in /examples (#6909) @app/dependabot
* Bump com.google.cloud:google-cloud-spanner from 6.36.1 to 6.38.2 in /modules/gcloud (#6882) @app/dependabot
* Bump redis.clients:jedis from 4.3.1 to 4.3.2 in /core (#6872) @app/dependabot
* Bump org.apache.commons:commons-compress from 1.22 to 1.23.0 in /core (#6871) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.3 to 3.12.6 in /examples (#6818) @app/dependabot
* Bump com.google.cloud:google-cloud-firestore from 3.8.1 to 3.9.3 in /modules/gcloud (#6816) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.3 to 3.12.6 (#6812) @app/dependabot
* Bump io.trino:trino-jdbc from 408 to 409 in /modules/trino (#6769) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.16 to 3.2.17 in /modules/orientdb (#6760) @app/dependabot
* Bump io.kubernetes:client-java from 17.0.1 to 18.0.0 in /modules/k3s (#6744) @app/dependabot
