### PR TITLE
Make RabbitMQ SSL configuration compatible with 3.9+ (#5599)

### DIFF
--- a/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
+++ b/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
@@ -603,4 +603,29 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
             throw new RuntimeException("Failed to convert arguments into json: " + e.getMessage(), e);
         }
     }
+
+    private String createAdvancedConfigFileContent(
+        final SslVerification verify,
+        boolean failIfNoCert,
+        int verificationDepth
+    ) {
+        return String.format(
+            "[\n" +
+            "  {rabbit, [{ssl_listeners, [%d]},\n" +
+            "            {ssl_options,   [{cacertfile,           \"%s\"},\n" +
+            "                             {certfile,             \"%s\"},\n" +
+            "                             {keyfile,              \"%s\"},\n" +
+            "                             {verify,               %s},\n" +
+            "                             {fail_if_no_peer_cert, %b},\n" +
+            "                             {depth,                %d}]}]}\n" +
+            "].",
+            DEFAULT_AMQPS_PORT,
+            null,
+            null,
+            null,
+            verify.value,
+            failIfNoCert,
+            verificationDepth
+        );
+    }
 }

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerJUnitIntegrationTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerJUnitIntegrationTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RabbitMQContainerJUnitIntegrationTest {
 
     @ClassRule
-    public static RabbitMQContainer rabbitMQContainer = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE);
+    public static RabbitMQContainer rabbitMQContainer = new RabbitMQContainer(RabbitMQTestImages.RABBITMQ_IMAGE_3_12);
 
     @Test
     public void shouldStart() {

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQContainerTest.java
@@ -120,8 +120,7 @@ public class RabbitMQContainerTest {
             container.start();
 
             assertThat(container.execInContainer("rabbitmqctl", "list_queues", "name", "arguments").getStdout())
-                .containsPattern("queue-one");
-            assertThat(container.execInContainer("rabbitmqctl", "list_queues", "name", "arguments").getStdout())
+                .containsPattern("queue-one")
                 .containsPattern("queue-two\\s.*x-message-ttl");
         }
     }

--- a/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQTestImages.java
+++ b/modules/rabbitmq/src/test/java/org/testcontainers/containers/RabbitMQTestImages.java
@@ -3,5 +3,7 @@ package org.testcontainers.containers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface RabbitMQTestImages {
-    DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.7.25-management-alpine");
+    DockerImageName RABBITMQ_IMAGE_3_7 = DockerImageName.parse("rabbitmq:3.7-management");
+    DockerImageName RABBITMQ_IMAGE_3_9 = DockerImageName.parse("rabbitmq:3.9-management");
+    DockerImageName RABBITMQ_IMAGE_3_12 = DockerImageName.parse("rabbitmq:3.12-management");
 }


### PR DESCRIPTION
Enables configuring RabbitMQ SSL for RabbitMQ 3.9+ versions. Until 3.9, SSL could be configured by environment variables. These variables were deprecated in RabbitMQ 3.9 version. If defined, the broker is generating an error on startup.

We solved this issue by adding an additional advanced configuration file that is merged with the default configuration file included in the Docker image.
We chose this solution because the advanced configuration is not configured using Testcontainers DSL, and it doesn't interfere with the optional configuration added with withRabbitMQConfig method.

RabbitMQ container tests have been update to make them parametrized to run all the tests on different versions of RabbitMQ. We choose the following:
- 3.7 which was the version used in this project
- 3.9 which introduce a change in SSL configuration
- 3.12 which is the latest one

Co-authored-by: Joan Fisbein <joan@fisbein.com>
Co-authored-by: Marcin Gryszko <mgryszko@gmail.com>
Co-authored-by: Julien Giovaresco <dev@giovaresco.fr>

Fixes #5599

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before committing, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
