### PR TITLE
WaitStrategy to wait for one shot containers to finish by themselves.

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategy.java
@@ -1,0 +1,35 @@
+package org.testcontainers.containers.wait.strategy;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.rnorth.ducttape.TimeoutException;
+import org.rnorth.ducttape.unreliables.Unreliables;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.utility.DockerStatus;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Wait strategy for OneShotStartupStrategy containers to wait until the container finishes successfully.
+ *
+ */
+public class ContainerFinishedWaitStrategy extends AbstractWaitStrategy {
+
+    protected boolean isContainerFinished() {
+            InspectContainerResponse.ContainerState state = waitStrategyTarget.getCurrentContainerInfo().getState();
+            return DockerStatus.isContainerStopped( state ) && DockerStatus.isContainerExitCodeSuccess( state );
+    }
+
+    @Override
+    protected void waitUntilReady() {
+        try {
+            Unreliables.retryUntilTrue(
+                (int) startupTimeout.getSeconds(),
+                TimeUnit.SECONDS,
+                this::isContainerFinished
+            );
+        } catch (TimeoutException e) {
+            throw new ContainerLaunchException("Timed out waiting for container to finish");
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategy.java
@@ -6,7 +6,6 @@ import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.utility.DockerStatus;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -16,18 +15,14 @@ import java.util.concurrent.TimeUnit;
 public class ContainerFinishedWaitStrategy extends AbstractWaitStrategy {
 
     protected boolean isContainerFinished() {
-            InspectContainerResponse.ContainerState state = waitStrategyTarget.getCurrentContainerInfo().getState();
-            return DockerStatus.isContainerStopped( state ) && DockerStatus.isContainerExitCodeSuccess( state );
+        InspectContainerResponse.ContainerState state = waitStrategyTarget.getCurrentContainerInfo().getState();
+        return DockerStatus.isContainerStopped(state) && DockerStatus.isContainerExitCodeSuccess(state);
     }
 
     @Override
     protected void waitUntilReady() {
         try {
-            Unreliables.retryUntilTrue(
-                (int) startupTimeout.getSeconds(),
-                TimeUnit.SECONDS,
-                this::isContainerFinished
-            );
+            Unreliables.retryUntilTrue((int) startupTimeout.getSeconds(), TimeUnit.SECONDS, this::isContainerFinished);
         } catch (TimeoutException e) {
             throw new ContainerLaunchException("Timed out waiting for container to finish");
         }

--- a/core/src/test/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategyTest.java
@@ -1,0 +1,49 @@
+package org.testcontainers.containers.wait.strategy;
+
+import org.bouncycastle.asn1.x9.DHDomainParameters;
+import org.junit.Test;
+import org.testcontainers.TestImages;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ContainerFinishedWaitStrategyTest {
+
+    @Test
+    public void shouldWaitUntilContainerClosed() {
+        try ( GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand( "/bin/echo \"hello world\"")
+                .withStartupCheckStrategy( new OneShotStartupCheckStrategy() )
+                .waitingFor( new ContainerFinishedWaitStrategy() )) {
+            container.start();
+            assertThat( container.isRunning() ).as( "Wait strategy should wait until container has stopped" ).isFalse();
+        }
+    }
+
+    @Test
+    public void shouldWaitUntilContainerClosed_slow() {
+        try ( GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand( "/bin/sleep", "3s")
+                .withStartupCheckStrategy( new OneShotStartupCheckStrategy() )
+                .waitingFor( new ContainerFinishedWaitStrategy().withStartupTimeout( Duration.ofSeconds( 5 ))) ) {
+            container.start();
+            assertThat( container.isRunning() ).as( "Wait strategy should wait until container has stopped" ).isFalse();
+        }
+    }
+
+    @Test
+    public void shouldFailStartIfWaitTimeout()
+    {
+        try ( GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand( "tail", "-f", "/dev/null")
+                .waitingFor( new ContainerFinishedWaitStrategy().withStartupTimeout( Duration.ofSeconds( 1 ))) ) {
+            assertThatThrownBy( container::start ).as( "Should error with timeout when time out" )
+                                                  .hasStackTraceContaining( "Timed out waiting for container to finish" );
+        }
+
+    }
+}

--- a/core/src/test/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/strategy/ContainerFinishedWaitStrategyTest.java
@@ -1,10 +1,9 @@
 package org.testcontainers.containers.wait.strategy;
 
-import org.bouncycastle.asn1.x9.DHDomainParameters;
 import org.junit.Test;
 import org.testcontainers.TestImages;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+import org.testcontainers.containers.startupcheck.IndefiniteWaitOneShotStartupCheckStrategy;
 
 import java.time.Duration;
 
@@ -15,35 +14,27 @@ public class ContainerFinishedWaitStrategyTest {
 
     @Test
     public void shouldWaitUntilContainerClosed() {
-        try ( GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
-                .withCommand( "/bin/echo \"hello world\"")
-                .withStartupCheckStrategy( new OneShotStartupCheckStrategy() )
-                .waitingFor( new ContainerFinishedWaitStrategy() )) {
+        try (
+            GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand("/bin/echo \"hello world\"")
+                .withStartupCheckStrategy(new IndefiniteWaitOneShotStartupCheckStrategy())
+                .waitingFor(new ContainerFinishedWaitStrategy())
+        ) {
             container.start();
-            assertThat( container.isRunning() ).as( "Wait strategy should wait until container has stopped" ).isFalse();
+            assertThat(container.isRunning()).as("Wait strategy should wait until container has stopped").isFalse();
         }
     }
 
     @Test
-    public void shouldWaitUntilContainerClosed_slow() {
-        try ( GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
-                .withCommand( "/bin/sleep", "3s")
-                .withStartupCheckStrategy( new OneShotStartupCheckStrategy() )
-                .waitingFor( new ContainerFinishedWaitStrategy().withStartupTimeout( Duration.ofSeconds( 5 ))) ) {
-            container.start();
-            assertThat( container.isRunning() ).as( "Wait strategy should wait until container has stopped" ).isFalse();
+    public void shouldFailStartIfWaitTimeout() {
+        try (
+            GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand("tail", "-f", "/dev/null")
+                .waitingFor(new ContainerFinishedWaitStrategy().withStartupTimeout(Duration.ofSeconds(1)))
+        ) {
+            assertThatThrownBy(container::start)
+                .as("Should error with timeout when time out")
+                .hasStackTraceContaining("Timed out waiting for container to finish");
         }
-    }
-
-    @Test
-    public void shouldFailStartIfWaitTimeout()
-    {
-        try ( GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
-                .withCommand( "tail", "-f", "/dev/null")
-                .waitingFor( new ContainerFinishedWaitStrategy().withStartupTimeout( Duration.ofSeconds( 1 ))) ) {
-            assertThatThrownBy( container::start ).as( "Should error with timeout when time out" )
-                                                  .hasStackTraceContaining( "Timed out waiting for container to finish" );
-        }
-
     }
 }


### PR DESCRIPTION
Enhancement.
This is a new wait strategy to wait until the container has successfully closed.

This code is mostly copied from `DockerHealthcheckWaitStrategy.java`. There may be more test cases worth considering other than the two I've added? I am not familiar with how wait strategies and startup check strategies and container timeouts overlap.

why is it useful
-------
I found I needed to start a quick container that starts up, does an operation, then closes. The log output isn't repetitive enough to use a `LogMessageWaitStrategy` and it doesn't do anything with ports.
There was no inbuilt way of just telling TestContainers to wait for a successful exit code from the container (at least not that I could find).

There does seem to be potential crossover with this enhancement behaviour and `*StartupCheckStrategy` but I could not find a way of replicating the functionality I needed without adding the new wait strategy. When starting the container using `Wait.defaultWaitStrategy()` it would just wait until the check strategy timed out, even after the container had successfully closed.
