### PR TITLE
Fix documentation for BigQuery in gcloud module

### DIFF
--- a/docs/modules/gcloud.md
+++ b/docs/modules/gcloud.md
@@ -9,7 +9,7 @@ Currently, the module supports `BigQuery`, `Bigtable`, `Datastore`, `Firestore`,
 
 Class | Container Image
 -|-
-BigQueryEmulatorContainer | ["ghcr.io/goccy/bigquery-emulator"]("ghcr.io/goccy/bigquery-emulator")
+BigQueryEmulatorContainer | [ghcr.io/goccy/bigquery-emulator](https://ghcr.io/goccy/bigquery-emulator)
 BigtableEmulatorContainer | [gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators](https://gcr.io/google.com/cloudsdktool/google-cloud-cli)
 DatastoreEmulatorContainer | [gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators](https://gcr.io/google.com/cloudsdktool/google-cloud-cli)
 FirestoreEmulatorContainer | [gcr.io/google.com/cloudsdktool/google-cloud-cli:emulators](https://gcr.io/google.com/cloudsdktool/google-cloud-cli)


### PR DESCRIPTION
Hey,
I just noticed that the link for BigQuery in the documentation for `gcloud` module does not work due to quotations. This change just removes them so that the link now works.