### PR TITLE
Added note about Node.js being required for ./gradlew spotlessApply

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,7 +8,7 @@
     * follow the style, naming and structure conventions of the rest of the project.
     * make commits atomic and easy to merge.
     * when updating documentation, please see [our guidance for documentation contributions](contributing_docs.md).
-    * apply format running `./gradlew spotlessApply`
+    * apply format running `./gradlew spotlessApply` (this requires [Node.js](https://nodejs.org/) to be installed on your machine, one of the [package managers](https://nodejs.org/en/download/package-manager/) might be handy)
     * verify all tests are passing. Build the project with `./gradlew check` to do this.
     **N.B.** Gradle's Build Cache is enabled by default, but you can add `--no-build-cache` flag to disable it.
 


### PR DESCRIPTION
For Spotless to work, Node.js is required. If someone doesn't have it installed, the error message from Gradle task might be somewhat cryptic.