### PR TITLE
Clarify Neo4j enterprise edition definition in docs.

### DIFF
--- a/docs/modules/databases/neo4j.md
+++ b/docs/modules/databases/neo4j.md
@@ -1,8 +1,11 @@
 # Neo4j Module
 
-This module helps running [Neo4j](https://neo4j.com/download/) using Testcontainers.
+This module helps to run [Neo4j](https://neo4j.com/download/) using Testcontainers.
 
 Note that it's based on the [official Docker image](https://hub.docker.com/_/neo4j/) provided by Neo4j, Inc.
+
+Even though the latest LTS version of Neo4j 4.4 is used in the examples of this documentation,
+the Testcontainers integration supports also newer 5.x images of Neo4j.
 
 ## Usage example
 
@@ -17,7 +20,7 @@ The following example uses the JUnit 5 extension `@Testcontainers` and demonstra
 [JUnit 5 example](../../../examples/neo4j-container/src/test/java/org/testcontainers/containers/Neo4jExampleTest.java) inside_block:junitExample
 <!--/codeinclude-->
 
-You are not limited to Unit tests and can of course use an instance of the Neo4j Testcontainers in vanilla Java code as well.
+You are not limited to Unit tests, and you can use an instance of the Neo4j Testcontainers in vanilla Java code as well.
 
 ## Additional features
 
@@ -102,9 +105,13 @@ If you need the Neo4j enterprise license, you can declare your Neo4j container l
 [Enterprise edition](../../../modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java) inside_block:enterpriseEdition
 <!--/codeinclude-->
 
-This creates a Testcontainers based on the Docker image build with the Enterprise version of Neo4j. 
+This creates a Testcontainers based on the Docker image build with the Enterprise version of Neo4j 4.4. 
 The call to `withEnterpriseEdition` adds the required environment variable that you accepted the terms and condition of the enterprise version.
-You accept those by adding a file named `container-license-acceptance.txt` to the root of your classpath containing the text `neo4j:3.5.0-enterprise` in one line.
+You accept those by adding a file named `container-license-acceptance.txt` to the root of your classpath containing the text `neo4j:4.4-enterprise` in one line.
+
+If you are planning to run a newer Neo4j 5.x enterprise edition image, you have to manually define the proper enterprise image (e.g. `neo4j:5-enterprise`)
+and set the environment variable `NEO4J_ACCEPT_LICENSE_AGREEMENT` by adding `.withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")` to your container definition.
+
 You'll find more information about licensing Neo4j here: [About Neo4j Licenses](https://neo4j.com/licensing/).
 
 
@@ -131,7 +138,7 @@ Add the following dependency to your `pom.xml`/`build.gradle` file:
     
     === "Gradle"
         ```groovy
-        compile "org.neo4j.driver:neo4j-java-driver:4.4.3"
+        compile "org.neo4j.driver:neo4j-java-driver:4.4.13"
         ```
     
     === "Maven"
@@ -139,6 +146,6 @@ Add the following dependency to your `pom.xml`/`build.gradle` file:
         <dependency>
             <groupId>org.neo4j.driver</groupId>
             <artifactId>neo4j-java-driver</artifactId>
-            <version>4.4.3</version>
+            <version>4.4.13</version>
         </dependency>
         ```


### PR DESCRIPTION
This change targets the documentation page for the Neo4j module.

1. Clarify that the Neo4j test module also supports Neo4j 5 images.
2. Describe how to use enterprise images without the built-in feature `.withEnterpriseEdition()`.

Minor things: Wording and version maintenance for the Java driver.
