### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v4.1.0
+        uses: github/combine-prs@v5.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,7 +110,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'redis.clients:jedis:5.0.2'
+    testImplementation 'redis.clients:jedis:5.1.0'
     testImplementation 'com.rabbitmq:amqp-client:5.20.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testCompileOnly 'org.jetbrains:annotations:24.0.1'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api 'org.apache.commons:commons-compress:1.25.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(":mysql")
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.15.0"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.16.1"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.6.RELEASE"
+    api "io.lettuce:lettuce-core:6.3.0.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.6.RELEASE"
+    api "io.lettuce:lettuce-core:6.3.0.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.1"

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.2.6.RELEASE"
+    api "io.lettuce:lettuce-core:6.3.0.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'
 
-    testImplementation platform('io.cucumber:cucumber-bom:7.14.0')
+    testImplementation platform('io.cucumber:cucumber-bom:7.15.0')
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit'
     testImplementation 'org.testcontainers:selenium'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('org.seleniumhq.selenium:selenium-bom:4.15.0')
+    implementation platform('org.seleniumhq.selenium:selenium-bom:4.16.1')
     implementation 'org.seleniumhq.selenium:selenium-remote-driver'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.30"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.6.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.json:json:20231013'
-    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.11'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.24.2'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.17'
+    id 'org.springframework.boot' version '2.7.18'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/examples/settings.gradle
+++ b/examples/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "gradle.plugin.ch.myniva.gradle:s3-build-cache:0.10.0"
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15.1"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.16"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.12"
     }
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.7.17'
+    id 'org.springframework.boot' version '2.7.18'
 }
 apply plugin: 'io.spring.dependency-management'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'com.azure:azure-cosmos:4.52.0'
+    testImplementation 'com.azure:azure-cosmos:4.53.1'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
-    testImplementation 'io.rest-assured:rest-assured:5.3.2'
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.4.11'
+    testImplementation 'com.couchbase.client:java-client:3.5.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
 
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'com.ibm.db2:jcc:11.5.8.0'
+    testRuntimeOnly 'com.ibm.db2:jcc:11.5.9.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.587'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.587'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.609'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.609'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.27.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.28.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:24.0.1")
 
     shaded("org.apache.commons:commons-lang3:3.13.0")
-    shaded("commons-io:commons-io:2.15.0")
+    shaded("commons-io:commons-io:2.15.1")
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.22.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.23.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.11")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: HiveMQ"
 
 dependencies {
     api(project(":testcontainers"))
-    api("org.jetbrains:annotations:24.0.1")
+    api("org.jetbrains:annotations:24.1.0")
 
     shaded("org.apache.commons:commons-lang3:3.13.0")
     shaded("commons-io:commons-io:2.15.1")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.23.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.4.11")
+    testImplementation("ch.qos.logback:logback-classic:1.4.14")
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
 }

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.influxdb:influxdb-java:2.23'
-    testImplementation "com.influxdb:influxdb-client-java:6.10.0"
+    testImplementation "com.influxdb:influxdb-client-java:6.11.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(':jdbc')
 
     api 'com.google.guava:guava:32.1.3-jre'
