### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v3.0.1
+        uses: github/combine-prs@v3.1.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5.19.0
+      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v3.10.1
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v3.10.1
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v3.10.1
         with:
           title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |

--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ subprojects {
     }
 
     dependencies {
-        testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+        testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     }
 
     checkstyle {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,7 +105,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.3.2'
     testImplementation 'com.rabbitmq:amqp-client:5.17.0'
-    testImplementation 'org.mongodb:mongo-java-driver:3.12.12'
+    testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation project(":mysql")
 
     testImplementation 'mysql:mysql-connector-java:8.0.32'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.8.1"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.10.0"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.2.3.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.3"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.2"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.2.3.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
 }
 
 test {

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -9,6 +9,6 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.2.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
 }

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.26"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.26"
+    testCompileOnly "org.projectlombok:lombok:1.18.28"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.28"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'org.json:json:20230227'
     testImplementation 'org.postgresql:postgresql:42.6.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'org.json:json:20230227'
     testImplementation 'org.postgresql:postgresql:42.6.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.16.10'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.testng:testng:7.5'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,6 +13,6 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '2.7.13'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.10"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11"
     }
 }
 

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'com.jcraft:jsch:0.1.55'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.26"
-    annotationProcessor "org.projectlombok:lombok:1.18.26"
+    compileOnly "org.projectlombok:lombok:1.18.28"
+    annotationProcessor "org.projectlombok:lombok:1.18.28"
 
     implementation 'org.apache.solr:solr-solrj:8.11.2'
 

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.10'
+    id 'org.springframework.boot' version '2.7.13'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.4.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.5'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.azure:azure-cosmos:4.42.0'
+    testImplementation 'com.azure:azure-cosmos:4.47.0'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Azure"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.azure:azure-cosmos:4.47.0'

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     api project(":database-commons")
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
-    testImplementation 'com.datastax.oss:java-driver-core:4.15.0'
+    testImplementation 'com.datastax.oss:java-driver-core:4.16.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'com.couchbase.client:java-client:3.4.7'
     testImplementation 'org.awaitility:awaitility:4.2.0'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.10.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.4'
+    testImplementation 'com.couchbase.client:java-client:3.4.7'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.441'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.441'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.500'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.500'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.7.0"
-    testImplementation "org.elasticsearch.client:transport:7.17.9"
+    testImplementation "org.elasticsearch.client:transport:7.17.11"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.17.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.18.0")
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'
     testImplementation 'com.google.cloud:google-cloud-pubsub'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.8")
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.3")
 }
 
 test {

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.14.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.4.6")
+    testImplementation("ch.qos.logback:logback-classic:1.4.8")
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.14.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.16.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.8")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.5")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.2")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.16.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.0")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:24.0.1")
 
     shaded("org.apache.commons:commons-lang3:3.12.0")
-    shaded("commons-io:commons-io:2.11.0")
+    shaded("commons-io:commons-io:2.13.0")
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.influxdb:influxdb-java:2.23'
-    testImplementation "com.influxdb:influxdb-client-java:6.8.0"
+    testImplementation "com.influxdb:influxdb-client-java:6.9.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':jdbc')
 
-    api 'com.google.guava:guava:31.1-jre'
+    api 'com.google.guava:guava:32.1.1-jre'
     api 'org.apache.commons:commons-lang3:3.12.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.7'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.7'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.10'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    implementation platform('org.junit:junit-bom:5.9.2')
+    implementation platform('org.junit:junit-bom:5.9.3')
     implementation 'org.junit.jupiter:junit-jupiter-api'
 
     testImplementation project(':mysql')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 }
 
 test {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.3.2'
+    testImplementation 'redis.clients:jedis:4.4.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.5.1'
+    testImplementation 'io.fabric8:kubernetes-client:6.7.2'
     testImplementation 'io.kubernetes:client-java:18.0.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.5.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.489")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.500")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.38'
+    testImplementation 'software.amazon.awssdk:s3:2.20.97'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.3'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: MariaDB"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
 
     api project(':jdbc')
 

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.9.0")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.10.1")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.2.0.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.3.1.jre8-preview'
 
     testImplementation project(':r2dbc')
     testImplementation 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.3.1.jre8-preview'
 
     testImplementation project(':r2dbc')
