### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v3.0.1
+        uses: github/combine-prs@v3.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v3.10.1
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@981c551b17dbcf1940b1b4435afdb79babb7c13a # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@0407394b9d173dfc9cf5695f9f560fef6d61a5fe # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v3.10.1
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v3.10.1
         with:
           title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.3.2'
     testImplementation 'com.rabbitmq:amqp-client:5.17.0'
-    testImplementation 'org.mongodb:mongo-java-driver:3.12.12'
+    testImplementation 'org.mongodb:mongo-java-driver:3.12.13'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation project(":mysql")
 
     testImplementation 'mysql:mysql-connector-java:8.0.32'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.8.1"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.9.1"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.2.3.RELEASE"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.3"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.2"
     testImplementation project(":testcontainers")

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver:3.141.59'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver:3.141.59'
     testImplementation 'io.cucumber:cucumber-java:7.11.1'
-    testImplementation 'io.cucumber:cucumber-junit:7.11.1'
+    testImplementation 'io.cucumber:cucumber-junit:7.12.0'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'org.json:json:20230227'
     testImplementation 'org.postgresql:postgresql:42.6.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.5'
-    testImplementation 'org.testng:testng:7.5'
+    testImplementation 'org.testng:testng:7.5.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '2.7.12'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/spring-boot-kotlin-redis/build.gradle
+++ b/examples/spring-boot-kotlin-redis/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id("org.springframework.boot") version "2.7.10"
+    id("org.springframework.boot") version "2.7.12"
     id("org.jetbrains.kotlin.jvm") version "1.8.10"
     id("org.jetbrains.kotlin.plugin.spring") version "1.8.20"
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '2.7.12'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Azure"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.azure:azure-cosmos:4.42.0'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.4'
+    testImplementation 'com.couchbase.client:java-client:3.4.6'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'com.couchbase.client:java-client:3.4.6'
     testImplementation 'org.awaitility:awaitility:4.2.0'

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: CrateDB"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.1.0'
 
     api project(':jdbc')
 

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.441'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.441'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.481'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.481'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "TestContainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.7.0"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.8.0"
     testImplementation "org.elasticsearch.client:transport:7.17.9"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.google.cloud:google-cloud-datastore:2.14.2'
-    testImplementation 'com.google.cloud:google-cloud-firestore:3.9.3'
+    testImplementation 'com.google.cloud:google-cloud-firestore:3.12.0'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.8'
     testImplementation 'com.google.cloud:google-cloud-spanner:6.42.3'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.20.3'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-datastore:2.14.2'
     testImplementation 'com.google.cloud:google-cloud-firestore:3.9.3'
     testImplementation 'com.google.cloud:google-cloud-pubsub:1.123.8'
-    testImplementation 'com.google.cloud:google-cloud-spanner:6.38.2'
+    testImplementation 'com.google.cloud:google-cloud-spanner:6.42.3'
     testImplementation 'com.google.cloud:google-cloud-bigtable:2.20.3'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:24.0.1")
 
     shaded("org.apache.commons:commons-lang3:3.12.0")
-    shaded("commons-io:commons-io:2.11.0")
+    shaded("commons-io:commons-io:2.12.0")
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.15.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.4.6")
+    testImplementation("ch.qos.logback:logback-classic:1.4.7")
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.14.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.15.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.5")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.15.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.7")
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.3")
 }
 
 test {

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.influxdb:influxdb-java:2.23'
-    testImplementation "com.influxdb:influxdb-client-java:6.8.0"
+    testImplementation "com.influxdb:influxdb-client-java:6.9.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -12,5 +12,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.32'
+    api 'mysql:mysql-connector-java:8.0.33'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':jdbc')
 
