### PR TITLE
Fix paths-ignore for ci-examples.yml

### DIFF
--- a/.github/workflows/ci-examples.yml
+++ b/.github/workflows/ci-examples.yml
@@ -3,14 +3,25 @@ name: CI-Examples
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - 'docs/**/*.css'
+      - 'docs/**/*.html'
+      - 'docs/**/*.ico'
+      - 'docs/**/*.md'
+      - 'docs/**/*.png'
+      - 'docs/**/*.svg'
       - 'mkdocs.yml'
       - 'README.md'
       - 'RELEASING.md'
   push:
     branches: [ main ]
     paths-ignore:
-      - 'docs/**'
+      - 'docs/**/*.css'
+      - 'docs/**/*.html'
+      - 'docs/**/*.ico'
+      - 'docs/**/*.md'
+      - 'docs/**/*.png'
+      - 'docs/**/*.svg'
+      - 'docs/**/*.md'
       - 'mkdocs.yml'
       - 'README.md'
       - 'RELEASING.md'


### PR DESCRIPTION
Currently, `junit4`, `junit5`, `spock` at `docs/examples` don't run
because of the `paths-ignore: 'docs'`. It is important to run those
projects only when they are touched.
