### PR TITLE
chore: update docker compose image

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -62,7 +62,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker-compose.exe" : "docker-compose";
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker/compose:1.29.2");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker:24.0.7");
 
     private final ComposeDelegate composeDelegate;
 

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -55,7 +55,7 @@ public class TestcontainersConfiguration {
 
     private static final String VNC_RECORDER_IMAGE = "testcontainers/vnc-recorder";
 
-    private static final String COMPOSE_IMAGE = "docker/compose";
+    private static final String COMPOSE_IMAGE = "docker";
 
     private static final String ALPINE_IMAGE = "alpine";
 

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -59,7 +59,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > Used by VNC recorder in Testcontainers' Selenium integration
 
 > **socat.container.image = alpine/socat**  
-> **compose.container.image = docker/compose:1.8.0**  
+> **compose.container.image = docker:24.0.7**  
 > Required if using [Docker Compose](../modules/docker_compose.md)
 
 > **kafka.container.image = confluentinc/cp-kafka**  

--- a/docs/supported_docker_environment/image_registry_rate_limiting.md
+++ b/docs/supported_docker_environment/image_registry_rate_limiting.md
@@ -15,5 +15,5 @@ As of the current version of Testcontainers ({{latest_version}}):
     * [`alpine`](https://hub.docker.com/r/_/alpine) - used to check whether images can be pulled at startup, and always required (unless [startup checks are disabled](../features/configuration.md#disabling-the-startup-checks))
     * [`testcontainers/sshd`](https://hub.docker.com/r/testcontainers/sshd) - required if [exposing host ports to containers](../features/networking.md#exposing-host-ports-to-the-container)
     * [`testcontainers/vnc-recorder`](https://hub.docker.com/r/testcontainers/vnc-recorder) - required if using [Webdriver containers](../modules/webdriver_containers.md) and using the screen recording feature
-    * [`docker/compose`](https://hub.docker.com/r/docker/compose) - required if using [Docker Compose](../modules/docker_compose.md)
+    * [`docker`](https://hub.docker.com/_/docker) - required if using [Docker Compose](../modules/docker_compose.md)
     * [`alpine/socat`](https://hub.docker.com/r/alpine/socat) - required if using [Docker Compose](../modules/docker_compose.md)


### PR DESCRIPTION
As explained in the [docker/compose](https://hub.docker.com/r/docker/compose) page:
> 📣 Docker Compose is now included as part of the Docker official image 🎉
>
> This image contains Compose v1, which has reached end of life (EOL) and is no longer supported. This image’s tags are frozen and are not updated.

This PR switches to the Docker official image which is maintained.

The new image includes an alias to the previous `docker-compose` command, so everything should keep working as expected.