### PR TITLE
#6921 first migration of JUnit 4 to JUnit 5 of Hazelcast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ src/pip-delete-this-directory.txt
 
 # Python virtual environment
 /.venv/
+.idea

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -6,8 +6,10 @@ plugins {
 apply from: "$rootDir/../gradle/ci-support.gradle"
 
 subprojects {
-    apply plugin:"java"
+    apply plugin: "java"
     apply from: "$rootDir/../gradle/spotless.gradle"
+    apply from: "$rootDir/junit5.gradle"
+
     apply plugin: 'checkstyle'
 
     repositories {
@@ -17,5 +19,8 @@ subprojects {
     checkstyle {
         toolVersion = "9.3"
         configFile = rootProject.file('../config/checkstyle/checkstyle.xml')
+    }
+
+    task prepareKotlinBuildScriptModel {
     }
 }

--- a/examples/hazelcast/src/test/java/org/testcontainers/examples/HazelcastTest.java
+++ b/examples/hazelcast/src/test/java/org/testcontainers/examples/HazelcastTest.java
@@ -3,8 +3,8 @@ package org.testcontainers.examples;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastInstance;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
@@ -46,7 +46,7 @@ public class HazelcastTest {
 
     private static final String TRUE_VALUE = "true";
 
-    @After
+    @AfterEach
     public void cleanUp() {
         HazelcastClient.shutdownAll();
     }

--- a/examples/junit5.gradle
+++ b/examples/junit5.gradle
@@ -1,0 +1,11 @@
+def jjVersion = "5.9.2"
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:$jjVersion"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/examples/kafka-cluster/src/test/java/com/example/kafkacluster/KafkaContainerClusterTest.java
+++ b/examples/kafka-cluster/src/test/java/com/example/kafkacluster/KafkaContainerClusterTest.java
@@ -13,7 +13,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.rnorth.ducttape.unreliables.Unreliables;
 
 import java.time.Duration;

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -11,5 +11,4 @@ dependencies {
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
 }

--- a/examples/zookeeper/src/test/java/com/example/ZookeeperContainerTest.java
+++ b/examples/zookeeper/src/test/java/com/example/ZookeeperContainerTest.java
@@ -3,7 +3,7 @@ package com.example;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.RetryOneTime;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 
 import java.nio.charset.StandardCharsets;


### PR DESCRIPTION
Pl. check if this Migration approach is fine.

If ok, I can continue the same way a few at a time to be saved..

For now, examples support both JUnit 4 and JUnit 5 i.e. if Test Cases is JUnit 5 it would use JUnit 5 Launcher else JUnit 4 as per the old status