### PR TITLE
Fix broken tabs in Consul module docs

### DIFF
--- a/docs/modules/consul.md
+++ b/docs/modules/consul.md
@@ -19,18 +19,20 @@ test how your application behaves with Consul by writing different test scenario
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:
 
-```groovy tab='Gradle'
-testImplementation "org.testcontainers:consul:{{latest_version}}"
-```
+=== "Gradle"
+    ```groovy
+    testImplementation "org.testcontainers:consul:{{latest_version}}"
+    ```
 
-```xml tab='Maven'
-<dependency>
-    <groupId>org.testcontainers</groupId>
-    <artifactId>consul</artifactId>
-    <version>{{latest_version}}</version>
-    <scope>test</scope>
-</dependency>
-```
+=== "Maven"
+    ```xml
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>consul</artifactId>
+        <version>{{latest_version}}</version>
+        <scope>test</scope>
+    </dependency>
+    ```
 
 See [AUTHORS](https://raw.githubusercontent.com/testcontainers/testcontainers-java/main/modules/consul/AUTHORS) for contributors.
 


### PR DESCRIPTION
![image](https://github.com/testcontainers/testcontainers-java/assets/11611397/03de3ba4-55c8-426e-9471-e88ee27f1d91)
Before (https://java.testcontainers.org/modules/consul/)

![image](https://github.com/testcontainers/testcontainers-java/assets/11611397/ebc84921-db9d-4675-b652-fc728ffdf347)
After (ran it locally)

Also, I noticed that [AUTHOR link](https://raw.githubusercontent.com/testcontainers/testcontainers-java/main/modules/consul/AUTHORS) is not working, since there is no  `modules/consul/AUTHOR` file. Seems like `AUTHOR` files are not maintained and we can check it via github [contributors](https://github.com/testcontainers/testcontainers-java/graphs/contributors) listing. How do you think about clean it?