### PR TITLE
Add convenience method for creating connections

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -207,6 +207,17 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     }
 
     /**
+     * Creates a connection to the underlying containerized database
+     * instance without any parameters.
+     *
+     * @return a Connection
+     * @throws SQLException if there is a repeated failure to create the connection
+     */
+    public Connection createConnection() throws SQLException, NoDriverFoundException {
+        return createConnection("");
+    }
+
+    /**
      * Creates a connection to the underlying containerized database instance.
      *
      * @param queryString query string parameters that should be appended to the JDBC connection URL.


### PR DESCRIPTION
This PR adds a convenience method  for creating JDBC connections that doesn't require any parameters. When writing test involving DB containers, I was unsure what to pass as `queryString` parameter and had to read the code to see that passing the empty string does what I need. After repeating a couple of times I thought this could be useful to have in general and make people's lives a tiny bit easier.

Please let me know if this MR is missing something.

Thank you for taking the time to look at it!