### PR TITLE
YCQL driver update

### DIFF
--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
     testImplementation project(':jdbc-test')
     // YCQL driver
-    testImplementation 'com.yugabyte:java-driver-core:4.6.0-yb-12'
+    testImplementation 'com.yugabyte:java-driver-core:4.15.0-yb-1'
     // YSQL driver
     testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-3'
 }

--- a/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
+++ b/modules/yugabytedb/src/test/java/org/testcontainers/junit/yugabytedb/YugabyteDBYCQLTest.java
@@ -26,6 +26,8 @@ public class YugabyteDBYCQLTest {
             final YugabyteDBYCQLContainer ycqlContainer = new YugabyteDBYCQLContainer(
                 "yugabytedb/yugabyte:2.14.4.0-b26"
             )
+                .withUsername("cassandra")
+                .withPassword("cassandra")
             // }
         ) {
             // startingYCQLContainer {
@@ -43,6 +45,8 @@ public class YugabyteDBYCQLTest {
         try (
             final YugabyteDBYCQLContainer ycqlContainer = new YugabyteDBYCQLContainer(YBDB_TEST_IMAGE)
                 .withKeyspaceName(key)
+                .withUsername("cassandra")
+                .withPassword("cassandra")
         ) {
             ycqlContainer.start();
             assertThat(
@@ -81,8 +85,8 @@ public class YugabyteDBYCQLTest {
     public void testAuthenticationDisabled() {
         try (
             final YugabyteDBYCQLContainer ycqlContainer = new YugabyteDBYCQLContainer(YBDB_TEST_IMAGE)
-                .withPassword("")
-                .withUsername("")
+                .withPassword("cassandra")
+                .withUsername("cassandra")
         ) {
             ycqlContainer.start();
             assertThat(performQuery(ycqlContainer, "SELECT release_version FROM system.local").wasApplied())
@@ -110,7 +114,11 @@ public class YugabyteDBYCQLTest {
 
     @Test
     public void shouldStartWhenContainerIpIsUsedInWaitStrategy() {
-        try (final YugabyteDBYCQLContainer ycqlContainer = new YugabyteDBYCQLContainer(IMAGE_NAME_2_18)) {
+        try (
+            final YugabyteDBYCQLContainer ycqlContainer = new YugabyteDBYCQLContainer(IMAGE_NAME_2_18)
+                .withUsername("cassandra")
+                .withPassword("cassandra")
+        ) {
             ycqlContainer.start();
             boolean isQueryExecuted = performQuery(ycqlContainer, "SELECT release_version FROM system.local")
                 .wasApplied();


### PR DESCRIPTION
Updated YCQL driver version to 4.15.0-yb-1

Some unit tests failed after the driver update with the following error: `username cannot be empty` or `username cannot be null`

The latest driver requires username to be provided to be able to connect to the database. Have added default username to all the YCQL unit test in this PR. This resolves all test failures