### PR TITLE
Add explicit SPI for R2DBC

### DIFF
--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -1,9 +1,6 @@
 description = "Testcontainers :: JDBC :: MariaDB"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
-
     api project(':jdbc')
 
     compileOnly project(':r2dbc')

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerProvider.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerProvider.java
@@ -1,6 +1,5 @@
 package org.testcontainers.containers;
 
-import com.google.auto.service.AutoService;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.mariadb.r2dbc.MariadbConnectionFactoryProvider;
@@ -9,7 +8,6 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
 
 import javax.annotation.Nullable;
 
-@AutoService(R2DBCDatabaseContainerProvider.class)
 public class MariaDBR2DBCDatabaseContainerProvider implements R2DBCDatabaseContainerProvider {
 
     static final String DRIVER = MariadbConnectionFactoryProvider.MARIADB_DRIVER;

--- a/modules/mariadb/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
+++ b/modules/mariadb/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.testcontainers.containers.MariaDBR2DBCDatabaseContainerProvider

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -1,9 +1,6 @@
 description = "Testcontainers :: MS SQL Server"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
-
     api project(':jdbc')
 
     compileOnly project(':r2dbc')

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerProvider.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainerProvider.java
@@ -1,6 +1,5 @@
 package org.testcontainers.containers;
 
-import com.google.auto.service.AutoService;
 import io.r2dbc.mssql.MssqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
@@ -9,7 +8,6 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
 
 import javax.annotation.Nullable;
 
-@AutoService(R2DBCDatabaseContainerProvider.class)
 public class MSSQLR2DBCDatabaseContainerProvider implements R2DBCDatabaseContainerProvider {
 
     static final String DRIVER = MssqlConnectionFactoryProvider.MSSQL_DRIVER;

--- a/modules/mssqlserver/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
+++ b/modules/mssqlserver/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.testcontainers.containers.MSSQLR2DBCDatabaseContainerProvider

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -1,9 +1,6 @@
 description = "Testcontainers :: JDBC :: MySQL"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
-
     api project(':jdbc')
 
     compileOnly project(':r2dbc')

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerProvider.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainerProvider.java
@@ -1,6 +1,5 @@
 package org.testcontainers.containers;
 
-import com.google.auto.service.AutoService;
 import io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
@@ -9,7 +8,6 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
 
 import javax.annotation.Nullable;
 
-@AutoService(R2DBCDatabaseContainerProvider.class)
 public class MySQLR2DBCDatabaseContainerProvider implements R2DBCDatabaseContainerProvider {
 
     static final String DRIVER = MySqlConnectionFactoryProvider.MYSQL_DRIVER;

--- a/modules/mysql/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
+++ b/modules/mysql/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.testcontainers.containers.MySQLR2DBCDatabaseContainerProvider

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -1,9 +1,6 @@
 description = "Testcontainers :: JDBC :: Oracle XE"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
-
     api project(':jdbc')
 
     compileOnly project(':r2dbc')

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleR2DBCDatabaseContainerProvider.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleR2DBCDatabaseContainerProvider.java
@@ -1,13 +1,11 @@
 package org.testcontainers.containers;
 
-import com.google.auto.service.AutoService;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import org.jetbrains.annotations.Nullable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
 
-@AutoService(R2DBCDatabaseContainerProvider.class)
 public class OracleR2DBCDatabaseContainerProvider implements R2DBCDatabaseContainerProvider {
 
     static final String DRIVER = "oracle";

--- a/modules/oracle-xe/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
+++ b/modules/oracle-xe/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.testcontainers.containers.OracleR2DBCDatabaseContainerProvider

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -1,9 +1,6 @@
 description = "Testcontainers :: JDBC :: PostgreSQL"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
-
     api project(':jdbc')
 
     compileOnly project(':r2dbc')

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainerProvider.java
@@ -1,6 +1,5 @@
 package org.testcontainers.containers;
 
-import com.google.auto.service.AutoService;
 import io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryMetadata;
 import io.r2dbc.spi.ConnectionFactoryOptions;
@@ -9,7 +8,6 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider;
 
 import javax.annotation.Nullable;
 
-@AutoService(R2DBCDatabaseContainerProvider.class)
 public final class PostgreSQLR2DBCDatabaseContainerProvider implements R2DBCDatabaseContainerProvider {
 
     static final String DRIVER = PostgresqlConnectionFactoryProvider.POSTGRESQL_DRIVER;

--- a/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
+++ b/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider
@@ -1,0 +1,1 @@
+org.testcontainers.containers.PostgreSQLR2DBCDatabaseContainerProvider

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -5,9 +5,6 @@ plugins {
 description = "Testcontainers :: R2DBC"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
-
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'
 

--- a/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/Hidden.java
+++ b/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/Hidden.java
@@ -1,6 +1,5 @@
 package org.testcontainers.r2dbc;
 
-import com.google.auto.service.AutoService;
 import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.ConnectionFactoryProvider;
@@ -10,7 +9,6 @@ import io.r2dbc.spi.ConnectionFactoryProvider;
  */
 class Hidden {
 
-    @AutoService(ConnectionFactoryProvider.class)
     public static final class TestcontainersR2DBCConnectionFactoryProvider implements ConnectionFactoryProvider {
 
         public static final String DRIVER = "tc";

--- a/modules/r2dbc/src/main/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
+++ b/modules/r2dbc/src/main/resources/META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider
@@ -1,0 +1,1 @@
+org.testcontainers.r2dbc.Hidden$TestcontainersR2DBCConnectionFactoryProvider


### PR DESCRIPTION
Testcontainers has been using `com.google.auto.service:auto-service`
to declare `R2DBCDatabaseContainerProvider` implementations. In order
to be consistent with `JdbcDatabaseContainerProvider`, dependency
`com.google.auto.service:auto-service` is dropped and implementations
are declared explicitly under `META-INF/services/org.testcontainers.r2dbc.R2DBCDatabaseContainerProvider`.
