### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 }

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.12.6"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.14.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
     }
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.9.0"
-    testImplementation "org.elasticsearch.client:transport:7.17.11"
+    testImplementation "org.elasticsearch.client:transport:7.17.12"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.16.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.18.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.1")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.8")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(':jdbc')
 
     api 'com.google.guava:guava:32.1.2-jre'
-    api 'org.apache.commons:commons-lang3:3.12.0'
+    api 'org.apache.commons:commons-lang3:3.13.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.7'
 

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.8.0'
-    testImplementation 'io.kubernetes:client-java:18.0.0'
+    testImplementation 'io.kubernetes:client-java:18.0.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.5.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.0.jre8-preview'
 
     testImplementation project(':r2dbc')
-    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.1.RELEASE'
+    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':r2dbc'))

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.0'
 
     testCompileOnly 'org.jetbrains:annotations:24.0.1'

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.14.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
-        classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
+        classpath "org.gradle.toolchains:foojay-resolver:0.6.0"
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.13.4"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.14.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
         classpath "org.gradle.toolchains:foojay-resolver:0.4.0"
     }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.12.6 to 3.14.1 in /examples (#7372) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.9.2 to 5.10.0 in /examples (#7371) @app/dependabot
* Bump org.gradle.toolchains:foojay-resolver from 0.4.0 to 0.6.0 in /examples (#7369) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.11 to 7.17.12 in /modules/elasticsearch (#7368) @app/dependabot
* Bump io.kubernetes:client-java from 18.0.0 to 18.0.1 in /modules/k3s (#7359) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.5.0 to 3.5.1 in /modules/kafka (#7358) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.9.3 to 1.10.0 in /modules/spock (#7356) @app/dependabot
* Bump io.r2dbc:r2dbc-mssql from 1.0.1.RELEASE to 1.0.2.RELEASE in /modules/mssqlserver (#7355) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.12.0 to 3.13.0 in /modules/jdbc-test (#7345) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.16.0 to 4.18.0 in /modules/hivemq (#7344) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.13.4 to 3.14.1 (#7343) @app/dependabot
