### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v3.1.2
+        uses: github/combine-prs@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testCompileOnly 'org.jetbrains:annotations:24.0.1'
-    api 'org.apache.commons:commons-compress:1.23.0'
+    api 'org.apache.commons:commons-compress:1.24.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'
 
-    testImplementation platform('io.cucumber:cucumber-bom:7.13.0')
+    testImplementation platform('io.cucumber:cucumber-bom:7.14.0')
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit'
     testImplementation 'org.testcontainers:selenium'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.28"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.28"
+    testCompileOnly "org.projectlombok:lombok:1.18.30"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.15'
+    id 'org.springframework.boot' version '2.7.16'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.14.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.2"
     }
 }
 

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.28"
-    annotationProcessor "org.projectlombok:lombok:1.18.28"
+    compileOnly "org.projectlombok:lombok:1.18.30"
+    annotationProcessor "org.projectlombok:lombok:1.18.30"
 
     implementation 'org.apache.solr:solr-solrj:8.11.2'
 

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.15'
+    id 'org.springframework.boot' version '2.7.16'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
-    testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.9'
+    testImplementation 'com.couchbase.client:java-client:3.4.10'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.545'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.545'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.557'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.557'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.9.1"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.10.2"
     testImplementation "org.elasticsearch.client:transport:7.17.13"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.22.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.23.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.19.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.20.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.2")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api 'com.google.guava:guava:32.1.2-jre'
     api 'org.apache.commons:commons-lang3:3.13.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
-    api 'commons-dbutils:commons-dbutils:1.8.0'
+    api 'commons-dbutils:commons-dbutils:1.8.1'
 
     api 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
 

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':database-commons')
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
-    testImplementation 'commons-dbutils:commons-dbutils:1.8.0'
+    testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.13'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.142'
+    testImplementation 'software.amazon.awssdk:s3:2.20.154'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.545")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.557")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:8.5.5")
+    testImplementation("io.minio:minio:8.5.6")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.asyncer:r2dbc-mysql:1.0.2'
+    compileOnly 'io.asyncer:r2dbc-mysql:1.0.3'
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.0.2'
+    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.0.3'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.0'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.22"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.23"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.22"
+    api "com.orientechnologies:orientdb-client:3.2.23"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.0'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.3.1'
+    testImplementation 'org.questdb:questdb:7.3.2'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.9'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.10'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:425'
+    testRuntimeOnly 'io.trino:trino-jdbc:426'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    testImplementation 'io.rest-assured:rest-assured:5.3.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.14.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.1"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.2"
         classpath "org.gradle.toolchains:foojay-resolver:0.7.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.545 to 1.12.557 in /modules/dynalite (#7583) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.142 to 2.20.154 in /modules/localstack (#7582) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-bom from 1.12.545 to 1.12.557 in /modules/localstack (#7581) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.1 to 5.3.2 in /modules/vault (#7574) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.11.1 to 1.11.2 (#7575) @app/dependabot
* Bump org.springframework.boot from 2.7.15 to 2.7.16 in /examples (#7573) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.14.1 to 3.15 (#7572) @app/dependabot
* Bump org.projectlombok:lombok from 1.18.28 to 1.18.30 in /examples (#7570) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.11.1 to 1.11.2 in /examples (#7569) @app/dependabot
* Bump io.cucumber:cucumber-bom from 7.13.0 to 7.14.0 in /examples (#7568) @app/dependabot
* Bump github/combine-prs from 3.1.2 to 4.0.0 (#7566) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.22 to 3.2.23 in /modules/orientdb (#7565) @app/dependabot
* Bump io.asyncer:r2dbc-mysql from 1.0.2 to 1.0.3 in /modules/mysql (#7563) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.9.1 to 8.10.2 in /modules/elasticsearch (#7564) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.9 to 3.5.10 in /modules/r2dbc (#7562) @app/dependabot
* Bump commons-dbutils:commons-dbutils from 1.8.0 to 1.8.1 in /modules/jdbc (#7559) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.22 to 3.2.23 in /modules/orientdb (#7560) @app/dependabot
* Bump commons-dbutils:commons-dbutils from 1.8.0 to 1.8.1 in /modules/jdbc-test (#7561) @app/dependabot
* Bump org.questdb:questdb from 7.3.1 to 7.3.2 in /modules/questdb (#7556) @app/dependabot
* Bump io.minio:minio from 8.5.5 to 8.5.6 in /modules/minio (#7553) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.1 to 5.3.2 in /modules/redpanda (#7554) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.19.0 to 4.20.0 in /modules/hivemq (#7551) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.22.0 to 26.23.0 in /modules/gcloud (#7550) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.1 to 5.3.2 in /modules/consul (#7552) @app/dependabot
* Bump org.apache.commons:commons-compress from 1.23.0 to 1.24.0 in /core (#7549) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.9 to 3.4.10 in /modules/couchbase (#7548) @app/dependabot
* Bump io.trino:trino-jdbc from 425 to 426 in /modules/trino (#7509) @app/dependabot
