### PR TITLE
Add static `forByteArray()`, `forString()` and `forUtf8String()` methods to  `MountableFile`.

### DIFF
--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -11,6 +11,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
@@ -130,6 +131,37 @@ public class MountableFileTest {
             assertThat(entry.getName()).as("no entries should have a trailing slash").doesNotEndWith("/");
         }
     }
+
+    @Test
+    public void forByteArray() {
+        performChecks(MountableFile.forByteArray("FOOBAR".getBytes(StandardCharsets.UTF_8), TEST_FILE_MODE));
+    }
+
+    @Test
+    public void forByteArrayWithoutMode() {
+        performChecks(MountableFile.forByteArray("FOOBAR".getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void forString() {
+        performChecks(MountableFile.forString("FOOBAR", StandardCharsets.UTF_8, TEST_FILE_MODE));
+    }
+
+    @Test
+    public void forStringWithoutMode() {
+        performChecks(MountableFile.forString("FOOBAR", StandardCharsets.UTF_8));
+    }
+
+    @Test
+    public void forUtf8String() {
+        performChecks(MountableFile.forUtf8String("FOOBAR", TEST_FILE_MODE));
+    }
+
+    @Test
+    public void forUtf8StringWithoutMode() {
+        performChecks(MountableFile.forUtf8String("FOOBAR"));
+    }
+
 
     private TarArchiveInputStream intoTarArchive(Consumer<TarArchiveOutputStream> consumer) throws IOException {
         @Cleanup


### PR DESCRIPTION
**CHANGES**
- Add `forByteArray(byte[] content, int mode)` to  `MountableFile`.
- Add `forByteArray(byte[] content)` to  `MountableFile`.
- Add `forString(String content, Charset charset, int mode)` to  `MountableFile`.
- Add `forString(String content, Charset charset)` to  `MountableFile`.
- Add `forUtf8String(String content, int mode)` to  `MountableFile`.
- Add `forUtf8String(String content)` to  `MountableFile`.

**DESCRIPTION**
As a very frequent Testcontainers user, I see the use case that I have to manipulate the content of a file during runtime of the test before using `withCopyToContainer()`.
The current way to do this, is to create a temporary file where I write my desired content to, and than create a `MoutableFile` for that.
This is boilerplate and can be moved inside the `MountableFile` class.

**EXAMPLE USE CASE**
Create a configuration file for a Container during the test-runtime. Sometimes this is needed when some information is only present at a certain stage of the test-runtime. E.g. credentials.
