### PR TITLE
Fix generated pom with duplicated entries

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -125,7 +125,6 @@ dependencies {
 tasks.generatePomFileForMavenJavaPublication.finalizedBy(
     tasks.register('checkPOMdependencies', org.testcontainers.build.ComparePOMWithLatestReleasedTask) {
         ignore = [
-            "com.google.cloud.tools:jib-core"
         ]
     }
 )

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -57,8 +57,12 @@ publishing {
 
                 def dependenciesNode = rootNode.appendNode('dependencies')
 
-                def addDependencies = { Configuration configuration, scope ->
-                    for (dependency in configuration.resolvedConfiguration.firstLevelModuleDependencies) {
+                def apiDeps= project.configurations.api.resolvedConfiguration.firstLevelModuleDependencies
+                def providedDeps = project.configurations.provided.resolvedConfiguration.firstLevelModuleDependencies
+                def newApiDeps = apiDeps - providedDeps
+
+                def addDependencies = { Set<ResolvedDependency> resolvedDependencies, scope ->
+                    for (dependency in resolvedDependencies) {
                         if (dependency.configuration.startsWith("platform-")) {
                             continue
                         }
@@ -66,6 +70,7 @@ publishing {
                             if (!dependency.moduleGroup || !dependency.moduleName || !dependency.moduleVersion) {
                                 throw new IllegalStateException("Wrong dependency: $dependency")
                             }
+
                             appendNode('groupId', dependency.moduleGroup)
                             appendNode('artifactId', dependency.moduleName)
                             appendNode('version', dependency.moduleVersion)
@@ -83,8 +88,8 @@ publishing {
                         }
                     }
                 }
-                addDependencies(project.configurations.api, 'compile')
-                addDependencies(project.configurations.provided, 'provided')
+                addDependencies(newApiDeps, 'compile')
+                addDependencies(providedDeps, 'provided')
             }
         }
     }


### PR DESCRIPTION
In d512ca5, a change was introduced which started generating pom.xml
with duplicated entries when a dependency is declared as `provided`.
The dependency is added with `compile` and `provided` scopes.
