### PR TITLE
Fix typos in HiveMQ doc

### DIFF
--- a/docs/modules/hivemq.md
+++ b/docs/modules/hivemq.md
@@ -34,7 +34,7 @@ Using the Enterprise Edition:
 [Enterprise Edition HiveMQ image](../../modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoHiveMQContainerIT.java) inside_block:hiveEEVersion
 <!--/codeinclude-->
 
-Using a specifc version is possible by using the tag:
+Using a specific version is possible by using the tag:
 <!--codeinclude-->
 [Specific HiveMQ Version](../../modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoHiveMQContainerIT.java) inside_block:specificVersion
 <!--/codeinclude-->
@@ -151,7 +151,7 @@ If the extension folder contains a DISABLED file, the extension will be disabled
 
 ---
 
-We first load the extension from the filesytem:
+We first load the extension from the filesystem:
 <!--codeinclude-->
 [Extension from filesystem](../../modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoDisableExtensionsIT.java) inside_block:startFromFilesystem
 <!--/codeinclude-->


### PR DESCRIPTION
Hi,
Browsing documentation I noticed that there are a couple of typos in HiveMQ doc.

Following modifications were applied.

from “We first load the extension from the **filesytem**” to “We first load the extension from the **filesystem**”
from “Using a **specifc** version is possible by using the tag” to “Using a **specific** version is possible by using the tag"