### PR TITLE
Fix BigQueryEmulatorContainer to work with BigQuery write requests

### DIFF
--- a/modules/gcloud/src/main/java/org/testcontainers/containers/BigQueryEmulatorContainer.java
+++ b/modules/gcloud/src/main/java/org/testcontainers/containers/BigQueryEmulatorContainer.java
@@ -1,22 +1,43 @@
 package org.testcontainers.containers;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.testcontainers.utility.DockerImageName;
+
+import javax.annotation.Nullable;
+import javax.net.ServerSocketFactory;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.Optional;
+import java.util.Random;
+import java.util.function.Supplier;
 
 /**
  * Testcontainers implementation for BigQuery.
  * <p>
  * Supported image: {@code ghcr.io/goccy/bigquery-emulator}
  * <p>
+ *
+ * For further information on settings see
+ * <a href="https://github.com/goccy/bigquery-emulator">https://github.com/goccy/bigquery-emulator</a>.
+ *
+ * The image <tt>ghcr.io/goccy/bigquery-emulator</tt> currently cannot be used with a docker host port
+ * that differs from the container's Http and Grcp ports. By default, the container selects free random
+ * Http and Grpc ports on the docker host system and sets them as the container's Http and Grpc ports.
+ * See also <a href="https://github.com/goccy/bigquery-emulator/issues/160#issuecomment-1801515384">here</a>.
  */
 public class BigQueryEmulatorContainer extends GenericContainer<BigQueryEmulatorContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("ghcr.io/goccy/bigquery-emulator");
 
-    private static final int HTTP_PORT = 9050;
-
-    private static final int GRPC_PORT = 9060;
-
-    private static final String PROJECT_ID = "test-project";
+    private int httpPort = TestSocketUtils.findAvailableTcpPort();
+    private int grpcPort = TestSocketUtils.findAvailableTcpPort();
+    private String projectId = "test-project";
+    private Optional<String> dataset = Optional.empty();
+    private Optional<String> logLevel = Optional.empty();
+    private Optional<String> logFormat = Optional.empty();
+    private Optional<String> database = Optional.empty();
+    private Optional<String> dataFromYaml = Optional.empty();
+    private Optional<InitFunction> initFunction = Optional.empty();
 
     public BigQueryEmulatorContainer(String image) {
         this(DockerImageName.parse(image));
@@ -25,15 +46,220 @@ public class BigQueryEmulatorContainer extends GenericContainer<BigQueryEmulator
     public BigQueryEmulatorContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-        addExposedPorts(HTTP_PORT, GRPC_PORT);
-        withCommand("--project", PROJECT_ID);
+    }
+
+    @Override
+    protected void configure() {
+        StringBuilder command = new StringBuilder();
+        command.append("bigquery-emulator --project=" + projectId + " --port=" + httpPort + " --grpc-port=" + grpcPort);
+        dataset.ifPresent(it -> command.append(" --dataset=" + it));
+        logLevel.ifPresent(it -> command.append(" --log-level=" + it));
+        logFormat.ifPresent(it -> command.append(" --log-format=" + it));
+        database.ifPresent(it -> command.append(" --database=" + it));
+        dataFromYaml.ifPresent(it -> command.append(" --data-from-yaml=" + it));
+        withCommand(command.toString());
+        addFixedExposedPort(httpPort, httpPort);
+        addFixedExposedPort(grpcPort, grpcPort);
     }
 
     public String getEmulatorHttpEndpoint() {
-        return String.format("http://%s:%d", getHost(), getMappedPort(HTTP_PORT));
+        return String.format("http://%s:%d", getHost(), httpPort);
+    }
+
+    public BigQueryEmulatorContainer withProjectId(String projectId) {
+        this.projectId = projectId;
+        return this;
+    }
+    public BigQueryEmulatorContainer withHttpPort(int httpPort) {
+        this.httpPort = httpPort;
+        return this;
+    }
+    public BigQueryEmulatorContainer withGrpcPort(int grpcPort) {
+        this.grpcPort = grpcPort;
+        return this;
+    }
+
+    public BigQueryEmulatorContainer withDataset(String dataset) {
+        this.dataset = Optional.of(dataset);
+        return this;
+    }
+
+    public BigQueryEmulatorContainer withLogLevel(String logLevel) {
+        this.logLevel = Optional.of(logLevel);
+        return this;
+    }
+
+    public BigQueryEmulatorContainer withLogFormat(String logFormat) {
+        this.logFormat = Optional.of(logFormat);
+        return this;
+    }
+
+    public BigQueryEmulatorContainer withDatabase(String database) {
+        this.database = Optional.of(database);
+        return this;
+    }
+
+    public BigQueryEmulatorContainer withDataFromYaml(String dataFromYaml) {
+        this.dataFromYaml = Optional.of(dataFromYaml);
+        return this;
+    }
+
+    /**
+     * Function is called after the container has started.
+     */
+    public interface InitFunction {
+        void init(BigQueryEmulatorContainer container, boolean reused);
+    }
+
+    /**
+     * Perform tasks, such as populating BigQuery with schemas and data after the container
+     * has started.
+     */
+    public BigQueryEmulatorContainer withInitFunction(InitFunction initFunction) {
+        this.initFunction = Optional.of(initFunction);
+        return this;
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo, boolean reused) {
+        super.containerIsStarted(containerInfo, reused);
+        initFunction.ifPresent(f -> f.init(this, reused));
     }
 
     public String getProjectId() {
-        return PROJECT_ID;
+        return projectId;
     }
