### PR TITLE
Pull retry policy for pulling remote images

### DIFF
--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -3,7 +3,6 @@ package org.testcontainers.images;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.exception.DockerClientException;
-import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.google.common.util.concurrent.Futures;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -21,8 +20,6 @@ import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.ImageNameSubstitutor;
 import org.testcontainers.utility.LazyFuture;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;

--- a/core/src/main/java/org/testcontainers/images/retry/DefaultPullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/DefaultPullRetryPolicy.java
@@ -1,0 +1,37 @@
+package org.testcontainers.images.retry;
+
+import com.github.dockerjava.api.exception.InternalServerErrorException;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+/**
+ * Default pull retry policy.
+ *
+ * Will retry on <code>InterruptedException</code> and <code>InternalServerErrorException</code>
+ * exceptions for a time limit of two minutes.
+ */
+@Slf4j
+@ToString
+public class DefaultPullRetryPolicy extends LimitedDurationPullRetryPolicy {
+    private static final Duration PULL_RETRY_TIME_LIMIT = Duration.ofMinutes(2);
+
+    public DefaultPullRetryPolicy() {
+        super(PULL_RETRY_TIME_LIMIT);
+    }
+
+    @Override
+    public boolean shouldRetry(DockerImageName imageName, Throwable error) {
+        if (!mayRetry(error)) {
+            return false;
+        }
+
+        return super.shouldRetry(imageName, error);
+    }
+
+    private boolean mayRetry(Throwable error) {
+        return error instanceof InterruptedException || error instanceof InternalServerErrorException;
+    }
+}

