### PR TITLE
Remove superficial Kafka optimization for the sake of clarity

### DIFF
--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -190,14 +190,10 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
             );
 
         if (this.kraftEnabled && isLessThanCP740()) {
-            // Optimization: skip the checks
-            command += "echo '' > /etc/confluent/docker/ensure \n";
             command += commandKraft();
         }
 
         if (!this.kraftEnabled) {
-            // Optimization: skip the checks
-            command += "echo '' > /etc/confluent/docker/ensure \n";
             command += commandZookeeper();
         }
 


### PR DESCRIPTION
The Kafka module is skipping the `/etc/confluent/docker/ensure` checks for the optimization reasons.

The checks performed in this script are super lightweight and don't worth the code complexity it brings.

Discussions
https://github.com/testcontainers/testcontainers-java/pull/7014#discussion_r1188806816