### PR TITLE
Fix MSSQL's default username

### DIFF
--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -20,7 +20,7 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
 
     public static final Integer MS_SQL_SERVER_PORT = 1433;
 
-    static final String DEFAULT_USER = "SA";
+    static final String DEFAULT_USER = "sa";
 
     static final String DEFAULT_PASSWORD = "A_Str0ng_Required_Password";
 


### PR DESCRIPTION
Fixes #7237

If `MSSQL_COLLATION` is set to a collation with case-sensetive (`_CS` not `_CI`), the username `SA` will fail to login to DB, as `sa` is the correct username.