### PR TITLE
Enable ci for 1.18.x maintenance release

### DIFF
--- a/.github/workflows/ci-docker-wormhole.yml
+++ b/.github/workflows/ci-docker-wormhole.yml
@@ -8,7 +8,7 @@ on:
       - 'README.md'
       - 'RELEASING.md'
   push:
-    branches: [ main ]
+    branches: [ main, 1.18.x ]
     paths-ignore:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -8,7 +8,7 @@ on:
       - 'README.md'
       - 'RELEASING.md'
   push:
-    branches: [ main ]
+    branches: [ main, 1.18.x ]
     paths-ignore:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -8,7 +8,7 @@ on:
       - 'README.md'
       - 'RELEASING.md'
   push:
-    branches: [ main ]
+    branches: [ main, 1.18.x ]
     paths-ignore:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
       - 'README.md'
       - 'RELEASING.md'
   push:
-    branches: [ main ]
+    branches: [ main, 1.18.x ]
     paths-ignore:
       - 'docs/**'
       - 'mkdocs.yml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.target_commitish }}
       - uses: actions/setup-java@v3
         with:
           java-version: '8'


### PR DESCRIPTION
At the moment, CI runs always from `main` branch. There are some
cases when `main` branch contains changes that are not going to be
released yet and a maintenance branch should be created, so, CI
should also run.

Also, use `ref` in `actions/checkout` in order to build from the
release branch.
