### PR TITLE
Update Docker requirements page to be more container runtime agnostic

### DIFF
--- a/docs/supported_docker_environment/index.md
+++ b/docs/supported_docker_environment/index.md
@@ -1,28 +1,25 @@
-# General Docker requirements
+# General Container runtime requirements
 
 ## Overview
 
-Testcontainers requires a Docker-API compatible container runtime. 
-During development, Testcontainers is actively tested against recent versions of Docker on Linux, as well as against Docker Desktop on Mac and Windows. 
+To run Testcontainers-based tests, 
+you need a Docker-API compatible container runtime, 
+such as using [Testcontainers Cloud](https://www.testcontainers.cloud/) or installing Docker locally.
+During development, Testcontainers is actively tested against recent versions of Docker on Linux,
+as well as against Docker Desktop on Mac and Windows.
 These Docker environments are automatically detected and used by Testcontainers without any additional configuration being necessary.
 
-It is possible to configure Testcontainers to work for other Docker setups, such as a remote Docker host or Docker alternatives. 
-However, these are not actively tested in the main development workflow, so not all Testcontainers features might be available and additional manual configuration might be necessary. 
-If you have further questions about configuration details for your setup or whether it supports running Testcontainers-based tests, 
+It is possible to configure Testcontainers to work with alternative container runtimes.
+Making use of the free [Testcontainers Desktop](https://testcontainers.com/desktop/) app will take care of most of the manual configuration.
+When using those alternatives without Testcontainers Desktop, 
+sometimes some manual configuration might be necessary 
+(see further down for specific runtimes, or [Customizing Docker host detection](/features/configuration/#customizing-docker-host-detection) for general configuration mechanisms).
+Alternative container runtimes are not actively tested in the main development workflow,
+so not all Testcontainers features might be available.
+If you have further questions about configuration details for your setup or whether it supports running Testcontainers-based tests,
 please contact the Testcontainers team and other users from the Testcontainers community on [Slack](https://slack.testcontainers.org/).
 
-| Host Operating System / Environment | Minimum recommended docker versions | Known issues / tips                                                                                                                                                                                                                                                                       |
-|-------------------------------------|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Linux - general                     | Docker v17.09              | After docker installation, follow [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/).                                                                                                                                                                   |
-| Linux - CircleCI (LXC driver)      | Docker v17.09               | The `exec` feature is not compatible with CircleCI. See CircleCI configuration [example](./continuous_integration/circle_ci.md)                                                                                                                                                           |
-| Linux - within a Docker container            | Docker v17.09              | See [Running inside Docker](continuous_integration/dind_patterns.md) for Docker-in-Docker and Docker wormhole patterns                                                                                                                                                                    |
-| Mac OS X - Docker Toolbox           | Docker Machine v0.8.0  |                                                                                                                                                                                                                                                                                           |
-| Mac OS X - Docker for Mac      | v17.09          | Starting 4.13, run `sudo ln -s $HOME/.docker/run/docker.sock /var/run/docker.sock`<br>Support is best-efforts at present<br>`getTestHostIpAddress()` is [not currently supported](https://github.com/testcontainers/testcontainers-java/issues/166) due to limitations in Docker for Mac. |
-| Windows - Docker Toolbox            |                             | *Support is limited at present and this is not currently tested on a regular basis*.                                                                                                                                                                                                      |
-| Windows - Docker for Windows   |                             | *Support is best-efforts at present.* Only Linux Containers (LCOW) are supported at the moment. See [Windows Support](windows.md)                                                                                                                                                         |
-| Windows - Windows Subsystem for Linux (WSL) | Docker v17.09                       | *Support is best-efforts at present.* Only Linux Containers (LCOW) are supported at the moment. See [Windows Support](windows.md).                                                                                                                                                        |
-
-## Using Colima?
+## Colima
 
 In order to run testcontainers against [colima](https://github.com/abiosoft/colima) the env vars bellow should be set
 


### PR DESCRIPTION
## What does this PR do?

Updates the "Docker Requirements" page to become more container runtime agnostic.
It also references Testcontainers Cloud as a supported container runtime, as well as mentioning Testcontainers Desktop as a tool that can make using alternative container runtimes easier.

The table of supported Docker-Environment combinations has been removed.

Aligns the messaging with [Testcontainers.com Getting Started Page](https://testcontainers.com/getting-started/#supported-languages-and-prerequisites).

## Why is it important?

The previous provided a table that was very detailed with regard to certain Docker versions and environments, however, those were not actively tested. In addition, some of the information and workarounds in this table have become outdated and some mentioned technologies (such as Docker Toolbox) are nowadays obsolete and unmaintained. 

Mentioning Testcontainers Cloud and Testcontainers Desktop helps with discovery of these products for OSS users. 

This change also embraces the fact, that the container runtime has become much more heterogenous in the recent years, while putting the emphasis on Testcontainers integrating against the Docker-API.

