### PR TITLE
Log image pull and container startup time independently

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -383,7 +383,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             String dockerImageName = getDockerImageName();
             logger().debug("Starting container: {}", dockerImageName);
 
-            Instant createdAt = Instant.now();
+            Instant startedAt = Instant.now();
             logger().info("Creating container for image: {}", dockerImageName);
             CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName);
             applyConfiguration(createCommand);
@@ -539,7 +539,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 throw e;
             }
 
-            logger().info("Container {} started in {}", dockerImageName, Duration.between(createdAt, Instant.now()));
+            logger().info("Container {} started in {}", dockerImageName, Duration.between(startedAt, Instant.now()));
             containerIsStarted(containerInfo, reused);
         } catch (Exception e) {
             if (e instanceof UndeclaredThrowableException && e.getCause() instanceof Exception) {

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1496,7 +1496,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     }
 
     /**
-     * Allow low level modifications of {@link CreateContainerCmd} after it was pre-configured in {@link #tryStart(Instant)}.
+     * Allow low level modifications of {@link CreateContainerCmd} after it was pre-configured in {@link #tryStart()}.
      * Invocation happens eagerly on a moment when container is created.
      * Warning: this does expose the underlying docker-java API so might change outside of our control.
      *

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -338,8 +338,6 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         try {
             configure();
 
-            Instant startedAt = Instant.now();
-
             logger().debug("Starting container: {}", getDockerImageName());
 
             AtomicInteger attempt = new AtomicInteger(0);
@@ -353,7 +351,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                             attempt.incrementAndGet(),
                             startupAttempts
                         );
-                    tryStart(startedAt);
+                    tryStart();
                     return true;
                 }
             );
@@ -380,11 +378,12 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         return true;
     }
 
-    private void tryStart(Instant startedAt) {
+    private void tryStart() {
         try {
             String dockerImageName = getDockerImageName();
             logger().debug("Starting container: {}", dockerImageName);
 
+            Instant createdAt = Instant.now();
             logger().info("Creating container for image: {}", dockerImageName);
             CreateContainerCmd createCommand = dockerClient.createContainerCmd(dockerImageName);
             applyConfiguration(createCommand);
@@ -540,7 +539,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 throw e;
             }
 
-            logger().info("Container {} started in {}", dockerImageName, Duration.between(startedAt, Instant.now()));
+            logger().info("Container {} started in {}", dockerImageName, Duration.between(createdAt, Instant.now()));
             containerIsStarted(containerInfo, reused);
         } catch (Exception e) {
             if (e instanceof UndeclaredThrowableException && e.getCause() instanceof Exception) {

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -81,7 +81,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
             final Instant lastRetryAllowed = Instant.now().plus(PULL_RETRY_TIME_LIMIT);
 
             Instant startedAt = Instant.now();
-            while (startedAt.isBefore(lastRetryAllowed)) {
+            while (Instant.now().isBefore(lastRetryAllowed)) {
                 try {
                     PullImageCmd pullImageCmd = dockerClient
                         .pullImageCmd(imageName.getUnversionedPart())

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -80,7 +80,8 @@ public class RemoteDockerImage extends LazyFuture<String> {
             Exception lastFailure = null;
             final Instant lastRetryAllowed = Instant.now().plus(PULL_RETRY_TIME_LIMIT);
 
-            while (Instant.now().isBefore(lastRetryAllowed)) {
+            Instant startedAt = Instant.now();
+            while (startedAt.isBefore(lastRetryAllowed)) {
                 try {
                     PullImageCmd pullImageCmd = dockerClient
                         .pullImageCmd(imageName.getUnversionedPart())
@@ -95,10 +96,12 @@ public class RemoteDockerImage extends LazyFuture<String> {
                             .exec(new TimeLimitedLoggedPullImageResultCallback(logger))
                             .awaitCompletion();
                     }
+                    String dockerImageName = imageName.asCanonicalNameString();
+                    logger.info("Image {} pull took {}", dockerImageName, Duration.between(startedAt, Instant.now()));
 
                     LocalImagesCache.INSTANCE.refreshCache(imageName);
 
-                    return imageName.asCanonicalNameString();
+                    return dockerImageName;
                 } catch (InterruptedException | InternalServerErrorException e) {
                     // these classes of exception often relate to timeout/connection errors so should be retried
                     lastFailure = e;
@@ -109,6 +112,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
                     );
                 }
             }
+
             logger.error(
                 "Failed to pull image: {}. Please check output of `docker pull {}`",
                 imageName,


### PR DESCRIPTION
Currently, contianer startup is logged taking into account the
image pull. Logging those independently is accurate.
