### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v3.1.1
+        uses: github/combine-prs@v3.1.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.3.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.6.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.3.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.6.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.2.3.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.9.3"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.3.RELEASE"
+    api "io.lettuce:lettuce-core:6.2.6.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.28"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.28"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.4.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.13'
+    testImplementation 'io.nats:jnats:2.16.14'
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.11'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.12'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:4.3.2'
+    implementation 'redis.clients:jedis:4.4.3'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:4.3.2'
+    implementation 'redis.clients:jedis:4.4.3'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.13'
+    id 'org.springframework.boot' version '2.7.15'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:4.3.2'
+    implementation 'redis.clients:jedis:4.4.3'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.13'
+    id 'org.springframework.boot' version '2.7.15'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.azure:azure-cosmos:4.48.0'
+    testImplementation 'com.azure:azure-cosmos:4.49.0'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.8'
+    testImplementation 'com.couchbase.client:java-client:3.4.9'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.520'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.520'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.543'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.543'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.9.0"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.9.1"
     testImplementation "org.elasticsearch.client:transport:7.17.12"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.21.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.22.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.18.0")
-    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.1")
+    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.2")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.18.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.1")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.4.8")
+    testImplementation("ch.qos.logback:logback-classic:1.4.11")
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api 'com.google.guava:guava:32.1.2-jre'
     api 'org.apache.commons:commons-lang3:3.13.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
-    api 'commons-dbutils:commons-dbutils:1.7'
+    api 'commons-dbutils:commons-dbutils:1.8.0'
 
     api 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
 

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.7'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.11'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.13'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.8.0'
+    testImplementation 'io.fabric8:kubernetes-client:6.8.1'
     testImplementation 'io.kubernetes:client-java:18.0.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.520")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.543")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.117'
+    testImplementation 'software.amazon.awssdk:s3:2.20.139'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.1.4'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.2.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.1.jre8'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.4'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.21"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.22"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.21"
+    api "com.orientechnologies:orientdb-client:3.2.22"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.6.4'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.0.0'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.0.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.0.0'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.0'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.2.1'
+    testImplementation 'org.questdb:questdb:7.3.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.8'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.9'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:422'
+    testRuntimeOnly 'io.trino:trino-jdbc:425'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.mariadb.jdbc:mariadb-java-client from 3.1.4 to 3.2.0 in /modules/mariadb (#7493) @app/dependabot
* Bump org.springframework.boot from 2.7.13 to 2.7.15 in /examples (#7490) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.11 to 4.4.12 in /examples (#7489) @app/dependabot
* Bump redis.clients:jedis from 4.3.2 to 4.4.3 in /examples (#7488) @app/dependabot
* Bump io.nats:jnats from 2.16.13 to 2.16.14 in /examples (#7487) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.8 to 1.3.11 in /examples (#7486) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.9.3 to 5.10.0 in /examples (#7484) @app/dependabot
* Bump io.lettuce:lettuce-core from 6.2.3.RELEASE to 6.2.6.RELEASE in /examples (#7483) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.4.0 to 3.5.1 in /examples (#7482) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.8 to 3.5.9 in /modules/r2dbc (#7481) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.9.0 to 8.9.1 in /modules/elasticsearch (#7480) @app/dependabot
* Bump io.trino:trino-jdbc from 422 to 425 in /modules/trino (#7479) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.4.8 to 1.4.11 in /modules/hivemq (#7478) @app/dependabot
* Bump com.hivemq:hivemq-mqtt-client from 1.3.1 to 1.3.2 in /modules/hivemq (#7477) @app/dependabot
* Bump commons-dbutils:commons-dbutils from 1.7 to 1.8.0 in /modules/jdbc-test (#7476) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.520 to 1.12.543 in /modules/dynalite (#7475) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.8 to 3.4.9 in /modules/couchbase (#7474) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.21 to 3.2.22 in /modules/orientdb (#7473) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.21 to 3.2.22 in /modules/orientdb (#7472) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.6.4 to 3.7.0 in /modules/orientdb (#7471) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.11 to 10.1.13 in /modules/jdbc (#7470) @app/dependabot
* Bump github/combine-prs from 3.1.1 to 3.1.2 (#7468) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.8.0 to 6.8.1 in /modules/k3s (#7467) @app/dependabot
* Bump org.apache.pulsar:pulsar-client-admin from 3.0.0 to 3.1.0 in /modules/pulsar (#7465) @app/dependabot
* Bump org.apache.pulsar:pulsar-client from 3.0.0 to 3.1.0 in /modules/pulsar (#7464) @app/dependabot
* Bump com.azure:azure-cosmos from 4.48.0 to 4.49.0 in /modules/azure (#7462) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.21.0 to 26.22.0 in /modules/gcloud (#7461) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.4.0.jre8-preview to 12.4.1.jre8 in /modules/mssqlserver (#7460) @app/dependabot
* Bump org.questdb:questdb from 7.2.1 to 7.3.1 in /modules/questdb (#7459) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-bom from 1.12.520 to 1.12.543 in /modules/localstack (#7458) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.117 to 2.20.139 in /modules/localstack (#7457) @app/dependabot
