### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5.19.0
+      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,7 +110,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'redis.clients:jedis:5.0.1'
+    testImplementation 'redis.clients:jedis:5.0.2'
     testImplementation 'com.rabbitmq:amqp-client:5.19.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -99,7 +99,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded 'com.google.guava:guava:32.1.2-jre'
+    shaded 'com.google.guava:guava:32.1.3-jre'
     shaded "org.yaml:snakeyaml:1.33"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'com.hazelcast:hazelcast:5.3.2'
+    testImplementation 'com.hazelcast:hazelcast:5.3.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'com.squareup.okhttp3:okhttp:4.11.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.json:json:20230618'
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.17.0'
+    testImplementation 'io.nats:jnats:2.17.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.0.1'
+    implementation 'redis.clients:jedis:5.0.2'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.0.1'
+    implementation 'redis.clients:jedis:5.0.2'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.16'
+    id 'org.springframework.boot' version '2.7.17'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.3"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.12"
     }
 }
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:5.0.1'
+    implementation 'redis.clients:jedis:5.0.2'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.16'
+    id 'org.springframework.boot' version '2.7.17'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Azure"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.azure:azure-cosmos:4.51.0'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'com.couchbase.client:java-client:3.4.11'
     testImplementation 'org.awaitility:awaitility:4.2.0'

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.565'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.565'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.572'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.572'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.10.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.10.4"
     testImplementation "org.elasticsearch.client:transport:7.17.13"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.24.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.25.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.20.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.21.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.13'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.15'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:5.0.1'
+    testImplementation 'redis.clients:jedis:5.0.2'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.565")
+    testImplementation platform("com.amazonaws:aws-java-sdk-bom:1.12.572")
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.20.162'
+    testImplementation 'software.amazon.awssdk:s3:2.21.5'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.10.2")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.11.0")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.10'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.11'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Solr"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.11.0'
+    shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.2'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:428'
+    testRuntimeOnly 'io.trino:trino-jdbc:430'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15.1"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.11.3"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.12"
         classpath "org.gradle.toolchains:foojay-resolver:0.7.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.11.3 to 1.12 in /examples (#7712) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-bom from 1.12.565 to 1.12.572 in /modules/localstack (#7711) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.565 to 1.12.572 in /modules/dynalite (#7710) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.11.3 to 1.12 (#7709) @app/dependabot
* Bump redis.clients:jedis from 5.0.1 to 5.0.2 in /examples (#7706) @app/dependabot
* Bump io.nats:jnats from 2.17.0 to 2.17.1 in /examples (#7705) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.11.0 to 4.12.0 in /examples (#7704) @app/dependabot
* Bump org.springframework.boot from 2.7.16 to 2.7.17 in /examples (#7703) @app/dependabot
* Bump com.hazelcast:hazelcast from 5.3.2 to 5.3.4 in /examples (#7702) @app/dependabot
* Bump release-drafter/release-drafter from 5.24.0 to 5.25.0 (#7701) @app/dependabot
* Bump io.trino:trino-jdbc from 428 to 430 in /modules/trino (#7700) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.11.0 to 4.12.0 in /modules/solr (#7698) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.11.0 to 4.12.0 in /modules/couchbase (#7696) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.20.162 to 2.21.5 in /modules/localstack (#7697) @app/dependabot
* Bump redis.clients:jedis from 5.0.1 to 5.0.2 in /modules/junit-jupiter (#7692) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.10.2 to 8.10.4 in /modules/elasticsearch (#7693) @app/dependabot
* Bump redis.clients:jedis from 5.0.1 to 5.0.2 in /core (#7691) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.11.0 to 4.12.0 in /modules/azure (#7689) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.13 to 7.17.14 in /modules/elasticsearch (#7675) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.10.2 to 4.11.0 in /modules/mongodb (#7673) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.24.0 to 26.25.0 in /modules/gcloud (#7672) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.10 to 3.5.11 in /modules/r2dbc (#7671) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.13 to 10.1.15 in /modules/jdbc (#7669) @app/dependabot
* Bump com.google.guava:guava from 32.1.2-jre to 32.1.3-jre in /core (#7668) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.20.0 to 4.21.0 in /modules/hivemq (#7666) @app/dependabot
* Bump org.json:json from 20230618 to 20231013 in /examples (#7664) @app/dependabot
