### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,7 +110,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.9'
-    testImplementation 'redis.clients:jedis:5.0.0'
+    testImplementation 'redis.clients:jedis:5.0.1'
     testImplementation 'com.rabbitmq:amqp-client:5.19.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.codenotary:immudb4j:1.0.0'
+    implementation 'io.codenotary:immudb4j:1.0.1'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.30"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.6.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.16.14'
+    testImplementation 'io.nats:jnats:2.17.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.3"
     }
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.11.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.10'
+    testImplementation 'com.couchbase.client:java-client:3.4.11'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.560'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.560'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.565'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.565'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.20.0")
-    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.2")
+    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.8.1'
+    testImplementation 'io.fabric8:kubernetes-client:6.9.0'
     testImplementation 'io.kubernetes:client-java:18.0.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.6.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.157'
+    testImplementation 'software.amazon.awssdk:s3:2.20.162'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.560")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.565")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.asyncer:r2dbc-mysql:1.0.3'
+    compileOnly 'io.asyncer:r2dbc-mysql:1.0.4'
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.0.3'
+    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.0.4'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.3.2'
+    testImplementation 'org.questdb:questdb:7.3.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.32'
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.5.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.6.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'io.rest-assured:rest-assured:5.3.2'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:427'
+    testRuntimeOnly 'io.trino:trino-jdbc:428'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.3"
         classpath "org.gradle.toolchains:foojay-resolver:0.7.0"
     }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.questdb:questdb from 7.3.2 to 7.3.3 in /modules/questdb (#7642) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.15 to 3.15.1 (#7641) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.5.1 to 3.6.0 in /modules/redpanda (#7640) @app/dependabot
* Bump com.hivemq:hivemq-mqtt-client from 1.3.2 to 1.3.3 in /modules/hivemq (#7639) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.560 to 1.12.565 in /modules/dynalite (#7638) @app/dependabot
* Bump io.nats:jnats from 2.16.14 to 2.17.0 in /examples (#7637) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.15 to 3.15.1 in /examples (#7636) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.5.1 to 3.6.0 in /examples (#7635) @app/dependabot
* Bump io.codenotary:immudb4j from 1.0.0 to 1.0.1 in /examples (#7634) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.8.1 to 6.9.0 in /modules/k3s (#7633) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.5.1 to 3.6.0 in /modules/kafka (#7632) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.10 to 3.4.11 in /modules/couchbase (#7631) @app/dependabot
* Bump io.trino:trino-jdbc from 427 to 428 in /modules/trino (#7630) @app/dependabot
* Bump io.asyncer:r2dbc-mysql from 1.0.3 to 1.0.4 in /modules/mysql (#7629) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-bom from 1.12.560 to 1.12.565 in /modules/localstack (#7628) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.157 to 2.20.162 in /modules/localstack (#7627) @app/dependabot
* Bump redis.clients:jedis from 5.0.0 to 5.0.1 in /core (#7611) @app/dependabot
