### PR TITLE
Support icr.io/db2_community/db2 as a compatible image

### DIFF
--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -12,7 +12,10 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
 
     public static final String NAME = "db2";
 
+    @Deprecated
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("ibmcom/db2");
+
+    private static final DockerImageName DEFAULT_NEW_IMAGE_NAME = DockerImageName.parse("icr.io/db2_community/db2");
 
     @Deprecated
     public static final String DEFAULT_DB2_IMAGE_NAME = DEFAULT_IMAGE_NAME.getUnversionedPart();
@@ -42,7 +45,7 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
 
     public Db2Container(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_NEW_IMAGE_NAME, DEFAULT_IMAGE_NAME);
 
         withPrivilegedMode(true);
         this.waitStrategy =

--- a/modules/db2/src/test/java/org/testcontainers/junit/db2/SimpleDb2Test.java
+++ b/modules/db2/src/test/java/org/testcontainers/junit/db2/SimpleDb2Test.java
@@ -26,6 +26,19 @@ public class SimpleDb2Test extends AbstractContainerDatabaseTest {
     }
 
     @Test
+    public void testSimpleWithNewImage() throws SQLException {
+        try (Db2Container db2 = new Db2Container("icr.io/db2_community/db2:11.5.8.0").acceptLicense()) {
+            db2.start();
+
+            ResultSet resultSet = performQuery(db2, "SELECT 1 FROM SYSIBM.SYSDUMMY1");
+
+            int resultSetInt = resultSet.getInt(1);
+            assertThat(resultSetInt).as("A basic SELECT query succeeds").isEqualTo(1);
+            assertHasCorrectExposedAndLivenessCheckPorts(db2);
+        }
+    }
+
+    @Test
     public void testWithAdditionalUrlParamInJdbcUrl() {
         try (
             Db2Container db2 = new Db2Container(Db2TestImages.DB2_IMAGE)


### PR DESCRIPTION
`ibmcom/db2` is deprecated. New image location is `icr.io/db2_community/db2`
