### PR TITLE
Feature url parse tests

### DIFF
--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
@@ -190,5 +190,21 @@ public class ConnectionUrlTest {
             .contains("host-name_123");
     }
 
+    @Test
+    public void testDaemonModeParsing() {
+        String daemonModeUrl = "jdbc:tc:mysql://hostname/databasename?TC_DAEMON=true";
+        ConnectionUrl url = ConnectionUrl.newInstance(daemonModeUrl);
+
+        assertThat(url.isInDaemonMode()).as("Daemon mode should be enabled").isTrue();
+    }
+
+    @Test
+    public void testReusableFlagParsing() {
+        String reusableFlagUrl = "jdbc:tc:mysql://hostname/databasename?TC_REUSABLE=true";
+        ConnectionUrl url = ConnectionUrl.newInstance(reusableFlagUrl);
+
+        assertThat(url.isReusable()).as("Reusable flag should be enabled").isTrue();
+    }
+
 
 }


### PR DESCRIPTION
---

### "Add Daemon Mode and Reusable Flag Tests in `ConnectionUrlTest`"


### Description:

#### Overview
This pull request introduces new tests in the `ConnectionUrlTest` class, specifically targeting the Daemon Mode and Reusable Flag parsing in `ConnectionUrl`. The aim is to ensure that these flags are correctly interpreted and handled by the URL parsing logic.

#### Changes Included
1. **Daemon Mode Test:**
   - A test has been added to verify that `ConnectionUrl` correctly identifies and sets the daemon mode when the `TC_DAEMON` flag is present in the URL.

2. **Reusable Flag Test:**
   - A test has been included to check the accurate parsing and recognition of the `TC_REUSABLE` flag in the URL. This test ensures that `ConnectionUrl` correctly interprets the reusable state of the container.

#### Rationale
The addition of these tests is driven by the need to ensure comprehensive and accurate URL parsing in `ConnectionUrl`, particularly concerning the handling of specific flags that influence the behavior of containerized databases. Proper parsing of these flags is crucial for the expected operation of TestContainers in various scenarios.

#### Benefits
- **Enhanced Accuracy:** With these tests, we can confidently assert that `ConnectionUrl` correctly handles URLs with daemon mode and reusable flags.
- **Improved Code Reliability:** These tests help prevent future regressions and ensure that changes to `ConnectionUrl` maintain the correct handling of these important flags.
- **Clarity in Functionality:** They provide clear examples of expected behavior when using daemon mode and reusable flags, serving as documentation for developers.

Looking forward to feedback and suggestions on these test additions.

---

