### PR TITLE
Add shutdownHook to send sigterm to ryuk

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RyukResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/RyukResourceReaper.java
@@ -77,6 +77,19 @@ class RyukResourceReaper extends ResourceReaper {
 
         ryukContainer.start();
 
+        Runtime
+            .getRuntime()
+            .addShutdownHook(
+                new Thread(
+                    DockerClientFactory.TESTCONTAINERS_THREAD_GROUP,
+                    () -> {
+                        this.dockerClient.killContainerCmd(this.ryukContainer.getContainerId())
+                            .withSignal("SIGTERM")
+                            .exec();
+                    }
+                )
+            );
+
         CountDownLatch ryukScheduledLatch = new CountDownLatch(1);
 
         String host = ryukContainer.getHost();


### PR DESCRIPTION
Currently, `Ryuk` container finishes after around 10s. This commit register
a shutdown hook which will send a sigterm to the Ryuk container when JVM
is terminating causing Ryuk to finish sooner (hence cleaning up all resources that weren't yet removed directly).
