### PR TITLE
Disable default geoip database downloading for Elasticsearch container

### DIFF
--- a/modules/elasticsearch/src/main/resources/elasticsearch-default-memory-vm.options
+++ b/modules/elasticsearch/src/main/resources/elasticsearch-default-memory-vm.options
@@ -1,2 +1,3 @@
 -Xms2147483648
 -Xmx2147483648
+-Dingest.geoip.downloader.enabled.default=false


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before committing, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
### Motivation

By default, Elasticsearch container will download the geoip lite database.
It's better to disable this behavior by default.
There's also an elastic issue about this default behavior: https://github.com/elastic/elasticsearch/issues/90673. Fixed since v8.7.0 with https://github.com/elastic/elasticsearch/pull/92335 .

### Modifications

geoip downloading can be disabled by passing `-Dingest.geoip.downloader.enabled.default=false` in JVM options or passing `ingest.geoip.downloader.enabled=false` in the environment. 

The problem with passing `ingest.geoip.downloader.enabled=false` in the environment is that it's not compatible with OpenSearch. OpenSearch will fail to start with a configuration validation error `org.opensearch.bootstrap.StartupException: java.lang.IllegalArgumentException: unknown setting [ingest.geoip.downloader.enabled] please check that any required plugins are installed, or check the breaking changes documentation for removed settings`. Some users might be using ElasticsearchContainer class together with the OpenSearch docker image.


 