### PR TITLE
Resolve strategy to detect the remote docker socket

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -160,14 +160,15 @@ public class DockerClientFactory {
 
     @UnstableAPI
     public String getRemoteDockerUnixSocketPath() {
-        if (this.strategy != null && this.strategy.allowUserOverrides()) {
+        DockerClientProviderStrategy strategy = getOrInitializeStrategy();
+        if (strategy.allowUserOverrides()) {
             String dockerSocketOverride = System.getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE");
             if (!StringUtils.isBlank(dockerSocketOverride)) {
                 return dockerSocketOverride;
             }
         }
-        if (this.strategy != null && this.strategy.getRemoteDockerUnixSocketPath() != null) {
-            return this.strategy.getRemoteDockerUnixSocketPath();
+        if (strategy.getRemoteDockerUnixSocketPath() != null) {
+            return strategy.getRemoteDockerUnixSocketPath();
         }
 
         URI dockerHost = getTransportConfig().getDockerHost();


### PR DESCRIPTION
Currently, if `DockerClientFactory.instance().getRemoteDockerUnixSocketPath()`
is called without resolving the strategy then the remote docker socket
can be invalid, for example, using Docker Desktop for Mac with unchecked
`Allow the default Docker socket to be used` option.

Fixes #7678
