### PR TITLE
Improve javadoc for Testcontainers implementations

### DIFF
--- a/modules/azure/src/main/java/org/testcontainers/containers/CosmosDBEmulatorContainer.java
+++ b/modules/azure/src/main/java/org/testcontainers/containers/CosmosDBEmulatorContainer.java
@@ -6,7 +6,9 @@ import org.testcontainers.utility.DockerImageName;
 import java.security.KeyStore;
 
 /**
- * An Azure CosmosDB container
+ * Testcontainers implementation for CosmosDB Emulator.
+ * <p>
+ * Exposed ports: 8081
  */
 public class CosmosDBEmulatorContainer extends GenericContainer<CosmosDBEmulatorContainer> {
 

--- a/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
+++ b/modules/cassandra/src/main/java/org/testcontainers/containers/CassandraContainer.java
@@ -19,9 +19,9 @@ import java.util.Optional;
 import javax.script.ScriptException;
 
 /**
- * Cassandra container
- *
  * Testcontainers implementation for Apache Cassandra.
+ * <p>
+ * Exposed ports: 9042
  */
 public class CassandraContainer<SELF extends CassandraContainer<SELF>> extends GenericContainer<SELF> {
 

--- a/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseContainer.java
@@ -10,6 +10,12 @@ import java.util.Set;
 
 /**
  * Testcontainers implementation for ClickHouse.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Database: 8123</li>
+ *     <li>Console: 9000</li>
+ * </ul>
  */
 public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContainer> {
 

--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -6,6 +6,15 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 
+/**
+ * Testcontainers implementation for CockroachDB.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Database: 26257</li>
+ *     <li>Console: 8080</li>
+ * </ul>
+ */
 public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("cockroachdb/cockroach");

--- a/modules/consul/src/main/java/org/testcontainers/consul/ConsulContainer.java
+++ b/modules/consul/src/main/java/org/testcontainers/consul/ConsulContainer.java
@@ -14,6 +14,12 @@ import java.util.stream.Collectors;
 
 /**
  * Testcontainers implementation for Consul.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>HTTP: 8500</li>
+ *     <li>gRPC: 8502</li>
+ * </ul>
  */
 public class ConsulContainer extends GenericContainer<ConsulContainer> {
 

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -48,7 +48,12 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
- * The couchbase container initializes and configures a Couchbase Server single node cluster.
+ * Testcontainers implementation for Couchbase.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Console: 8091</li>
+ * </ul>
  * <p>
  * Note that it does not depend on a specific couchbase SDK, so it can be used with both the Java SDK 2 and 3 as well
  * as the Scala SDK 1 or newer. We recommend using the latest and greatest SDKs for the best experience.

--- a/modules/cratedb/src/main/java/org/testcontainers/cratedb/CrateDBContainer.java
+++ b/modules/cratedb/src/main/java/org/testcontainers/cratedb/CrateDBContainer.java
@@ -7,6 +7,15 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.Set;
 
+/**
+ * Testcontainers implementation for CrateDB.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Database: 5432</li>
+ *     <li>Console: 4200</li>
+ * </ul>
+ */
 public class CrateDBContainer extends JdbcDatabaseContainer<CrateDBContainer> {
 
     static final String NAME = "cratedb";

--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -8,6 +8,14 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 
+/**
+ * Testcontainers implementation for IBM DB2.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Database: 50000</li>
+ * </ul>
+ */
 public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
 
     public static final String NAME = "db2";

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -23,8 +23,13 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 
 /**
- * Represents an elasticsearch docker instance which exposes by default port 9200 and 9300 (transport.tcp.port)
- * The docker image is by default fetched from docker.elastic.co/elasticsearch/elasticsearch
+ * Testcontainers implementation for Elasticsearch.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>HTTP: 9200</li>
+ *     <li>TCP Transport: 9300</li>
+ * </ul>
  */
 @Slf4j
 public class ElasticsearchContainer extends GenericContainer<ElasticsearchContainer> {

--- a/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
+++ b/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
@@ -29,6 +29,16 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+/**
+ * Testcontainers implementation for HiveMQ.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>MQTT: 1883</li>
+ *     <li>Control Center: 8080</li>
+ *     <li>Debug: 9000</li>
+ * </ul>
+ */
 public class HiveMQContainer extends GenericContainer<HiveMQContainer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(HiveMQContainer.class);

--- a/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
+++ b/modules/influxdb/src/main/java/org/testcontainers/containers/InfluxDBContainer.java
@@ -13,6 +13,8 @@ import java.util.Set;
 
 /**
  * Testcontainers implementation for InfluxDB.
+ * <p>
+ * Exposed ports: 8086
  */
 public class InfluxDBContainer<SELF extends InfluxDBContainer<SELF>> extends GenericContainer<SELF> {
 

--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -9,7 +9,14 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.Objects;
 
 /**
- * This container wraps Confluent Kafka and Zookeeper (optionally)
+ * Testcontainers implementation for Apache Kafka.
+ * Zookeeper can be optionally configured.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Kafka: 9093</li>
+ *     <li>Zookeeper: 2181</li>
+ * </ul>
  */
 public class KafkaContainer extends GenericContainer<KafkaContainer> {
 

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -22,6 +22,8 @@ import java.util.stream.Collectors;
 
 /**
  * Testcontainers implementation for LocalStack.
+ * <p>
+ * Exposed ports: 4566
  */
 @Slf4j
 public class LocalStackContainer extends GenericContainer<LocalStackContainer> {

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -7,7 +7,9 @@ import org.testcontainers.utility.DockerImageName;
 import java.util.Set;
 
 /**
- * Container implementation for the MariaDB project.
+ * Testcontainers implementation for MariaDB.
+ * <p>
+ * Exposed ports: 3306
  */
 public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 

--- a/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/containers/MongoDBContainer.java
@@ -11,9 +11,9 @@ import org.testcontainers.utility.MountableFile;
 import java.io.IOException;
 
 /**
- * Constructs a single node MongoDB replica set for testing transactions.
- * <p>To construct a multi-node MongoDB cluster, consider the <a href="https://github.com/silaev/mongodb-replica-set/">mongodb-replica-set project on GitHub</a>
- * <p>Tested on a MongoDB version 4.0.10+ (that is the default version if not specified).
+ * Testcontainers implementation for MongoDB.
+ * <p>
+ * Exposed ports: 27017
  */
 @Slf4j
 public class MongoDBContainer extends GenericContainer<MongoDBContainer> {

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -7,6 +7,11 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+/**
+ * Testcontainers implementation for Microsoft SQL Server.
+ * <p>
+ * Exposed ports: 1433
+ */
 public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mcr.microsoft.com/mssql/server");

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -6,6 +6,11 @@ import org.testcontainers.utility.DockerImageName;
 
 import java.util.Set;
 
+/**
+ * Testcontainers implementation for MySQL.
+ * <p>
+ * Exposed ports: 3306
+ */
 public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
     public static final String NAME = "mysql";

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -20,9 +20,14 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
- * Testcontainer for Neo4j.
- *
- * @param <S> "SELF" to be used in the <code>withXXX</code> methods.
+ * Testcontainers implementation for Neo4j.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Bolt: 7687</li>
+ *     <li>HTTP: 7474</li>
+ *     <li>HTTPS: 7473</li>
+ * </ul>
  */
 public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContainer<S> {
 

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -13,6 +13,11 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Future;
 
+/**
+ * Testcontainers implementation for Oracle.
+ * <p>
+ * Exposed ports: 1521
+ */
 public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     public static final String NAME = "oracle";

--- a/modules/orientdb/src/main/java/org/testcontainers/containers/OrientDBContainer.java
+++ b/modules/orientdb/src/main/java/org/testcontainers/containers/OrientDBContainer.java
@@ -19,6 +19,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Optional;
 
+/**
+ * Testcontainers implementation for OrientDB.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Database: 2424</li>
+ *     <li>Studio: 2480</li>
+ * </ul>
+ */
 public class OrientDBContainer extends GenericContainer<OrientDBContainer> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OrientDBContainer.class);

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLContainer.java
@@ -8,6 +8,11 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Set;
 
+/**
+ * Testcontainers implementation for PostgreSQL.
+ * <p>
+ * Exposed ports: 5432
+ */
 public class PostgreSQLContainer<SELF extends PostgreSQLContainer<SELF>> extends JdbcDatabaseContainer<SELF> {
 
     public static final String NAME = "postgresql";

--- a/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
+++ b/modules/pulsar/src/main/java/org/testcontainers/containers/PulsarContainer.java
@@ -5,7 +5,13 @@ import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * This container wraps Apache Pulsar running in standalone mode
+ * Testcontainers implementation for Apache Pulsar.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Pulsar: 6650</li>
+ *     <li>HTTP: 8080</li>
+ * </ul>
  */
 public class PulsarContainer extends GenericContainer<PulsarContainer> {
 

--- a/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
+++ b/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
@@ -6,6 +6,13 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Testcontainers implementation for QuestDB.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Postgres: 8812</li>
+ *     <li>HTTP: 9000</li>
+ *     <li>ILP: 9009</li>
+ * </ul>
  */
 public class QuestDBContainer extends JdbcDatabaseContainer<QuestDBContainer> {
 

--- a/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
+++ b/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
@@ -18,6 +18,14 @@ import java.util.Set;
 
 /**
  * Testcontainers implementation for RabbitMQ.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>5671 (AMQPS)</li>
+ *     <li>5672 (AMQP)</li>
+ *     <li>15671 (HTTPS)</li>
+ *     <li>15672 (HTTP)</li>
+ * </ul>
  */
 public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
 

--- a/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
+++ b/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
@@ -9,6 +9,12 @@ import org.testcontainers.utility.DockerImageName;
 
 /**
  * Testcontainers implementation for Redpanda.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Broker: 9092</li>
+ *     <li>Schema Registry: 8081</li>
+ * </ul>
  */
 public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
 

--- a/modules/solace/src/main/java/org/testcontainers/solace/SolaceContainer.java
+++ b/modules/solace/src/main/java/org/testcontainers/solace/SolaceContainer.java
@@ -16,7 +16,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Testcontainers implementation of Solace PubSub+
+ * Testcontainers implementation of Solace PubSub+.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>AMQP: 5672</li>
+ *     <li>MQTT: 1883</li>
+ *     <li>HTTP: 9000</li>
+ *     <li>SMF: 55555</li>
+ *     <li>SMF SSL: 55443</li>
+ * </ul>
  */
 public class SolaceContainer extends GenericContainer<SolaceContainer> {
 

--- a/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
+++ b/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
@@ -13,7 +13,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * SolrContainer allows a solr container to be launched and controlled.
+ * Testcontainers implementation for Solr.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Solr: 8983</li>
+ *     <li>Zookeeper: 9983</li>
+ * </ul>
  */
 public class SolrContainer extends GenericContainer<SolrContainer> {
 

--- a/modules/tidb/src/main/java/org/testcontainers/tidb/TiDBContainer.java
+++ b/modules/tidb/src/main/java/org/testcontainers/tidb/TiDBContainer.java
@@ -10,6 +10,12 @@ import java.util.Set;
 
 /**
  * Testcontainers implementation for TiDB.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Database: 4000</li>
+ *     <li>HTTP: 10080</li>
+ * </ul>
  */
 public class TiDBContainer extends JdbcDatabaseContainer<TiDBContainer> {
 

--- a/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
+++ b/modules/toxiproxy/src/main/java/org/testcontainers/containers/ToxiproxyContainer.java
@@ -17,7 +17,13 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Container for resiliency testing using <a href="https://github.com/Shopify/toxiproxy">Toxiproxy</a>.
+ * Testcontainers implementation for Toxiproxy.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>HTTP: 8474</li>
+ *     <li>Proxied Ports: 8666-8697</li>
+ * </ul>
  */
 public class ToxiproxyContainer extends GenericContainer<ToxiproxyContainer> {
 

--- a/modules/trino/src/main/java/org/testcontainers/containers/TrinoContainer.java
+++ b/modules/trino/src/main/java/org/testcontainers/containers/TrinoContainer.java
@@ -9,6 +9,11 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Set;
 
+/**
+ * Testcontainers implementation for TrinoDB.
+ * <p>
+ * Exposed ports: 8080
+ */
 public class TrinoContainer extends JdbcDatabaseContainer<TrinoContainer> {
 
     static final String NAME = "trino";

--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -16,11 +16,9 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
- * GenericContainer subclass for Vault specific configuration and features. The main feature is the
- * withSecretInVault method, where users can specify which secrets to be pre-loaded into Vault for
- * their specific test scenario.
+ * Testcontainers implementation for Vault.
  * <p>
- * Other helpful features include the withVaultPort, and withVaultToken methods for convenience.
+ * Exposure ports: 8200
  */
 public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericContainer<SELF> {
 

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYCQLContainer.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYCQLContainer.java
@@ -13,6 +13,13 @@ import java.util.Set;
 
 /**
  * Testcontainers implementation for YugabyteDB YCQL API.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>YCQL: 5433</li>
+ *     <li>Master dashboard: 7000</li>
+ *     <li>Tserver dashboard: 9000</li>
+ * </ul>
  *
  * @see <a href="https://docs.yugabyte.com/stable/api/ycql/">YCQL API</a>
  */

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
@@ -9,10 +9,16 @@ import java.util.Set;
 
 /**
  * Testcontainers implementation for YugabyteDB YSQL API.
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>YSQL: 5433</li>
+ *     <li>Master dashboard: 7000</li>
+ *     <li>Tserver dashboard: 9000</li>
+ * </ul>
  *
  * @see <a href="https://docs.yugabyte.com/stable/api/ysql/">YSQL API</a>
  */
-
 public class YugabyteDBYSQLContainer extends JdbcDatabaseContainer<YugabyteDBYSQLContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("yugabytedb/yugabyte");


### PR DESCRIPTION
Add exposed ports in the documentation.

It is useful for [Testcontainers Desktop](https://testcontainers.com/desktop/) and fixed ports.