### PR TITLE
[Core] Fix custom configuration not work

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -162,7 +162,9 @@ public class DockerClientFactory {
     public String getRemoteDockerUnixSocketPath() {
         DockerClientProviderStrategy strategy = getOrInitializeStrategy();
         if (strategy.allowUserOverrides()) {
-            String dockerSocketOverride = System.getenv("TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE");
+            String dockerSocketOverride = TestcontainersConfiguration
+                .getInstance()
+                .getEnvVarOrProperty("docker.socket.override", null);
             if (!StringUtils.isBlank(dockerSocketOverride)) {
                 return dockerSocketOverride;
             }

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -436,7 +436,9 @@ public abstract class DockerClientProviderStrategy {
     @VisibleForTesting
     static String resolveDockerHostIpAddress(DockerClient client, URI dockerHost, boolean allowUserOverrides) {
         if (allowUserOverrides) {
-            String hostOverride = System.getenv("TESTCONTAINERS_HOST_OVERRIDE");
+            String hostOverride = TestcontainersConfiguration
+                .getInstance()
+                .getEnvVarOrProperty("host.override", null);
             if (!StringUtils.isBlank(hostOverride)) {
                 return hostOverride;
             }

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -436,9 +436,7 @@ public abstract class DockerClientProviderStrategy {
     @VisibleForTesting
     static String resolveDockerHostIpAddress(DockerClient client, URI dockerHost, boolean allowUserOverrides) {
         if (allowUserOverrides) {
-            String hostOverride = TestcontainersConfiguration
-                .getInstance()
-                .getEnvVarOrProperty("host.override", null);
+            String hostOverride = TestcontainersConfiguration.getInstance().getEnvVarOrProperty("host.override", null);
             if (!StringUtils.isBlank(hostOverride)) {
                 return hostOverride;
             }

--- a/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategy.java
@@ -58,7 +58,7 @@ public final class EnvironmentAndSystemPropertyClientProviderStrategy extends Do
     }
 
     private Optional<String> getSetting(final String name) {
-        return Optional.ofNullable(TestcontainersConfiguration.getInstance().getEnvVarOrUserProperty(name, null));
+        return Optional.ofNullable(TestcontainersConfiguration.getInstance().getEnvVarOrProperty(name, null));
     }
 
     @Override

--- a/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
@@ -54,9 +54,7 @@ public class DockerMachineClient {
         String ls = CommandLine.runShellCommand(executableName, "ls", "-q");
         List<String> machineNames = Arrays.asList(ls.split("\n"));
 
-        String envMachineName = TestcontainersConfiguration
-            .getInstance()
-            .getEnvVarOrProperty("machine.name",null);
+        String envMachineName = TestcontainersConfiguration.getInstance().getEnvVarOrProperty("machine.name", null);
 
         if (machineNames.contains(envMachineName)) {
             LOGGER.debug("Using docker-machine set in DOCKER_MACHINE_NAME: {}", envMachineName);

--- a/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerMachineClient.java
@@ -54,7 +54,9 @@ public class DockerMachineClient {
         String ls = CommandLine.runShellCommand(executableName, "ls", "-q");
         List<String> machineNames = Arrays.asList(ls.split("\n"));
 
-        String envMachineName = System.getenv("DOCKER_MACHINE_NAME");
+        String envMachineName = TestcontainersConfiguration
+            .getInstance()
+            .getEnvVarOrProperty("machine.name",null);
 
         if (machineNames.contains(envMachineName)) {
             LOGGER.debug("Using docker-machine set in DOCKER_MACHINE_NAME: {}", envMachineName);

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -79,7 +79,9 @@ public class RegistryAuthLocator {
             .getenv()
             .getOrDefault("DOCKER_CONFIG", System.getProperty("user.home") + "/.docker");
         this.configFile = new File(dockerConfigLocation + "/config.json");
-        this.configEnv = System.getenv(DOCKER_AUTH_ENV_VAR);
+        this.configEnv = TestcontainersConfiguration
+            .getInstance()
+            .getEnvVarOrProperty(DOCKER_AUTH_ENV_VAR, null);
         this.commandPathPrefix = "";
         this.commandExtension = "";
 

--- a/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
+++ b/core/src/main/java/org/testcontainers/utility/RegistryAuthLocator.java
@@ -79,9 +79,7 @@ public class RegistryAuthLocator {
             .getenv()
             .getOrDefault("DOCKER_CONFIG", System.getProperty("user.home") + "/.docker");
         this.configFile = new File(dockerConfigLocation + "/config.json");
-        this.configEnv = TestcontainersConfiguration
-            .getInstance()
-            .getEnvVarOrProperty(DOCKER_AUTH_ENV_VAR, null);
+        this.configEnv = TestcontainersConfiguration.getInstance().getEnvVarOrProperty(DOCKER_AUTH_ENV_VAR, null);
         this.commandPathPrefix = "";
         this.commandExtension = "";
 

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -74,7 +74,9 @@ public class ResourceReaper {
 
     public static synchronized ResourceReaper instance() {
         if (instance == null) {
-            boolean useRyuk = !Boolean.parseBoolean(System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
+            boolean useRyuk = !Boolean.parseBoolean(TestcontainersConfiguration
+                .getInstance()
+                .getEnvVarOrProperty("ryuk.disabled", "false"));
             if (useRyuk) {
                 //noinspection deprecation
                 instance = new RyukResourceReaper();

--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -74,9 +74,9 @@ public class ResourceReaper {
 
     public static synchronized ResourceReaper instance() {
         if (instance == null) {
-            boolean useRyuk = !Boolean.parseBoolean(TestcontainersConfiguration
-                .getInstance()
-                .getEnvVarOrProperty("ryuk.disabled", "false"));
+            boolean useRyuk = !Boolean.parseBoolean(
+                TestcontainersConfiguration.getInstance().getEnvVarOrProperty("ryuk.disabled", "false")
+            );
             if (useRyuk) {
                 //noinspection deprecation
                 instance = new RyukResourceReaper();

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -176,13 +176,13 @@ public class TestcontainersConfiguration {
     }
 
     public boolean isDisableChecks() {
-        return Boolean.parseBoolean(getEnvVarOrUserProperty("checks.disable", "false"));
+        return Boolean.parseBoolean(getEnvVarOrProperty("checks.disable", "false"));
     }
 
     @UnstableAPI
     public boolean environmentSupportsReuse() {
         // specifically not supported as an environment variable or classpath property
-        return Boolean.parseBoolean(getEnvVarOrUserProperty("testcontainers.reuse.enable", "false"));
+        return Boolean.parseBoolean(getEnvVarOrProperty("testcontainers.reuse.enable", "false"));
     }
 
     public String getDockerClientStrategyClassName() {
@@ -198,7 +198,7 @@ public class TestcontainersConfiguration {
         }
 
         // looks for unprefixed env var or unprefixed property, or null if the strategy is not set at all
-        return getEnvVarOrUserProperty("docker.client.strategy", null);
+        return getEnvVarOrProperty("docker.client.strategy", null);
     }
 
     public String getTransportType() {
@@ -267,22 +267,6 @@ public class TestcontainersConfiguration {
     }
 
     /**
-     * Gets a configured setting from an environment variable (if present) or a configuration file property otherwise.
-     * The configuration file will be the <code>.testcontainers.properties</code> file in the user's home directory.
-     * <p>
-     * Note that when searching environment variables, the prefix `TESTCONTAINERS_` will usually be applied to the
-     * property name, which will be converted to upper-case with underscore separators. This prefix will not be added
-     * if the property name begins `docker.`.
-     *
-     * @param propertyName name of configuration file property (dot-separated lower case)
-     * @return the found value, or null if not set
-     */
-    @Contract("_, !null -> !null")
-    public String getEnvVarOrUserProperty(@NotNull final String propertyName, @Nullable final String defaultValue) {
-        return getConfigurable(propertyName, defaultValue, userProperties);
-    }
-
-    /**
      * Gets a configured setting from <code>~/.testcontainers.properties</code>.
      *
      * @param propertyName name of configuration file property (dot-separated lower case)
@@ -299,7 +283,7 @@ public class TestcontainersConfiguration {
      * @return properties values available from user properties and classpath properties. Values set by environment
      * variable are NOT included.
      * @deprecated usages should be removed ASAP. See {@link TestcontainersConfiguration#getEnvVarOrProperty(String, String)},
-     * {@link TestcontainersConfiguration#getEnvVarOrUserProperty(String, String)} or {@link TestcontainersConfiguration#getUserProperty(String, String)}
+     * {@link TestcontainersConfiguration#getEnvVarOrProperty(String, String)} or {@link TestcontainersConfiguration#getUserProperty(String, String)}
      * for suitable replacements.
      */
     @Deprecated

--- a/core/src/test/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/EnvironmentAndSystemPropertyClientProviderStrategyTest.java
@@ -53,15 +53,15 @@ public class EnvironmentAndSystemPropertyClientProviderStrategyTest {
         Mockito
             .doReturn(null)
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.host"), isNull());
+            .getEnvVarOrProperty(eq("docker.host"), isNull());
         Mockito
             .doReturn(null)
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.tls.verify"), isNull());
+            .getEnvVarOrProperty(eq("docker.tls.verify"), isNull());
         Mockito
             .doReturn(null)
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.cert.path"), isNull());
+            .getEnvVarOrProperty(eq("docker.cert.path"), isNull());
 
         EnvironmentAndSystemPropertyClientProviderStrategy strategy = new EnvironmentAndSystemPropertyClientProviderStrategy();
 
@@ -79,15 +79,15 @@ public class EnvironmentAndSystemPropertyClientProviderStrategyTest {
         Mockito
             .doReturn("tcp://1.2.3.4:2375")
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.host"), isNull());
+            .getEnvVarOrProperty(eq("docker.host"), isNull());
         Mockito
             .doReturn(null)
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.tls.verify"), isNull());
+            .getEnvVarOrProperty(eq("docker.tls.verify"), isNull());
         Mockito
             .doReturn(null)
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.cert.path"), isNull());
+            .getEnvVarOrProperty(eq("docker.cert.path"), isNull());
 
         EnvironmentAndSystemPropertyClientProviderStrategy strategy = new EnvironmentAndSystemPropertyClientProviderStrategy();
 
@@ -108,15 +108,15 @@ public class EnvironmentAndSystemPropertyClientProviderStrategyTest {
         Mockito
             .doReturn("tcp://1.2.3.4:2375")
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.host"), isNull());
+            .getEnvVarOrProperty(eq("docker.host"), isNull());
         Mockito
             .doReturn("1")
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.tls.verify"), isNull());
+            .getEnvVarOrProperty(eq("docker.tls.verify"), isNull());
         Mockito
             .doReturn(tempDirPath)
             .when(TestcontainersConfiguration.getInstance())
-            .getEnvVarOrUserProperty(eq("docker.cert.path"), isNull());
+            .getEnvVarOrProperty(eq("docker.cert.path"), isNull());
 
         EnvironmentAndSystemPropertyClientProviderStrategy strategy = new EnvironmentAndSystemPropertyClientProviderStrategy();
 

--- a/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
+++ b/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
@@ -103,7 +103,7 @@ public class TestcontainersConfigurationTest {
     public void shouldReadDockerSettingsFromEnvironmentWithoutTestcontainersPrefix() {
         userProperties.remove("docker.foo");
         environment.put("DOCKER_FOO", "some value");
-        assertThat(newConfig().getEnvVarOrUserProperty("docker.foo", "default"))
+        assertThat(newConfig().getEnvVarOrProperty("docker.foo", "default"))
             .as("reads unprefixed env vars for docker. settings")
             .isEqualTo("some value");
     }
@@ -112,7 +112,7 @@ public class TestcontainersConfigurationTest {
     public void shouldNotReadDockerSettingsFromEnvironmentWithTestcontainersPrefix() {
         userProperties.remove("docker.foo");
         environment.put("TESTCONTAINERS_DOCKER_FOO", "some value");
-        assertThat(newConfig().getEnvVarOrUserProperty("docker.foo", "default"))
+        assertThat(newConfig().getEnvVarOrProperty("docker.foo", "default"))
             .as("reads unprefixed env vars for docker. settings")
             .isEqualTo("default");
     }
@@ -121,7 +121,7 @@ public class TestcontainersConfigurationTest {
     public void shouldReadDockerSettingsFromUserProperties() {
         environment.remove("DOCKER_FOO");
         userProperties.put("docker.foo", "some value");
-        assertThat(newConfig().getEnvVarOrUserProperty("docker.foo", "default"))
+        assertThat(newConfig().getEnvVarOrProperty("docker.foo", "default"))
             .as("reads unprefixed user properties for docker. settings")
             .isEqualTo("some value");
     }
@@ -129,7 +129,7 @@ public class TestcontainersConfigurationTest {
     @Test
     public void shouldNotReadSettingIfCorrespondingEnvironmentVarIsEmptyString() {
         environment.put("DOCKER_FOO", "");
-        assertThat(newConfig().getEnvVarOrUserProperty("docker.foo", "default"))
+        assertThat(newConfig().getEnvVarOrProperty("docker.foo", "default"))
             .as("reads unprefixed env vars for docker. settings")
             .isEqualTo("default");
     }


### PR DESCRIPTION
Fix #8316 . Use `getConfigurable(propertyName, defaultValue, userProperties, classpathProperties);` to retrieve custom configurations uniformly.