--- a/core/src/main/java/org/testcontainers/images/retry/DefaultPullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/DefaultPullRetryPolicy.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 @Slf4j
 @ToString
 public class DefaultPullRetryPolicy extends LimitedDurationPullRetryPolicy {
+
     private static final Duration PULL_RETRY_TIME_LIMIT = Duration.ofMinutes(2);
 
     public DefaultPullRetryPolicy() {

--- a/core/src/main/java/org/testcontainers/images/retry/FailFastPullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/FailFastPullRetryPolicy.java
@@ -15,5 +15,4 @@ public class FailFastPullRetryPolicy implements ImagePullRetryPolicy {
     public boolean shouldRetry(DockerImageName imageName, Throwable error) {
         return false;
     }
-
 }

--- a/core/src/main/java/org/testcontainers/images/retry/FailFastPullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/FailFastPullRetryPolicy.java
@@ -1,0 +1,19 @@
+package org.testcontainers.images.retry;
+
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Fail-fast, i.e. not retry, pull policy
+ */
+@Slf4j
+@ToString
+public class FailFastPullRetryPolicy implements ImagePullRetryPolicy {
+
+    @Override
+    public boolean shouldRetry(DockerImageName imageName, Throwable error) {
+        return false;
+    }
+
+}

--- a/core/src/main/java/org/testcontainers/images/retry/ImagePullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/ImagePullRetryPolicy.java
@@ -4,5 +4,6 @@ import org.testcontainers.utility.DockerImageName;
 
 public interface ImagePullRetryPolicy {
     default void pullStarted() {}
+
     boolean shouldRetry(DockerImageName imageName, Throwable error);
 }

--- a/core/src/main/java/org/testcontainers/images/retry/ImagePullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/ImagePullRetryPolicy.java
@@ -1,0 +1,8 @@
+package org.testcontainers.images.retry;
+
+import org.testcontainers.utility.DockerImageName;
+
+public interface ImagePullRetryPolicy {
+    default void pullStarted() {}
+    boolean shouldRetry(DockerImageName imageName, Throwable error);
+}

--- a/core/src/main/java/org/testcontainers/images/retry/LimitedDurationPullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/LimitedDurationPullRetryPolicy.java
@@ -1,0 +1,44 @@
+package org.testcontainers.images.retry;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * An ImagePullRetryPolicy which will retry a failed image pull if the time elapsed since the
+ * pull started is less than or equal to the configured {@link #maxAllowedDuration}.
+ *
+ */
+@Slf4j
+@RequiredArgsConstructor
+@ToString
+public class LimitedDurationPullRetryPolicy implements ImagePullRetryPolicy {
+
+    @NonNull
+    @Getter
+    Duration maxAllowedDuration;
+
+    Instant lastRetryAllowed;
+
+    @Override
+    public void pullStarted() {
+        this.lastRetryAllowed = Instant.now().plus(maxAllowedDuration);
+    }
+
+    @Override
+    public boolean shouldRetry(DockerImageName imageName, Throwable error) {
+        log.warn(
+            "Retrying pull for image: {} ({}s remaining)",
+            imageName,
+            Duration.between(Instant.now(), lastRetryAllowed).getSeconds()
+        );
+
+        return Instant.now().isBefore(lastRetryAllowed);
+    }
+}

--- a/core/src/main/java/org/testcontainers/images/retry/NoOfAttemptsPullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/NoOfAttemptsPullRetryPolicy.java
@@ -27,5 +27,4 @@ public class NoOfAttemptsPullRetryPolicy implements ImagePullRetryPolicy {
     public boolean shouldRetry(DockerImageName imageName, Throwable error) {
         return ++currentNoOfAttempts > maxAllowedNoOfAttempts;
     }
-
 }

--- a/core/src/main/java/org/testcontainers/images/retry/NoOfAttemptsPullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/NoOfAttemptsPullRetryPolicy.java
@@ -1,0 +1,31 @@
+package org.testcontainers.images.retry;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * An ImagePullRetryPolicy which will retry a failed image pull if the number of attempts
+ * is less than or equal to the configured {@link #maxAllowedNoOfAttempts}.
+ *
+ */
+@Slf4j
+@RequiredArgsConstructor
+@ToString
+public class NoOfAttemptsPullRetryPolicy implements ImagePullRetryPolicy {
+
+    @NonNull
+    @Getter
+    private final int maxAllowedNoOfAttempts;
+
+    private int currentNoOfAttempts = 0;
+
+    @Override
+    public boolean shouldRetry(DockerImageName imageName, Throwable error) {
+        return ++currentNoOfAttempts > maxAllowedNoOfAttempts;
+    }
+
+}

--- a/core/src/main/java/org/testcontainers/images/retry/PullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/PullRetryPolicy.java
@@ -43,5 +43,4 @@ public class PullRetryPolicy {
     public static ImagePullRetryPolicy defaultRetryPolicy() {
         return new DefaultPullRetryPolicy();
     }
-
 }

--- a/core/src/main/java/org/testcontainers/images/retry/PullRetryPolicy.java
+++ b/core/src/main/java/org/testcontainers/images/retry/PullRetryPolicy.java
@@ -1,0 +1,47 @@
+package org.testcontainers.images.retry;
+
+import lombok.experimental.UtilityClass;
+
+import java.time.Duration;
+
+/**
+ * Convenience class with logic for building common {@link ImagePullRetryPolicy} instances.
+ *
+ */
+@UtilityClass
+public class PullRetryPolicy {
+
+    /**
+     * Convenience method for returning the {@link FailFastPullRetryPolicy} failFast image pull retry policy
+     * @return {@link ImagePullRetryPolicy}
+     */
+    public static ImagePullRetryPolicy failFast() {
+        return new FailFastPullRetryPolicy();
+    }
+
+    /**
+     * Convenience method for returning the {@link NoOfAttemptsPullRetryPolicy} number of attempts based image pull
+     * retry policy.
+     * @return {@link ImagePullRetryPolicy}
+     */
+    public static ImagePullRetryPolicy noOfAttempts(int allowedNoOfAttempts) {
+        return new NoOfAttemptsPullRetryPolicy(allowedNoOfAttempts);
+    }
+
+    /**
+     * Convenience method for returning the {@link LimitedDurationPullRetryPolicy} duration image pull retry policy
+     * @return {@link ImagePullRetryPolicy}
+     */
+    public static ImagePullRetryPolicy limitedDuration(Duration maxAllowedDuration) {
+        return new LimitedDurationPullRetryPolicy(maxAllowedDuration);
+    }
+
+    /**
+     * Convenience method for returning the {@link DefaultPullRetryPolicy} default image pull retry policy.
+     * @return {@link ImagePullRetryPolicy}
+     */
+    public static ImagePullRetryPolicy defaultRetryPolicy() {
+        return new DefaultPullRetryPolicy();
+    }
+
+}


### PR DESCRIPTION
The pull request try proposing the definition of the concept of image pull retry policy if an error occurs when pulling remote images.

Try to address #3829 and #6675, allowing both the definition of custom retry policies when dealing with a remote image pull error and provides different retry policies with custom timeouts, number of attempts, etc.

It is a work in progress, test cases should be added: please, consider it a starting point for discussing the proposal.