### PR TITLE
use thread-safe collection for Startables.deepStart

### DIFF
--- a/core/src/main/java/org/testcontainers/lifecycle/Startables.java
+++ b/core/src/main/java/org/testcontainers/lifecycle/Startables.java
@@ -88,8 +88,10 @@ public class Startables {
                 // avoid a recursive update in `computeIfAbsent`
                 CompletableFuture<Void> future = started.computeIfAbsent(
                     it,
-                    startable -> deepStart(started, startable.getDependencies().stream())
-                        .thenRunAsync(startable::start, EXECUTOR)
+                    startable -> {
+                        return deepStart(started, startable.getDependencies().stream())
+                            .thenRunAsync(startable::start, EXECUTOR);
+                    }
                 );
                 return future;
             })


### PR DESCRIPTION
I recently had issue with starting my test because two containers were spin instead of one

```
12:11:26.016 [testcontainers-lifecycle-3] INFO  tc.consul:1.7.4 {} - Container consul:1.7.4 is starting: ff83d54218d3f8e5493262eb146922fedba7ccc1b65ba413c55ea4347a1b3249
12:11:26.019 [testcontainers-lifecycle-0] INFO  tc.consul:1.7.4 {} - Container consul:1.7.4 is starting: e23ef25df892e3a0e192ac48d1e3d59cb5916ac35419ba76b7bf245535f81374
```
I suspect that it could be issue with multithreaded access to collection that is not thread safe.
