### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
     testImplementation 'redis.clients:jedis:5.0.0'
-    testImplementation 'com.rabbitmq:amqp-client:5.18.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.19.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.0.0'
+    implementation 'redis.clients:jedis:5.0.1'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.0.0'
+    implementation 'redis.clients:jedis:5.0.1'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.2"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.3"
     }
 }
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:5.0.0'
+    implementation 'redis.clients:jedis:5.0.1'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.azure:azure-cosmos:4.49.0'
+    testImplementation 'com.azure:azure-cosmos:4.51.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.557'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.557'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.560'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.560'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.23.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.24.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:24.0.1")
 
     shaded("org.apache.commons:commons-lang3:3.13.0")
-    shaded("commons-io:commons-io:2.13.0")
+    shaded("commons-io:commons-io:2.14.0")
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:5.0.0'
+    testImplementation 'redis.clients:jedis:5.0.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.557")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.560")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.154'
+    testImplementation 'software.amazon.awssdk:s3:2.20.157'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.2.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.18.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.19.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:426'
+    testRuntimeOnly 'io.trino:trino-jdbc:427'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.2"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.3"
         classpath "org.gradle.toolchains:foojay-resolver:0.7.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.amazonaws:aws-java-sdk-bom from 1.12.557 to 1.12.560 in /modules/localstack (#7616) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.154 to 2.20.157 in /modules/localstack (#7615) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.18.0 to 5.19.0 in /modules/rabbitmq (#7614) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.557 to 1.12.560 in /modules/dynalite (#7613) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.18.0 to 5.19.0 in /core (#7612) @app/dependabot
* Bump io.trino:trino-jdbc from 426 to 427 in /modules/trino (#7610) @app/dependabot
* Bump commons-io:commons-io from 2.13.0 to 2.14.0 in /modules/hivemq (#7609) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.2.0.0 to 23.3.0.23.09 in /modules/oracle-xe (#7608) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.11.2 to 1.11.3 (#7607) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.23.0 to 26.24.0 in /modules/gcloud (#7606) @app/dependabot
* Bump redis.clients:jedis from 5.0.0 to 5.0.1 in /examples (#7605) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.11.2 to 1.11.3 in /examples (#7604) @app/dependabot
* Bump com.azure:azure-cosmos from 4.49.0 to 4.51.0 in /modules/azure (#7603) @app/dependabot
* Bump redis.clients:jedis from 5.0.0 to 5.0.1 in /modules/junit-jupiter (#7602) @app/dependabot
