### PR TITLE
Fix regression using GenericContainer#setImage

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -267,6 +267,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     }
 
     public void setImage(Future<String> image) {
+        this.image = new RemoteDockerImage(image);
         this.containerDef.setImage(new RemoteDockerImage(image));
     }
 

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -20,6 +20,7 @@ import org.testcontainers.DockerClientFactory;
 import org.testcontainers.TestImages;
 import org.testcontainers.containers.startupcheck.StartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
+import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.MountableFile;
@@ -220,6 +221,14 @@ public class GenericContainerTest {
                 .filteredOn(event -> event.getMessage().matches(regexMatch))
                 .isNotEmpty();
         }
+    }
+
+    @Test
+    public void shouldReturnTheProvidedImage() {
+        GenericContainer container = new GenericContainer(TestImages.REDIS_IMAGE);
+        assertThat(container.getImage().get()).isEqualTo("redis:3.0.2");
+        container.setImage(new RemoteDockerImage(TestImages.ALPINE_IMAGE));
+        assertThat(container.getImage().get()).isEqualTo("alpine:3.16");
     }
 
     static class NoopStartupCheckStrategy extends StartupCheckStrategy {


### PR DESCRIPTION
1dba8d1 introduced a breaking change. `GenericContainer#getImage`
returns the value of `ContainerDef#getImage` instead of `RemoteImageName`
because this is not set anymore when using `GenericContainer#setImage`.
