### PR TITLE
[cratedb] Enable single node by default

### DIFF
--- a/modules/cratedb/src/main/java/org/testcontainers/cratedb/CrateDBContainer.java
+++ b/modules/cratedb/src/main/java/org/testcontainers/cratedb/CrateDBContainer.java
@@ -13,7 +13,7 @@ public class CrateDBContainer extends JdbcDatabaseContainer<CrateDBContainer> {
 
     static final String IMAGE = "crate";
 
-    static final String DEFAULT_TAG = "5.2.5";
+    static final String DEFAULT_TAG = "5.3.1";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("crate");
 
@@ -34,6 +34,7 @@ public class CrateDBContainer extends JdbcDatabaseContainer<CrateDBContainer> {
     public CrateDBContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        withCommand("crate -C discovery.type=single-node");
 
         this.waitStrategy = Wait.forHttp("/").forPort(CRATEDB_HTTP_PORT).forStatusCode(200);
 

--- a/modules/cratedb/src/test/java/org/testcontainers/junit/cratedb/SimpleCrateDBTest.java
+++ b/modules/cratedb/src/test/java/org/testcontainers/junit/cratedb/SimpleCrateDBTest.java
@@ -34,7 +34,7 @@ public class SimpleCrateDBTest extends AbstractContainerDatabaseTest {
     public void testCommandOverride() throws SQLException {
         try (
             CrateDBContainer cratedb = new CrateDBContainer(CrateDBTestImages.CRATEDB_TEST_IMAGE)
-                .withCommand("crate -C cluster.name=testcontainers")
+                .withCommand("crate -C discovery.type=single-node -C cluster.name=testcontainers")
         ) {
             cratedb.start();
 


### PR DESCRIPTION
- Pass `discovery.type=single-node` to `CrateDBContainer` to disable
bootstrap checks and prevent errors regarding low limit for
max virtual memory

- Upgrade CrateDB docker image to latest stable: 5.3.1

Fixes: https://github.com/testcontainers/testcontainers-java/issues/7038