### PR TITLE
Add an ability to implement custom hashing for container subclasses

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -586,7 +586,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @UnstableAPI
     @SneakyThrows(JsonProcessingException.class)
-    final String hash(CreateContainerCmd createCommand) {
+    protected String hash(CreateContainerCmd createCommand) {
         DefaultDockerClientConfig dockerClientConfig = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
 
         byte[] commandJson = dockerClientConfig


### PR DESCRIPTION
Since the original [proposal](https://github.com/testcontainers/testcontainers-java/issues/8285) and [pull request](https://github.com/testcontainers/testcontainers-java/pull/8282) both have been rejected, I'd like to propose an alternative here.

We are looking for the way to implement custom hashing to make containers reusable across different platforms. We understand that it is not supported by testcontainers nor it is the intended behavior whatsoever. We also understand that the feature is experimental in general, with no guarantees provided. 

However, we'd like to find a way to give a green light to our engineering decisions and take the risks involved in introducing any deviation to standard behavior via inheritance. In this particular proposal, we don't make any adjustments to the API whatsoever, but at the same time give people like us a chance to workaround some limitations.

`GenericContainer` already has plenty of `protected` methods which may significantly amend the behavior of the library, including `protected boolean canBeReused()`, so I don't think we add any (significant) risks here.