### PR TITLE
Use stop instead of kill to stop containers

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -195,7 +195,7 @@ public class ResourceReaper {
         if (running) {
             try {
                 LOGGER.trace("Stopping container: {}", containerId);
-                dockerClient.killContainerCmd(containerId).exec();
+                dockerClient.stopContainerCmd(containerId).exec();
                 LOGGER.trace("Stopped container: {}", imageName);
             } catch (Exception e) {
                 LOGGER.trace(


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:
Make sure to add it to `bug_report.yaml`, `enhancement.yaml` and `feature.yaml`.
Also, add it to `dependabot.yml` and `labeler.yml`.

Before committing, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Switched from docker kill command to docker stop command to give containers an opportunity to stop gracefully.
This is useful for testing various shutdown hooks, i.e.: akka http/streams, jvm, etc... with Testcontainers.
