### PR TITLE
feat: ceph testcontainer support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -32,6 +32,7 @@ body:
         - LocalStack
         - MariaDB
         - MinIO
+        - Ceph
         - MockServer
         - MongoDB
         - MSSQLServer

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -32,6 +32,7 @@ body:
         - LocalStack
         - MariaDB
         - MinIO
+        - Ceph
         - MockServer
         - MongoDB
         - MSSQLServer

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -32,6 +32,7 @@ body:
         - LocalStack
         - MariaDB
         - MinIO
+        - Ceph
         - MockServer
         - MongoDB
         - MSSQLServer

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -160,6 +160,11 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
   - package-ecosystem: "gradle"
+    directory: "/modules/ceph"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gradle"
     directory: "/modules/mockserver"
     schedule:
       interval: "weekly"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -49,6 +49,8 @@
   - modules/mariadb/**/*
 "modules/minio":
   - modules/minio/**/*
+"modules/ceph":
+  - modules/ceph/**/*
 "modules/mockserver":
   - modules/mockserver/**/*
 "modules/mongodb":

--- a/docs/modules/ceph.md
+++ b/docs/modules/ceph.md
@@ -1,0 +1,39 @@
+# Ceph Containers
+
+Testcontainers can be used to automatically instantiate and manage [Ceph](https://ceph.io) containers.
+
+## Usage example
+
+Create a `CephContainer` to use it in your tests:
+<!--codeinclude-->
+[Starting a Ceph container](../../modules/ceph/src/test/java/org/testcontainers/containers/CephContainerTest.java) inside_block:cephContainer
+<!--/codeinclude-->
+
+The [AWS Java SDK](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/AmazonS3.html) can be configured with the container as such:
+<!--codeinclude-->
+[Configuring a Ceph client](../../modules/ceph/src/test/java/org/testcontainers/containers/CephContainerTest.java) inside_block:configuringClient
+<!--/codeinclude-->
+
+If needed the username and password can be overridden as such:
+<!--codeinclude-->
+[Overriding a Ceph container](../../modules/ceph/src/test/java/org/testcontainers/containers/CephContainerTest.java) inside_block:cephOverrides
+<!--/codeinclude-->
+
+## Adding this module to your project dependencies
+
+Add the following dependency to your `pom.xml`/`build.gradle` file:
+
+=== "Gradle"
+    ```groovy
+     testImplementation "org.testcontainers:ceph:{{latest_version}}"
+    ```
+
+=== "Maven"
+    ```xml
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>ceph</artifactId>
+        <version>{{latest_version}}</version>
+        <scope>test</scope>
+    </dependency>
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
           - modules/kafka.md
           - modules/localstack.md
           - modules/minio.md
+          - modules/ceph.md
           - modules/mockserver.md
           - modules/nginx.md
           - modules/pulsar.md

--- a/modules/ceph/build.gradle
+++ b/modules/ceph/build.gradle
@@ -1,0 +1,8 @@
+description = "Testcontainers :: Ceph"
+
+dependencies {
+    api project(':testcontainers')
+
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.562'
+}

--- a/modules/ceph/src/main/java/org/testcontainers/containers/CephContainer.java
+++ b/modules/ceph/src/main/java/org/testcontainers/containers/CephContainer.java
@@ -1,0 +1,97 @@
+package org.testcontainers.containers;
+
+import lombok.Getter;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Testcontainers implementation for Ceph.
+ * <p>
+ * Supported image: {@code quay.io/ceph/demo}
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Ceph: 8080</li>
+ *     <li>Monitor: 3300</li>
+ * </ul>
+ */
+@Getter
+public class CephContainer extends GenericContainer<CephContainer> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("quay.io/ceph/demo");
+
+    private static final Integer CEPH_MON_DEFAULT_PORT = 3300;
+
+    private static final Integer CEPH_RGW_DEFAULT_PORT = 8080;
+
+    private static final String CEPH_DEMO_UID = "admin";
+
+    private static final String CEPH_END_START = ".*/opt/ceph-container/bin/demo: SUCCESS.*";
+
+    private static final Set<String> CEPH_DEMO_DAEMONS = new HashSet<>(Collections.singletonList("all"));
+
+    private String cephAccessKey;
+
+    private String cephSecretKey;
+
+    public CephContainer(final String dockerImageName) {
+        this(DockerImageName.parse(dockerImageName));
+    }
+
+    public CephContainer(final DockerImageName dockerImageName) {
+        super(dockerImageName);
+    }
+
+    @Override
+    public void configure() {
+        addExposedPorts(CEPH_MON_DEFAULT_PORT, CEPH_RGW_DEFAULT_PORT);
+
+        addEnv("DEMO_DAEMONS", String.join(",", CEPH_DEMO_DAEMONS));
+        addEnv("CEPH_DEMO_UID", CEPH_DEMO_UID);
+        addEnv(
+            "CEPH_DEMO_ACCESS_KEY",
+            this.cephAccessKey != null
+                ? this.cephAccessKey
+                : (this.cephAccessKey = RandomStringUtils.randomAlphanumeric(32))
+        );
+        addEnv(
+            "CEPH_DEMO_SECRET_KEY",
+            this.cephSecretKey != null
+                ? this.cephSecretKey
+                : (this.cephSecretKey = RandomStringUtils.randomAlphanumeric(32))
+        );
+        addEnv("NETWORK_AUTO_DETECT", "1");
+        addEnv("CEPH_DAEMON", "DEMO");
+        addEnv("CEPH_PUBLIC_NETWORK", "0.0.0.0/0");
+        addEnv("MON_IP", "127.0.0.1");
+        addEnv("RGW_NAME", "localhost");
+
+        setWaitStrategy(Wait.forLogMessage(CEPH_END_START, 1).withStartupTimeout(Duration.ofMinutes(5)));
+    }
+
+    public CephContainer withCephAccessKey(String cephAccessKey) {
+        this.cephAccessKey = cephAccessKey;
+        return this;
+    }
+
+    public CephContainer withCephSecretKey(String cephSecretKey) {
+        this.cephSecretKey = cephSecretKey;
+        return this;
+    }
+
+    public int getCephPort() {
+        return getMappedPort(8080);
+    }
+
+    public URI getCephUrl() throws URISyntaxException {
+        return new URI(String.format("http://%s:%s", this.getHost(), getCephPort()));
+    }
+}

--- a/modules/ceph/src/test/java/org/testcontainers/containers/CephContainerTest.java
+++ b/modules/ceph/src/test/java/org/testcontainers/containers/CephContainerTest.java
@@ -1,0 +1,81 @@
+package org.testcontainers.containers;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.junit.Test;
+
+import java.net.URL;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CephContainerTest {
+
+    @Test
+    public void testBasicUsage() throws Exception {
+        try (
+            // minioContainer {
+            CephContainer container = new CephContainer("quay.io/ceph/demo:latest");
+            // }
+        ) {
+            container.start();
+
+            // configuringClient {
+            AWSCredentials credentials = new BasicAWSCredentials(
+                container.getCephAccessKey(),
+                container.getCephSecretKey()
+            );
+            AwsClientBuilder.EndpointConfiguration endpointConfiguration = new AwsClientBuilder.EndpointConfiguration(
+                container.getCephUrl().toString(),
+                ""
+            );
+            AmazonS3 s3client = AmazonS3ClientBuilder
+                .standard()
+                .withEndpointConfiguration(endpointConfiguration)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withPathStyleAccessEnabled(true)
+                .build();
+            // }
+
+            s3client.createBucket("test-bucket");
+            assertThat(s3client.doesBucketExistV2("test-bucket"));
+
+            URL file = this.getClass().getResource("/object_to_upload.txt");
+            assertThat(file).isNotNull();
+            s3client.putObject("test-bucket", "my-objectname", file.getFile());
+
+            List<S3ObjectSummary> objets = s3client.listObjectsV2("test-bucket").getObjectSummaries();
+            assertThat(objets.size()).isEqualTo(1);
+            assertThat(objets.get(0).getKey()).isEqualTo("my-objectname");
+        }
+    }
+
+    @Test
+    public void testDefaultUserPassword() {
+        try (CephContainer container = new CephContainer("quay.io/ceph/demo:latest")) {
+            container.start();
+            assertThat(container.getCephAccessKey()).isNotBlank();
+            assertThat(container.getCephSecretKey()).isNotBlank();
+        }
+    }
+
+    @Test
+    public void testOverwriteUserPassword() {
+        try (
+            // cephOverrides {
+            CephContainer container = new CephContainer("quay.io/ceph/demo:latest")
+                .withCephAccessKey("testuser123")
+                .withCephSecretKey("testpassword123");
+            // }
+        ) {
+            container.start();
+            assertThat(container.getCephAccessKey()).isEqualTo("testuser123");
+            assertThat(container.getCephSecretKey()).isEqualTo("testpassword123");
+        }
+    }
+}

--- a/modules/ceph/src/test/resources/logback-test.xml
+++ b/modules/ceph/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+</configuration>

--- a/modules/ceph/src/test/resources/object_to_upload.txt
+++ b/modules/ceph/src/test/resources/object_to_upload.txt
@@ -1,0 +1,1 @@
+This is a file


### PR DESCRIPTION
Adding testcontainer support for Ceph, because it's valuable to test against the real thing when you actually need to make an integration test against a Ceph S3 service. Copied the test setup from minio and I have added all the parts I saw minio was added to. 

To run Ceph testcontainer on m1/m2 macOS, docker desktop needs "Use Rosetta for x86/amd64 emulation on Apple Silicon" toggled on.