### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/ci-docker-wormhole.yml
+++ b/.github/workflows/ci-docker-wormhole.yml
@@ -38,7 +38,7 @@ jobs:
   in-docker_test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build with Gradle
         run: |
           docker run -i --rm \

--- a/.github/workflows/ci-rootless.yml
+++ b/.github/workflows/ci-rootless.yml
@@ -38,7 +38,7 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup rootless Docker
         uses: ScribeMD/rootless-docker@0.2.2
       - name: Remove Docket root socket

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
   core:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
       - name: Build and test with Gradle
         run: |
@@ -54,7 +54,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
       - name: Setup Testcontainers Cloud Client
         uses: atomicjar/testcontainers-cloud-setup-action@main
@@ -72,7 +72,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
       - name: Setup Gradle Build Action
         uses: gradle/gradle-build-action@v2
@@ -92,7 +92,7 @@ jobs:
       matrix: ${{ fromJson(needs.find_gradle_jobs.outputs.matrix) }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
       - name: Build and test with Gradle (${{matrix.gradle_args}})
         run: |
@@ -104,7 +104,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
       - name: Setup Gradle Build Action
         uses: gradle/gradle-build-action@v2
@@ -125,7 +125,7 @@ jobs:
       matrix: ${{ fromJson(needs.find_examples_jobs.outputs.matrix) }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
       - name: Build and test Examples with Gradle (${{matrix.gradle_args}})
         working-directory: ./examples/
@@ -138,7 +138,7 @@ jobs:
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
       - name: Setup Gradle Build Action
         uses: gradle/gradle-build-action@v2
@@ -158,7 +158,7 @@ jobs:
       matrix: ${{ fromJson(needs.find_docs_examples_jobs.outputs.matrix) }}
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
       - name: Build and test with Gradle (${{matrix.gradle_args}})
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-java
       - name: Clear existing docker image cache
         run: docker image prune -af

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
       - name: Update latest_version property in mkdocs.yml

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@0407394b9d173dfc9cf5695f9f560fef6d61a5fe # v1.0.13

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: main
       - name: Update testcontainers.version property in gradle.properties

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -105,7 +105,7 @@ dependencies {
 
     testImplementation 'com.google.cloud.tools:jib-core:0.23.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:4.4.3'
+    testImplementation 'redis.clients:jedis:5.0.0'
     testImplementation 'com.rabbitmq:amqp-client:5.18.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
-    implementation 'org.json:json:20230227'
+    implementation 'org.json:json:20230618'
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.testcontainers:postgresql'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:4.4.3'
+    implementation 'redis.clients:jedis:5.0.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:4.4.3'
+    implementation 'redis.clients:jedis:5.0.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:4.4.3'
+    implementation 'redis.clients:jedis:5.0.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.543'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.543'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.545'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.545'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.9.1"
-    testImplementation "org.elasticsearch.client:transport:7.17.12"
+    testImplementation "org.elasticsearch.client:transport:7.17.13"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.18.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.19.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.2")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:4.4.3'
+    testImplementation 'redis.clients:jedis:5.0.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.139'
+    testImplementation 'software.amazon.awssdk:s3:2.20.142'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.543")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.545")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.14.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
-        classpath "org.gradle.toolchains:foojay-resolver:0.6.0"
+        classpath "org.gradle.toolchains:foojay-resolver:0.7.0"
     }
 }
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump redis.clients:jedis from 4.4.3 to 5.0.0 in /examples (#7518) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-bom from 1.12.543 to 1.12.545 in /modules/localstack (#7517) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.12 to 7.17.13 in /modules/elasticsearch (#7516) @app/dependabot
* Bump org.gradle.toolchains:foojay-resolver from 0.6.0 to 0.7.0 in /examples (#7515) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.543 to 1.12.545 in /modules/dynalite (#7513) @app/dependabot
* Bump org.json:json from 20230227 to 20230618 in /examples (#7512) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.9.1 to 8.9.2 in /modules/elasticsearch (#7511) @app/dependabot
* Bump actions/checkout from 3 to 4 (#7510) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.18.0 to 4.19.0 in /modules/hivemq (#7507) @app/dependabot
* Bump redis.clients:jedis from 4.4.3 to 5.0.0 in /modules/junit-jupiter (#7508) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.139 to 2.20.142 in /modules/localstack (#7506) @app/dependabot
* Bump redis.clients:jedis from 4.4.3 to 5.0.0 in /core (#7505) @app/dependabot
