### PR TITLE
Deprecate `dynalite`

### DIFF
--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -1,4 +1,4 @@
-description = "Testcontainers :: Dynalite"
+description = "Testcontainers :: Dynalite (deprecated)"
 
 dependencies {
     api project(':testcontainers')

--- a/modules/dynalite/src/main/java/org/testcontainers/dynamodb/DynaliteContainer.java
+++ b/modules/dynalite/src/main/java/org/testcontainers/dynamodb/DynaliteContainer.java
@@ -11,6 +11,8 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Container for Dynalite, a DynamoDB clone.
+ *
+ * @deprecated use localstack module instead
  */
 public class DynaliteContainer extends GenericContainer<DynaliteContainer> {
 


### PR DESCRIPTION
Nowdays, Testcontainers provides a LocalStack modules which offers
DynamoDB integration.