-    api 'com.google.guava:guava:31.1-jre'
+    api 'com.google.guava:guava:32.0.0-jre'
     api 'org.apache.commons:commons-lang3:3.12.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.7'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.7'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.9'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 }
 
 test {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.3.2'
+    testImplementation 'redis.clients:jedis:4.4.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.5.1'
+    testImplementation 'io.fabric8:kubernetes-client:6.7.0'
     testImplementation 'io.kubernetes:client-java:18.0.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'com.amazonaws:aws-java-sdk-s3:1.12.446'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs:1.12.441'
-    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.446'
+    testImplementation 'com.amazonaws:aws-java-sdk-logs:1.12.481'
     testImplementation 'software.amazon.awssdk:s3:2.20.38'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: MariaDB"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.1.0'
 
     api project(':jdbc')
 

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.3'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.9.0")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.9.1")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: MS SQL Server"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.1.0'
 
     api project(':jdbc')
 

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.3.0.jre8-preview'
 
     testImplementation project(':r2dbc')
-    testImplementation 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
+    testImplementation 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':r2dbc'))

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.3.0.jre8-preview'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: MySQL"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.1.0'
 
     api project(':jdbc')
 

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.asyncer:r2dbc-mysql:0.9.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.32'
+    testImplementation 'mysql:mysql-connector-java:8.0.33'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.asyncer:r2dbc-mysql:0.9.0'

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:21.9.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.2.0.0'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
+    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.2.0.0'
@@ -15,7 +15,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
+    testImplementation 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
 }
 
 test {

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: Oracle XE"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.1.0'
 
     api project(':jdbc')
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     api "com.orientechnologies:orientdb-client:3.2.17"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'
+    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.4'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.17"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "TestContainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.17"
+    api "com.orientechnologies:orientdb-client:3.2.19"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.4'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: PostgreSQL"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.1.0'
 
     api project(':jdbc')
 

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.0.1-jdk8'
+    testImplementation 'org.questdb:questdb:7.1.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.4'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.6'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -5,8 +5,8 @@ plugins {
 description = "Testcontainers :: R2DBC"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.0'
+    compileOnly 'com.google.auto.service:auto-service:1.1.0'
 
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Solr"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.3'
 
     testCompileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'
 

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:411'
+    testImplementation 'io.trino:trino-jdbc:418'
     compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // YCQL driver
     testImplementation 'com.yugabyte:java-driver-core:4.6.0-yb-12'
     // YSQL driver
-    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-2'
+    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-3'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.10"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11"
         classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.seleniumhq.selenium:selenium-api from 4.8.1 to 4.9.1 in /examples (#7141) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.441 to 1.12.481 in /modules/dynalite (#7137) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-logs from 1.12.446 to 1.12.481 in /modules/localstack (#7135) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-sqs from 1.12.441 to 1.12.481 in /modules/localstack (#7136) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.38 to 2.20.78 in /modules/localstack (#7133) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.0 in /modules/cratedb (#7130) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.0 in /modules/r2dbc (#7129) @app/dependabot
* Bump com.yugabyte:jdbc-yugabytedb from 42.3.5-yb-2 to 42.3.5-yb-3 in /modules/yugabytedb (#7128) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.10 to 1.11 (#7127) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.6.2 to 3.6.4 in /modules/orientdb (#7126) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.14.0 to 4.15.0 in /modules/hivemq (#7125) @app/dependabot
* Bump commons-io:commons-io from 2.11.0 to 2.12.0 in /modules/hivemq (#7124) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.5.1 to 6.7.0 in /modules/k3s (#7123) @app/dependabot
* Bump com.google.cloud:google-cloud-spanner from 6.38.2 to 6.42.3 in /modules/gcloud (#7122) @app/dependabot
* Bump peter-evans/create-pull-request from 4.2.4 to 5.0.1 (#7120) @app/dependabot
* Bump gradle-update/update-gradle-wrapper-action from 1.0.18 to 1.0.20 (#7118) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0 to 1.1.0 in /modules/oracle-xe (#7115) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.0 in /modules/mysql (#7114) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.0 in /modules/mssqlserver (#7112) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.7.0 to 8.8.0 in /modules/elasticsearch (#7113) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.8.0 to 6.9.0 in /modules/influxdb (#7109) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.0 in /modules/mariadb (#7110) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.2.0.jre8 to 12.3.0.jre8-preview in /modules/mssqlserver (#7107) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.0 in /modules/postgresql (#7104) @app/dependabot
* Bump redis.clients:jedis from 4.3.2 to 4.4.1 in /modules/junit-jupiter (#7106) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.9 to 7.17.10 in /modules/elasticsearch (#7105) @app/dependabot
* Bump io.r2dbc:r2dbc-mssql from 1.0.0.RELEASE to 1.0.1.RELEASE in /modules/mssqlserver (#7102) @app/dependabot
* Bump com.google.guava:guava from 31.1-jre to 32.0.0-jre in /modules/jdbc-test (#7101) @app/dependabot
* Bump com.google.cloud:google-cloud-pubsub from 1.123.8 to 1.123.13 in /modules/gcloud (#7094) @app/dependabot
* Bump com.google.cloud:google-cloud-firestore from 3.9.3 to 3.12.0 in /modules/gcloud (#7089) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.7 to 10.1.9 in /modules/jdbc (#7081) @app/dependabot
* Bump org.springframework.boot from 2.7.10 to 2.7.12 in /examples (#7080) @app/dependabot
* Bump org.questdb:questdb from 7.0.1-jdk8 to 7.1.3 in /modules/questdb (#7078) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.17 to 3.2.19 in /modules/orientdb (#7076) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.6 to 3.13.3 (#7073) @app/dependabot
* Bump io.trino:trino-jdbc from 411 to 418 in /modules/trino (#7069) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.17 to 3.2.19 in /modules/orientdb (#7065) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.4 to 3.5.6 in /modules/r2dbc (#7024) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.4 to 3.4.6 in /modules/couchbase (#7017) @app/dependabot
* Bump org.testng:testng from 7.5 to 7.5.1 in /examples (#7004) @app/dependabot
* Bump io.cucumber:cucumber-junit from 7.11.1 to 7.12.0 in /examples (#7003) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.2 to 5.9.3 in /examples (#7001) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.5 to 1.3.7 in /examples (#7000) @app/dependabot
* Bump org.jetbrains.kotlin.jvm from 1.8.10 to 1.8.21 in /examples (#6998) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.2 to 5.9.3 in /modules/hivemq (#6992) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.4.6 to 1.4.7 in /modules/hivemq (#6990) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.2 to 5.9.3 in /modules/hivemq (#6986) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /modules/azure (#6985) @app/dependabot
* Bump com.hivemq:hivemq-mqtt-client from 1.3.0 to 1.3.1 in /modules/hivemq (#6983) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.9.0 to 4.9.1 in /modules/mongodb (#6979) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /modules/solr (#6978) @app/dependabot
* Bump github/combine-prs from 3.0.1 to 3.1.1 (#6973) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /modules/couchbase (#6966) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/spock (#6967) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 21.9.0.0 to 23.2.0.0 in /modules/oracle-xe (#6963) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.9.2 to 1.9.3 in /modules/spock (#6964) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /examples (#6960) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.1.3 to 3.1.4 in /modules/mariadb (#6962) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/junit-jupiter (#6961) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/jdbc-test (#6959) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.9.2 to 1.9.3 in /modules/spock (#6958) @app/dependabot
* Bump org.mongodb:mongo-java-driver from 3.12.12 to 3.12.13 in /core (#6953) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/mysql (#6952) @app/dependabot
* Bump com.oracle.database.r2dbc:oracle-r2dbc from 1.0.0 to 1.1.1 in /modules/oracle-xe (#6844) @app/dependabot
* Bump io.trino:trino-jdbc from 408 to 409 in /modules/trino (#6769) @app/dependabot
