### PR TITLE
Fix SQLUtils.splitSqlScript: keep semicolons after END when semicolon is not the statement separator

### DIFF
--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptSplitter.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptSplitter.java
@@ -101,8 +101,8 @@ class ScriptSplitter {
                     if (";".equals(scanner.getCurrentMatch())) {
                         if (recursive) {
                             sb.append(temporary);
-                            appendMatch();
                         }
+                        appendMatch();
                         return true;
                     }
                     sb.append(temporary);

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptSplittingTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptSplittingTest.java
@@ -320,10 +320,17 @@ public class ScriptSplittingTest {
             "        IF something_wrong THEN LEAVE rec_loop; END IF;\n" +
             "        do_something_else;\n" +
             "    END LOOP;\n" +
-            "END",
+            "END;",
             "CALL something();"
         );
         splitAndCompare(script, expected, "@");
+    }
+
+    @Test
+    public void oracleStyleBlocks() {
+        String script = "BEGIN END; /\n" + "BEGIN END;";
+        List<String> expected = Arrays.asList("BEGIN END;", "BEGIN END;");
+        splitAndCompare(script, expected, "/");
     }
 
     @Test


### PR DESCRIPTION
This PR continues to stabilize `ScriptUtils.splitSqlScript` after major rework in https://github.com/testcontainers/testcontainers-java/pull/7646 and bug fixes in https://github.com/testcontainers/testcontainers-java/pull/7818

# Problem

Currently in scripts for Oracle, where `/` is typically used as a statement separator, top-level `BEGIN...END` blocks are stripped from the semicolon. But unlike other databases, Oracle requires that semicolon is present, otherwise a syntax error occurs.

<table>
<tr><th>Input</th><th>Current (incorrect) output</th><th>Expected output</th></tr>
<tr>
<td>

```sql
BEGIN
  -- do something
END;
/
BEGIN
   -- do something else
END;
```
</td>
<td>

```sql
BEGIN
  -- do something
END
```
----
```sql
BEGIN
   -- do something else
END
```
</td>
<td>

```sql
BEGIN
  -- do something
END;
```
----
```sql
BEGIN
   -- do something else
END;
```


</td>
</tr>
</table>

This behaviour occurs because of a [misplaced line of code](https://github.com/testcontainers/testcontainers-java/commit/bff056c011b8077741a507eb2ec84b0aa5eddb15#diff-e983db5436684878d72c530ab917a1f52581c3e43c0774e44b912c9722e5eeb3L102) 

This PR does not change the original behaviour of "recognizing" top-level `BEGIN...END` blocks when a specific statement separator is not set, i. e. 

<table>
<tr><th>Input</th><th>Current (correct) output</th></tr>
<tr>
<td>

```sql
BEGIN
  -- do something
END;

BEGIN
   -- do something else
END;
```
</td>
<td>

```sql
BEGIN
  -- do something
END
```
----
```sql
BEGIN
   -- do something else
END
```
</td>
</tr>
</table>
