### PR TITLE
Update docs domain from www to java

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Testcontainers logo](docs/logo.png)
 
-# [Read the documentation here](http://www.testcontainers.org)
+# [Read the documentation here](https://java.testcontainers.org)
 
 ## License
 

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -269,7 +269,7 @@ public abstract class DockerClientProviderStrategy {
                     "Could not find a valid Docker environment. Please check configuration. Attempted configurations were:\n" +
                     configurationFailures.stream().map(it -> "\t" + it).collect(Collectors.joining("\n")) +
                     "As no valid configuration was found, execution cannot continue.\n" +
-                    "See https://www.testcontainers.org/on_failure.html for more details."
+                    "See https://java.testcontainers.org/on_failure.html for more details."
                 );
 
                 FAIL_FAST_ALWAYS.set(true);

--- a/docs/error_missing_container_runtime_environment.md
+++ b/docs/error_missing_container_runtime_environment.md
@@ -13,4 +13,4 @@ Here is a list of supported container runtime environments:
 * [Testcontainers Cloud](https://www.testcontainers.cloud?utm_medium=direct&utm_source=testcontainers.com&utm_content=docs&utm_term=on-failure)
 
 For more extensive information on supported container runtime environments, as well as known limitations of alternative container runtime environments,
-please refer to [this page](https://www.testcontainers.org/supported_docker_environment/) in our documentation.
+please refer to [this page](https://java.testcontainers.org/supported_docker_environment/) in our documentation.

--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -30,7 +30,7 @@ publishing {
 
                     name project.description
                     description 'Isolated container management for Java code testing'
-                    url 'https://testcontainers.org'
+                    url 'https://java.testcontainers.org'
                     issueManagement {
                         system 'GitHub'
                         url 'https://github.com/testcontainers/testcontainers-java/issues'


### PR DESCRIPTION
The Java docs are migrating subdomain from `www` to `java`. This updates the domain in any links in the docs. 