### PR TITLE
Correct testcontainers for use with latest MySQL 8.3 version

### DIFF
--- a/core/src/test/resources/compose-test.yml
+++ b/core/src/test/resources/compose-test.yml
@@ -1,6 +1,6 @@
 redis:
   image: redis
 db:
-  image: mysql:5.7.34
+  image: mysql:8.0.36
   environment:
     MYSQL_RANDOM_ROOT_PASSWORD: "true"

--- a/core/src/test/resources/composev2/compose-test.yml
+++ b/core/src/test/resources/composev2/compose-test.yml
@@ -2,6 +2,6 @@ services:
   redis:
     image: redis
   db:
-    image: mysql:8.0.33
+    image: mysql:8.0.36
     environment:
       MYSQL_RANDOM_ROOT_PASSWORD: "true"

--- a/docs/examples/junit4/generic/src/test/java/generic/ImageNameSubstitutionTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ImageNameSubstitutionTest.java
@@ -12,9 +12,9 @@ public class ImageNameSubstitutionTest {
         try (
             // spotless:off
             // directDockerHubReference {
-            // Referring directly to an image on Docker Hub (mysql:8.0.24)
+            // Referring directly to an image on Docker Hub (mysql:8.0.36)
             final MySQLContainer<?> mysql = new MySQLContainer<>(
-                DockerImageName.parse("mysql:8.0.24")
+                DockerImageName.parse("mysql:8.0.36")
             )
             // start the container and use it for testing
             // }
@@ -36,7 +36,7 @@ public class ImageNameSubstitutionTest {
             // hardcodedMirror {
             // Referring directly to an image on a private registry - image name will vary
             final MySQLContainer<?> mysql = new MySQLContainer<>(
-                DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.24")
+                DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.36")
                     .asCompatibleSubstituteFor("mysql")
             )
             // start the container and use it for testing

--- a/docs/examples/junit4/generic/src/test/java/generic/support/TestSpecificImageNameSubstitutor.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/support/TestSpecificImageNameSubstitutor.java
@@ -12,7 +12,7 @@ public class TestSpecificImageNameSubstitutor extends ImageNameSubstitutor {
 
     @Override
     public DockerImageName apply(final DockerImageName original) {
-        if (original.equals(DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.24"))) {
+        if (original.equals(DockerImageName.parse("registry.mycompany.com/mirror/mysql:8.0.36"))) {
             return DockerImageName.parse("mysql");
         } else {
             return original;

--- a/docs/features/image_name_substitution.md
+++ b/docs/features/image_name_substitution.md
@@ -53,7 +53,7 @@ Consider this if:
 
 * Developers and CI machines need to use different image names. For example, developers are able to pull images from Docker Hub, but CI machines need to pull from a private registry
 * Your private registry has copies of images from Docker Hub where the names are predictable, and just adding a prefix is enough. 
-  For example, `registry.mycompany.com/mirror/mysql:8.0.24` can be derived from the original Docker Hub image name (`mysql:8.0.24`) with a consistent prefix string: `registry.mycompany.com/mirror/`
+  For example, `registry.mycompany.com/mirror/mysql:8.0.36` can be derived from the original Docker Hub image name (`mysql:8.0.36`) with a consistent prefix string: `registry.mycompany.com/mirror/`
 
 In this case, image name references in code are **unchanged**.
 i.e. you would leave as-is:

--- a/docs/features/reuse.md
+++ b/docs/features/reuse.md
@@ -30,5 +30,5 @@ GenericContainer container = new GenericContainer("redis:6-alpine")
 ### Reusable Container with Testcontainers JDBC URL
 
 If using the [Testcontainers JDBC URL support](../../modules/databases/jdbc#database-containers-launched-via-jdbc-url-scheme)
-the URL **must** follow the pattern of `jdbc:tc:mysql:5.7.34:///databasename?TC_REUSABLE=true`.
+the URL **must** follow the pattern of `jdbc:tc:mysql:8.0.36:///databasename?TC_REUSABLE=true`.
 `TC_REUSABLE=true` is set as a parameter of the JDBC URL.

--- a/docs/modules/databases/jdbc.md
+++ b/docs/modules/databases/jdbc.md
@@ -45,7 +45,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 #### Using MariaDB
 
-`jdbc:tc:mariadb:10.2.14:///databasename`
+`jdbc:tc:mariadb:10.3.39:///databasename`
 
 #### Using MySQL
 

--- a/docs/modules/databases/jdbc.md
+++ b/docs/modules/databases/jdbc.md
@@ -20,7 +20,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 !!! note
     We will use `///` (host-less URIs) from now on to emphasis the unimportance of the `host:port` pair.  
-    From Testcontainers' perspective, `jdbc:mysql:5.7.34://localhost:3306/databasename` and `jdbc:mysql:5.7.34:///databasename` is the same URI.
+    From Testcontainers' perspective, `jdbc:mysql:8.0.36://localhost:3306/databasename` and `jdbc:mysql:8.0.36:///databasename` is the same URI.
 
 !!! warning
     If you're using the JDBC URL support, there is no need to instantiate an instance of the container - Testcontainers will do it automagically.
@@ -49,7 +49,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 #### Using MySQL
 
-`jdbc:tc:mysql:5.7.34:///databasename`
+`jdbc:tc:mysql:8.0.36:///databasename`
 
 #### Using MSSQL Server
 
@@ -92,7 +92,7 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 Testcontainers can run an init script after the database container is started, but before your code is given a connection to it. The script must be on the classpath, and is referenced as follows:
 
-`jdbc:tc:mysql:5.7.34:///databasename?TC_INITSCRIPT=somepath/init_mysql.sql`
+`jdbc:tc:mysql:8.0.36:///databasename?TC_INITSCRIPT=somepath/init_mysql.sql`
 
 This is useful if you have a fixed script for setting up database schema, etc.
 
@@ -100,13 +100,13 @@ This is useful if you have a fixed script for setting up database schema, etc.
 
 If the init script path is prefixed `file:`, it will be loaded from a file (relative to the working directory, which will usually be the project root).
 
-`jdbc:tc:mysql:5.7.34:///databasename?TC_INITSCRIPT=file:src/main/resources/init_mysql.sql`
+`jdbc:tc:mysql:8.0.36:///databasename?TC_INITSCRIPT=file:src/main/resources/init_mysql.sql`
 
 ### Using an init function
 
 Instead of running a fixed script for DB setup, it may be useful to call a Java function that you define. This is intended to allow you to trigger database schema migration tools. To do this, add TC_INITFUNCTION to the URL as follows, passing a full path to the class name and method:
 
- `jdbc:tc:mysql:5.7.34:///databasename?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction`
+ `jdbc:tc:mysql:8.0.36:///databasename?TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction`
 
 The init function must be a public static method which takes a `java.sql.Connection` as its only parameter, e.g.
 ```java
@@ -121,7 +121,7 @@ public class JDBCDriverTest {
 
 By default database container is being stopped as soon as last connection is closed. There are cases when you might need to start container and keep it running till you stop it explicitly or JVM is shutdown. To do this, add `TC_DAEMON` parameter to the URL as follows:
 
- `jdbc:tc:mysql:5.7.34:///databasename?TC_DAEMON=true`
+ `jdbc:tc:mysql:8.0.36:///databasename?TC_DAEMON=true`
 
 With this parameter database container will keep running even when there're no open connections.
 

--- a/docs/modules/databases/mysql.md
+++ b/docs/modules/databases/mysql.md
@@ -7,7 +7,7 @@ See [Database containers](./index.md) for documentation and usage that is common
 For MySQL databases, it is possible to override configuration settings using resources on the classpath. Assuming `somepath/mysql_conf_override`
 is a directory on the classpath containing .cnf files, the following URL can be used:
 
-  `jdbc:tc:mysql:5.7.34://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override`
+  `jdbc:tc:mysql:8.0.36://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override`
 
 Any .cnf files in this classpath directory will be mapped into the database container's /etc/mysql/conf.d directory,
 and will be able to override server settings when the container starts.

--- a/docs/modules/databases/r2dbc.md
+++ b/docs/modules/databases/r2dbc.md
@@ -39,7 +39,7 @@ So that the URL becomes:
 
 #### Using MariaDB
 
-`r2dbc:tc:mariadb:///databasename?TC_IMAGE_TAG=10.3.6`
+`r2dbc:tc:mariadb:///databasename?TC_IMAGE_TAG=10.3.39`
 
 #### Using PostgreSQL
 

--- a/docs/modules/databases/r2dbc.md
+++ b/docs/modules/databases/r2dbc.md
@@ -22,7 +22,7 @@ The started container will be terminated when the `ConnectionFactory` is closed.
 **Note that, unlike Testcontainers' JDBC URL support, it is not possible to specify an image tag in the 'scheme' part of the URL, and it is always necessary to specify a tag using `TC_IMAGE_TAG`.**
 
 So that the URL becomes:  
-`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=5.7.34`
+`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=8.0.36`
 
 !!! note
     We will use `///` (host-less URIs) from now on to emphasis the unimportance of the `host:port` pair.  
@@ -35,7 +35,7 @@ So that the URL becomes:
 
 #### Using MySQL
 
-`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=5.7.34`
+`r2dbc:tc:mysql:///databasename?TC_IMAGE_TAG=8.0.36`
 
 #### Using MariaDB
 

--- a/modules/jdbc-test/src/main/java/org/testcontainers/jdbc/AbstractJDBCDriverTest.java
+++ b/modules/jdbc-test/src/main/java/org/testcontainers/jdbc/AbstractJDBCDriverTest.java
@@ -204,13 +204,13 @@ public class AbstractJDBCDriverTest {
     private void performTestForCustomIniFile(HikariDataSource dataSource) throws SQLException {
         assumeFalse(SystemUtils.IS_OS_WINDOWS);
         Statement statement = dataSource.getConnection().createStatement();
-        statement.execute("SELECT @@GLOBAL.innodb_file_format");
+        statement.execute("SELECT @@GLOBAL.innodb_max_undo_log_size");
         ResultSet resultSet = statement.getResultSet();
 
         assertThat(resultSet.next()).as("The query returns a result").isTrue();
-        String result = resultSet.getString(1);
+        long result = resultSet.getLong(1);
 
-        assertThat(result).as("The InnoDB file format has been set by the ini file content").isEqualTo("Barracuda");
+        assertThat(result).as("The InnoDB max undo log size has been set by the ini file content").isEqualTo(20000000);
     }
 
     private HikariDataSource getDataSource(String jdbcUrl, int poolSize) {

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlDriversTests.java
@@ -35,7 +35,7 @@ public class ConnectionUrlDriversTests {
     public static Iterable<Object[]> data() {
         return Arrays.asList(
             new Object[][] {
-                { "jdbc:tc:mysql:5.7.34://hostname/test", "mysql", Optional.of("5.7.34"), "hostname/test", "test" },
+                { "jdbc:tc:mysql:8.0.36://hostname/test", "mysql", Optional.of("8.0.36"), "hostname/test", "test" },
                 { "jdbc:tc:mysql://hostname/test", "mysql", Optional.empty(), "hostname/test", "test" },
                 {
                     "jdbc:tc:postgresql:1.2.3://hostname/test",

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/ConnectionUrlTest.java
@@ -13,11 +13,11 @@ public class ConnectionUrlTest {
 
     @Test
     public void testConnectionUrl1() {
-        String urlString = "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d";
+        String urlString = "jdbc:tc:mysql:8.0.36://somehostname:3306/databasename?a=b&c=d";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertThat(url.getDatabaseType()).as("Database Type value is as expected").isEqualTo("mysql");
-        assertThat(url.getImageTag()).as("Database Image tag value is as expected").contains("5.7.34");
+        assertThat(url.getImageTag()).as("Database Image tag value is as expected").contains("8.0.36");
         assertThat(url.getDbHostString())
             .as("Database Host String is as expected")
             .isEqualTo("somehostname:3306/databasename");
@@ -71,7 +71,7 @@ public class ConnectionUrlTest {
     @Test
     public void testInitScriptPathCapture() {
         String urlString =
-            "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
+            "jdbc:tc:mysql:8.0.36://somehostname:3306/databasename?a=b&c=d&TC_INITSCRIPT=somepath/init_mysql.sql";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertThat(url.getInitScriptPath())
@@ -91,7 +91,7 @@ public class ConnectionUrlTest {
     @Test
     public void testInitFunctionCapture() {
         String urlString =
-            "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
+            "jdbc:tc:mysql:8.0.36://somehostname:3306/databasename?a=b&c=d&TC_INITFUNCTION=org.testcontainers.jdbc.JDBCDriverTest::sampleInitFunction";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertThat(url.getInitFunction()).as("Init Function parameter exists").isPresent();
@@ -106,7 +106,7 @@ public class ConnectionUrlTest {
 
     @Test
     public void testDaemonCapture() {
-        String urlString = "jdbc:tc:mysql:5.7.34://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
+        String urlString = "jdbc:tc:mysql:8.0.36://somehostname:3306/databasename?a=b&c=d&TC_DAEMON=true";
         ConnectionUrl url = ConnectionUrl.newInstance(urlString);
 
         assertThat(url.isInDaemonMode()).as("Daemon flag is set to true.").isTrue();

--- a/modules/jdbc/src/test/java/org/testcontainers/jdbc/MissingJdbcDriverTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/jdbc/MissingJdbcDriverTest.java
@@ -43,7 +43,7 @@ public class MissingJdbcDriverTest {
         private final AtomicInteger connectionAttempts = new AtomicInteger();
 
         MissingDriverContainer() {
-            super(DockerImageName.parse("mysql:5.7.34"));
+            super(DockerImageName.parse("mysql:8.0.36"));
             withEnv("MYSQL_ROOT_PASSWORD", "test");
             withExposedPorts(3306);
         }

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -18,7 +18,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mariadb");
 
     @Deprecated
-    public static final String DEFAULT_TAG = "10.3.39";
+    public static final String DEFAULT_TAG = "10.3.6";
 
     public static final String NAME = "mariadb";
 

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -18,7 +18,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mariadb");
 
     @Deprecated
-    public static final String DEFAULT_TAG = "10.3.6";
+    public static final String DEFAULT_TAG = "10.3.39";
 
     public static final String NAME = "mariadb";
 

--- a/modules/mariadb/src/test/java/org/testcontainers/MariaDBTestImages.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/MariaDBTestImages.java
@@ -3,5 +3,5 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface MariaDBTestImages {
-    DockerImageName MARIADB_IMAGE = DockerImageName.parse("mariadb:10.3.6");
+    DockerImageName MARIADB_IMAGE = DockerImageName.parse("mariadb:10.3.39");
 }

--- a/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
@@ -13,11 +13,11 @@ public class MariaDBR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseCont
 
     @Override
     protected String createR2DBCUrl() {
-        return "r2dbc:tc:mariadb:///db?TC_IMAGE_TAG=10.3.6";
+        return "r2dbc:tc:mariadb:///db?TC_IMAGE_TAG=10.3.39";
     }
 
     @Override
     protected MariaDBContainer<?> createContainer() {
-        return new MariaDBContainer<>(DockerImageName.parse("mariadb:10.3.6"));
+        return new MariaDBContainer<>(DockerImageName.parse("mariadb:10.3.39"));
     }
 }

--- a/modules/mariadb/src/test/java/org/testcontainers/jdbc/mariadb/MariaDBJDBCDriverTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/jdbc/mariadb/MariaDBJDBCDriverTest.java
@@ -19,29 +19,29 @@ public class MariaDBJDBCDriverTest extends AbstractJDBCDriverTest {
                     "jdbc:tc:mariadb://hostname/databasename?user=someuser&TC_INITSCRIPT=somepath/init_mariadb.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
-                { "jdbc:tc:mariadb:10.2.14://hostname/databasename", EnumSet.noneOf(Options.class) },
+                { "jdbc:tc:mariadb:10.3.39://hostname/databasename", EnumSet.noneOf(Options.class) },
                 {
-                    "jdbc:tc:mariadb:10.2.14://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mariadb.sql&useUnicode=yes&characterEncoding=utf8",
+                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mariadb.sql&useUnicode=yes&characterEncoding=utf8",
                     EnumSet.of(Options.CharacterSet),
                 },
                 {
-                    "jdbc:tc:mariadb:10.2.14://hostname/databasename?user=someuser&TC_INITSCRIPT=somepath/init_mariadb.sql",
+                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&TC_INITSCRIPT=somepath/init_mariadb.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.2.14://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
+                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.2.14://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mariadb.sql",
+                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mariadb.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.2.14://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
+                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.2.14://hostname/databasename?TC_MY_CNF=somepath/mariadb_conf_override",
+                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?TC_MY_CNF=somepath/mariadb_conf_override",
                     EnumSet.of(Options.CustomIniFile),
                 },
             }

--- a/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
@@ -133,9 +133,11 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
     }
 
     private void assertThatCustomIniFileWasUsed(MariaDBContainer<?> mariadb) throws SQLException {
-        try (ResultSet resultSet = performQuery(mariadb, "SELECT @@GLOBAL.innodb_file_format")) {
-            String result = resultSet.getString(1);
-            assertThat(result).as("The InnoDB file format has been set by the ini file content").isEqualTo("Barracuda");
+        try (ResultSet resultSet = performQuery(mariadb, "SELECT @@GLOBAL.innodb_max_undo_log_size")) {
+            long result = resultSet.getLong(1);
+            assertThat(result)
+                .as("The InnoDB max undo log size has been set by the ini file content")
+                .isEqualTo(20000000);
         }
     }
 }

--- a/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
@@ -39,7 +39,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
     public void testSpecificVersion() throws SQLException {
         try (
             MariaDBContainer<?> mariadbOldVersion = new MariaDBContainer<>(
-                MariaDBTestImages.MARIADB_IMAGE.withTag("5.5.51")
+                MariaDBTestImages.MARIADB_IMAGE.withTag("10.3.39")
             )
         ) {
             mariadbOldVersion.start();
@@ -49,7 +49,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
             assertThat(resultSetString)
                 .as("The database version can be set using a container rule parameter")
-                .startsWith("5.5.51");
+                .startsWith("10.3.39");
         }
     }
 
@@ -59,7 +59,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
         try (
             MariaDBContainer<?> mariadbCustomConfig = new MariaDBContainer<>(
-                MariaDBTestImages.MARIADB_IMAGE.withTag("10.1.16")
+                MariaDBTestImages.MARIADB_IMAGE.withTag("10.3.39")
             )
                 .withConfigurationOverride("somepath/mariadb_conf_override")
         ) {
@@ -107,7 +107,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
         try (
             MariaDBContainer<?> mariadbCustomConfig = new MariaDBContainer<>(
-                MariaDBTestImages.MARIADB_IMAGE.withTag("10.1.16")
+                MariaDBTestImages.MARIADB_IMAGE.withTag("10.3.39")
             )
                 .withConfigurationOverride("somepath/mariadb_conf_override")
         ) {

--- a/modules/mariadb/src/test/resources/somepath/mariadb_conf_override/my.cnf
+++ b/modules/mariadb/src/test/resources/somepath/mariadb_conf_override/my.cnf
@@ -9,16 +9,12 @@ sort_buffer_size = 64K
 read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K
-thread_stack = 128K
+thread_stack = 512K
 skip-host-cache
 skip-name-resolve
 
-
-innodb_file_format=Barracuda
-
-
-
-
+# This configuration is custom to test whether config override works
+innodb_max_undo_log_size = 20000000
 
 # Don't listen on a TCP/IP port at all. This can be a security enhancement,
 # if all processes that need to connect to mysqld run on the same host.

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -20,7 +20,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mysql");
 
     @Deprecated
-    public static final String DEFAULT_TAG = "5.7.44";
+    public static final String DEFAULT_TAG = "5.7.34";
 
     @Deprecated
     public static final String IMAGE = DEFAULT_IMAGE_NAME.getUnversionedPart();

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -20,7 +20,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mysql");
 
     @Deprecated
-    public static final String DEFAULT_TAG = "5.7.34";
+    public static final String DEFAULT_TAG = "5.7.44";
 
     @Deprecated
     public static final String IMAGE = DEFAULT_IMAGE_NAME.getUnversionedPart();

--- a/modules/mysql/src/main/resources/mysql-default-conf/my.cnf
+++ b/modules/mysql/src/main/resources/mysql-default-conf/my.cnf
@@ -11,7 +11,7 @@ sort_buffer_size = 64K
 read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K
-skip-host-cache
+host_cache_size = 0
 skip-name-resolve
 
 # Don't listen on a TCP/IP port at all. This can be a security enhancement,

--- a/modules/mysql/src/test/java/org/testcontainers/MySQLTestImages.java
+++ b/modules/mysql/src/test/java/org/testcontainers/MySQLTestImages.java
@@ -4,9 +4,9 @@ import org.testcontainers.utility.DockerImageName;
 
 public class MySQLTestImages {
 
-    public static final DockerImageName MYSQL_56_IMAGE = DockerImageName.parse("mysql:5.6.51");
+    public static final DockerImageName MYSQL_57_IMAGE = DockerImageName.parse("mysql:5.7.44");
 
-    public static final DockerImageName MYSQL_57_IMAGE = DockerImageName.parse("mysql:5.7.34");
+    public static final DockerImageName MYSQL_80_IMAGE = DockerImageName.parse("mysql:8.0.36");
 
-    public static final DockerImageName MYSQL_80_IMAGE = DockerImageName.parse("mysql:8.0.24");
+    public static final DockerImageName MYSQL_INNOVATION_IMAGE = DockerImageName.parse("mysql:8.3.0");
 }

--- a/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/containers/MySQLRootAccountTest.java
@@ -18,7 +18,11 @@ public class MySQLRootAccountTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static DockerImageName[] params() {
-        return new DockerImageName[] { MySQLTestImages.MYSQL_80_IMAGE, MySQLTestImages.MYSQL_57_IMAGE };
+        return new DockerImageName[] {
+            MySQLTestImages.MYSQL_57_IMAGE,
+            MySQLTestImages.MYSQL_80_IMAGE,
+            MySQLTestImages.MYSQL_INNOVATION_IMAGE,
+        };
     }
 
     @Parameterized.Parameter

--- a/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/JDBCDriverWithPoolTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/JDBCDriverWithPoolTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JDBCDriverWithPoolTest {
 
     public static final String URL =
-        "jdbc:tc:mysql:5.7.34://hostname/databasename?TC_INITFUNCTION=org.testcontainers.jdbc.mysql.JDBCDriverWithPoolTest::sampleInitFunction";
+        "jdbc:tc:mysql:8.0.36://hostname/databasename?TC_INITFUNCTION=org.testcontainers.jdbc.mysql.JDBCDriverWithPoolTest::sampleInitFunction";
 
     private final DataSource dataSource;
 

--- a/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/MySQLDatabaseContainerDriverTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/MySQLDatabaseContainerDriverTest.java
@@ -16,7 +16,7 @@ public class MySQLDatabaseContainerDriverTest {
     @Test
     public void shouldRespectBothUrlPropertiesAndParameterProperties() throws SQLException {
         ContainerDatabaseDriver driver = new ContainerDatabaseDriver();
-        String url = "jdbc:tc:mysql:5.7.22://hostname/databasename?padCharsWithSpace=true";
+        String url = "jdbc:tc:mysql:8.0.36://hostname/databasename?padCharsWithSpace=true";
         Properties properties = new Properties();
         properties.setProperty("maxRows", "1");
 

--- a/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/MySQLJDBCDriverTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/jdbc/mysql/MySQLJDBCDriverTest.java
@@ -20,29 +20,29 @@ public class MySQLJDBCDriverTest extends AbstractJDBCDriverTest {
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
+                    "jdbc:tc:mysql:8.0.36://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mysql.sql",
+                    "jdbc:tc:mysql:8.0.36://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mysql.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=file:sql/init_mysql.sql",
+                    "jdbc:tc:mysql:8.0.36://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=file:sql/init_mysql.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mysql:5.7.34://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
+                    "jdbc:tc:mysql:8.0.36://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mysql:5.7.34://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mysql.sql&useUnicode=yes&characterEncoding=utf8",
+                    "jdbc:tc:mysql:8.0.36://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mysql.sql&useUnicode=yes&characterEncoding=utf8",
                     EnumSet.of(Options.CharacterSet),
                 },
-                { "jdbc:tc:mysql:5.7.34://hostname/databasename", EnumSet.noneOf(Options.class) },
-                { "jdbc:tc:mysql:5.7.34://hostname/databasename?useSSL=false", EnumSet.noneOf(Options.class) },
+                { "jdbc:tc:mysql:8.0.36://hostname/databasename", EnumSet.noneOf(Options.class) },
+                { "jdbc:tc:mysql:8.0.36://hostname/databasename?useSSL=false", EnumSet.noneOf(Options.class) },
                 {
-                    "jdbc:tc:mysql:5.6.51://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override",
+                    "jdbc:tc:mysql:8.0.36://hostname/databasename?TC_MY_CNF=somepath/mysql_conf_override",
                     EnumSet.of(Options.CustomIniFile),
                 },
             }

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/CustomizableMysqlTest.java
@@ -22,7 +22,7 @@ public class CustomizableMysqlTest extends AbstractContainerDatabaseTest {
     public void testSimple() throws SQLException {
         // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
         try (
-            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withDatabaseName(DB_NAME)
                 .withUsername(USER)
                 .withPassword(PWD)

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/MultiVersionMySQLTest.java
@@ -19,9 +19,9 @@ public class MultiVersionMySQLTest extends AbstractContainerDatabaseTest {
     @Parameterized.Parameters(name = "{0}")
     public static DockerImageName[] params() {
         return new DockerImageName[] {
-            MySQLTestImages.MYSQL_56_IMAGE,
             MySQLTestImages.MYSQL_57_IMAGE,
             MySQLTestImages.MYSQL_80_IMAGE,
+            MySQLTestImages.MYSQL_INNOVATION_IMAGE,
         };
     }
 

--- a/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/junit/mysql/SimpleMySQLTest.java
@@ -34,27 +34,10 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     private static final Logger logger = LoggerFactory.getLogger(SimpleMySQLTest.class);
 
-    /*
-     * Ordinarily you wouldn't try and run multiple containers simultaneously - this is just used for testing.
-     * To avoid memory issues with the default, low memory, docker machine setup, we instantiate only one container
-     * at a time, inside the test methods themselves.
-     */
-    /*
-    @ClassRule
-    public static MySQLContainer<?> mysql = new MySQLContainer<>(MYSQL_IMAGE);
-
-    @ClassRule
-    public static MySQLContainer<?> mysqlOldVersion = new MySQLContainer<>(DockerImageName.parse("mysql:5.5");)
-
-    @ClassRule
-    public static MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(DockerImageName.parse("mysql:5.6"))
-                                                            .withConfigurationOverride("somepath/mysql_conf_override");
-    */
-
     @Test
     public void testSimple() throws SQLException {
         try (
-            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withLogConsumer(new Slf4jLogConsumer(logger))
         ) {
             mysql.start();
@@ -70,7 +53,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     @Test
     public void testSpecificVersion() throws SQLException {
         try (
-            MySQLContainer<?> mysqlOldVersion = new MySQLContainer<>(MySQLTestImages.MYSQL_56_IMAGE)
+            MySQLContainer<?> mysqlOldVersion = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withConfigurationOverride("somepath/mysql_conf_override")
                 .withLogConsumer(new Slf4jLogConsumer(logger))
         ) {
@@ -81,14 +64,14 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
             assertThat(resultSetString)
                 .as("The database version can be set using a container rule parameter")
-                .startsWith("5.6");
+                .startsWith("8.0");
         }
     }
 
     @Test
     public void testMySQLWithCustomIniFile() throws SQLException {
         try (
-            MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MySQLTestImages.MYSQL_56_IMAGE)
+            MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withConfigurationOverride("somepath/mysql_conf_override")
         ) {
             mysqlCustomConfig.start();
@@ -100,7 +83,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     @Test
     public void testCommandOverride() throws SQLException {
         try (
-            MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+            MySQLContainer<?> mysqlCustomConfig = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withCommand("mysqld --auto_increment_increment=42")
         ) {
             mysqlCustomConfig.start();
@@ -115,7 +98,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     @Test
     public void testExplicitInitScript() throws SQLException {
         try (
-            MySQLContainer<?> container = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+            MySQLContainer<?> container = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withInitScript("somepath/init_mysql.sql")
                 .withLogConsumer(new Slf4jLogConsumer(logger))
         ) {
@@ -131,7 +114,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     @Test(expected = ContainerLaunchException.class)
     public void testEmptyPasswordWithNonRootUser() {
         try (
-            MySQLContainer<?> container = new MySQLContainer<>(MySQLTestImages.MYSQL_56_IMAGE)
+            MySQLContainer<?> container = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withDatabaseName("TEST")
                 .withUsername("test")
                 .withPassword("")
@@ -146,7 +129,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     public void testEmptyPasswordWithRootUser() throws SQLException {
         // Add MYSQL_ROOT_HOST environment so that we can root login from anywhere for testing purposes
         try (
-            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_56_IMAGE)
+            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withDatabaseName("foo")
                 .withUsername("root")
                 .withPassword("")
@@ -163,7 +146,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamTimeZone() throws SQLException {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+        MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
             .withUrlParam("serverTimezone", "Europe/Zurich")
             .withEnv("TZ", "Europe/Zurich")
             .withLogConsumer(new Slf4jLogConsumer(logger));
@@ -198,7 +181,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamMultiQueries() throws SQLException {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+        MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
             .withUrlParam("allowMultiQueries", "true")
             .withLogConsumer(new Slf4jLogConsumer(logger));
         mysql.start();
@@ -223,7 +206,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
 
     @Test
     public void testWithAdditionalUrlParamInJdbcUrl() {
-        MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_57_IMAGE)
+        MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
             .withUrlParam("allowMultiQueries", "true")
             .withUrlParam("rewriteBatchedStatements", "true")
             .withLogConsumer(new Slf4jLogConsumer(logger));
@@ -244,7 +227,7 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     public void testWithOnlyUserReadableCustomIniFile() throws Exception {
         assumeThat(FileSystems.getDefault().supportedFileAttributeViews().contains("posix")).isTrue();
         try (
-            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_56_IMAGE)
+            MySQLContainer<?> mysql = new MySQLContainer<>(MySQLTestImages.MYSQL_80_IMAGE)
                 .withConfigurationOverride("somepath/mysql_conf_override")
                 .withLogConsumer(new Slf4jLogConsumer(logger))
         ) {
@@ -274,9 +257,11 @@ public class SimpleMySQLTest extends AbstractContainerDatabaseTest {
     }
 
     private void assertThatCustomIniFileWasUsed(MySQLContainer<?> mysql) throws SQLException {
-        try (ResultSet resultSet = performQuery(mysql, "SELECT @@GLOBAL.innodb_file_format")) {
-            String result = resultSet.getString(1);
-            assertThat(result).as("The InnoDB file format has been set by the ini file content").isEqualTo("Barracuda");
+        try (ResultSet resultSet = performQuery(mysql, "SELECT @@GLOBAL.innodb_max_undo_log_size")) {
+            long result = resultSet.getLong(1);
+            assertThat(result)
+                .as("The InnoDB max undo log size has been set by the ini file content")
+                .isEqualTo(20000000);
         }
     }
 }

--- a/modules/mysql/src/test/resources/somepath/mysql_conf_override/my.cnf
+++ b/modules/mysql/src/test/resources/somepath/mysql_conf_override/my.cnf
@@ -1,5 +1,6 @@
 [mysqld]
 user = mysql
+datadir = /var/lib/mysql
 port   		= 3306
 #socket 		= /tmp/mysql.sock
 skip-external-locking
@@ -10,14 +11,11 @@ sort_buffer_size = 64K
 read_buffer_size = 256K
 read_rnd_buffer_size = 256K
 net_buffer_length = 2K
-thread_stack = 128K
+host_cache_size = 0
+skip-name-resolve
 
-
-innodb_file_format=Barracuda
-
-
-
-
+# This configuration is custom to test whether config override works
+innodb_max_undo_log_size = 20000000
 
 # Don't listen on a TCP/IP port at all. This can be a security enhancement,
 # if all processes that need to connect to mysqld run on the same host.

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
@@ -3,7 +3,7 @@ package org.testcontainers.spock
 import org.testcontainers.utility.DockerImageName
 
 interface SpockTestImages {
-	DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:5.7.34")
+	DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0.36")
 	DockerImageName POSTGRES_TEST_IMAGE = DockerImageName.parse("postgres:9.6.12")
 	DockerImageName HTTPD_IMAGE = DockerImageName.parse("httpd:2.4-alpine")
 	DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.16")


### PR DESCRIPTION
- Fixes #8130 
- Updates testing and doc defaults to be against [non-EOL MySQL versions](https://endoflife.date/mysql)

Testcontainers default configuration no longer works with MySQL `8.3.0` since they have removed the `skip-host-cache` option which was [deprecated in `8.0.30`](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-30.html). This change replaces with [`host_cache_size = 0`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_host_cache_size) which is equivalent and backward compatible back through previous releases (incl `5.7` and even `5.6`).

This likely breaks for people that were depending on the rolling `mysql:8` tag, since there is now a different release and LTS strategy which probably makes them more inclined to add breaking changes. `8.1` (Jun 2023) `8.2` (Oct 2023) and `8.3` (Dec 2023) have come in rapid succession as "**innovation**" releases with the [new release strategy](https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions/). Most users should probably be testing against `mysql:8.0` tags so they stick to LTS, but that's probably a different concern :-)

To avoid regressions and refresh things, this PR updates the docs and mysql testing images accordingly based on https://endoflife.date/mysql
- `5.6` went EOL in Feb 2021. Stop testing against it, and remove references.
- `5.7` went EOL in Oct 2023. Retain tests for a bit, but stop using it as the default.
- `8.0.34`+ is now LTS rather than rolling - use this as the default for most tests
- Add `8.3.0` as a candidate "innovation" version to sanity test against. This could be periodically updated to stay ahead of the curve before the next LTS.