### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@981c551b17dbcf1940b1b4435afdb79babb7c13a # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@0407394b9d173dfc9cf5695f9f560fef6d61a5fe # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     testImplementation 'com.google.cloud.tools:jib-core:0.23.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:4.3.2'
-    testImplementation 'com.rabbitmq:amqp-client:5.17.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.18.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.7.0"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.8.2"
     testImplementation "org.elasticsearch.client:transport:7.17.11"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -12,5 +12,5 @@ dependencies {
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'
-    api 'mysql:mysql-connector-java:8.0.32'
+    api 'mysql:mysql-connector-java:8.0.33'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.13.4"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11"
         classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
     }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.rabbitmq:amqp-client from 5.17.0 to 5.18.0 in /core (#7279) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.7.0 to 8.8.2 in /modules/elasticsearch (#7278) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.6 to 3.13.4 (#7231) @app/dependabot
* Bump redis.clients:jedis from 4.3.2 to 4.4.3 in /core (#7213) @app/dependabot
* Bump gradle-update/update-gradle-wrapper-action from 1.0.18 to 1.0.20 (#7118) @app/dependabot
* Bump org.testng:testng from 7.5 to 7.5.1 in /examples (#7004) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /examples (#6999) @app/dependabot
* Bump com.hivemq:hivemq-mqtt-client from 1.3.0 to 1.3.1 in /modules/hivemq (#6983) @app/dependabot
* Bump mysql:mysql-connector-java from 8.0.32 to 8.0.33 in /modules/jdbc-test (#6959) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.9.2 to 1.9.3 in /modules/spock (#6958) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.0 to 24.0.1 in /modules/trino (#6763) @app/dependabot
