### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -24,4 +24,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies
 
-      - uses: gradle/wrapper-validation-action@8d49e559aae34d3e0eb16cde532684bc9702762b # v1.0.3
+      - uses: gradle/wrapper-validation-action@56b90f209b02bf6d1deae490e9ef18b21a389cd4 # v1.0.3

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'me.champeau.gradle.japicmp' version '0.4.1' apply false
+    id 'me.champeau.gradle.japicmp' version '0.4.2' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
 }
 

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.2.3.RELEASE"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.3"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.3"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.3"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.9.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('org.seleniumhq.selenium:selenium-bom:4.10.0')
+    implementation platform('org.seleniumhq.selenium:selenium-bom:4.11.0')
     implementation 'org.seleniumhq.selenium:selenium-remote-driver'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'
 
-    testImplementation platform('io.cucumber:cucumber-bom:7.12.1')
+    testImplementation platform('io.cucumber:cucumber-bom:7.13.0')
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit'
     testImplementation 'org.testcontainers:selenium'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.10'
+    testImplementation 'io.nats:jnats:2.16.13'
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
     }
 }
 

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.apache.curator:curator-framework:5.4.0'
+    testImplementation 'org.apache.curator:curator-framework:5.5.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.azure:azure-cosmos:4.47.0'
+    testImplementation 'com.azure:azure-cosmos:4.48.0'
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -10,6 +10,6 @@ dependencies {
     api project(":database-commons")
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
-    testImplementation 'com.datastax.oss:java-driver-core:4.16.0'
+    testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.7'
+    testImplementation 'com.couchbase.client:java-client:3.4.8'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.500'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.500'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.520'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.520'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.8.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.9.0"
     testImplementation "org.elasticsearch.client:transport:7.17.11"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.18.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.21.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api(project(":testcontainers"))
     api("org.jetbrains:annotations:24.0.1")
 
-    shaded("org.apache.commons:commons-lang3:3.12.0")
+    shaded("org.apache.commons:commons-lang3:3.13.0")
     shaded("commons-io:commons-io:2.13.0")
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.5")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.3")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.16.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.1")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.8")
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.3")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 }
 
 test {

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.influxdb:influxdb-java:2.23'
-    testImplementation "com.influxdb:influxdb-client-java:6.9.0"
+    testImplementation "com.influxdb:influxdb-client-java:6.10.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':jdbc')
 
-    api 'com.google.guava:guava:32.1.1-jre'
+    api 'com.google.guava:guava:32.1.2-jre'
     api 'org.apache.commons:commons-lang3:3.12.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.7'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.10'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.11'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    implementation platform('org.junit:junit-bom:5.9.3')
+    implementation platform('org.junit:junit-bom:5.10.0')
     implementation 'org.junit.jupiter:junit-jupiter-api'
 
     testImplementation project(':mysql')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.7.2'
+    testImplementation 'io.fabric8:kubernetes-client:6.8.0'
     testImplementation 'io.kubernetes:client-java:18.0.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.97'
+    testImplementation 'software.amazon.awssdk:s3:2.20.117'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.500")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.520")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.10.1")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.10.2")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.3.1.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.0.jre8-preview'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.20"
+    api "com.orientechnologies:orientdb-client:3.2.21"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.4'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.4'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.20"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.21"
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.2'
+    testImplementation 'org.questdb:questdb:7.2.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.7'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.8'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Redpanda"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.5.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     provided 'org.seleniumhq.selenium:selenium-remote-driver:4.10.0'
     provided 'org.seleniumhq.selenium:selenium-chrome-driver:4.10.0'
 
-    testImplementation platform('org.seleniumhq.selenium:selenium-bom:4.10.0')
+    testImplementation platform('org.seleniumhq.selenium:selenium-bom:4.11.0')
     testImplementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     testImplementation 'org.seleniumhq.selenium:selenium-edge-driver'
     testImplementation 'org.seleniumhq.selenium:selenium-support'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.3'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.9.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.0'
 
     testCompileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:420'
+    testRuntimeOnly 'io.trino:trino-jdbc:422'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.13.4"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
         classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.azure:azure-cosmos from 4.47.0 to 4.48.0 in /modules/azure (#7387) @app/dependabot
* Bump io.trino:trino-jdbc from 420 to 422 in /modules/trino (#7386) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.97 to 2.20.117 in /modules/localstack (#7385) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-bom from 1.12.500 to 1.12.520 in /modules/localstack (#7384) @app/dependabot
* Bump gradle/wrapper-validation-action from 1.0.6 to 1.1.0 (#7383) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.5.0 to 3.5.1 in /modules/redpanda (#7382) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.18.0 to 26.21.0 in /modules/gcloud (#7381) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-bom from 4.10.0 to 4.11.0 in /modules/selenium (#7380) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-bom from 4.10.0 to 4.11.0 in /examples (#7379) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.11 to 1.11.1 in /examples (#7378) @app/dependabot
* Bump org.apache.curator:curator-framework from 5.4.0 to 5.5.0 in /examples (#7377) @app/dependabot
* Bump io.cucumber:cucumber-bom from 7.12.1 to 7.13.0 in /examples (#7376) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.3 to 5.10.0 in /examples (#7375) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.2 to 5.10.0 in /examples (#7374) @app/dependabot
* Bump me.champeau.gradle.japicmp from 0.4.1 to 0.4.2 in /examples (#7373) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.6 to 3.14.1 in /examples (#7372) @app/dependabot
* Bump io.nats:jnats from 2.16.10 to 2.16.13 in /examples (#7370) @app/dependabot
* Bump org.gradle.toolchains:foojay-resolver from 0.4.0 to 0.6.0 in /examples (#7369) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.8.2 to 8.9.0 in /modules/elasticsearch (#7367) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.10.1 to 4.10.2 in /modules/mongodb (#7366) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.10 to 10.1.11 in /modules/jdbc (#7365) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.7 to 3.4.8 in /modules/couchbase (#7364) @app/dependabot
* Bump org.junit:junit-bom from 5.9.3 to 5.10.0 in /modules/junit-jupiter (#7363) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.500 to 1.12.520 in /modules/dynalite (#7362) @app/dependabot
* Bump com.datastax.oss:java-driver-core from 4.16.0 to 4.17.0 in /modules/cassandra (#7361) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.7.2 to 6.8.0 in /modules/k3s (#7360) @app/dependabot
* Bump io.kubernetes:client-java from 18.0.0 to 18.0.1 in /modules/k3s (#7359) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.9.3 to 1.10.0 in /modules/spock (#7357) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.9.3 to 1.10.0 in /modules/spock (#7356) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.3.1.jre8-preview to 12.4.0.jre8-preview in /modules/mssqlserver (#7354) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.20 to 3.2.21 in /modules/orientdb (#7353) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.20 to 3.2.21 in /modules/orientdb (#7352) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.9.0 to 6.10.0 in /modules/influxdb (#7351) @app/dependabot
* Bump org.questdb:questdb from 7.2 to 7.2.1 in /modules/questdb (#7350) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.9.3 to 5.10.0 in /modules/hivemq (#7349) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.9.3 to 5.10.0 in /modules/hivemq (#7348) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.12.0 to 3.13.0 in /modules/hivemq (#7347) @app/dependabot
* Bump com.google.guava:guava from 32.1.1-jre to 32.1.2-jre in /modules/jdbc-test (#7346) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.12.0 to 3.13.0 in /modules/jdbc-test (#7345) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.13.4 to 3.14.1 (#7343) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.7 to 3.5.8 in /modules/r2dbc (#7341) @app/dependabot
