### PR TITLE
fix: Copy super constructors to JDBC and PostgreSQL

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 import org.testcontainers.containers.traits.LinkableContainer;
 import org.testcontainers.delegate.DatabaseDelegate;
 import org.testcontainers.ext.ScriptUtils;
+import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.jdbc.JdbcDatabaseDelegate;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -50,15 +51,19 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
      * @deprecated use {@link #JdbcDatabaseContainer(DockerImageName)} instead
      */
     public JdbcDatabaseContainer(@NonNull final String dockerImageName) {
-        this(DockerImageName.parse(dockerImageName));
+        super(dockerImageName);
     }
 
     public JdbcDatabaseContainer(@NonNull final Future<String> image) {
         super(image);
     }
 
-    public JdbcDatabaseContainer(final DockerImageName dockerImageName) {
+    public JdbcDatabaseContainer(@NonNull final DockerImageName dockerImageName) {
         super(dockerImageName);
+    }
+
+    public JdbcDatabaseContainer(@NonNull final RemoteDockerImage image) {
+        super(image);
     }
 
     /**


### PR DESCRIPTION
Copy constructors to JDBC and PostgreSQL to support builder pattern (migrate Future image first with Flyway, then start pre-migrated image).
After the major changes in 1.19.2 the custom GenericContainer couldn't recognize the successful start anymore.

Support waitingFor PostgreSQL replicas: "database system is ready to accept read-only connections"

Is GenericContainer#waitingFor(WaitStrategy) still consistent? It seems calling setWaitStrategy(WaitStrategy) there would make more sense now to stay compaptible/in sync with ContainerDef.