### PR TITLE
Update RedpandaContainer.java

### DIFF
--- a/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
+++ b/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
@@ -55,7 +55,7 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
 
         String command = "#!/bin/bash\n";
 
-        command += "/usr/bin/rpk redpanda start --mode dev-container ";
+        command += "/usr/bin/rpk redpanda start --mode dev-container --overprovisioned --smp 1 ";
         command += "--kafka-addr PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092 ";
         command +=
             "--advertise-kafka-addr PLAINTEXT://127.0.0.1:29092,OUTSIDE://" + getHost() + ":" + getMappedPort(9092);


### PR DESCRIPTION
Add --overprovisioned and --smp flags to the default RedpandaContainer configuration to make it more resilient on systems with Docker having access to lots of resources. 

We were having issues with these on the https://github.com/testcontainers/testcontainers-showcase when running tests in parallel (with something similar to https://github.com/redpanda-data/redpanda/issues/4004). 

/cc @weimeilin79

