### PR TITLE
Disable default disk threshold check in ElasticsearchContainer

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -98,6 +98,8 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
         withNetworkAliases("elasticsearch-" + Base58.randomString(6));
         withEnv("discovery.type", "single-node");
+        // disable disk threshold checks
+        withEnv("cluster.routing.allocation.disk.threshold_enabled", "false");
         // Sets default memory of elasticsearch instance to 2GB
         // Spaces are deliberate to allow user to define additional jvm options as elasticsearch resolves option files lexicographically
         withClasspathResourceMapping(


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before committing, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
### Motivation

Elasticsearch stops writing to disk when the usage goes above 90%. 
This problem can be hard to detect in CI environments. 

Only after adding `.withLogConsumer(o -> log.info("elastic> {}", o.getUtf8String()))` did I find out that Elastic had logged this kind of warning:
high disk watermark [90%] exceeded on [WSN4y7xITamrUzTvic-eEg][94f6a74e1f83][/usr/share/elasticsearch/data] free: 8.1gb[9.7%], **shards will be relocated away from this node**; currently relocating away shards totalling [0] bytes; the node is expected to continue to exceed the high disk watermark when these relocations are complete

### Modifications

Set `cluster.routing.allocation.disk.threshold_enabled` to `false` to disable the disk threshold check.