### PR TITLE
Deprecate CLI utility methods in RabbitMQ module

### DIFF
--- a/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
+++ b/modules/rabbitmq/src/main/java/org/testcontainers/containers/RabbitMQContainer.java
@@ -216,6 +216,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
             .withCopyFileToContainer(keyFile, "/etc/rabbitmq/rabbitmq_key.pem");
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withPluginsEnabled(String... pluginNames) {
         List<String> command = new ArrayList<>(Arrays.asList("rabbitmq-plugins", "enable"));
         command.addAll(Arrays.asList(pluginNames));
@@ -223,6 +227,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withBinding(String source, String destination) {
         values.add(
             Arrays.asList("rabbitmqadmin", "declare", "binding", "source=" + source, "destination=" + destination)
@@ -230,6 +238,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withBinding(String vhost, String source, String destination) {
         values.add(
             Arrays.asList(
@@ -244,6 +256,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withBinding(
         String source,
         String destination,
@@ -266,6 +282,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withBinding(
         String vhost,
         String source,
@@ -290,6 +310,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withParameter(String component, String name, String value) {
         values.add(
             Arrays.asList(
@@ -304,6 +328,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withPermission(String vhost, String user, String configure, String write, String read) {
         values.add(
             Arrays.asList(
@@ -320,11 +348,19 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withUser(String name, String password) {
         values.add(Arrays.asList("rabbitmqadmin", "declare", "user", "name=" + name, "password=" + password, "tags="));
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withUser(String name, String password, Set<String> tags) {
         values.add(
             Arrays.asList(
@@ -339,6 +375,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withPolicy(String name, String pattern, Map<String, Object> definition) {
         values.add(
             Arrays.asList(
@@ -353,6 +393,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withPolicy(String vhost, String name, String pattern, Map<String, Object> definition) {
         values.add(
             Arrays.asList(
@@ -368,6 +412,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withPolicy(
         String name,
         String pattern,
@@ -390,6 +438,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withOperatorPolicy(String name, String pattern, Map<String, Object> definition) {
         values.add(
             new ArrayList<>(
@@ -406,6 +458,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withOperatorPolicy(
         String name,
         String pattern,
@@ -428,16 +484,28 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withVhost(String name) {
         values.add(Arrays.asList("rabbitmqadmin", "declare", "vhost", "name=" + name));
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withVhost(String name, boolean tracing) {
         values.add(Arrays.asList("rabbitmqadmin", "declare", "vhost", "name=" + name, "tracing=" + tracing));
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withVhostLimit(String vhost, String name, int value) {
         values.add(
             Arrays.asList("rabbitmqadmin", "declare", "vhost_limit", "vhost=" + vhost, "name=" + name, "value=" + value)
@@ -445,16 +513,28 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withQueue(String name) {
         values.add(Arrays.asList("rabbitmqadmin", "declare", "queue", "name=" + name));
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withQueue(String vhost, String name) {
         values.add(Arrays.asList("rabbitmqadmin", "--vhost=" + vhost, "declare", "queue", "name=" + name));
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withQueue(
         String name,
         boolean autoDelete,
@@ -475,6 +555,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withQueue(
         String vhost,
         String name,
@@ -497,11 +581,19 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withExchange(String name, String type) {
         values.add(Arrays.asList("rabbitmqadmin", "declare", "exchange", "name=" + name, "type=" + type));
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withExchange(String vhost, String name, String type) {
         values.add(
             Arrays.asList("rabbitmqadmin", "--vhost=" + vhost, "declare", "exchange", "name=" + name, "type=" + type)
@@ -509,6 +601,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withExchange(
         String name,
         String type,
@@ -533,6 +629,10 @@ public class RabbitMQContainer extends GenericContainer<RabbitMQContainer> {
         return self();
     }
 
+    /**
+     * @deprecated use {@link #execInContainer(String...)} instead
+     */
+    @Deprecated
     public RabbitMQContainer withExchange(
         String vhost,
         String name,


### PR DESCRIPTION
Those utility methods couple the implementation to the cli, which is only provided when using `management` image. Also, although very convinient methods, it will be hard to maintain for every command in the cli.