### PR TITLE
Keep exposed ports order in ContainerDef

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ContainerDef.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerDef.java
@@ -32,7 +32,7 @@ class ContainerDef {
     @Getter
     private RemoteDockerImage image;
 
-    Set<ExposedPort> exposedPorts = new HashSet<>();
+    List<ExposedPort> exposedPorts = new ArrayList<>();
 
     Set<PortBinding> portBindings = new HashSet<>();
 
@@ -149,11 +149,11 @@ class ContainerDef {
         setImage(new RemoteDockerImage(image));
     }
 
-    public Set<ExposedPort> getExposedPorts() {
-        return new HashSet<>(this.exposedPorts);
+    public List<ExposedPort> getExposedPorts() {
+        return new ArrayList<>(this.exposedPorts);
     }
 
-    protected void setExposedPorts(Set<ExposedPort> exposedPorts) {
+    protected void setExposedPorts(List<ExposedPort> exposedPorts) {
         this.exposedPorts.clear();
         this.exposedPorts.addAll(exposedPorts);
     }

--- a/core/src/main/java/org/testcontainers/containers/ContainerDef.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerDef.java
@@ -32,7 +32,7 @@ class ContainerDef {
     @Getter
     private RemoteDockerImage image;
 
-    List<ExposedPort> exposedPorts = new ArrayList<>();
+    Set<ExposedPort> exposedPorts = new HashSet<>();
 
     Set<PortBinding> portBindings = new HashSet<>();
 
@@ -149,11 +149,11 @@ class ContainerDef {
         setImage(new RemoteDockerImage(image));
     }
 
-    public List<ExposedPort> getExposedPorts() {
-        return new ArrayList<>(this.exposedPorts);
+    public Set<ExposedPort> getExposedPorts() {
+        return new HashSet<>(this.exposedPorts);
     }
 
-    protected void setExposedPorts(List<ExposedPort> exposedPorts) {
+    protected void setExposedPorts(Set<ExposedPort> exposedPorts) {
         this.exposedPorts.clear();
         this.exposedPorts.addAll(exposedPorts);
     }

--- a/core/src/main/java/org/testcontainers/containers/ContainerDef.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerDef.java
@@ -32,7 +32,7 @@ class ContainerDef {
     @Getter
     private RemoteDockerImage image;
 
-    Set<ExposedPort> exposedPorts = new HashSet<>();
+    Set<ExposedPort> exposedPorts = new LinkedHashSet<>();
 
     Set<PortBinding> portBindings = new HashSet<>();
 
@@ -150,7 +150,7 @@ class ContainerDef {
     }
 
     public Set<ExposedPort> getExposedPorts() {
-        return new HashSet<>(this.exposedPorts);
+        return new LinkedHashSet<>(this.exposedPorts);
     }
 
     protected void setExposedPorts(Set<ExposedPort> exposedPorts) {

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -281,6 +281,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @Override
     public void setExposedPorts(List<Integer> exposedPorts) {
+        this.containerDef.exposedPorts.clear();
         for (Integer exposedPort : exposedPorts) {
             this.containerDef.addExposedTcpPort(exposedPort);
         }

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -272,12 +272,18 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @Override
     public List<Integer> getExposedPorts() {
-        return this.containerDef.getExposedPorts().stream().map(ExposedPort::getPort).collect(Collectors.toList());
+        List<Integer> exposedPorts = new ArrayList<>();
+        for (ExposedPort exposedPort : this.containerDef.getExposedPorts()) {
+            exposedPorts.add(exposedPort.getPort());
+        }
+        return exposedPorts;
     }
 
     @Override
     public void setExposedPorts(List<Integer> exposedPorts) {
-        this.containerDef.setExposedPorts(exposedPorts.stream().map(ExposedPort::tcp).collect(Collectors.toSet()));
+        for (Integer exposedPort : exposedPorts) {
+            this.containerDef.addExposedTcpPort(exposedPort);
+        }
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -277,7 +277,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @Override
     public void setExposedPorts(List<Integer> exposedPorts) {
-        this.containerDef.setExposedPorts(exposedPorts.stream().map(ExposedPort::tcp).collect(Collectors.toSet()));
+        this.containerDef.setExposedPorts(exposedPorts.stream().map(ExposedPort::tcp).collect(Collectors.toList()));
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -277,7 +277,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @Override
     public void setExposedPorts(List<Integer> exposedPorts) {
-        this.containerDef.setExposedPorts(exposedPorts.stream().map(ExposedPort::tcp).collect(Collectors.toList()));
+        this.containerDef.setExposedPorts(exposedPorts.stream().map(ExposedPort::tcp).collect(Collectors.toSet()));
     }
 
     /**


### PR DESCRIPTION
Order is lost and break modules with multiple ports defined
when using `getFirstMappedPort()`