-    testImplementation 'io.r2dbc:r2dbc-mssql:1.0.0.RELEASE'
+    testImplementation 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':r2dbc'))

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: MS SQL Server"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
 
     api project(':jdbc')
 

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.asyncer:r2dbc-mysql:1.0.2'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.32'
+    testImplementation 'mysql:mysql-connector-java:8.0.33'
 
     testImplementation testFixtures(project(':r2dbc'))
     testImplementation 'io.asyncer:r2dbc-mysql:1.0.2'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: MySQL"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
 
     api project(':jdbc')
 

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.asyncer:r2dbc-mysql:0.9.0'
+    compileOnly 'io.asyncer:r2dbc-mysql:1.0.2'
 
     testImplementation project(':jdbc-test')
     testImplementation 'mysql:mysql-connector-java:8.0.32'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'io.asyncer:r2dbc-mysql:0.9.0'
+    testImplementation 'io.asyncer:r2dbc-mysql:1.0.2'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.12'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:21.9.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.2.0.0'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: Oracle XE"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
 
     api project(':jdbc')
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
+    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.2.0.0'
@@ -15,7 +15,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testImplementation 'com.oracle.database.r2dbc:oracle-r2dbc:1.0.0'
+    testImplementation 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
 }
 
 test {

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.17"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.20"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.17"
+    api "com.orientechnologies:orientdb-client:3.2.20"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.2'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -1,8 +1,8 @@
 description = "Testcontainers :: JDBC :: PostgreSQL"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
 
     api project(':jdbc')
 

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.1.3'
+    testImplementation 'org.questdb:questdb:7.2'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.4'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.7'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -5,8 +5,8 @@ plugins {
 description = "Testcontainers :: R2DBC"
 
 dependencies {
-    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
-    compileOnly 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.1.1'
+    compileOnly 'com.google.auto.service:auto-service:1.1.1'
 
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.17.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.18.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Redpanda"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.5.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'io.rest-assured:rest-assured:5.3.0'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     shaded 'org.awaitility:awaitility:4.2.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.solacesystems:sol-jcsmp:10.19.0'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.21.0'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Solr"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.10.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.3'
 
     testCompileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
-    testRuntimeOnly 'mysql:mysql-connector-java:8.0.32'
+    testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.2'
 

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'mysql:mysql-connector-java:8.0.32'
+    testImplementation 'mysql:mysql-connector-java:8.0.33'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testImplementation 'io.trino:trino-jdbc:411'
+    testImplementation 'io.trino:trino-jdbc:420'
     compileOnly 'org.jetbrains:annotations:24.0.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.3.0'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // YCQL driver
     testImplementation 'com.yugabyte:java-driver-core:4.6.0-yb-12'
     // YSQL driver
-    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-2'
+    testImplementation 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-3'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.10"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11"
         classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.rest-assured:rest-assured from 5.3.0 to 5.3.1 in /modules/consul (#7286) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.5 to 1.3.8 in /examples (#7285) @app/dependabot
* Bump com.google.guava:guava from 31.1-jre to 32.1.1-jre in /modules/jdbc-test (#7284) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.9.2 to 5.9.3 in /examples (#7283) @app/dependabot
* Bump org.projectlombok:lombok from 1.18.26 to 1.18.28 in /examples (#7282) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.10 to 1.11 in /examples (#7281) @app/dependabot
* Bump org.mongodb:mongo-java-driver from 3.12.12 to 3.12.14 in /core (#7280) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.17.0 to 5.18.0 in /core (#7279) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.9 to 7.17.11 in /modules/elasticsearch (#7277) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.0 to 5.3.1 in /modules/vault (#7276) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.4 to 3.4.7 in /modules/couchbase (#7275) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.4.6 to 1.4.8 in /modules/hivemq (#7274) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.4 to 3.5.7 in /modules/r2dbc (#7273) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.38 to 2.20.97 in /modules/localstack (#7272) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-bom from 1.12.489 to 1.12.500 in /modules/localstack (#7271) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.9.0 to 4.10.1 in /modules/mongodb (#7270) @app/dependabot
* Bump release-drafter/release-drafter from 5.23.0 to 5.24.0 (#7269) @app/dependabot
* Bump peter-evans/create-pull-request from 4.2.4 to 5.0.2 (#7268) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.0 to 5.3.1 in /modules/redpanda (#7267) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.17.0 to 26.18.0 in /modules/gcloud (#7266) @app/dependabot
* Bump org.questdb:questdb from 7.1.3 to 7.2 in /modules/questdb (#7265) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.11 to 4.4.12 in /modules/neo4j (#7264) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.17.0 to 5.18.0 in /modules/rabbitmq (#7263) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.441 to 1.12.500 in /modules/dynalite (#7262) @app/dependabot
* Bump com.azure:azure-cosmos from 4.42.0 to 4.47.0 in /modules/azure (#7253) @app/dependabot
* Bump org.springframework.boot from 2.7.10 to 2.7.13 in /examples (#7252) @app/dependabot
* Bump io.trino:trino-jdbc from 411 to 420 in /modules/trino (#7251) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.6 to 3.13.4 (#7231) @app/dependabot
* Bump redis.clients:jedis from 4.3.2 to 4.4.3 in /modules/junit-jupiter (#7212) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.5.1 to 6.7.2 in /modules/k3s (#7210) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.4.0 to 3.5.0 in /modules/redpanda (#7207) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.19.0 to 10.21.0 in /modules/solace (#7208) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.1 in /modules/r2dbc (#7206) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.4.0 to 3.5.0 in /modules/kafka (#7205) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.1 in /modules/mssqlserver (#7204) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0 to 1.1.1 in /modules/oracle-xe (#7203) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.1 in /modules/mysql (#7202) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.1 in /modules/mariadb (#7199) @app/dependabot
* Bump com.google.auto.service:auto-service from 1.0.1 to 1.1.1 in /modules/postgresql (#7198) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.17 to 3.2.20 in /modules/orientdb (#7194) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.7 to 10.1.10 in /modules/jdbc (#7193) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.17 to 3.2.20 in /modules/orientdb (#7192) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.8.1 to 4.10.0 in /examples (#7171) @app/dependabot
* Bump commons-io:commons-io from 2.11.0 to 2.13.0 in /modules/hivemq (#7169) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.2.0.jre8 to 12.3.1.jre8-preview in /modules/mssqlserver (#7167) @app/dependabot
* Bump io.asyncer:r2dbc-mysql from 0.9.0 to 1.0.2 in /modules/mysql (#7156) @app/dependabot
* Bump com.datastax.oss:java-driver-core from 4.15.0 to 4.16.0 in /modules/cassandra (#7153) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.14.0 to 4.16.0 in /modules/hivemq (#7152) @app/dependabot
* Bump com.yugabyte:jdbc-yugabytedb from 42.3.5-yb-2 to 42.3.5-yb-3 in /modules/yugabytedb (#7128) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.10 to 1.11 (#7127) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.6.2 to 3.6.4 in /modules/orientdb (#7126) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.8.0 to 6.9.0 in /modules/influxdb (#7109) @app/dependabot
* Bump io.r2dbc:r2dbc-mssql from 1.0.0.RELEASE to 1.0.1.RELEASE in /modules/mssqlserver (#7102) @app/dependabot
* Bump org.testng:testng from 7.5 to 7.5.1 in /examples (#7004) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /examples (#6999) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/tidb (#6996) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.2 to 5.9.3 in /modules/hivemq (#6992) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.2 to 5.9.3 in /modules/hivemq (#6986) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /modules/azure (#6985) @app/dependabot
* Bump com.hivemq:hivemq-mqtt-client from 1.3.0 to 1.3.1 in /modules/hivemq (#6983) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /modules/solr (#6978) @app/dependabot
* Bump github/combine-prs from 3.0.1 to 3.1.1 (#6973) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /modules/couchbase (#6966) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/spock (#6967) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.9.2 to 1.9.3 in /modules/spock (#6964) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 21.9.0.0 to 23.2.0.0 in /modules/oracle-xe (#6963) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/junit-jupiter (#6961) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.11.0 in /examples (#6960) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.1.3 to 3.1.4 in /modules/mariadb (#6962) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.9.2 to 1.9.3 in /modules/spock (#6958) @app/dependabot
* Bump org.junit:junit-bom from 5.9.2 to 5.9.3 in /modules/junit-jupiter (#6954) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/mysql (#6952) @app/dependabot
* Bump com.oracle.database.r2dbc:oracle-r2dbc from 1.0.0 to 1.1.1 in /modules/oracle-xe (#6844) @app/dependabot
* Bump io.trino:trino-jdbc from 408 to 409 in /modules/trino (#6769) @app/dependabot
