### PR TITLE
Support Colima out of the box

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/NpipeSocketClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/NpipeSocketClientProviderStrategy.java
@@ -13,7 +13,7 @@ public final class NpipeSocketClientProviderStrategy extends DockerClientProvide
 
     protected static final String DOCKER_SOCK_PATH = "//./pipe/docker_engine";
 
-    private static final String SOCKET_LOCATION = "npipe://" + DOCKER_SOCK_PATH;
+    protected static final String SOCKET_LOCATION = "npipe://" + DOCKER_SOCK_PATH;
 
     public static final int PRIORITY = EnvironmentAndSystemPropertyClientProviderStrategy.PRIORITY - 20;
 

--- a/core/src/main/java/org/testcontainers/dockerclient/UnixSocketClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/UnixSocketClientProviderStrategy.java
@@ -17,7 +17,7 @@ public final class UnixSocketClientProviderStrategy extends DockerClientProvider
 
     protected static final String DOCKER_SOCK_PATH = "/var/run/docker.sock";
 
-    private static final String SOCKET_LOCATION = "unix://" + DOCKER_SOCK_PATH;
+    protected static final String SOCKET_LOCATION = "unix://" + DOCKER_SOCK_PATH;
 
     private static final int SOCKET_FILE_MODE_MASK = 0xc000;
 

--- a/docs/supported_docker_environment/index.md
+++ b/docs/supported_docker_environment/index.md
@@ -2,55 +2,46 @@
 
 ## Overview
 
-Testcontainers requires a Docker-API compatible container runtime. 
-During development, Testcontainers is actively tested against recent versions of Docker on Linux, as well as against Docker Desktop on Mac and Windows. 
+Testcontainers requires a Docker-API compatible container runtime.
+During development, Testcontainers is actively tested against recent versions of Docker on Linux, as well as against Docker Desktop on Mac and Windows.
 These Docker environments are automatically detected and used by Testcontainers without any additional configuration being necessary.
 
