### PR TITLE
Ignore jackson-datatype-jsr310 in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,8 @@ updates:
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "org.yaml:snakeyaml"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]
   - package-ecosystem: "gradle"
     directory: "/"
     allow:


### PR DESCRIPTION
`testcontainers` module declares `com.fasterxml.jackson.datatype:jackson-datatype-jsr310`
as a dependency and it should be aligned with `com.fasterxml.jackson.core:jackson-databind`.