-    api 'org.apache.commons:commons-lang3:3.13.0'
+    api 'org.apache.commons:commons-lang3:3.14.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'
 

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.0.1'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.15'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.16'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:5.0.2'
+    testImplementation 'redis.clients:jedis:5.1.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 }
 

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.6.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
-    testImplementation 'software.amazon.awssdk:s3:2.21.22'
+    testImplementation 'software.amazon.awssdk:s3:2.21.43'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.3.0'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.3.1'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.4.2.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.5.0.jre8-preview'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.0.5'
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -2,6 +2,6 @@ description = "Testcontainers :: Nginx"
 
 dependencies {
     api project(':testcontainers')
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.24"
+    api "com.orientechnologies:orientdb-client:3.2.25"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.0'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     api "com.orientechnologies:orientdb-client:3.2.25"
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.0'
+    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.1'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.24"
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/presto/build.gradle
+++ b/modules/presto/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'io.prestosql:presto-jdbc:350'
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.questdb:questdb:7.3.7'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.questdb:questdb:7.3.4'
+    testImplementation 'org.questdb:questdb:7.3.7'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.20.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.32'
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.6.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation 'org.apache.kafka:kafka-clients:3.6.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'io.rest-assured:rest-assured:5.3.2'
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation project(':nginx')
     testImplementation 'org.assertj:assertj-core:3.24.2'
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.6.0'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.1'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.1'
 
-    testCompileOnly 'org.jetbrains:annotations:24.0.1'
+    testCompileOnly 'org.jetbrains:annotations:24.1.0'
 }
 
 sourceJar {

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:433'
+    testRuntimeOnly 'io.trino:trino-jdbc:434'
     compileOnly 'org.jetbrains:annotations:24.0.1'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.3.2'
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // YCQL driver
     testImplementation 'com.yugabyte:java-driver-core:4.15.0-yb-1'
     // YSQL driver
-    testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-3'
+    testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-4'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.15.1"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.16"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:1.12"
         classpath "org.gradle.toolchains:foojay-resolver:0.7.0"
     }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.seleniumhq.selenium:selenium-bom from 4.15.0 to 4.16.1 in /examples (#7953) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.0 to 3.6.1 in /examples (#7952) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.15.0 to 4.16.1 in /examples (#7951) @app/dependabot
* Bump org.postgresql:postgresql from 42.6.0 to 42.7.1 in /examples (#7950) @app/dependabot
* Bump io.cucumber:cucumber-bom from 7.14.0 to 7.15.0 in /examples (#7949) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.15.1 to 3.16 in /examples (#7948) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.2 to 5.4.0 in /modules/consul (#7947) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.22.0 to 4.23.0 in /modules/hivemq (#7946) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.21.22 to 2.21.43 in /modules/localstack (#7944) @app/dependabot
* Bump com.azure:azure-cosmos from 4.52.0 to 4.53.1 in /modules/azure (#7943) @app/dependabot
* Bump com.couchbase.client:java-client from 3.4.11 to 3.5.1 in /modules/couchbase (#7942) @app/dependabot
* Bump org.postgresql:postgresql from 42.6.0 to 42.7.1 in /modules/postgresql (#7941) @app/dependabot
* Bump org.postgresql:postgresql from 42.6.0 to 42.7.1 in /modules/spock (#7940) @app/dependabot
* Bump org.postgresql:postgresql from 42.6.0 to 42.7.1 in /modules/junit-jupiter (#7939) @app/dependabot
* Bump org.postgresql:postgresql from 42.6.0 to 42.7.1 in /modules/cratedb (#7938) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.27.0 to 26.28.0 in /modules/gcloud (#7937) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.10.0 to 6.11.0 in /modules/influxdb (#7936) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.2 to 5.4.0 in /modules/redpanda (#7934) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.0 to 3.6.1 in /modules/redpanda (#7935) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.15.1 to 3.16 (#7933) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.12 to 1.12.1 (#7932) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.0 to 3.6.1 in /modules/kafka (#7930) @app/dependabot
* Bump org.postgresql:postgresql from 42.6.0 to 42.7.1 in /modules/cockroachdb (#7929) @app/dependabot
* Bump org.questdb:questdb from 7.3.4 to 7.3.7 in /modules/questdb (#7928) @app/dependabot
* Bump org.postgresql:postgresql from 42.6.0 to 42.7.1 in /modules/questdb (#7927) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.587 to 1.12.609 in /modules/dynalite (#7926) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.3.2 to 5.4.0 in /modules/vault (#7925) @app/dependabot
* Bump io.trino:trino-jdbc from 433 to 434 in /modules/trino (#7918) @app/dependabot
* Bump actions/labeler from 4 to 5 (#7917) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.24 to 3.2.25 in /modules/orientdb (#7914) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.7.0 to 3.7.1 in /modules/orientdb (#7913) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.11 to 1.3.14 in /examples (#7912) @app/dependabot
* Bump commons-io:commons-io from 2.15.0 to 2.15.1 in /modules/hivemq (#7910) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.4.11 to 1.4.14 in /modules/hivemq (#7909) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.3.0 to 3.3.1 in /modules/mariadb (#7906) @app/dependabot
* Bump redis.clients:jedis from 5.0.2 to 5.1.0 in /core (#7890) @app/dependabot
* Bump github/combine-prs from 4.1.0 to 5.0.0 (#7889) @app/dependabot
* Bump redis.clients:jedis from 5.0.2 to 5.1.0 in /modules/junit-jupiter (#7886) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.13.0 to 3.14.0 in /modules/jdbc-test (#7885) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.13.0 to 3.14.0 in /modules/hivemq (#7884) @app/dependabot
* Bump org.springframework.boot from 2.7.17 to 2.7.18 in /examples (#7879) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/hivemq (#7860) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/tidb (#7858) @app/dependabot
* Bump com.ibm.db2:jcc from 11.5.8.0 to 11.5.9.0 in /modules/db2 (#7857) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/oracle-free (#7856) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/selenium (#7855) @app/dependabot
* Bump org.apache.commons:commons-compress from 1.24.0 to 1.25.0 in /core (#7854) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /core (#7853) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.15 to 10.1.16 in /modules/jdbc (#7851) @app/dependabot
* Bump com.yugabyte:jdbc-yugabytedb from 42.3.5-yb-3 to 42.3.5-yb-4 in /modules/yugabytedb (#7848) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/trino (#7847) @app/dependabot
* Bump io.lettuce:lettuce-core from 6.2.6.RELEASE to 6.3.0.RELEASE in /examples (#7844) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/spock (#7842) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/rabbitmq (#7840) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/presto (#7839) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/nginx (#7838) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/mysql (#7837) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/postgresql (#7835) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/oracle-xe (#7834) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/cratedb (#7832) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.4.2.jre8 to 12.5.0.jre8-preview in /modules/mssqlserver (#7831) @app/dependabot
