### PR TITLE
Combined dependencies PR

### DIFF
--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(":mysql")
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.14.1"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.15.0"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.2.6.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.0"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.1"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'com.hazelcast:hazelcast:5.3.4'
+    testImplementation 'com.hazelcast:hazelcast:5.3.6'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.11.1"
-    testImplementation "org.elasticsearch.client:transport:7.17.14"
+    testImplementation "org.elasticsearch.client:transport:7.17.15"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.elasticsearch.client:transport from 7.17.14 to 7.17.15 in /modules/elasticsearch (#7803) @app/dependabot
* Bump com.hazelcast:hazelcast from 5.3.4 to 5.3.6 in /examples (#7802) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.0 to 5.10.1 in /examples (#7768) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.10.0 to 5.10.1 in /examples (#7767) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.14.1 to 4.15.0 in /examples (#7761) @app/dependabot
