### PR TITLE
Fix call to stop containers when using parallel in JUnit Jupiter Extension

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -71,7 +71,13 @@ public class TestcontainersExtension
         }
 
         if (isParallelExecutionEnabled(context)) {
-            Startables.deepStart(storeAdapters.stream().map(storeAdapter -> storeAdapter.container)).join();
+            Stream<Startable> startables = storeAdapters
+                .stream()
+                .map(storeAdapter -> {
+                    store.getOrComputeIfAbsent(storeAdapter.getKey(), k -> storeAdapter);
+                    return storeAdapter.container;
+                });
+            Startables.deepStart(startables).join();
         } else {
             storeAdapters.forEach(adapter -> store.getOrComputeIfAbsent(adapter.getKey(), k -> adapter.start()));
         }


### PR DESCRIPTION
Currently, containers are shutdown because of JVMHookResourceReaper instead
of Ryuk when enabling parallel using `@Testcontainers`. This commits,
register containers to be initialized so `stop()` is called.