+
+    public int getHttpPort() {
+        return httpPort;
+    }
+
+    public int getGrpcPort() {
+        return grpcPort;
+    }
+
+    public Optional<String> getDataset() {
+        return dataset;
+    }
+
+    public Optional<String> getLogLevel() {
+        return logLevel;
+    }
+
+    public Optional<String> getLogFormat() {
+        return logFormat;
+    }
+
+    public Optional<String> getDatabase() {
+        return database;
+    }
+
+    public Optional<String> getDataFromYaml() {
+        return dataFromYaml;
+    }
+
+    /**
+     * Copied over from org.springframework.test.util.TestSocketUtils
+     */
+    private static class TestSocketUtils {
+
+        /**
+         * The minimum value for port ranges used when finding an available TCP port.
+         */
+        static final int PORT_RANGE_MIN = 1024;
+
+        /**
+         * The maximum value for port ranges used when finding an available TCP port.
+         */
+        static final int PORT_RANGE_MAX = 65535;
+
+        private static final int PORT_RANGE_PLUS_ONE = PORT_RANGE_MAX - PORT_RANGE_MIN + 1;
+
+        private static final int MAX_ATTEMPTS = 1_000;
+
+        private static final Random random = new Random(System.nanoTime());
+
+        private static final TestSocketUtils INSTANCE = new TestSocketUtils();
+
+
+        /**
+         * Although {@code TestSocketUtils} consists solely of static utility methods,
+         * this constructor is intentionally {@code public}.
+         * <h5>Rationale</h5>
+         * <p>Static methods from this class may be invoked from within XML
+         * configuration files using the Spring Expression Language (SpEL) and the
+         * following syntax.
+         * <pre><code>
+         * &lt;bean id="myBean" ... p:port="#{T(org.springframework.test.util.TestSocketUtils).findAvailableTcpPort()}" /&gt;</code>
+         * </pre>
+         * <p>If this constructor were {@code private}, you would be required to supply
+         * the fully qualified class name to SpEL's {@code T()} function for each usage.
+         * Thus, the fact that this constructor is {@code public} allows you to reduce
+         * boilerplate configuration with SpEL as can be seen in the following example.
+         * <pre><code>
+         * &lt;bean id="socketUtils" class="org.springframework.test.util.TestSocketUtils" /&gt;
+         * &lt;bean id="myBean" ... p:port="#{socketUtils.findAvailableTcpPort()}" /&gt;</code>
+         * </pre>
+         */
+        public TestSocketUtils() {
+        }
+
+        /**
+         * Find an available TCP port randomly selected from the range [1024, 65535].
+         *
+         * @return an available TCP port number
+         * @throws IllegalStateException if no available port could be found
+         */
+        public static int findAvailableTcpPort() {
+            return INSTANCE.findAvailableTcpPortInternal();
+        }
+
+
+        /**
+         * Internal implementation of {@link #findAvailableTcpPort()}.
+         * <p>Package-private solely for testing purposes.
+         */
+        int findAvailableTcpPortInternal() {
+            int candidatePort;
+            int searchCounter = 0;
+            do {
+                state(++searchCounter <= MAX_ATTEMPTS, () -> String.format(
+                    "Could not find an available TCP port in the range [%d, %d] after %d attempts",
+                    PORT_RANGE_MIN, PORT_RANGE_MAX, MAX_ATTEMPTS));
+                candidatePort = PORT_RANGE_MIN + random.nextInt(PORT_RANGE_PLUS_ONE);
+            }
+            while (!isPortAvailable(candidatePort));
+
+            return candidatePort;
+        }
+
+        /**
+         * Determine if the specified TCP port is currently available on {@code localhost}.
+         * <p>Package-private solely for testing purposes.
+         */
+        boolean isPortAvailable(int port) {
+            try {
+                ServerSocket serverSocket = ServerSocketFactory.getDefault()
+                    .createServerSocket(port, 1, InetAddress.getByName("localhost"));
+                serverSocket.close();
+                return true;
+            } catch (Exception ex) {
+                return false;
+            }
+        }
+
+        private static void state(boolean expression, Supplier<String> messageSupplier) {
+            if (!expression) {
+                throw new IllegalStateException(nullSafeGet(messageSupplier));
+            }
+        }
+
+        @Nullable
+        private static String nullSafeGet(@Nullable Supplier<String> messageSupplier) {
+            return (messageSupplier != null ? messageSupplier.get() : null);
+        }
+
+
+    }
+
 }

