### PR TITLE
Fix missing WaitStrategy support in JdbcDatabaseContainer

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -140,6 +140,8 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     @SneakyThrows(InterruptedException.class)
     @Override
     protected void waitUntilContainerStarted() {
+        super.waitUntilContainerStarted();
+
         logger()
             .info(
                 "Waiting for database connection to become available at {} using query '{}'",


### PR DESCRIPTION
As pointed out in https://github.com/testcontainers/testcontainers-java/issues/2994, the fact that `JdbcDatabaseContainer` ignores any `WaitStrategy` set on the container is very confusing to the user. This change tries to make the public API less confusing.
