### PR TITLE
Changing default localstack credentials

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -47,6 +47,10 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
     private static final String DEFAULT_REGION = "us-east-1";
 
+    private static final String DEFAULT_AWS_ACCESS_KEY_ID = "test";
+
+    private static final String DEFAULT_AWS_SECRET_ACCESS_KEY = "test";
+
     @Deprecated
     public static final String VERSION = DEFAULT_TAG;
 
@@ -293,6 +297,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
 
     /**
      * Provides a default access key that is preconfigured to communicate with a given simulated service.
+     * <a href="https://github.com/localstack/localstack/blob/master/doc/interaction/README.md?plain=1#L32">AWS Access Key</a>
      * The access key can be used to construct AWS SDK v2 clients:
      * <pre><code>S3Client s3 = S3Client
              .builder()
@@ -306,11 +311,12 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * @return a default access key
      */
     public String getAccessKey() {
-        return "accesskey";
+        return this.getEnvMap().getOrDefault("AWS_ACCESS_KEY_ID", DEFAULT_AWS_ACCESS_KEY_ID);
     }
 
     /**
      * Provides a default secret key that is preconfigured to communicate with a given simulated service.
+     * <a href="https://github.com/localstack/localstack/blob/master/doc/interaction/README.md?plain=1#L32">AWS Secret Key</a>
      * The secret key can be used to construct AWS SDK v2 clients:
      * <pre><code>S3Client s3 = S3Client
              .builder()
@@ -324,7 +330,7 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * @return a default secret key
      */
     public String getSecretKey() {
-        return "secretkey";
+        return this.getEnvMap().getOrDefault("AWS_SECRET_ACCESS_KEY", DEFAULT_AWS_SECRET_ACCESS_KEY);
     }
 
     /**

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -456,7 +456,7 @@ public class LocalstackContainerTest {
         }
     }
 
-    public static class WithEnvironmentVariables {
+    public static class S3SkipSignatureValidation {
 
         @ClassRule
         public static LocalStackContainer localstack = new LocalStackContainer(LocalstackTestImages.LOCALSTACK_2_3_IMAGE)

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -464,7 +464,7 @@ public class LocalstackContainerTest {
             .withEnv("S3_SKIP_SIGNATURE_VALIDATION", "0");
 
         @Test
-        public void s3TestWithPresignedURL() throws IOException {
+        public void shouldBeAccessibleWithCredentials() throws IOException {
             AmazonS3 s3 = AmazonS3ClientBuilder
                 .standard()
                 .withEndpointConfiguration(

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -459,7 +459,7 @@ public class LocalstackContainerTest {
     public static class WithEnvironmentVariables {
 
         @ClassRule
-        public static LocalStackContainer localstack = new LocalStackContainer(LocalstackTestImages.LOCALSTACK_LATEST)
+        public static LocalStackContainer localstack = new LocalStackContainer(LocalstackTestImages.LOCALSTACK_2_3_IMAGE)
             .withServices(Service.S3)
             .withEnv("S3_SKIP_SIGNATURE_VALIDATION", "0");
 

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -460,7 +460,6 @@ public class LocalstackContainerTest {
 
         @ClassRule
         public static LocalStackContainer localstack = new LocalStackContainer(LocalstackTestImages.LOCALSTACK_2_3_IMAGE)
-            .withServices(Service.S3)
             .withEnv("S3_SKIP_SIGNATURE_VALIDATION", "0");
 
         @Test

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -37,7 +37,11 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
 import java.io.IOException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -449,6 +453,55 @@ public class LocalstackContainerTest {
             final String logs = execResult.getStdout() + execResult.getStderr();
             log.info(logs);
             return logs;
+        }
+    }
+
+    public static class WithEnvironmentVariables {
+
+        @ClassRule
+        public static LocalStackContainer localstack = new LocalStackContainer(LocalstackTestImages.LOCALSTACK_LATEST)
+            .withServices(Service.S3)
+            .withEnv("S3_SKIP_SIGNATURE_VALIDATION", "0");
+
+        @Test
+        public void s3TestWithPresignedURL() throws IOException {
+            AmazonS3 s3 = AmazonS3ClientBuilder
+                .standard()
+                .withEndpointConfiguration(
+                    new AwsClientBuilder.EndpointConfiguration(
+                        localstack.getEndpoint().toString(),
+                        localstack.getRegion()
+                    )
+                )
+                .withCredentials(
+                    new AWSStaticCredentialsProvider(
+                        new BasicAWSCredentials(localstack.getAccessKey(), localstack.getSecretKey())
+                    )
+                )
+                .build();
+
+            final String bucketName = "foo";
+
+            s3.createBucket(bucketName);
+
+            s3.putObject(bucketName, "bar", "baz");
+
+            final List<Bucket> buckets = s3.listBuckets();
+            final Optional<Bucket> maybeBucket = buckets
+                .stream()
+                .filter(b -> b.getName().equals(bucketName))
+                .findFirst();
+            assertThat(maybeBucket).as("The created bucket is present").isPresent();
+
+            URL presignedUrl = s3.generatePresignedUrl(
+                bucketName,
+                "bar",
+                Date.from(Instant.now().plus(5, ChronoUnit.MINUTES))
+            );
+
+            assertThat(presignedUrl).as("The presigned url is valid").isNotNull();
+            final String content = IOUtils.toString(presignedUrl, StandardCharsets.UTF_8);
+            assertThat(content).as("The object can be retrieved").isEqualTo("baz");
         }
     }
 }

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackContainerTest.java
@@ -459,7 +459,9 @@ public class LocalstackContainerTest {
     public static class S3SkipSignatureValidation {
 
         @ClassRule
-        public static LocalStackContainer localstack = new LocalStackContainer(LocalstackTestImages.LOCALSTACK_2_3_IMAGE)
+        public static LocalStackContainer localstack = new LocalStackContainer(
+            LocalstackTestImages.LOCALSTACK_2_3_IMAGE
+        )
             .withEnv("S3_SKIP_SIGNATURE_VALIDATION", "0");
 
         @Test

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
@@ -9,5 +9,7 @@ public interface LocalstackTestImages {
     DockerImageName LOCALSTACK_0_11_IMAGE = LOCALSTACK_IMAGE.withTag("0.11.3");
     DockerImageName LOCALSTACK_0_12_IMAGE = LOCALSTACK_IMAGE.withTag("0.12.8");
     DockerImageName LOCALSTACK_0_13_IMAGE = LOCALSTACK_IMAGE.withTag("0.13.0");
+
+    DockerImageName LOCALSTACK_LATEST = LOCALSTACK_IMAGE.withTag("latest");
     DockerImageName AWS_CLI_IMAGE = DockerImageName.parse("amazon/aws-cli:2.7.27");
 }

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
@@ -10,6 +10,6 @@ public interface LocalstackTestImages {
     DockerImageName LOCALSTACK_0_12_IMAGE = LOCALSTACK_IMAGE.withTag("0.12.8");
     DockerImageName LOCALSTACK_0_13_IMAGE = LOCALSTACK_IMAGE.withTag("0.13.0");
 
-    DockerImageName LOCALSTACK_LATEST = LOCALSTACK_IMAGE.withTag("latest");
+    DockerImageName LOCALSTACK_2_3_IMAGE = LOCALSTACK_IMAGE.withTag("2.3");
     DockerImageName AWS_CLI_IMAGE = DockerImageName.parse("amazon/aws-cli:2.7.27");
 }


### PR DESCRIPTION
the default credentials according to the localstack are test , when we do `getAccessKey` and` getSecretKey` we will need to check the environment map if we have the following keys 
 - AWS_ACCESS_KEY_ID
 -  AWS_SECRET_ACCESS_KEY 
and fallback to the default values defined in a static final variable with the value `test` based on this https://github.com/localstack/localstack/blob/master/doc/interaction/README.md?plain=1#L34

