### PR TITLE
Add support for workdir and env var in exec command

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -52,7 +52,9 @@ tasks.japicmp {
 
     methodExcludes = [
         "org.testcontainers.containers.Container#getDockerClient()",
-        "org.testcontainers.containers.ContainerState#getDockerClient()"
+        "org.testcontainers.containers.ContainerState#getDockerClient()",
+        "org.testcontainers.containers.ContainerState#execInContainer(org.testcontainers.containers.ExecConfig)",
+        "org.testcontainers.containers.ContainerState#execInContainer(java.nio.charset.Charset,org.testcontainers.containers.ExecConfig)"
     ]
 
     fieldExcludes = []

--- a/core/src/main/java/org/testcontainers/containers/ContainerState.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerState.java
@@ -266,26 +266,49 @@ public interface ContainerState {
      * Run a command inside a running container as a given user, as using "docker exec -u user".
      * <p>
      * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, InspectContainerResponse, String, String...)
+     * @deprecated use {@link #execInContainer(ExecConfig)}
      */
+    @Deprecated
     default Container.ExecResult execInContainerWithUser(String user, String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {
-        return ExecInContainerPattern.execInContainerWithUser(getDockerClient(), getContainerInfo(), user, command);
+        return ExecInContainerPattern.execInContainer(
+            getDockerClient(),
+            getContainerInfo(),
+            ExecConfig.builder().user(user).command(command).build()
+        );
     }
 
     /**
      * Run a command inside a running container as a given user, as using "docker exec -u user".
      * <p>
      * @see ExecInContainerPattern#execInContainerWithUser(DockerClient, InspectContainerResponse, Charset, String, String...)
+     * @deprecated use {@link #execInContainer(Charset, ExecConfig)}
      */
+    @Deprecated
     default Container.ExecResult execInContainerWithUser(Charset outputCharset, String user, String... command)
         throws UnsupportedOperationException, IOException, InterruptedException {
-        return ExecInContainerPattern.execInContainerWithUser(
+        return ExecInContainerPattern.execInContainer(
             getDockerClient(),
             getContainerInfo(),
             outputCharset,
-            user,
-            command
+            ExecConfig.builder().user(user).command(command).build()
         );
+    }
+
+    /**
+     * Run a command inside a running container, as though using "docker exec".
+     */
+    default Container.ExecResult execInContainer(ExecConfig execConfig)
+        throws UnsupportedOperationException, IOException, InterruptedException {
+        return ExecInContainerPattern.execInContainer(getDockerClient(), getContainerInfo(), execConfig);
+    }
+
+    /**
+     * Run a command inside a running container, as though using "docker exec".
+     */
+    default Container.ExecResult execInContainer(Charset outputCharset, ExecConfig execConfig)
+        throws UnsupportedOperationException, IOException, InterruptedException {
+        return ExecInContainerPattern.execInContainer(getDockerClient(), getContainerInfo(), outputCharset, execConfig);
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/containers/ExecConfig.java
+++ b/core/src/main/java/org/testcontainers/containers/ExecConfig.java
@@ -1,0 +1,34 @@
+package org.testcontainers.containers;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+/**
+ * Exec configuration.
+ */
+@Builder
+@Getter
+public class ExecConfig {
+
+    /**
+     * The command to run.
+     */
+    private String[] command;
+
+    /**
+     * The user to run the exec process.
+     */
+    private String user;
+
+    /**
+     * Key-value pairs of environment variables.
+     */
+    private Map<String, String> envVars;
+
+    /**
+     * The working directory for the exec process.
+     */
+    private String workDir;
+}

--- a/core/src/test/java/org/testcontainers/junit/ExecInContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ExecInContainerTest.java
@@ -1,0 +1,73 @@
+package org.testcontainers.junit;
+
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.testcontainers.TestImages;
+import org.testcontainers.containers.ExecConfig;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.TestEnvironment;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExecInContainerTest {
+
+    @ClassRule
+    public static GenericContainer<?> redis = new GenericContainer<>(TestImages.REDIS_IMAGE).withExposedPorts(6379);
+
+    @Test
+    public void shouldExecuteCommand() throws Exception {
+        // The older "lxc" execution driver doesn't support "exec". At the time of writing (2016/03/29),
+        // that's the case for CircleCI.
+        // Once they resolve the issue, this clause can be removed.
+        Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
+
+        final GenericContainer.ExecResult result = redis.execInContainer("redis-cli", "role");
+        assertThat(result.getStdout())
+            .as("Output for \"redis-cli role\" command should start with \"master\"")
+            .startsWith("master");
+        assertThat(result.getStderr()).as("Stderr for \"redis-cli role\" command should be empty").isEmpty();
+        // We expect to reach this point for modern Docker versions.
+    }
+
+    @Test
+    public void shouldExecuteCommandWithUser() throws Exception {
+        // The older "lxc" execution driver doesn't support "exec". At the time of writing (2016/03/29),
+        // that's the case for CircleCI.
+        // Once they resolve the issue, this clause can be removed.
+        Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
+
+        final GenericContainer.ExecResult result = redis.execInContainerWithUser("redis", "whoami");
+        assertThat(result.getStdout())
+            .as("Output for \"whoami\" command should start with \"redis\"")
+            .startsWith("redis");
+        assertThat(result.getStderr()).as("Stderr for \"whoami\" command should be empty").isEmpty();
+        // We expect to reach this point for modern Docker versions.
+    }
+
+    @Test
+    public void shouldExecuteCommandWithWorkdir() throws Exception {
+        Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
+
+        final GenericContainer.ExecResult result = redis.execInContainer(
+            ExecConfig.builder().workDir("/opt").command(new String[] { "pwd" }).build()
+        );
+        assertThat(result.getStdout()).startsWith("/opt");
+    }
+
+    @Test
+    public void shouldExecuteCommandWithEnvVars() throws Exception {
+        Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
+
+        final GenericContainer.ExecResult result = redis.execInContainer(
+            ExecConfig
+                .builder()
+                .envVars(Collections.singletonMap("TESTCONTAINERS", "JAVA"))
+                .command(new String[] { "env" })
+                .build()
+        );
+        assertThat(result.getStdout()).contains("TESTCONTAINERS=JAVA");
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
+++ b/core/src/test/java/org/testcontainers/junit/GenericContainerRuleTest.java
@@ -14,7 +14,6 @@ import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.Envelope;
 import org.apache.commons.io.FileUtils;
 import org.bson.Document;
-import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Ignore;
@@ -28,7 +27,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.SelinuxContext;
 import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
 import org.testcontainers.utility.Base58;
-import org.testcontainers.utility.TestEnvironment;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -357,36 +355,6 @@ public class GenericContainerRuleTest {
         } finally {
             failsImmediately.stop();
         }
-    }
-
-    @Test
-    public void testExecInContainer() throws Exception {
-        // The older "lxc" execution driver doesn't support "exec". At the time of writing (2016/03/29),
-        // that's the case for CircleCI.
-        // Once they resolve the issue, this clause can be removed.
-        Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
-
-        final GenericContainer.ExecResult result = redis.execInContainer("redis-cli", "role");
-        assertThat(result.getStdout())
-            .as("Output for \"redis-cli role\" command should start with \"master\"")
-            .startsWith("master");
-        assertThat(result.getStderr()).as("Stderr for \"redis-cli role\" command should be empty").isEmpty();
-        // We expect to reach this point for modern Docker versions.
-    }
-
-    @Test
-    public void testExecInContainerWithUser() throws Exception {
-        // The older "lxc" execution driver doesn't support "exec". At the time of writing (2016/03/29),
-        // that's the case for CircleCI.
-        // Once they resolve the issue, this clause can be removed.
-        Assume.assumeTrue(TestEnvironment.dockerExecutionDriverSupportsExec());
-
-        final GenericContainer.ExecResult result = redis.execInContainerWithUser("redis", "whoami");
-        assertThat(result.getStdout())
-            .as("Output for \"whoami\" command should start with \"redis\"")
-            .startsWith("redis");
-        assertThat(result.getStderr()).as("Stderr for \"whoami\" command should be empty").isEmpty();
-        // We expect to reach this point for modern Docker versions.
     }
 
     @Test


### PR DESCRIPTION
Currently, only `user` and `command` can be used with `execInContainer`.
This commit introduces `ExecConfig`, which allows to set workdir and
env vars when running an exec process.

`execInContainerWithUser` is deprecated in favor of `execInContainer(ExecConfig)`
