### PR TITLE
[Enhancement]: Alternative waiting strategy for Mockserver container

### DIFF
--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -36,7 +36,7 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, DockerImageName.parse("mockserver/mockserver"));
 
-        waitingFor(Wait.forHttp("/mockserver/status").withMethod("PUT").forStatusCode(200));
+        waitingFor(Wait.forLogMessage(".*started on port: " + PORT + ".*", 1));
 
         withCommand("-serverPort " + PORT);
         addExposedPorts(PORT);
@@ -44,6 +44,10 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
     public String getEndpoint() {
         return String.format("http://%s:%d", getHost(), getMappedPort(PORT));
+    }
+
+    public String getSecureEndpoint() {
+        return String.format("https://%s:%d", getHost(), getMappedPort(PORT));
     }
 
     public Integer getServerPort() {

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -57,14 +57,18 @@ public class MockServerContainerTest {
 
     @Test
     public void shouldCallMockserverUsingMutualTlsProtocol() throws Exception {
-        try (MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE)
-                .withEnv("MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_REQUIRED", "true")) {
+        try (
+            MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE)
+                .withEnv("MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_REQUIRED", "true")
+        ) {
             mockServer.start();
 
             String expectedBody = "Hello World!";
 
-            try (MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
-                    .withSecure(true)) {
+            try (
+                MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
+                    .withSecure(true)
+            ) {
                 assertThat(client.hasStarted()).as("Mockserver running").isTrue();
 
                 client.when(request().withPath("/hello")).respond(response().withBody(expectedBody));

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/MockServerContainerTest.java
@@ -34,6 +34,49 @@ public class MockServerContainerTest {
     }
 
     @Test
+    public void shouldCallMockserverUsingTlsProtocol() throws Exception {
+        try (MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE)) {
+            mockServer.start();
+
+            String expectedBody = "Hello World!";
+
+            try (
+                MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
+                    .withSecure(true)
+            ) {
+                assertThat(client.hasStarted()).as("Mockserver running").isTrue();
+
+                client.when(request().withPath("/hello")).respond(response().withBody(expectedBody));
+
+                assertThat(SimpleHttpClient.secureResponseFromMockserver(mockServer, "/hello"))
+                    .as("MockServer returns correct result")
+                    .isEqualTo(expectedBody);
+            }
+        }
+    }
+
+    @Test
+    public void shouldCallMockserverUsingMutualTlsProtocol() throws Exception {
+        try (MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE)
+                .withEnv("MOCKSERVER_TLS_MUTUAL_AUTHENTICATION_REQUIRED", "true")) {
+            mockServer.start();
+
+            String expectedBody = "Hello World!";
+
+            try (MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())
+                    .withSecure(true)) {
+                assertThat(client.hasStarted()).as("Mockserver running").isTrue();
+
+                client.when(request().withPath("/hello")).respond(response().withBody(expectedBody));
+
+                assertThat(SimpleHttpClient.secureResponseFromMockserver(mockServer, "/hello"))
+                    .as("MockServer returns correct result")
+                    .isEqualTo(expectedBody);
+            }
+        }
+    }
+
+    @Test
     public void newVersionStartsWithDefaultWaitStrategy() {
         try (MockServerContainer mockServer = new MockServerContainer(MOCKSERVER_IMAGE)) {
             mockServer.start();

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/SimpleHttpClient.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/SimpleHttpClient.java
@@ -1,14 +1,16 @@
 package org.testcontainers.containers;
 
 import lombok.Cleanup;
-
+import org.mockserver.configuration.Configuration;
 import org.mockserver.logging.MockServerLogger;
 import org.mockserver.socket.tls.KeyStoreFactory;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+
 import javax.net.ssl.HttpsURLConnection;
 
 public class SimpleHttpClient {
@@ -25,7 +27,10 @@ public class SimpleHttpClient {
             .openConnection();
         try {
             httpUrlConnection.setSSLSocketFactory(
-                new KeyStoreFactory(new MockServerLogger()).sslContext().getSocketFactory());
+                new KeyStoreFactory(Configuration.configuration(), new MockServerLogger())
+                    .sslContext()
+                    .getSocketFactory()
+            );
             @Cleanup
             BufferedReader reader = new BufferedReader(new InputStreamReader(httpUrlConnection.getInputStream()));
             return reader.readLine();

--- a/modules/mockserver/src/test/java/org/testcontainers/containers/SimpleHttpClient.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/containers/SimpleHttpClient.java
@@ -2,11 +2,14 @@ package org.testcontainers.containers;
 
 import lombok.Cleanup;
 
+import org.mockserver.logging.MockServerLogger;
+import org.mockserver.socket.tls.KeyStoreFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import javax.net.ssl.HttpsURLConnection;
 
 public class SimpleHttpClient {
 
@@ -15,5 +18,19 @@ public class SimpleHttpClient {
         @Cleanup
         BufferedReader reader = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
         return reader.readLine();
+    }
+
+    public static String secureResponseFromMockserver(MockServerContainer mockServer, String path) throws IOException {
+        HttpsURLConnection httpUrlConnection = (HttpsURLConnection) new URL(mockServer.getSecureEndpoint() + path)
+            .openConnection();
+        try {
+            httpUrlConnection.setSSLSocketFactory(
+                new KeyStoreFactory(new MockServerLogger()).sslContext().getSocketFactory());
+            @Cleanup
+            BufferedReader reader = new BufferedReader(new InputStreamReader(httpUrlConnection.getInputStream()));
+            return reader.readLine();
+        } finally {
+            httpUrlConnection.disconnect();
+        }
     }
 }


### PR DESCRIPTION
Hi

As discussed in  #6647, this PR changes the Waiting Strategy for Mockserver container so it becomes possible for it to work with HTTP and HTTPS requests.

Test cases  were implemented to validate successful HTTPS requests to Mockserver, testing both cases when requests are made using TLS and mTLS which is described in Mockserver docs https://www.mock-server.com/mock_server/HTTPS_TLS.html