### PR TITLE
MongoDBContainer: Fix user supplied command parts overriden by configure method

### DIFF
--- a/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
@@ -56,7 +56,7 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
     @Override
     public void configure() {
         String[] commandParts = getCommandParts();
-        if (commandParts != null && commandParts.length > 0)  {
+        if (commandParts != null && commandParts.length > 0) {
             return;
         }
 

--- a/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
@@ -55,6 +55,11 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
 
     @Override
     public void configure() {
+        String[] commandParts = getCommandParts();
+        if (commandParts != null && commandParts.length > 0)  {
+            return;
+        }
+
         if (shardingEnabled) {
             withCreateContainerCmdModifier(cmd -> {
                 cmd.withEntrypoint("sh");

--- a/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
+++ b/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
@@ -114,6 +114,15 @@ public class MongoDBContainerTest {
         }
     }
 
+    @Test
+    public void shouldRunWithCustomCommand() {
+        try (final MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
+            .withCommand("--replSet", "rs0")) {
+            mongoDBContainer.start();
+            assertThat(mongoDBContainer.getCommandParts()).containsExactly("--replSet", "rs0");
+        }
+    }
+
     private boolean isReplicaSet(MongoClient mongoClient) {
         return runIsMaster(mongoClient).get("setName") != null;
     }

--- a/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
+++ b/modules/mongodb/src/test/java/org/testcontainers/containers/MongoDBContainerTest.java
@@ -116,8 +116,10 @@ public class MongoDBContainerTest {
 
     @Test
     public void shouldRunWithCustomCommand() {
-        try (final MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
-            .withCommand("--replSet", "rs0")) {
+        try (
+            final MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("mongo:4.0.10"))
+                .withCommand("--replSet", "rs0")
+        ) {
             mongoDBContainer.start();
             assertThat(mongoDBContainer.getCommandParts()).containsExactly("--replSet", "rs0");
         }


### PR DESCRIPTION
In [this commit](https://github.com/testcontainers/testcontainers-java/commit/34aa967c562acd578ae724d408ee4807897b9d27), **configure** method  overrides command parts if they were supplied using **withCommand** method like so:
`
var mongoDBContainer = new MongoDBContainer(dockerImageName).withCommand("--replSet", "rs0");
`

Added test scenario and potential fix.
I think, if client supplied custom command, then we shouldn't run configuration for him, that's why in fix, I simply return from the configure method.

My tests that utilize **withCommand** pass on 1.17.6, but fail on 1.18.x due to this issue.