### PR TITLE
Support docker context when using autoIgnoringUserProperties

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
@@ -46,15 +46,15 @@ public final class EnvironmentAndSystemPropertyClientProviderStrategy extends Do
                 applicable = dockerHost.isPresent();
                 getSetting("docker.tls.verify").ifPresent(configBuilder::withDockerTlsVerify);
                 getSetting("docker.cert.path").ifPresent(configBuilder::withDockerCertPath);
+                dockerClientConfig = configBuilder.build();
                 break;
             case "autoIgnoringUserProperties":
-                applicable = configBuilder.isDockerHostSetExplicitly();
+                dockerClientConfig = configBuilder.build();
+                applicable = dockerClientConfig.getDockerHost() != null;
                 break;
             default:
                 throw new InvalidConfigurationException("Invalid value for dockerconfig.source: " + dockerConfigSource);
         }
-
-        dockerClientConfig = configBuilder.build();
     }
 
     private Optional<String> getSetting(final String name) {


### PR DESCRIPTION
This change enable support for docker context
I used existing option of `dockerconfig.source=autoIgnoringUserProperties`
when this option is enabled, it use docker-java configuration that is aware of context already

This PR requires fix from docker https://github.com/docker-java/docker-java/pull/2130 to support TLS in context, other use cases could work without this fix.
