### PR TITLE
Fix K3S start command

### DIFF
--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -46,7 +46,7 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
         tmpFsMapping.put("/var/run", "");
         setTmpFsMapping(tmpFsMapping);
 
-        setCommand("server", "--no-deploy=traefik", "--tls-san=" + this.getHost());
+        setCommand("server", "--disable=traefik", "--tls-san=" + this.getHost());
         setWaitStrategy(new LogMessageWaitStrategy().withRegEx(".*Node controller sync successful.*"));
     }
 

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
@@ -26,18 +26,9 @@ public class Fabric8K3sContainerTest {
 
     @Test
     public void shouldStartAndHaveListableNode() {
-        runK3s(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"));
-    }
-
-    @Test
-    public void shouldStartAndHaveListableNode_backwardsCompat() {
-        runK3s(DockerImageName.parse("rancher/k3s:v1.17.17-k3s1"));
-    }
-
-    private void runK3s(DockerImageName k3sDockerImage) {
         try (
             // starting_k3s {
-            K3sContainer k3s = new K3sContainer(k3sDockerImage)
+            K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
                 .withLogConsumer(new Slf4jLogConsumer(log))
             // }
         ) {

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/Fabric8K3sContainerTest.java
@@ -26,9 +26,18 @@ public class Fabric8K3sContainerTest {
 
     @Test
     public void shouldStartAndHaveListableNode() {
+        runK3s(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"));
+    }
+
+    @Test
+    public void shouldStartAndHaveListableNode_backwardsCompat() {
+        runK3s(DockerImageName.parse("rancher/k3s:v1.17.17-k3s1"));
+    }
+
+    private void runK3s(DockerImageName k3sDockerImage) {
         try (
             // starting_k3s {
-            K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
+            K3sContainer k3s = new K3sContainer(k3sDockerImage)
                 .withLogConsumer(new Slf4jLogConsumer(log))
             // }
         ) {

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
@@ -29,12 +29,7 @@ public class OfficialClientK3sContainerTest {
     }
 
     private void runK3s(DockerImageName k3sDockerImage) throws IOException, ApiException {
-        try (
-            // starting_k3s {
-            K3sContainer k3s = new K3sContainer(k3sDockerImage)
-                .withLogConsumer(new Slf4jLogConsumer(log))
-            // }
-        ) {
+        try (K3sContainer k3s = new K3sContainer(k3sDockerImage).withLogConsumer(new Slf4jLogConsumer(log))) {
             k3s.start();
 
             // connecting_with_k8sio {

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
@@ -25,7 +25,7 @@ public class OfficialClientK3sContainerTest {
 
     @Test
     public void shouldStartAndHaveListableNodeUsingLowerVersion() throws IOException, ApiException {
-        runK3s(DockerImageName.parse("rancher/k3s:v1.17.17-k3s1"));
+        runK3s(DockerImageName.parse("rancher/k3s:v1.20.15-k3s1"));
     }
 
     private void runK3s(DockerImageName k3sDockerImage) throws IOException, ApiException {

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
@@ -20,9 +20,18 @@ public class OfficialClientK3sContainerTest {
 
     @Test
     public void shouldStartAndHaveListableNode() throws IOException, ApiException {
+        runK3s(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"));
+    }
+
+    @Test
+    public void shouldStartAndHaveListableNode_backwardsCompat() throws IOException, ApiException {
+        runK3s(DockerImageName.parse("rancher/k3s:v1.17.17-k3s1"));
+    }
+
+    private void runK3s(DockerImageName k3sDockerImage) throws IOException, ApiException {
         try (
             // starting_k3s {
-            K3sContainer k3s = new K3sContainer(DockerImageName.parse("rancher/k3s:v1.21.3-k3s1"))
+            K3sContainer k3s = new K3sContainer(k3sDockerImage)
                 .withLogConsumer(new Slf4jLogConsumer(log))
             // }
         ) {

--- a/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
+++ b/modules/k3s/src/test/java/org/testcontainers/k3s/OfficialClientK3sContainerTest.java
@@ -24,7 +24,7 @@ public class OfficialClientK3sContainerTest {
     }
 
     @Test
-    public void shouldStartAndHaveListableNode_backwardsCompat() throws IOException, ApiException {
+    public void shouldStartAndHaveListableNodeUsingLowerVersion() throws IOException, ApiException {
         runK3s(DockerImageName.parse("rancher/k3s:v1.17.17-k3s1"));
     }
 


### PR DESCRIPTION
This PR fixes #6770 by swapping the deprecated/removed `--no-deploy` flag with the replacement flag `--disable`

This change is backwards compatible and tested with a wide range of versions:
- oldest version succesfully tested: `rancher/k3s:v1.17.17-k3s1`
- current version (updated in tests): `rancher/k3s:v1.25.14-k3s1`

See:
- https://docs.k3s.io/cli/server#deprecated-options
- https://docs.k3s.io/installation/packaged-components#using-the---disable-flag
