### PR TITLE
[draft] Introduce Container Definition

### DIFF
--- a/core/src/main/java/org/testcontainers/core/ContainerDef.java
+++ b/core/src/main/java/org/testcontainers/core/ContainerDef.java
@@ -1,0 +1,142 @@
+package org.testcontainers.core;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.InternetProtocol;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+import lombok.Getter;
+import org.testcontainers.UnstableAPI;
+import org.testcontainers.images.RemoteDockerImage;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Getter
+@UnstableAPI
+public class ContainerDef {
+
+    private RemoteDockerImage image;
+
+    private final Set<ExposedPort> exposedPorts = new HashSet<>();
+
+    private final Set<PortBinding> portBindings = new HashSet<>();
+
+    private final Map<String, String> envVars = new HashMap<>();
+
+    private String[] command = null;
+
+    public static ContainerDef from(RemoteDockerImage image) {
+        return new ContainerDef().withImage(image);
+    }
+
+    public static ContainerDef from(String image) {
+        return new ContainerDef().withImage(image);
+    }
+
+    public static ContainerDef from(DockerImageName image) {
+        return new ContainerDef().withImage(image);
+    }
+
+    private ContainerDef withImage(RemoteDockerImage image) {
+        this.image = image;
+        return this;
+    }
+
+    private ContainerDef withImage(String image) {
+        return withImage(DockerImageName.parse(image));
+    }
+
+    private ContainerDef withImage(DockerImageName image) {
+        return withImage(new RemoteDockerImage(image));
+    }
+
+    public ContainerDef withExposedPorts(Set<ExposedPort> exposedPorts) {
+        this.exposedPorts.addAll(exposedPorts);
+        return this;
+    }
+
+    public ContainerDef withExposedPort(ExposedPort exposedPort) {
+        this.exposedPorts.add(exposedPort);
+        return this;
+    }
+
+    public ContainerDef withExposedPort(int port) {
+        return withExposedPort(new ExposedPort(port));
+    }
+
+    public ContainerDef withExposedPort(int port, InternetProtocol protocol) {
+        this.exposedPorts.add(new ExposedPort(port, protocol));
+        return this;
+    }
+
+    public ContainerDef withExposedPorts(int... ports) {
+        for (int port : ports) {
+            withExposedPort(port);
+        }
+        return this;
+    }
+
+    public ContainerDef withPortBindings(Set<PortBinding> portBindings) {
+        this.portBindings.addAll(portBindings);
+        return this;
+    }
+
+    public ContainerDef withEnvVars(Map<String, String> envVars) {
+        this.envVars.putAll(envVars);
+        return this;
+    }
+
+    public ContainerDef withEnvVar(String key, String value) {
+        this.envVars.put(key, value);
+        return this;
+    }
+
+    public ContainerDef withCommand(String... command) {
+        this.command = command;
+        return this;
+    }
+
+    public void applyTo(CreateContainerCmd createCmd) {
+        HostConfig hostConfig = createCmd.getHostConfig();
+        if (hostConfig == null) {
+            hostConfig = new HostConfig();
+            createCmd.withHostConfig(hostConfig);
+        }
+
+        // PortBindings must contain:
+        //  * all exposed ports with a randomized host port (equivalent to -p CONTAINER_PORT)
+        //  * all exposed ports with a fixed host port (equivalent to -p HOST_PORT:CONTAINER_PORT)
+        Map<ExposedPort, PortBinding> allPortBindings = new HashMap<>();
+        // First collect all the randomized host ports from our 'exposedPorts' field
+        for (final ExposedPort exposedPort : this.exposedPorts) {
+            allPortBindings.put(exposedPort, new PortBinding(Ports.Binding.empty(), exposedPort));
+        }
+        // Next collect all the fixed host ports from our 'portBindings' field, overwriting any randomized ports so that
+        // we don't create two bindings for the same container port.
+        for (final PortBinding portBinding : this.portBindings) {
+            allPortBindings.put(portBinding.getExposedPort(), portBinding);
+        }
+        hostConfig.withPortBindings(new ArrayList<>(allPortBindings.values()));
+
+        // Next, ExposedPorts must be set up to publish all of the above ports, both randomized and fixed.
+        createCmd.withExposedPorts(new ArrayList<>(allPortBindings.keySet()));
+
+        if (this.command != null) {
+            createCmd.withCmd(this.command);
+        }
+
+        String[] envArray = getEnvVars()
+            .entrySet()
+            .stream()
+            .filter(it -> it.getValue() != null)
+            .map(it -> it.getKey() + "=" + it.getValue())
+            .toArray(String[]::new);
+        createCmd.withEnv(envArray);
+    }
+}

--- a/core/src/test/java/org/testcontainers/containers/ExposedHostTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ExposedHostTest.java
@@ -9,6 +9,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.testcontainers.TestImages;
 import org.testcontainers.Testcontainers;
