### PR TITLE
Allow `@Container` to be used as a meta-annotation

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Container.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/Container.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  *
  * @see Testcontainers
  */
-@Target(ElementType.FIELD)
+@Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Container {
 }

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/MetaAnnotationTest.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/MetaAnnotationTest.java
@@ -1,0 +1,28 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class MetaAnnotationTest {
+
+    @TcContainer
+    private static final PostgreSQLContainer<?> POSTGRESQL = new PostgreSQLContainer<>(
+        JUnitJupiterTestImages.POSTGRES_IMAGE
+    );
+
+    @Test
+    void test() {
+        assertThat(POSTGRESQL.isRunning()).isTrue();
+    }
+}
+
+@Container
+@Retention(RetentionPolicy.RUNTIME)
+@interface TcContainer {
+}


### PR DESCRIPTION
Fixes #6913
