### PR TITLE
DockerComposeContainer: add 'removeVolumes' parameter

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -121,6 +121,8 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     private RemoveImages removeImages;
 
+    private boolean removeVolumes = true;
+
     @Deprecated
     public DockerComposeContainer(File composeFile, String identifier) {
         this(identifier, composeFile);
@@ -368,7 +370,11 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 ambassadorContainer.stop();
 
                 // Kill the services using docker-compose
-                String cmd = "down -v";
+                String cmd = "down";
+
+                if (removeVolumes) {
+                    cmd += " -v";
+                }
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
@@ -597,6 +603,17 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
      */
     public SELF withRemoveImages(RemoveImages removeImages) {
         this.removeImages = removeImages;
+        return self();
+    }
+
+    /**
+     * Remove volumes after containers shut down.
+     *
+     * @param removeVolumes whether volumes are to be removed.
+     * @return this instance, for chaining.
+     */
+    public SELF withRemoveVolumes(boolean removeVolumes) {
+        this.removeVolumes = removeVolumes;
         return self();
     }
 

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeContainerVolumeRemovalTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeContainerVolumeRemovalTest.java
@@ -1,0 +1,96 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.DockerComposeContainer;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class DockerComposeContainerVolumeRemovalTest {
+
+    public DockerComposeContainerVolumeRemovalTest(
+        final boolean removeVolumes,
+        final boolean shouldVolumesBePresentAfterRunning
+    ) {
+        this.removeVolumes = removeVolumes;
+        this.shouldVolumesBePresentAfterRunning = shouldVolumesBePresentAfterRunning;
+    }
+
+    public final boolean removeVolumes;
+
+    public final boolean shouldVolumesBePresentAfterRunning;
+
+    @Parameterized.Parameters(name = "removeVolumes = {0}")
+    public static Object[][] params() {
+        return new Object[][] { { true, false }, { false, true } };
+    }
+
+    @Test
+    public void performTest() {
+        final File composeFile = new File("src/test/resources/compose-test.yml");
+
+        final AtomicReference<String> volumeName = new AtomicReference<>("");
+        try (
+            DockerComposeContainer environment = new DockerComposeContainer<>(composeFile)
+                .withExposedService("redis", 6379)
+                .withRemoveVolumes(removeVolumes)
+                .withRemoveImages(DockerComposeContainer.RemoveImages.ALL)
+        ) {
+            environment.start();
+
+            volumeName.set(volumeNameForRunningContainer("_redis_1"));
+            final boolean isVolumePresentWhileRunning = isVolumePresent(volumeName.get());
+            assertThat(isVolumePresentWhileRunning).as("the container volume is present while running").isEqualTo(true);
+        }
+
+        Unreliables.retryUntilSuccess(
+            10,
+            TimeUnit.SECONDS,
+            () -> {
+                final boolean isVolumePresentAfterRunning = isVolumePresent(volumeName.get());
+                assertThat(isVolumePresentAfterRunning)
+                    .as("the container volume is present after running")
+                    .isEqualTo(shouldVolumesBePresentAfterRunning);
+                return null;
+            }
+        );
+    }
+
+    private String volumeNameForRunningContainer(final String containerNameSuffix) {
+        return DockerClientFactory
+            .instance()
+            .client()
+            .listContainersCmd()
+            .exec()
+            .stream()
+            .filter(it -> Stream.of(it.getNames()).anyMatch(name -> name.endsWith(containerNameSuffix)))
+            .findFirst()
+            .map(container -> container.getMounts().get(0).getName())
+            .orElseThrow(IllegalStateException::new);
+    }
+
+    private boolean isVolumePresent(final String volumeName) {
+        LinkedHashSet<String> nameFilter = new LinkedHashSet<>(1);
+        nameFilter.add(volumeName);
+        return DockerClientFactory
+            .instance()
+            .client()
+            .listVolumesCmd()
+            .withFilter("name", nameFilter)
+            .exec()
+            .getVolumes()
+            .stream()
+            .findFirst()
+            .isPresent();
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before comitting, run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:


-->
Adds a `removeVolumes` parameter which can be controlled through the `withRemoveVolumes()` method.
This parameter defaults to `true` (as per the original ticket #7008 and to retain backward-compatibility) but can be set to false.

I have also written tests to ensure that this parameter works as intended.

Closes #7008