### PR TITLE
feat: Add getDatabaseName() method to ClickHouseContainer

### DIFF
--- a/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseContainer.java
@@ -98,6 +98,11 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
     }
 
     @Override
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    @Override
     public String getTestQueryString() {
         return TEST_QUERY;
     }


### PR DESCRIPTION
Add getDatabaseName() method to ClickHouseContainer.java.

avoid such exceptions:

![unsupported-get-database-name](https://github.com/testcontainers/testcontainers-java/assets/14800684/9800782a-d7bb-4fe6-b4a0-b9319e8bb2f3)

