### PR TITLE
Register default network alias using ContainerDef

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -215,9 +215,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     private ContainerDef containerDef;
 
     ContainerDef createContainerDef() {
-        ContainerDef def = new ContainerDef();
-        def.addNetworkAlias("tc-" + Base58.randomString(8));
-        return def;
+        return new ContainerDef();
     }
 
     ContainerDef getContainerDef() {
@@ -242,6 +240,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     public GenericContainer(@NonNull final RemoteDockerImage image) {
         this.image = image;
         this.containerDef = createContainerDef();
+        this.containerDef.addNetworkAlias("tc-" + Base58.randomString(8));
         this.containerDef.setImage(image);
     }
 

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -23,6 +23,7 @@ import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.util.Arrays;
@@ -231,6 +232,30 @@ public class GenericContainerTest {
         assertThat(container.getImage().get()).isEqualTo("alpine:3.16");
     }
 
+    @Test
+    public void shouldContainDefaultNetworkAlias() {
+        try (GenericContainer<?> container = new GenericContainer<>("testcontainers/helloworld:1.1.0")) {
+            container.start();
+            assertThat(container.getNetworkAliases()).hasSize(1);
+        }
+    }
+
+    @Test
+    public void shouldContainDefaultNetworkAliasWhenUsingGenericContainer() {
+        try (HelloWorldContainer container = new HelloWorldContainer("testcontainers/helloworld:1.1.0")) {
+            container.start();
+            assertThat(container.getNetworkAliases()).hasSize(1);
+        }
+    }
+
+    @Test
+    public void shouldContainDefaultNetworkAliasWhenUsingContainerDef() {
+        try (TcHelloWorldContainer container = new TcHelloWorldContainer("testcontainers/helloworld:1.1.0")) {
+            container.start();
+            assertThat(container.getNetworkAliases()).hasSize(1);
+        }
+    }
+
     static class NoopStartupCheckStrategy extends StartupCheckStrategy {
 
         @Override
@@ -265,6 +290,33 @@ public class GenericContainerTest {
             );
 
             throw new IllegalStateException("Nope!");
+        }
+    }
+
+    static class HelloWorldContainer extends GenericContainer<HelloWorldContainer> {
+
+        public HelloWorldContainer(String image) {
+            super(DockerImageName.parse(image));
+            withExposedPorts(8080);
+        }
+    }
+
+    static class TcHelloWorldContainer extends GenericContainer<HelloWorldContainer> {
+
+        public TcHelloWorldContainer(String image) {
+            super(DockerImageName.parse(image));
+        }
+
+        @Override
+        ContainerDef createContainerDef() {
+            return new HelloWorldContainerDef();
+        }
+
+        class HelloWorldContainerDef extends ContainerDef {
+
+            HelloWorldContainerDef() {
+                addExposedTcpPort(8080);
+            }
         }
     }
 }


### PR DESCRIPTION
Changes in 1dba8d1 doesn't register a default network alias
when implementing the new `ContainerDef`. This impacts to
kafka and mongodb modules.

Fixes #7823
