### PR TITLE
Properly invoke the custom wait strategy if one exists for MSSQL cont…

### DIFF
--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -127,6 +127,11 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
         return self();
     }
 
+    @Override
+    protected void waitUntilContainerStarted() {
+        getWaitStrategy().waitUntilReady(this);
+    }
+
     private void checkPasswordStrength(String password) {
         if (password == null) {
             throw new IllegalArgumentException("Null password is not allowed");


### PR DESCRIPTION
Without this change, the `MSSQLServerContainer` container ignores any custom wait strategy that is defined using the `waitFor` builder method. All of the other container classes have this overriden. The practical difference is that without a custom wait strategy, it will instead default to `HostPortWaitStrategy` instead of issuing statements against the DB. Thanks!