### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v4.0.0
+        uses: github/combine-prs@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -109,7 +109,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'redis.clients:jedis:5.0.2'
-    testImplementation 'com.rabbitmq:amqp-client:5.19.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.20.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.0"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.1"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('org.seleniumhq.selenium:selenium-bom:4.14.1')
+    implementation platform('org.seleniumhq.selenium:selenium-bom:4.15.0')
     implementation 'org.seleniumhq.selenium:selenium-remote-driver'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'com.hazelcast:hazelcast:5.3.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation 'io.nats:jnats:2.17.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.12'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:postgresql'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 
 test {

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.azure:azure-cosmos:4.51.0'
+    testImplementation 'com.azure:azure-cosmos:4.52.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.572'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.572'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.587'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.587'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.10.4"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.11.1"
     testImplementation "org.elasticsearch.client:transport:7.17.14"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.25.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.27.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.21.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.22.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.5")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.22.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
 }
 
 test {

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:24.0.1")
 
     shaded("org.apache.commons:commons-lang3:3.13.0")
-    shaded("commons-io:commons-io:2.14.0")
+    shaded("commons-io:commons-io:2.15.0")
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    implementation platform('org.junit:junit-bom:5.10.0')
+    implementation platform('org.junit:junit-bom:5.10.1')
     implementation 'org.junit.jupiter:junit-jupiter-api'
 
     testImplementation project(':mysql')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.9.0'
+    testImplementation 'io.fabric8:kubernetes-client:6.9.2'
     testImplementation 'io.kubernetes:client-java:19.0.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.21.5'
+    testImplementation 'software.amazon.awssdk:s3:2.21.22'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.2.0'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.3.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:8.5.6")
+    testImplementation("io.minio:minio:8.5.7")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.11.0")
+    testImplementation("org.mongodb:mongodb-driver-sync:4.11.1")
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.1.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.2.jre8'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
+    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
@@ -15,7 +15,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
+    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 }
 
 test {

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
+    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
@@ -15,7 +15,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.1.1'
+    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 }
 
 test {

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.0'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.23"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.24"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.23"
+    api "com.orientechnologies:orientdb-client:3.2.24"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.0'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.0'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.1'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.1'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.0'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.1'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.3.3'
+    testImplementation 'org.questdb:questdb:7.3.4'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.19.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.20.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.0'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.1'
 
     testCompileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:430'
+    testRuntimeOnly 'io.trino:trino-jdbc:433'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.trino:trino-jdbc from 430 to 433 in /modules/trino (#7805) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.10.4 to 8.11.1 in /modules/elasticsearch (#7804) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.14 to 7.17.15 in /modules/elasticsearch (#7803) @app/dependabot
* Bump com.oracle.database.r2dbc:oracle-r2dbc from 1.1.1 to 1.2.0 in /modules/oracle-xe (#7801) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.21.5 to 2.21.22 in /modules/localstack (#7800) @app/dependabot
* Bump org.questdb:questdb from 7.3.3 to 7.3.4 in /modules/questdb (#7798) @app/dependabot
* Bump io.minio:minio from 8.5.6 to 8.5.7 in /modules/minio (#7797) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.25.0 to 26.27.0 in /modules/gcloud (#7796) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.2.0 to 3.3.0 in /modules/mariadb (#7795) @app/dependabot
* Bump com.oracle.database.r2dbc:oracle-r2dbc from 1.1.1 to 1.2.0 in /modules/oracle-free (#7794) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.572 to 1.12.587 in /modules/dynalite (#7793) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.21.0 to 4.22.0 in /modules/hivemq (#7792) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.11.0 to 4.11.1 in /modules/mongodb (#7791) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.10.0 to 5.10.1 in /modules/hivemq (#7775) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.10.0 to 5.10.1 in /modules/hivemq (#7774) @app/dependabot
* Bump org.junit:junit-bom from 5.10.0 to 5.10.1 in /modules/junit-jupiter (#7773) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.10.0 to 5.10.1 in /examples (#7770) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.10.0 to 5.10.1 in /examples (#7769) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.0 to 5.10.1 in /examples (#7768) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.10.0 to 1.10.1 in /modules/spock (#7765) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.0 to 1.10.1 in /modules/spock (#7764) @app/dependabot
* Bump github/combine-prs from 4.0.0 to 4.1.0 (#7759) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-bom from 4.14.1 to 4.15.0 in /examples (#7760) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.9.0 to 6.9.2 in /modules/k3s (#7754) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.19.0 to 5.20.0 in /modules/rabbitmq (#7741) @app/dependabot
* Bump org.apache.pulsar:pulsar-client-admin from 3.1.0 to 3.1.1 in /modules/pulsar (#7740) @app/dependabot
* Bump org.apache.pulsar:pulsar-client from 3.1.0 to 3.1.1 in /modules/pulsar (#7739) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.4.1.jre8 to 12.4.2.jre8 in /modules/mssqlserver (#7738) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.23 to 3.2.24 in /modules/orientdb (#7737) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.23 to 3.2.24 in /modules/orientdb (#7736) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.19.0 to 5.20.0 in /core (#7735) @app/dependabot
* Bump commons-io:commons-io from 2.14.0 to 2.15.0 in /modules/hivemq (#7734) @app/dependabot
* Bump com.azure:azure-cosmos from 4.51.0 to 4.52.0 in /modules/azure (#7733) @app/dependabot
