### PR TITLE
Changed YSQL wait strategy in YugabyteDB module

### DIFF
--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
@@ -57,7 +57,7 @@ public class YugabyteDBYSQLContainer extends JdbcDatabaseContainer<YugabyteDBYSQ
         super(imageName);
         imageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
         withExposedPorts(YSQL_PORT, MASTER_DASHBOARD_PORT, TSERVER_DASHBOARD_PORT);
-        waitingFor(new YugabyteDBYSQLWaitStrategy(this).withStartupTimeout(Duration.ofSeconds(60)));
+        waitingFor(new YugabyteDBYSQLWaitStrategy().withStartupTimeout(Duration.ofSeconds(60)));
         withCommand(ENTRYPOINT);
     }
 
@@ -153,5 +153,10 @@ public class YugabyteDBYSQLContainer extends JdbcDatabaseContainer<YugabyteDBYSQ
     public YugabyteDBYSQLContainer withPassword(final String password) {
         this.password = password;
         return this;
+    }
+
+    @Override
+    protected void waitUntilContainerStarted() {
+        getWaitStrategy().waitUntilReady(this);
     }
 }

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/YugabyteDBYSQLContainer.java
@@ -57,7 +57,7 @@ public class YugabyteDBYSQLContainer extends JdbcDatabaseContainer<YugabyteDBYSQ
         super(imageName);
         imageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
         withExposedPorts(YSQL_PORT, MASTER_DASHBOARD_PORT, TSERVER_DASHBOARD_PORT);
