### PR TITLE
Exec in container with custom user

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -53,6 +53,8 @@ tasks.japicmp {
     methodExcludes = [
         "org.testcontainers.containers.Container#getDockerClient()",
         "org.testcontainers.containers.ContainerState#getDockerClient()",
+        "org.testcontainers.containers.ContainerState#execInContainerWithUser(java.lang.String,java.lang.String[])",
+        "org.testcontainers.containers.ContainerState#execInContainerWithUser(java.nio.charset.Charset,java.lang.String,java.lang.String[])",
     ]
 
     fieldExcludes = []

--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -259,7 +259,33 @@ public interface ContainerState {
      */
     default Container.ExecResult execInContainer(Charset outputCharset, String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {
-        return ExecInContainerPattern.execInContainer(getDockerClient(), getContainerInfo(), outputCharset, command);
+        return execInContainerWithUser(outputCharset, null, command);
+    }
+
+    /**
+     * Run a command inside a running container as a given user, as using "docker exec -u user".
+     * <p>
+     * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, com.github.dockerjava.api.command.InspectContainerResponse, String, String...)
+     */
+    default Container.ExecResult execInContainerWithUser(String user, String... command)
+        throws UnsupportedOperationException, IOException, InterruptedException {
+        return ExecInContainerPattern.execInContainerWithUser(getDockerClient(), getContainerInfo(), user, command);
+    }
+
+    /**
+     * Run a command inside a running container as a given user, as using "docker exec -u user".
+     * <p>
+     * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, com.github.dockerjava.api.command.InspectContainerResponse, Charset, String, String...)
+     */
+    default Container.ExecResult execInContainerWithUser(Charset outputCharset, String user, String... command)
+        throws UnsupportedOperationException, IOException, InterruptedException {
+        return ExecInContainerPattern.execInContainerWithUser(
+            getDockerClient(),
+            getContainerInfo(),
+            outputCharset,
+            user,
+            command
+        );
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -245,7 +245,7 @@ public interface ContainerState {
      * Run a command inside a running container, as though using "docker exec", and interpreting
      * the output as UTF8.
      * <p>
-     * @see ExecInContainerPattern#execInContainer(com.github.dockerjava.api.command.InspectContainerResponse, String...)
+     * @see #execInContainer(Charset, String...)
      */
     default Container.ExecResult execInContainer(String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {
@@ -255,17 +255,17 @@ public interface ContainerState {
     /**
      * Run a command inside a running container, as though using "docker exec".
      * <p>
-     * @see ExecInContainerPattern#execInContainer(com.github.dockerjava.api.command.InspectContainerResponse, Charset, String...)
+     * @see ExecInContainerPattern#execInContainer(DockerClient, InspectContainerResponse, Charset, String...)
      */
     default Container.ExecResult execInContainer(Charset outputCharset, String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {
-        return execInContainerWithUser(outputCharset, null, command);
+        return ExecInContainerPattern.execInContainer(getDockerClient(), getContainerInfo(), outputCharset, command);
     }
 
     /**
      * Run a command inside a running container as a given user, as using "docker exec -u user".
      * <p>
-     * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, com.github.dockerjava.api.command.InspectContainerResponse, String, String...)
+     * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, InspectContainerResponse, String, String...)
      */
     default Container.ExecResult execInContainerWithUser(String user, String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {
@@ -275,7 +275,7 @@ public interface ContainerState {
     /**
      * Run a command inside a running container as a given user, as using "docker exec -u user".
      * <p>
-     * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, com.github.dockerjava.api.command.InspectContainerResponse, Charset, String, String...)
+     * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, InspectContainerResponse, Charset, String, String...)
      */
     default Container.ExecResult execInContainerWithUser(Charset outputCharset, String user, String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {

--- a/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
+++ b/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.DockerException;
-import com.google.common.base.Strings;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.DockerClientFactory;
@@ -150,7 +149,7 @@ public class ExecInContainerPattern {
             .withAttachStdout(true)
             .withAttachStderr(true)
             .withCmd(command);
-        if (!Strings.isNullOrEmpty(user)) {
+        if (user != null && !user.isEmpty()) {
             log.debug("{}: Running \"exec\" command with user: {}", containerName, user);
             execCreateCmd.withUser(user);
         }
@@ -166,11 +165,7 @@ public class ExecInContainerPattern {
 
             dockerClient.execStartCmd(execCreateCmdResponse.getId()).exec(callback).awaitCompletion();
         }
-        Integer exitCode = dockerClient
-            .inspectExecCmd(execCreateCmdResponse.getId())
-            .exec()
-            .getExitCodeLong()
-            .intValue();
+        int exitCode = dockerClient.inspectExecCmd(execCreateCmdResponse.getId()).exec().getExitCodeLong().intValue();
 
         final Container.ExecResult result = new Container.ExecResult(
             exitCode,

--- a/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
+++ b/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
@@ -1,9 +1,11 @@
 package org.testcontainers.containers;
 
 import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ExecCreateCmd;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.DockerException;
+import com.google.common.base.Strings;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.DockerClientFactory;
@@ -45,7 +47,7 @@ public class ExecInContainerPattern {
         String... command
     ) throws UnsupportedOperationException, IOException, InterruptedException {
         DockerClient dockerClient = DockerClientFactory.instance().client();
-        return execInContainer(dockerClient, containerInfo, outputCharset, command);
+        return execInContainerWithUser(dockerClient, containerInfo, outputCharset, null, command);
     }
 
     /**
@@ -55,34 +57,77 @@ public class ExecInContainerPattern {
      * @param dockerClient the {@link DockerClient}
      * @param containerInfo the container info
      * @param command the command to execute
-     * @see #execInContainer(DockerClient, InspectContainerResponse, Charset, String...)
+     * @see #execInContainerWithUser(DockerClient, InspectContainerResponse, String, String...)
      */
     public Container.ExecResult execInContainer(
         DockerClient dockerClient,
         InspectContainerResponse containerInfo,
         String... command
     ) throws UnsupportedOperationException, IOException, InterruptedException {
-        return execInContainer(dockerClient, containerInfo, StandardCharsets.UTF_8, command);
+        return execInContainerWithUser(dockerClient, containerInfo, StandardCharsets.UTF_8, null, command);
     }
 
     /**
-     * Run a command inside a running container, as though using "docker exec".
+     * Run a command inside a running container, as though using "docker exec", and interpreting
+     * the output as UTF8.
+     * <p></p>
+     * @param dockerClient the {@link DockerClient}
+     * @param containerInfo the container info
+     * @param outputCharset the character set used to interpret the output.
+     * @param command the command to execute
+     * @see #execInContainerWithUser(DockerClient, InspectContainerResponse, Charset, String, String...)
+     */
+    public Container.ExecResult execInContainer(
+        DockerClient dockerClient,
+        InspectContainerResponse containerInfo,
+        Charset outputCharset,
+        String... command
+    ) throws UnsupportedOperationException, IOException, InterruptedException {
+        return execInContainerWithUser(dockerClient, containerInfo, outputCharset, null, command);
+    }
+
+    /**
+     * Run a command inside a running container as a given user, as using "docker exec -u user" and
+     * interpreting the output as UTF8.
      * <p>
      * This functionality is not available on a docker daemon running the older "lxc" execution driver. At
      * the time of writing, CircleCI was using this driver.
      * @param dockerClient the {@link DockerClient}
      * @param containerInfo the container info
+     * @param user the user to run the command with, optional
+     * @param command the command to execute
+     * @see #execInContainerWithUser(DockerClient, InspectContainerResponse, Charset, String,
+     *     String...)
+     */
+    public Container.ExecResult execInContainerWithUser(
+        DockerClient dockerClient,
+        InspectContainerResponse containerInfo,
+        String user,
+        String... command
+    ) throws UnsupportedOperationException, IOException, InterruptedException {
+        return execInContainerWithUser(dockerClient, containerInfo, StandardCharsets.UTF_8, user, command);
+    }
+
+    /**
+     * Run a command inside a running container as a given user, as using "docker exec -u user".
+     * <p>
+     * This functionality is not available on a docker daemon running the older "lxc" execution
+     * driver. At the time of writing, CircleCI was using this driver.
+     * @param dockerClient the {@link DockerClient}
+     * @param containerInfo the container info
      * @param outputCharset the character set used to interpret the output.
+     * @param user the user to run the command with, optional
      * @param command the parts of the command to run
      * @return the result of execution
      * @throws IOException if there's an issue communicating with Docker
      * @throws InterruptedException if the thread waiting for the response is interrupted
      * @throws UnsupportedOperationException if the docker daemon you're connecting to doesn't support "exec".
      */
-    public Container.ExecResult execInContainer(
+    public Container.ExecResult execInContainerWithUser(
         DockerClient dockerClient,
         InspectContainerResponse containerInfo,
         Charset outputCharset,
+        String user,
         String... command
     ) throws UnsupportedOperationException, IOException, InterruptedException {
         if (!TestEnvironment.dockerExecutionDriverSupportsExec()) {
@@ -100,12 +145,17 @@ public class ExecInContainerPattern {
         String containerName = containerInfo.getName();
 
         log.debug("{}: Running \"exec\" command: {}", containerName, String.join(" ", command));
-        final ExecCreateCmdResponse execCreateCmdResponse = dockerClient
+        final ExecCreateCmd execCreateCmd = dockerClient
             .execCreateCmd(containerId)
             .withAttachStdout(true)
             .withAttachStderr(true)
-            .withCmd(command)
-            .exec();
+            .withCmd(command);
+        if (!Strings.isNullOrEmpty(user)) {
+            log.debug("{}: Running \"exec\" command with user: {}", containerName, user);
+            execCreateCmd.withUser(user);
+        }
+
+        final ExecCreateCmdResponse execCreateCmdResponse = execCreateCmd.exec();
 
         final ToStringConsumer stdoutConsumer = new ToStringConsumer();
         final ToStringConsumer stderrConsumer = new ToStringConsumer();
@@ -116,7 +166,11 @@ public class ExecInContainerPattern {
 
             dockerClient.execStartCmd(execCreateCmdResponse.getId()).exec(callback).awaitCompletion();
         }
-        Integer exitCode = dockerClient.inspectExecCmd(execCreateCmdResponse.getId()).exec().getExitCode();
+        Integer exitCode = dockerClient
+            .inspectExecCmd(execCreateCmdResponse.getId())
+            .exec()
+            .getExitCodeLong()
+            .intValue();
 
         final Container.ExecResult result = new Container.ExecResult(
             exitCode,

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -370,6 +370,19 @@ public class GenericContainerRuleTest {
     }
 
     @Test
+    public void testExecInContainerWithUser() throws Exception {
+        // The older "lxc" execution driver doesn't support "exec". At the time of writing (2016/03/29),
+        // that's the case for CircleCI.
+        // Once they resolve the issue, this clause can be removed.
+        Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
+
+        final GenericContainer.ExecResult result = redis.execInContainerWithUser("redis", "whoami");
+        assertThat(result.getStdout()).as("Output for \"whoami\" command should start with \"redis\"").startsWith("redis");
+        assertThat(result.getStderr()).as("Stderr for \"whoami\" command should be empty").isEmpty();
+        // We expect to reach this point for modern Docker versions.
+    }
+
+    @Test
     public void extraHostTest() throws IOException {
         BufferedReader br = getReaderForContainerPort80(alpineExtrahost);
 

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -377,7 +377,9 @@ public class GenericContainerRuleTest {
         Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
 
         final GenericContainer.ExecResult result = redis.execInContainerWithUser("redis", "whoami");
-        assertThat(result.getStdout()).as("Output for \"whoami\" command should start with \"redis\"").startsWith("redis");
+        assertThat(result.getStdout())
+            .as("Output for \"whoami\" command should start with \"redis\"")
+            .startsWith("redis");
         assertThat(result.getStderr()).as("Stderr for \"whoami\" command should be empty").isEmpty();
         // We expect to reach this point for modern Docker versions.
     }


### PR DESCRIPTION
<!--
Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Hey folks,
first of all many thanks for this great library!

We are about the change the default user used in our docker image on https://github.com/camunda/zeebe from root to a less privileged user to better comply with [docker security best practices](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user).

Unfortunately we have some test setup code where we'd like to make use of root privileges still though 🙃 . We thus made use of the docker-java-api directly bypassing the [`ContainerState.execInContainer`](https://github.com/testcontainers/testcontainers-java/blob/main/core/src/main/java/org/testcontainers/containers/ContainerState.java#L250) API offered by you to run commands, which we used previously. 

Thus we figured it would be nice to expose the [`ExecCreateCmd.withUser`](https://github.com/docker-java/docker-java/blob/main/docker-java-api/src/main/java/com/github/dockerjava/api/command/ExecCreateCmd.java#L51) API provided by the docker-java-api on testcontainer's ContainerState.

Curious on your feedback on this proposed change!
