### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ subprojects {
     }
 
     dependencies {
-        testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+        testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     }
 
     checkstyle {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,8 +71,8 @@ configurations.all {
 dependencies {
     api 'junit:junit:4.13.2'
     api 'org.slf4j:slf4j-api:1.7.36'
-    compileOnly 'org.jetbrains:annotations:24.0.1'
-    testCompileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
+    testCompileOnly 'org.jetbrains:annotations:24.1.0'
     api 'org.apache.commons:commons-compress:1.25.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.3.0.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
 }
 
 test {

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.3.6'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.json:json:20231013'
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.17.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.0.2'
+    implementation 'redis.clients:jedis:5.1.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testng:testng:7.5.1'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }
 

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.0.2'
+    implementation 'redis.clients:jedis:5.1.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'com.jcraft:jsch:0.1.55'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:5.0.2'
+    implementation 'redis.clients:jedis:5.1.0'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.5.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.11'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.11.1"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.11.2"
     testImplementation "org.elasticsearch.client:transport:7.17.15"
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api(project(":testcontainers"))
     api("org.jetbrains:annotations:24.1.0")
 
-    shaded("org.apache.commons:commons-lang3:3.13.0")
+    shaded("org.apache.commons:commons-lang3:3.14.0")
     shaded("commons-io:commons-io:2.15.1")
     shaded("org.javassist:javassist:3.29.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: JDBC"
 dependencies {
     api project(':database-commons')
 
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.16'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.1'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.24"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.25"
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.5.11'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.6.0'
     testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'io.trino:trino-jdbc:434'
-    compileOnly 'org.jetbrains:annotations:24.0.1'
+    compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.16"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.12"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.12.1"
         classpath "org.gradle.toolchains:foojay-resolver:0.7.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.12 to 1.12.1 (#7932) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.11.1 to 8.11.2 in /modules/elasticsearch (#7931) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.11 to 1.3.14 in /examples (#7912) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.24 to 3.2.25 in /modules/orientdb (#7911) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.13.0 to 3.14.0 in /modules/hivemq (#7884) @app/dependabot
* Bump redis.clients:jedis from 5.0.2 to 5.1.0 in /examples (#7880) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /core (#7853) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/jdbc (#7852) @app/dependabot
* Bump org.jetbrains:annotations from 24.0.1 to 24.1.0 in /modules/trino (#7847) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.5.11 to 3.6.0 in /modules/r2dbc (#7845) @app/dependabot
