### PR TITLE
Refactor spring-boot-kotlin-redis example to be more Kotlin idiomatic

### DIFF
--- a/examples/spring-boot-kotlin-redis/build.gradle.kts
+++ b/examples/spring-boot-kotlin-redis/build.gradle.kts
@@ -20,8 +20,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation(platform("org.testcontainers:testcontainers-bom:1.18.3"))
-    testImplementation("org.testcontainers:testcontainers:1.18.3")
+    testImplementation("org.testcontainers:testcontainers")
 
 
 }

--- a/examples/spring-boot-kotlin-redis/build.gradle.kts
+++ b/examples/spring-boot-kotlin-redis/build.gradle.kts
@@ -1,28 +1,34 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("org.springframework.boot") version "2.7.10"
-    id("org.jetbrains.kotlin.jvm") version "1.8.10"
-    id("org.jetbrains.kotlin.plugin.spring") version "1.8.20"
+    kotlin("jvm") version "1.8.10"
+    kotlin("plugin.spring") version "1.8.20"
 }
 
-apply plugin: 'io.spring.dependency-management'
+java.sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()
 }
 
 dependencies {
+    apply(plugin = "io.spring.dependency-management")
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-web")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.testcontainers:testcontainers")
+    testImplementation(platform("org.testcontainers:testcontainers-bom:1.18.3"))
+    testImplementation("org.testcontainers:testcontainers:1.18.3")
+
+
 }
 
-compileKotlin {
+tasks.withType<KotlinCompile> {
     kotlinOptions {
+        freeCompilerArgs = listOf("-Xjsr305=strict")
         jvmTarget = "1.8"
-        freeCompilerArgs = ["-Xjsr305=strict"]
     }
 }

--- a/examples/spring-boot-kotlin-redis/src/main/kotlin/com/example/redis/ExampleController.kt
+++ b/examples/spring-boot-kotlin-redis/src/main/kotlin/com/example/redis/ExampleController.kt
@@ -1,6 +1,5 @@
 package com.example.redis
 
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
@@ -8,12 +7,13 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class ExampleController {
+class ExampleController(
+    private val redisTemplate: RedisTemplate<String, String>
+) {
 
-    private val key = "testcontainers"
-
-    @Autowired
-    private lateinit var redisTemplate: RedisTemplate<String, String>
+    companion object {
+        const val key = "testcontainers"
+    }
 
     @PostMapping("/set-foo")
     fun setFoo(@RequestBody value: String) {


### PR DESCRIPTION
I have made several changes to the "spring-boot-kotlin-redis" example to make it more Kotlin idiomatic.

Here is a summary of the changes:

Refactored static fields to companion objects to follow Kotlin conventions. 

Replaced the usage of autowired with constructor injection. 

Converted the build.gradle file from Groovy to Kotlin DSL to align with the project's Kotlin nature.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before committing, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