-        waitingFor(new YugabyteDBYSQLWaitStrategy().withStartupTimeout(Duration.ofSeconds(60)));
+        waitingFor(new YugabyteDBYSQLWaitStrategy(this).withStartupTimeout(Duration.ofSeconds(60)));
         withCommand(ENTRYPOINT);
     }
 

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/delegate/YugabyteDBYCQLDelegate.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/delegate/YugabyteDBYCQLDelegate.java
@@ -33,9 +33,20 @@ public final class YugabyteDBYCQLDelegate extends AbstractYCQLDelegate {
         boolean continueOnError,
         boolean ignoreFailedDrops
     ) {
+        final String containerInterfaceIP = container
+            .getContainerInfo()
+            .getNetworkSettings()
+            .getNetworks()
+            .entrySet()
+            .stream()
+            .findFirst()
+            .get()
+            .getValue()
+            .getIpAddress();
         try {
             ExecResult result = container.execInContainer(
                 BIN_PATH,
+                containerInterfaceIP,
                 "-u",
                 container.getUsername(),
                 "-p",

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYCQLWaitStrategy.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYCQLWaitStrategy.java
@@ -37,6 +37,16 @@ public final class YugabyteDBYCQLWaitStrategy extends AbstractWaitStrategy {
     public void waitUntilReady(WaitStrategyTarget target) {
         YugabyteDBYCQLContainer container = (YugabyteDBYCQLContainer) target;
         AtomicBoolean status = new AtomicBoolean(true);
+        final String containerInterfaceIP = container
+            .getContainerInfo()
+            .getNetworkSettings()
+            .getNetworks()
+            .entrySet()
+            .stream()
+            .findFirst()
+            .get()
+            .getValue()
+            .getIpAddress();
         retryUntilSuccess(
             (int) startupTimeout.getSeconds(),
             TimeUnit.SECONDS,
@@ -46,6 +56,7 @@ public final class YugabyteDBYCQLWaitStrategy extends AbstractWaitStrategy {
                         try {
                             ExecResult result = container.execInContainer(
                                 BIN_PATH,
+                                containerInterfaceIP,
                                 "-u",
                                 container.getUsername(),
                                 "-p",

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYSQLWaitStrategy.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYSQLWaitStrategy.java
@@ -30,8 +30,7 @@ public final class YugabyteDBYSQLWaitStrategy extends AbstractWaitStrategy {
     private static final String YSQL_EXTENDED_PROBE =
         "CREATE TABLE IF NOT EXISTS YB_SAMPLE(k int, v int, primary key(k, v))";
 
-    private static final String YSQL_EXTENDED_PROBE_DROP_TABLE =
-        "DROP TABLE IF EXISTS YB_SAMPLE";
+    private static final String YSQL_EXTENDED_PROBE_DROP_TABLE = "DROP TABLE IF EXISTS YB_SAMPLE";
 
     @Override
     public void waitUntilReady() {

--- a/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYSQLWaitStrategy.java
+++ b/modules/yugabytedb/src/main/java/org/testcontainers/containers/strategy/YugabyteDBYSQLWaitStrategy.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.YugabyteDBYSQLContainer;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategyTarget;
 
 import java.sql.Connection;
 import java.sql.SQLException;
@@ -27,14 +28,16 @@ import static org.rnorth.ducttape.unreliables.Unreliables.retryUntilSuccess;
 @Slf4j
 public final class YugabyteDBYSQLWaitStrategy extends AbstractWaitStrategy {
 
+    private final WaitStrategyTarget target;
+
     private static final String YSQL_EXTENDED_PROBE =
         "CREATE TABLE IF NOT EXISTS YB_SAMPLE(k int, v int, primary key(k, v))";
 
     private static final String YSQL_EXTENDED_PROBE_DROP_TABLE = "DROP TABLE IF EXISTS YB_SAMPLE";
 
     @Override
-    public void waitUntilReady() {
-        YugabyteDBYSQLContainer container = (YugabyteDBYSQLContainer) waitStrategyTarget;
+    public void waitUntilReady(WaitStrategyTarget target) {
+        YugabyteDBYSQLContainer container = (YugabyteDBYSQLContainer) target;
         retryUntilSuccess(
             (int) startupTimeout.getSeconds(),
             TimeUnit.SECONDS,
@@ -51,5 +54,10 @@ public final class YugabyteDBYSQLWaitStrategy extends AbstractWaitStrategy {
                 return true;
             }
         );
+    }
+
+    @Override
+    public void waitUntilReady() {
+        waitUntilReady(target);
     }
 }

--- a/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
@@ -112,7 +112,9 @@ public class YugabyteDBYCQLTest {
     public void shouldStartWhenContainerIpIsUsedInWaitStrategy() {
         try (final YugabyteDBYCQLContainer ycqlContainer = new YugabyteDBYCQLContainer(IMAGE_NAME_2_18)) {
             ycqlContainer.start();
-            assertThat(performQuery(ycqlContainer, "SELECT release_version FROM system.local").wasApplied()).isTrue();
+            boolean isQueryExecuted = performQuery(ycqlContainer, "SELECT release_version FROM system.local")
+                .wasApplied();
+            assertThat(isQueryExecuted).isTrue();
         }
     }
 

--- a/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
@@ -15,6 +15,8 @@ public class YugabyteDBYCQLTest {
 
     private static final String IMAGE_NAME = "yugabytedb/yugabyte:2.14.4.0-b26";
 
+    private static final String IMAGE_NAME_2_18 = "yugabytedb/yugabyte:2.18.3.0-b75";
+
     private static final DockerImageName YBDB_TEST_IMAGE = DockerImageName.parse(IMAGE_NAME);
 
     @Test
@@ -103,6 +105,14 @@ public class YugabyteDBYCQLTest {
             ResultSet output = performQuery(ycqlContainer, "SELECT greet FROM random.dsql");
             assertThat(output.wasApplied()).as("Statements from a custom script execution succeeds").isTrue();
             assertThat(output.one().getString(0)).as("A record match succeeds").isEqualTo("Hello DSQL");
+        }
+    }
+
+    @Test
+    public void shouldStartWhenContainerIpIsUsedInWaitStrategy() {
+        try (final YugabyteDBYCQLContainer ycqlContainer = new YugabyteDBYCQLContainer(IMAGE_NAME_2_18)) {
+            ycqlContainer.start();
+            assertThat(performQuery(ycqlContainer, "SELECT release_version FROM system.local").wasApplied()).isTrue();
         }
     }
 

--- a/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYSQLTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYSQLTest.java
@@ -103,12 +103,12 @@ public class YugabyteDBYSQLTest extends AbstractContainerDatabaseTest {
             assertThat(performQuery(ysqlContainer, "SELECT 1").getInt(1))
                 .as("A sample test query succeeds")
                 .isEqualTo(1);
-            assertThat(
-                performQuery(ysqlContainer, "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'YB_SAMPLE')")
-                    .getBoolean(1)
+            boolean tableExists = performQuery(
+                ysqlContainer,
+                "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'YB_SAMPLE')"
             )
-                .as("yb_sample table does not exists")
-                .isEqualTo(false);
+                .getBoolean(1);
+            assertThat(tableExists).as("yb_sample table does not exists").isFalse();
         }
     }
 }

--- a/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYSQLTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYSQLTest.java
@@ -95,4 +95,20 @@ public class YugabyteDBYSQLTest extends AbstractContainerDatabaseTest {
                 .isEqualTo(1);
         }
     }
+
+    @Test
+    public void testWaitStrategy() throws SQLException {
+        try (final YugabyteDBYSQLContainer ysqlContainer = new YugabyteDBYSQLContainer(YBDB_TEST_IMAGE)) {
+            ysqlContainer.start();
+            assertThat(performQuery(ysqlContainer, "SELECT 1").getInt(1))
+                .as("A sample test query succeeds")
+                .isEqualTo(1);
+            assertThat(
+                performQuery(ysqlContainer, "SELECT EXISTS (SELECT FROM pg_tables WHERE tablename = 'YB_SAMPLE')")
+                    .getBoolean(1)
+            )
+                .as("yb_sample table does not exists")
+                .isEqualTo(false);
+        }
+    }
 }


### PR DESCRIPTION
Update YSQL wait strategy by using CREATE and DROP TABLE query instead of select statement.

Also, make YCQL container compatible with version YugabyteDB 2.18.
