### PR TITLE
Override ChainedImageNameSubstitutor toString

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ImageNameSubstitutor.java
+++ b/core/src/main/java/org/testcontainers/utility/ImageNameSubstitutor.java
@@ -155,6 +155,11 @@ public abstract class ImageNameSubstitutor implements Function<DockerImageName, 
                 configuredInstance.getDescription()
             );
         }
+
+        @Override
+        public String toString() {
+            return getDescription();
+        }
     }
 
     private static class NoopImageNameSubstitutor extends ImageNameSubstitutor {

--- a/core/src/test/java/org/testcontainers/utility/ImageNameSubstitutorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/ImageNameSubstitutorTest.java
@@ -5,8 +5,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.testcontainers.containers.GenericContainer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 
 public class ImageNameSubstitutorTest {
@@ -63,5 +65,20 @@ public class ImageNameSubstitutorTest {
         assertThat(result.asCanonicalNameString())
             .as("the image has been substituted by default then configured implementations")
             .isEqualTo("substituted-image:latest");
+    }
+
+    @Test
+    public void testImageNameSubstitutorToString() {
+        Mockito
+            .doReturn(FakeImageSubstitutor.class.getCanonicalName())
+            .when(TestcontainersConfiguration.getInstance())
+            .getImageSubstitutorClassName();
+
+        try (GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("original"))) {
+            assertThatThrownBy(container::start)
+                .hasMessageContaining(
+                    "imageNameSubstitutor=Chained substitutor of 'default implementation' and then 'test implementation'"
+                );
+        }
     }
 }


### PR DESCRIPTION
Returns ChainedImageNameSubstitutor's getDescription

Fixes #7039
