### PR TITLE
Lowercase identifier in DockerComposeContainer

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -143,7 +143,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
         this.dockerComposeFiles = new DockerComposeFiles(composeFiles);
 
         // Use a unique identifier so that containers created for this compose environment can be identified
-        this.identifier = identifier;
+        this.identifier = identifier.toLowerCase();
         this.project = randomProjectId();
 
         this.dockerClient = DockerClientFactory.lazyClient();

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeV2FormatWithIdentifierTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeV2FormatWithIdentifierTest.java
@@ -1,0 +1,21 @@
+package org.testcontainers.junit;
+
+import org.junit.Rule;
+import org.testcontainers.containers.DockerComposeContainer;
+
+import java.io.File;
+
+public class DockerComposeV2FormatWithIdentifierTest extends BaseDockerComposeTest {
+
+    @Rule
+    public DockerComposeContainer environment = new DockerComposeContainer(
+        "TEST",
+        new File("src/test/resources/v2-compose-test.yml")
+    )
+        .withExposedService("redis_1", REDIS_PORT);
+
+    @Override
+    protected DockerComposeContainer getEnvironment() {
+        return this.environment;
+    }
+}


### PR DESCRIPTION
According to the [docs](https://docs.docker.com/compose/environment-variables/envvars/#compose_project_name),
`COMPOSE_PROJECT_NAME` must be lowescase.

Fixes #6943
