### PR TITLE
Fix code examples in docs for localstash module.

### DIFF
--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -76,7 +76,7 @@ public class LocalstackContainerTest {
                 .standard()
                 .withEndpointConfiguration(
                     new AwsClientBuilder.EndpointConfiguration(
-                        localstack.getEndpoint().toString(),
+                        localstack.getEndpointOverride(Service.S3).toString(),
                         localstack.getRegion()
                     )
                 )
@@ -115,7 +115,7 @@ public class LocalstackContainerTest {
             // with_aws_sdk_v2 {
             S3Client s3 = S3Client
                 .builder()
-                .endpointOverride(localstack.getEndpoint())
+                .endpointOverride(localstack.getEndpointOverride(Service.S3))
                 .credentialsProvider(
                     StaticCredentialsProvider.create(
                         AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())


### PR DESCRIPTION
The code examples to initialize localstack's S3 container and client contains the method 'URI getEndpoint()' which is not available in the latest release of the project 1.18.1. Replace this method with 'URI getEndpointOverride(Service service)', which is what the developers using the released version need and have to use right now. 
This should be reflected in this project's official public documentation. 
For this purpose, update two tests in the class "LocalstackContainerTest.java" with the above-mentioned method changes. The docs will automatically update the examples.
