### PR TITLE
Add questdb as a database provider

### DIFF
--- a/docs/modules/databases/jdbc.md
+++ b/docs/modules/databases/jdbc.md
@@ -69,7 +69,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 #### Using QuestDB
 
-`jdbc:tc:postgresql:6.5.3:///databasename`
+`jdbc:tc:questdb:6.5.3:///databasename`
 
 #### Using TimescaleDB
 

--- a/modules/questdb/src/main/java/org/testcontainers/containers/LegacyQuestDBProvider.java
+++ b/modules/questdb/src/main/java/org/testcontainers/containers/LegacyQuestDBProvider.java
@@ -1,0 +1,15 @@
+package org.testcontainers.containers;
+
+@Deprecated
+public class LegacyQuestDBProvider extends JdbcDatabaseContainerProvider {
+
+    @Override
+    public boolean supports(String databaseType) {
+        return databaseType.equals(QuestDBContainer.LEGACY_DATABASE_PROVIDER);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(String tag) {
+        return new QuestDBContainer(QuestDBContainer.DEFAULT_IMAGE_NAME.withTag(tag));
+    }
+}

--- a/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
+++ b/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
@@ -9,7 +9,10 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class QuestDBContainer extends JdbcDatabaseContainer<QuestDBContainer> {
 
-    static final String DATABASE_PROVIDER = "postgresql";
+    @Deprecated
+    static final String LEGACY_DATABASE_PROVIDER = "postgresql";
+
+    static final String DATABASE_PROVIDER = "questdb";
 
     private static final String DEFAULT_DATABASE_NAME = "qdb";
 

--- a/modules/questdb/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
+++ b/modules/questdb/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
@@ -1,1 +1,2 @@
+org.testcontainers.containers.LegacyQuestDBProvider
 org.testcontainers.containers.QuestDBProvider

--- a/modules/questdb/src/test/java/org/testcontainers/jdbc/questdb/QuestDBJDBCDriverTest.java
+++ b/modules/questdb/src/test/java/org/testcontainers/jdbc/questdb/QuestDBJDBCDriverTest.java
@@ -13,7 +13,10 @@ public class QuestDBJDBCDriverTest extends AbstractJDBCDriverTest {
     @Parameterized.Parameters(name = "{index} - {0}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(
-            new Object[][] { { "jdbc:tc:postgresql://hostname/databasename", EnumSet.of(Options.PmdKnownBroken) } }
+            new Object[][] {
+                { "jdbc:tc:postgresql://hostname/databasename", EnumSet.of(Options.PmdKnownBroken) },
+                { "jdbc:tc:questdb://hostname/databasename", EnumSet.of(Options.PmdKnownBroken) },
+            }
         );
     }
 }


### PR DESCRIPTION
Previously, postgresql has been used as a database provider for
QuestDB along with Testcontainers JDBC URL. `postgresql` has been
deprecated and instead `questdb` has been added.