-It is possible to configure Testcontainers to work for other Docker setups, such as a remote Docker host or Docker alternatives. 
-However, these are not actively tested in the main development workflow, so not all Testcontainers features might be available and additional manual configuration might be necessary. 
-If you have further questions about configuration details for your setup or whether it supports running Testcontainers-based tests, 
+It is possible to configure Testcontainers to work for other Docker setups, such as a remote Docker host or Docker alternatives.
+However, these are not actively tested in the main development workflow, so not all Testcontainers features might be available and additional manual configuration might be necessary.
+If you have further questions about configuration details for your setup or whether it supports running Testcontainers-based tests,
 please contact the Testcontainers team and other users from the Testcontainers community on [Slack](https://slack.testcontainers.org/).
 
-| Host Operating System / Environment | Minimum recommended docker versions | Known issues / tips                                                                                                                                                                                                                                                                       |
-|-------------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Linux - general                     | Docker v17.09              | After docker installation, follow [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/).                                                                                                                                                                   |
-| Linux - CircleCI (LXC driver)      | Docker v17.09               | The `exec` feature is not compatible with CircleCI. See CircleCI configuration [example](./continuous_integration/circle_ci.md)                                                                                                                                                           |
-| Linux - within a Docker container            | Docker v17.09              | See [Running inside Docker](continuous_integration/dind_patterns.md) for Docker-in-Docker and Docker wormhole patterns                                                                                                                                                                    |
-| Mac OS X - Docker Toolbox           | Docker Machine v0.8.0  |                                                                                                                                                                                                                                                                                           |
-| Mac OS X - Docker for Mac      | v17.09          | Starting 4.13, run `sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock`<br>Support is best-efforts at present<br>`getTestHostIpAddress()` is [not currently supported](https://github.com/testcontainers/testcontainers-java/issues/166) due to limitations in Docker for Mac. |
-| Windows - Docker Toolbox            |                             | *Support is limited at present and this is not currently tested on a regular basis*.                                                                                                                                                                                                      |
-| Windows - Docker for Windows   |                             | *Support is best-efforts at present.* Only Linux Containers (LCOW) are supported at the moment. See [Windows Support](windows.md)                                                                                                                                                         |
-| Windows - Windows Subsystem for Linux (WSL) | Docker v17.09                       | *Support is best-efforts at present.* Only Linux Containers (LCOW) are supported at the moment. See [Windows Support](windows.md).                                                                                                                                                        |
-
-## Using Colima?
-
-In order to run testcontainers against [colima](https://github.com/abiosoft/colima) the env vars bellow should be set
-
-```bash
-export TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock
-export DOCKER_HOST="unix://${HOME}/.colima/docker.sock"
-```
+| Host Operating System / Environment         | Minimum recommended docker versions | Known issues / tips                                                                                                                                                                                                                                                                       |
+| ------------------------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Linux - general                             | Docker v17.09                       | After docker installation, follow [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/).                                                                                                                                                                   |
+| Linux - CircleCI (LXC driver)               | Docker v17.09                       | The `exec` feature is not compatible with CircleCI. See CircleCI configuration [example](./continuous_integration/circle_ci.md)                                                                                                                                                           |
+| Linux - within a Docker container           | Docker v17.09                       | See [Running inside Docker](continuous_integration/dind_patterns.md) for Docker-in-Docker and Docker wormhole patterns                                                                                                                                                                    |
+| Mac OS X - Docker Toolbox                   | Docker Machine v0.8.0               |                                                                                                                                                                                                                                                                                           |
+| Mac OS X - Docker for Mac                   | v17.09                              | Starting 4.13, run `sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock`<br>Support is best-efforts at present<br>`getTestHostIpAddress()` is [not currently supported](https://github.com/testcontainers/testcontainers-java/issues/166) due to limitations in Docker for Mac. |
+| Windows - Docker Toolbox                    |                                     | _Support is limited at present and this is not currently tested on a regular basis_.                                                                                                                                                                                                      |
+| Windows - Docker for Windows                |                                     | _Support is best-efforts at present._ Only Linux Containers (LCOW) are supported at the moment. See [Windows Support](windows.md)                                                                                                                                                         |
+| Windows - Windows Subsystem for Linux (WSL) | Docker v17.09                       | _Support is best-efforts at present._ Only Linux Containers (LCOW) are supported at the moment. See [Windows Support](windows.md).                                                                                                                                                        |
 
 ## Docker environment discovery
 
 Testcontainers will try to connect to a Docker daemon using the following strategies in order:
 
-* Environment variables:
-	* `DOCKER_HOST`
-	* `DOCKER_TLS_VERIFY`
-	* `DOCKER_CERT_PATH`
-* Defaults:
-	* `DOCKER_HOST=https://localhost:2376`
-	* `DOCKER_TLS_VERIFY=1`
-	* `DOCKER_CERT_PATH=~/.docker`
-* If Docker Machine is installed, the docker machine environment for the *first* machine found. Docker Machine needs to be on the PATH for this to succeed.
-* If you're going to run your tests inside a container, please read [Patterns for running tests inside a docker container](continuous_integration/dind_patterns.md) first.
+-   Environment variables:
+    -   `DOCKER_HOST`
+    -   `DOCKER_TLS_VERIFY`
+    -   `DOCKER_CERT_PATH`
+-   Defaults:
+    -   `DOCKER_HOST=https://localhost:2376`
+    -   `DOCKER_TLS_VERIFY=1`
+    -   `DOCKER_CERT_PATH=~/.docker`
+-   If Docker Machine is installed, the docker machine environment for the _first_ machine found. Docker Machine needs to be on the PATH for this to succeed.
+-   If you're going to run your tests inside a container, please read [Patterns for running tests inside a docker container](continuous_integration/dind_patterns.md) first.
 
 ## Docker registry authentication
 
 Testcontainers will try to authenticate to registries with supplied config using the following strategies in order:
 
-* Environment variables:
-    * `DOCKER_AUTH_CONFIG`
-* Docker config
-	* At location specified in `DOCKER_CONFIG` or at `{HOME}/.docker/config.json`
+-   Environment variables:
+    -   `DOCKER_AUTH_CONFIG`
+-   Docker config
+    -   At location specified in `DOCKER_CONFIG` or at `{HOME}/.docker/config.json`


### PR DESCRIPTION
This is related to #5837, though I'm not sure if it fully fixes it.

This makes two changes that make testcontainers work with Colima with no configuration for me:

- Since v3.3 docker-java supports looking in the context file to discover the Docker host, but EnvironmentAndSystemPropertyClientProviderStrategy ignored that. This change makes it so that if `DefaultDockerClientConfig.Builder.build` ever returns a non-default docker-host, it is used.
- With Colima, the path that you use to refer to the docker socket when setting up container volumes is different from the path you use to directly connect to Docker, because within the VM, you just use the standard `/var/run/docker.sock`. Add some hardcoded logic to always use `/var/run/docker.sock` if the chosen socket appears to be from Colima; you can always override with $TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE.
