### PR TITLE
Bump commons-compress

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api 'org.apache.commons:commons-compress:1.26.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
This addresses CVE-2024-25710 and CVE-2024-26308. I know your PR template says to not open PRs to bump dependencies. However, since this is security related it has IMO a higher urgency.

Fixes #8338
