### PR TITLE
[Docs] GCloud: Add BigQuery Client creation

### DIFF
--- a/docs/modules/gcloud.md
+++ b/docs/modules/gcloud.md
@@ -26,6 +26,10 @@ Start BigQuery Emulator during a test:
 [Starting a BigQuery Emulator container](../../modules/gcloud/src/test/java/org/testcontainers/containers/BigQueryEmulatorContainerTest.java) inside_block:emulatorContainer
 <!--/codeinclude-->
 
+<!--codeinclude-->
+[Creating BigQuery Client](../../modules/gcloud/src/test/java/org/testcontainers/containers/BigQueryEmulatorContainerTest.java) inside_block:bigQueryClient
+<!--/codeinclude-->
+
 ### Bigtable
 
 Start Bigtable Emulator during a test:

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/BigQueryEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/BigQueryEmulatorContainerTest.java
@@ -1,5 +1,6 @@
 package org.testcontainers.containers;
 
+import com.google.cloud.NoCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.cloud.bigquery.QueryJobConfiguration;
@@ -23,14 +24,17 @@ public class BigQueryEmulatorContainerTest {
         ) {
             container.start();
 
+            // bigQueryClient {
             String url = container.getEmulatorHttpEndpoint();
             BigQueryOptions options = BigQueryOptions
                 .newBuilder()
                 .setProjectId(container.getProjectId())
                 .setHost(url)
                 .setLocation(url)
+                .setCredentials(NoCredentials.getInstance())
                 .build();
             BigQuery bigQuery = options.getService();
+            // }
 
             String fn =
                 "CREATE FUNCTION testr(arr ARRAY<STRUCT<name STRING, val INT64>>) AS ((SELECT SUM(IF(elem.name = \"foo\",elem.val,null)) FROM UNNEST(arr) AS elem))";


### PR DESCRIPTION
Hello,

In order to make it consistent with the other GCloud containers, I would like to add this documentation showing how to create the BigQuery client explicitly without need of credentials. Also, it's relevant because the emulator does not need credentials, and it could avoid any misusage / override of credentials possibly coming from other libs.

Thanks.