+import org.testcontainers.core.ContainerDef;
 
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
@@ -50,8 +51,8 @@ public class ExposedHostTest {
     @Test
     public void testExposedHostAfterContainerIsStarted() {
         try (
-            GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)
-                .withCommand("top")
+            GenericContainer<?> container = GenericContainer
+                .with(ContainerDef.from(TestImages.TINY_IMAGE).withCommand("top"))
                 .withAccessToHost(true)
         ) {
             container.start();
@@ -61,29 +62,32 @@ public class ExposedHostTest {
     }
 
     @Test
-    public void testExposedHost() throws Exception {
+    public void testExposedHost() {
         Testcontainers.exposeHostPorts(server.getAddress().getPort());
-        assertResponse(new GenericContainer<>(TestImages.TINY_IMAGE).withCommand("top"), server.getAddress().getPort());
+        assertResponse(
+            GenericContainer.with(ContainerDef.from(TestImages.TINY_IMAGE).withCommand("top")),
+            server.getAddress().getPort()
+        );
     }
 
     @Test
-    public void testExposedHostWithNetwork() throws Exception {
+    public void testExposedHostWithNetwork() {
         Testcontainers.exposeHostPorts(server.getAddress().getPort());
         try (Network network = Network.newNetwork()) {
             assertResponse(
-                new GenericContainer<>(TestImages.TINY_IMAGE).withNetwork(network).withCommand("top"),
+                GenericContainer.with(ContainerDef.from(TestImages.TINY_IMAGE).withCommand("top")).withNetwork(network),
                 server.getAddress().getPort()
             );
         }
     }
 
     @Test
-    public void testExposedHostPortOnFixedInternalPorts() throws Exception {
+    public void testExposedHostPortOnFixedInternalPorts() {
         Testcontainers.exposeHostPorts(ImmutableMap.of(server.getAddress().getPort(), 80));
         Testcontainers.exposeHostPorts(ImmutableMap.of(server.getAddress().getPort(), 81));
 
-        assertResponse(new GenericContainer<>(TestImages.TINY_IMAGE).withCommand("top"), 80);
-        assertResponse(new GenericContainer<>(TestImages.TINY_IMAGE).withCommand("top"), 81);
+        assertResponse(GenericContainer.with(ContainerDef.from(TestImages.TINY_IMAGE).withCommand("top")), 80);
+        assertResponse(GenericContainer.with(ContainerDef.from(TestImages.TINY_IMAGE).withCommand("top")), 81);
     }
 
     @SneakyThrows

--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaServiceContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaServiceContainer.java
@@ -1,0 +1,63 @@
+package org.testcontainers.containers;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import org.testcontainers.core.ContainerDef;
+import org.testcontainers.utility.DockerImageName;
+
+@Getter(AccessLevel.MODULE)
+public class KafkaServiceContainer {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
+
+    private static final int KAFKA_PORT = 9093;
+
+    private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
+
+    private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
+
+    private boolean embeddedZookeeper = true;
+
+    private String externalZookeeperConnect = null;
+
+    private ContainerDef containerDef;
+
+    private boolean raftMode = false;
+
+    public void withEmbeddedZookeeper(boolean embeddedZookeeper) {
+        this.embeddedZookeeper = embeddedZookeeper;
+    }
+
+    public void withExternalZookeeperConnect(String externalZookeeperConnect) {
+        this.externalZookeeperConnect = externalZookeeperConnect;
+    }
+
+    public void withRaftMode(boolean raftMode) {
+        this.raftMode = raftMode;
+    }
+
+    static KafkaServiceContainer from(String image) {
+        return from(DockerImageName.parse(image));
+    }
+
+    static KafkaServiceContainer from(DockerImageName image) {
+        KafkaServiceContainer def = new KafkaServiceContainer();
+        image.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        def.containerDef =
+            ContainerDef
+                .from(image)
+                .withExposedPorts(KAFKA_PORT)
+                .withEnvVar("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:" + KAFKA_PORT + ",BROKER://0.0.0.0:9092")
+                .withEnvVar("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT")
+                .withEnvVar("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER")
+                .withEnvVar("KAFKA_BROKER_ID", "1")
+                .withEnvVar("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF)
+                .withEnvVar("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", DEFAULT_INTERNAL_TOPIC_RF)
+                .withEnvVar("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF)
+                .withEnvVar("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", DEFAULT_INTERNAL_TOPIC_RF)
+                .withEnvVar("KAFKA_LOG_FLUSH_INTERVAL_MESSAGES", Long.MAX_VALUE + "")
+                .withEnvVar("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
+                .withCommand("-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+        return def;
+    }
+}

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -39,7 +39,7 @@ public class KafkaContainerTest {
 
     @Test
     public void testUsage() throws Exception {
-        try (KafkaContainer kafka = new KafkaContainer(KAFKA_TEST_IMAGE)) {
+        try (KafkaContainer kafka = KafkaContainer.from(KAFKA_TEST_IMAGE)) {
             kafka.start();
             testKafkaFunctionality(kafka.getBootstrapServers());
         }


### PR DESCRIPTION
Nowadays, `Testcontainers` has been relying on `GenericContainer` to set the container definition (image, exposedPorts, command, etc) along with the container lifecycle. Introducing `ContainerDef` is the first step to split those concepts.

Looking at the commits we can see a basic `ContainerDef` (first commit) and how this is applied to `PortForwardingContainer`. Third commit introduces `KafkaServiceContainer`, Why `ServiceContainer`? In general, we look at those as a containers running but actually, those containers provide a service (databases, service brokers, etc), containers are how those services are provided. `ServiceContainer` implementations such as `KafkaServiceContainer` will provide the default `ContainerDef` and also how the service is going to be configured. As of today, Kafka can run with an embedded Zookeeper and also an external one, or Raft mode (Zookeeperless)