--- a/modules/gcloud/src/test/java/org/testcontainers/containers/BigQueryEmulatorContainerTest.java
+++ b/modules/gcloud/src/test/java/org/testcontainers/containers/BigQueryEmulatorContainerTest.java
@@ -3,15 +3,35 @@ package org.testcontainers.containers;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
+import com.google.cloud.bigquery.DatasetInfo;
+import com.google.cloud.bigquery.Field;
+import com.google.cloud.bigquery.FormatOptions;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardSQLTypeName;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDataWriteChannel;
+import com.google.cloud.bigquery.TableId;
+import com.google.cloud.bigquery.TableInfo;
 import com.google.cloud.bigquery.TableResult;
+import com.google.cloud.bigquery.WriteChannelConfiguration;
+import org.awaitility.Awaitility;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.Writer;
 import java.math.BigDecimal;
+import java.nio.channels.Channels;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 public class BigQueryEmulatorContainerTest {
 
@@ -51,4 +71,82 @@ public class BigQueryEmulatorContainerTest {
             assertThat(values).containsOnly(BigDecimal.valueOf(30));
         }
     }
+
+    /**
+     * When writing data to BigQuery, we run into the problem as documented
+     * <a href="https://github.com/goccy/bigquery-emulator/issues/160#issuecomment-1801515384">here</a>.
+     */
+    @Test
+    public void testThatTheContainerCanBeUsedWriteDataToBigQuery() throws Exception {
+        try (
+            // emulatorContainer {
+            BigQueryEmulatorContainer container = new BigQueryEmulatorContainer("ghcr.io/goccy/bigquery-emulator:0.4.3")
+            // }
+        ) {
+            container.start();
+
+            // bigQueryClient {
+            String url = container.getEmulatorHttpEndpoint();
+            BigQueryOptions options = BigQueryOptions
+                .newBuilder()
+                .setProjectId(container.getProjectId())
+                .setHost(url)
+                .setLocation(url)
+                .setCredentials(NoCredentials.getInstance())
+                .build();
+            BigQuery bigQuery = options.getService();
+            // }
+
+            bigQuery.create(DatasetInfo.of("write_test_dataset"));
+            StandardTableDefinition tableDefinition = StandardTableDefinition.newBuilder()
+                .setSchema(Schema.of(Field.of("value", StandardSQLTypeName.STRING)))
+                .build();
+            TableId tableId = TableId.of("write_test_dataset", "write_test");
+            bigQuery.create(TableInfo.of(tableId, tableDefinition));
+
+            WriteChannelConfiguration.Builder writeChannelConfiguration =
+                WriteChannelConfiguration.newBuilder(tableId)
+                    .setFormatOptions(FormatOptions.json())
+                    .setWriteDisposition(JobInfo.WriteDisposition.WRITE_APPEND)
+                    .setCreateDisposition(JobInfo.CreateDisposition.CREATE_NEVER)
+                    .setSchema(tableDefinition.getSchema());
+            TableDataWriteChannel writer = bigQuery.writer(writeChannelConfiguration.build());
+            try (Writer sink = Channels.newWriter(writer, "UTF-8")) {
+                sink.write("{\"value\":\"test\"}");
+            }
+            await()
+                .atMost(Duration.ofSeconds(10))
+                .until(() -> JobStatus.State.DONE.equals(writer.getJob().getStatus().getState()));
+
+            String sql =
+                "SELECT * FROM write_test_dataset.write_test";
+            TableResult result = bigQuery.query(QueryJobConfiguration.newBuilder(sql).build());
+            List<String> values = result
+                .streamValues()
+                .map(fieldValues -> fieldValues.get(0).getStringValue())
+                .collect(Collectors.toList());
+            assertThat(values).containsExactly("test");
+        }
+    }
+
+    @Test
+    public void testThatAnInitFunctionCanBeRunAfterTheContainerHasStarted() {
+        try (
+            // emulatorContainer {
+            BigQueryEmulatorContainer container = new BigQueryEmulatorContainer("ghcr.io/goccy/bigquery-emulator:0.4.3")
+            // }
+        ) {
+            Boolean[] initFunctionCalled = new Boolean[1];
+            container.withInitFunction((ctr, reused) -> {
+                initFunctionCalled[0] = true;
+                assertThat(ctr).isSameAs(container);
+                assertThat(reused).isFalse();
+                assertThat(ctr.isRunning()).isTrue();
+            });
+            container.start();
+            assertThat(initFunctionCalled[0]).isTrue();
+        }
+    }
+
+
 }


### PR DESCRIPTION
The image <tt>ghcr.io/goccy/bigquery-emulator</tt> currently cannot be used with a docker host port that differs from the container's Http and Grcp ports. You can find more detailed information on the underlying problem in this [comment](https://github.com/goccy/bigquery-emulator/issues/160#issuecomment-1801515384). 

The problem is also specified in the test org.testcontainers.containers.BigQueryEmulatorContainerTest#testThatTheContainerCanBeUsedWriteDataToBigQuery.

The fix is to change the container command to use the same ports that are exposed to the docker host system. In order to keep it convenient I've added some utilities to select a random, free docker host port.

New features introduced by this pull request
- Support for an init function to be called once the container has started
- Support for further parameters supported by https://github.com/goccy/bigquery-emulator