### PR TITLE
Combined dependencies PR

### DIFF
--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testImplementation "org.seleniumhq.selenium:selenium-api:4.17.0"
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }
 
 test {

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.1"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }
 
 test {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit'
     testImplementation 'org.testcontainers:selenium'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }
 
 test {

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.3.6'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'io.codenotary:immudb4j:1.0.1'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:postgresql'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }
 

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.17.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.13'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testng:testng:7.5.1'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }
 
 test {

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }
 
 test {

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'com.jcraft:jsch:0.1.55'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }
 

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.apache.curator:curator-framework:5.5.0'
+    testImplementation 'org.apache.curator:curator-framework:5.6.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.5.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation 'com.azure:azure-cosmos:4.53.1'
+    testImplementation 'com.azure:azure-cosmos:4.54.0'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.1'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.643'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.643'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.11.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.12.0"
     testImplementation "org.elasticsearch.client:transport:7.17.17"
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.11.2"
     testImplementation "org.elasticsearch.client:transport:7.17.17"
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.28.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.30.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:6.10.0'
     testImplementation 'io.kubernetes:client-java:19.0.0'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -8,5 +8,5 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'software.amazon.awssdk:s3:2.23.9'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("org.mongodb:mongodb-driver-sync:4.11.1")
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.1'
 }
 
 tasks.japicmp {

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.13'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.1'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.1'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.2'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.1'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.1'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.1'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.2'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation project(':jdbc-test')
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.questdb:questdb:7.3.9'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,10 +11,10 @@ dependencies {
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'
 
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.6.2'
-    testFixturesImplementation 'org.assertj:assertj-core:3.24.2'
+    testFixturesImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.20.0'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.1'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'org.slf4j:slf4j-api:1.7.36'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.25.2'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /modules/questdb (#8159) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /modules/r2dbc (#8158) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /modules/k3s (#8157) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /examples (#8156) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /modules/neo4j (#8155) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /modules/elasticsearch (#8154) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /modules/localstack (#8153) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.2 in /modules/dynalite (#8152) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.11.2 to 8.12.0 in /modules/elasticsearch (#8134) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.28.0 to 26.30.0 in /modules/gcloud (#8133) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.1 in /modules/mongodb (#8102) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.1 in /modules/kafka (#8075) @app/dependabot
* Bump com.azure:azure-cosmos from 4.53.1 to 4.54.0 in /modules/azure (#8071) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.1 in /modules/rabbitmq (#8070) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.25.1 in /modules/cockroachdb (#8067) @app/dependabot
* Bump org.apache.curator:curator-framework from 5.5.0 to 5.6.0 in /examples (#8063) @app/dependabot
* Bump org.apache.pulsar:pulsar-client-admin from 3.1.1 to 3.1.2 in /modules/pulsar (#8044) @app/dependabot
* Bump org.apache.pulsar:pulsar-client from 3.1.1 to 3.1.2 in /modules/pulsar (#8043) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.16 to 3.16.1 in /examples (#7977) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.21.0 to 10.22.0 in /modules/solace (#7972) @app/dependabot
