### PR TITLE
Add custom LogMessageWaitStrategy startup timeout

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/LogMessageWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/LogMessageWaitStrategy.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
+import java.time.Duration;
 
 public class LogMessageWaitStrategy extends AbstractWaitStrategy {
 
@@ -56,6 +57,11 @@ public class LogMessageWaitStrategy extends AbstractWaitStrategy {
 
     public LogMessageWaitStrategy withTimes(int times) {
         this.times = times;
+        return this;
+    }
+
+    public LogMessageWaitStrategy withTimeout(Duration timeout) {
+        this.startupTimeout = timeout;
         return this;
     }
 }


### PR DESCRIPTION
For some long starting services like kafka+zookeper it could take more than 60 sec to start and configure. As currently there is no possibility to set it to some custom timeout I propose this change.
