### PR TITLE
Deprecate withSecretInVault

### DIFF
--- a/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
+++ b/modules/vault/src/main/java/org/testcontainers/vault/VaultContainer.java
@@ -174,7 +174,9 @@ public class VaultContainer<SELF extends VaultContainer<SELF>> extends GenericCo
      * @param firstSecret      first secret to add to specifed path
      * @param remainingSecrets var args list of secrets to add to specified path
      * @return this
+     * @deprecated use {@link #withInitCommand(String...)} instead
      */
+    @Deprecated
     public SELF withSecretInVault(String path, String firstSecret, String... remainingSecrets) {
         List<String> list = new ArrayList<>();
         list.add(firstSecret);

--- a/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
+++ b/modules/vault/src/test/java/org/testcontainers/vault/VaultContainerTest.java
@@ -26,16 +26,12 @@ public class VaultContainerTest {
     // vaultContainer {
     public static VaultContainer<?> vaultContainer = new VaultContainer<>("hashicorp/vault:1.13")
         .withVaultToken(VAULT_TOKEN)
-        .withSecretInVault("secret/testing1", "top_secret=password123")
-        .withSecretInVault(
-            "secret/testing2",
-            "secret_one=password1",
-            "secret_two=password2",
-            "secret_three=password3",
-            "secret_three=password3",
-            "secret_four=password4"
-        )
-        .withInitCommand("secrets enable transit", "write -f transit/keys/my-key");
+        .withInitCommand(
+            "secrets enable transit",
+            "write -f transit/keys/my-key",
+            "kv put secret/testing1 top_secret=password123",
+            "kv put secret/testing2 secret_one=password1 secret_two=password2 secret_three=password3 secret_three=password3 secret_four=password4"
+        );
 
     // }
 


### PR DESCRIPTION
Use `withInitCommand`

It has been been confusing for users the use of `withSecreInVault` and `withInitCommand`, see https://github.com/testcontainers/testcontainers-java/issues/7532. In order to be aligned with consul module we are encouraging to use just `withInitCommand`.
