### PR TITLE
Cloudfare module

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -19,6 +19,7 @@ body:
         - Cassandra
         - ChromaDB
         - Clickhouse
+        - Cloudflare
         - CockroachDB
         - Consul
         - Couchbase

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -19,6 +19,7 @@ body:
         - Cassandra
         - ChromaDB
         - Clickhouse
+        - Cloudflare
         - CockroachDB
         - Consul
         - Couchbase

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -19,6 +19,7 @@ body:
         - Cassandra
         - ChromaDB
         - Clickhouse
+        - Cloudflare
         - CockroachDB
         - CrateDB
         - Consul

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,11 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
   - package-ecosystem: "gradle"
+    directory: "/modules/cloudflare"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gradle"
     directory: "/modules/cockroachdb"
     schedule:
       interval: "weekly"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,6 +35,10 @@
   - changed-files:
     - any-glob-to-any-file:
       - modules/clickhouse/**/*
+"modules/cloudflare":
+  - changed-files:
+      - any-glob-to-any-file:
+          - modules/cloudflare/**/*
 "modules/cockroachdb":
   - changed-files:
     - any-glob-to-any-file:

--- a/docs/modules/cloudflare.md
+++ b/docs/modules/cloudflare.md
@@ -1,0 +1,46 @@
+# Cloudflare Module
+
+Testcontainers module for Cloudflare Tunnels [](https://rancher.com/products/k3s/) for exposing your app to the internet. 
+
+This module is intended to be used for testing components that need to be exposed to public internet - for example to receive hooks from public cloud.
+Or to show your local state of the application to friends. 
+
+## Usage example
+
+Start a Cloudflared container as follows:
+
+<!--codeinclude-->
+[Starting a Cloudflared Container](../../modules/k3s/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java) inside_block:starting
+<!--/codeinclude-->
+
+### Getting the public Url
+
+`Cloudflared` contaienr exposes a port on your host, via a [Quick tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/).
+To get the public url on which this port is available to the internet, call the `getPublicUrl` method. 
+
+<!--codeinclude-->
+[Get the public Url](../../modules/k3s/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java) inside_block:get_public_url
+<!--/codeinclude-->
+
+## Known limitations
+
+!!! warning
+    * From the Cloudflare docs: "Quick Tunnels are subject to a hard limit on the number of concurrent requests that can be proxied at any point in time. Currently, this limit is 200 in-flight requests. If a Quick Tunnel hits this limit, the HTTP response will return a 429 status code."
+
+## Adding this module to your project dependencies
+
+Add the following dependency to your `pom.xml`/`build.gradle` file:
+
+=== "Gradle"
+    ```groovy
+    testImplementation "org.testcontainers:cloudflare:{{latest_version}}"
+    ```
+=== "Maven"
+    ```xml
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>cloudflare</artifactId>
+        <version>{{latest_version}}</version>
+        <scope>test</scope>
+    </dependency>
+    ```

--- a/docs/modules/cloudflare.md
+++ b/docs/modules/cloudflare.md
@@ -1,6 +1,6 @@
 # Cloudflare Module
 
-Testcontainers module for Cloudflare Tunnels [](https://rancher.com/products/k3s/) for exposing your app to the internet. 
+Testcontainers module for Cloudflare Quick Tunnels(https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/trycloudflare/) for exposing your app to the internet. 
 
 This module is intended to be used for testing components that need to be exposed to public internet - for example to receive hooks from public cloud.
 Or to show your local state of the application to friends. 
@@ -10,7 +10,7 @@ Or to show your local state of the application to friends.
 Start a Cloudflared container as follows:
 
 <!--codeinclude-->
-[Starting a Cloudflared Container](../../modules/k3s/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java) inside_block:starting
+[Starting a Cloudflared Container](../../modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java) inside_block:starting
 <!--/codeinclude-->
 
 ### Getting the public Url
@@ -19,7 +19,7 @@ Start a Cloudflared container as follows:
 To get the public url on which this port is available to the internet, call the `getPublicUrl` method. 
 
 <!--codeinclude-->
-[Get the public Url](../../modules/k3s/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java) inside_block:get_public_url
+[Get the public Url](../../modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java) inside_block:get_public_url
 <!--/codeinclude-->
 
 ## Known limitations

--- a/modules/cloudflare/build.gradle
+++ b/modules/cloudflare/build.gradle
@@ -1,4 +1,4 @@
-description = "Testcontainers :: Cloudflared"
+description = "Testcontainers :: Cloudflare"
 
 dependencies {
     api project(":testcontainers")

--- a/modules/cloudflare/build.gradle
+++ b/modules/cloudflare/build.gradle
@@ -1,0 +1,8 @@
+description = "Testcontainers :: Cloudflared"
+
+dependencies {
+    api project(":testcontainers")
+
+    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation project(':nginx')
+}

--- a/modules/cloudflare/src/main/java/org/testcontainers/cloudflare/CloudflaredContainer.java
+++ b/modules/cloudflare/src/main/java/org/testcontainers/cloudflare/CloudflaredContainer.java
@@ -1,0 +1,42 @@
+package org.testcontainers.cloudflare;
+
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Scanner;
+
+public class CloudflaredContainer extends GenericContainer<CloudflaredContainer> {
+    private String publicUrl;
+
+    public CloudflaredContainer(DockerImageName dockerImageName, int port) {
+        super(dockerImageName);
+        dockerImageName.assertCompatibleWith(DockerImageName.parse("cloudflare/cloudflared"));
+        withAccessToHost(true);
+        Testcontainers.exposeHostPorts(port);
+        withCommand("tunnel", "--url", "http://host.testcontainers.internal:%d".formatted(port));
+        waitingFor(Wait.forLogMessage(".*Registered tunnel connection.*", 1));
+    }
+
+    public String getPublicUrl() {
+        if (null != publicUrl) {
+            return publicUrl;
+        }
+        String logs = getLogs();
+        String[] split = logs.split(String.format("%n"));
+        boolean found = false;
+        for (int i = 0; i < split.length; i++) {
+            String currentLine = split[i];
+            if (currentLine.contains("Your quick Tunnel has been created")) {
+                found = true;
+                continue;
+            }
+            if (found) {
+                return publicUrl = currentLine.substring(currentLine.indexOf("http"), currentLine.indexOf(".com") + 4);
+            }
+        }
+        throw new IllegalStateException("Didn't find public url in logs. Has container started?");
+    }
+
+}

--- a/modules/cloudflare/src/main/java/org/testcontainers/cloudflare/CloudflaredContainer.java
+++ b/modules/cloudflare/src/main/java/org/testcontainers/cloudflare/CloudflaredContainer.java
@@ -5,9 +5,8 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Scanner;
-
 public class CloudflaredContainer extends GenericContainer<CloudflaredContainer> {
+
     private String publicUrl;
 
     public CloudflaredContainer(DockerImageName dockerImageName, int port) {
@@ -38,5 +37,4 @@ public class CloudflaredContainer extends GenericContainer<CloudflaredContainer>
         }
         throw new IllegalStateException("Didn't find public url in logs. Has container started?");
     }
-
 }

--- a/modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java
+++ b/modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java
@@ -1,19 +1,14 @@
 package org.testcontainers.cloudflare;
 
+import org.junit.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
-import org.junit.Test;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.time.Duration;
-
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,37 +16,35 @@ public class CloudflaredContainerTest {
 
     @Test
     public void shouldStartAndTunnelToHelloWorld() throws IOException {
-        try (GenericContainer<?> helloworld = new GenericContainer<>(
+        try (
+            GenericContainer<?> helloworld = new GenericContainer<>(
                 DockerImageName.parse("testcontainers/helloworld:1.1.0")
-        )
+            )
                 .withNetworkAliases("helloworld")
                 .withExposedPorts(8080, 8081)
-                .waitingFor(new HttpWaitStrategy())) {
-
+                .waitingFor(new HttpWaitStrategy())
+        ) {
             helloworld.start();
 
             try (
-            // starting {
-            CloudflaredContainer cloudflare = new CloudflaredContainer(DockerImageName.parse("cloudflare/cloudflared:latest"), helloworld.getFirstMappedPort());
-            //
+                // starting {
+                CloudflaredContainer cloudflare = new CloudflaredContainer(
+                    DockerImageName.parse("cloudflare/cloudflared:latest"),
+                    helloworld.getFirstMappedPort()
+                );
+                //
             ) {
                 cloudflare.start();
                 // get_public_url {
                 String url = cloudflare.getPublicUrl();
                 // }
 
-                assertThat(url)
-                        .as("Public url contains 'cloudflare'")
-                        .contains("cloudflare");
+                assertThat(url).as("Public url contains 'cloudflare'").contains("cloudflare");
                 String body = readUrl(url);
 
-                assertThat(body.trim())
-                        .as("the index page contains the title 'Hello world'")
-                        .contains("Hello world");
+                assertThat(body.trim()).as("the index page contains the title 'Hello world'").contains("Hello world");
             }
-
         }
-
     }
 
     private String readUrl(String url) throws IOException {

--- a/modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java
+++ b/modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java
@@ -1,0 +1,64 @@
+package org.testcontainers.cloudflare;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.time.Duration;
+
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CloudflaredContainerTest {
+
+    @Test
+    public void shouldStartAndTunnelToHelloWorld() throws IOException {
+        try (GenericContainer<?> helloworld = new GenericContainer<>(
+            DockerImageName.parse("testcontainers/helloworld:1.1.0")
+        )
+            .withNetworkAliases("helloworld")
+            .withExposedPorts(8080, 8081)
+            .waitingFor(new HttpWaitStrategy()) ) {
+
+            helloworld.start();
+
+            try (CloudflaredContainer cloudflare = new CloudflaredContainer(DockerImageName.parse("cloudflare/cloudflared:latest"), helloworld.getFirstMappedPort());) {
+                cloudflare.start();
+                String url = cloudflare.getPublicUrl();
+
+                assertThat(url)
+                    .as("Public url contains 'cloudflare'")
+                    .contains("cloudflare");
+                String body = readUrl(url);
+
+                assertThat(body.trim())
+                    .as("the index page contains the title 'Hello world'")
+                    .contains("Hello world");
+            }
+
+        }
+
+    }
+
+    private String readUrl(String url) throws IOException {
+        BufferedReader in = new BufferedReader(new InputStreamReader(new URL(url).openStream()));
+
+        StringBuilder sb = new StringBuilder();
+        String inputLine = null;
+        while ((inputLine = in.readLine()) != null) {
+            sb.append(inputLine);
+        }
+        in.close();
+
+        return sb.toString();
+    }
+}

--- a/modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java
+++ b/modules/cloudflare/src/test/java/org/testcontainers/cloudflare/CloudflaredContainerTest.java
@@ -15,7 +15,6 @@ import java.net.URL;
 import java.time.Duration;
 
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CloudflaredContainerTest {
@@ -23,26 +22,32 @@ public class CloudflaredContainerTest {
     @Test
     public void shouldStartAndTunnelToHelloWorld() throws IOException {
         try (GenericContainer<?> helloworld = new GenericContainer<>(
-            DockerImageName.parse("testcontainers/helloworld:1.1.0")
+                DockerImageName.parse("testcontainers/helloworld:1.1.0")
         )
-            .withNetworkAliases("helloworld")
-            .withExposedPorts(8080, 8081)
-            .waitingFor(new HttpWaitStrategy()) ) {
+                .withNetworkAliases("helloworld")
+                .withExposedPorts(8080, 8081)
+                .waitingFor(new HttpWaitStrategy())) {
 
             helloworld.start();
 
-            try (CloudflaredContainer cloudflare = new CloudflaredContainer(DockerImageName.parse("cloudflare/cloudflared:latest"), helloworld.getFirstMappedPort());) {
+            try (
+            // starting {
+            CloudflaredContainer cloudflare = new CloudflaredContainer(DockerImageName.parse("cloudflare/cloudflared:latest"), helloworld.getFirstMappedPort());
+            //
+            ) {
                 cloudflare.start();
+                // get_public_url {
                 String url = cloudflare.getPublicUrl();
+                // }
 
                 assertThat(url)
-                    .as("Public url contains 'cloudflare'")
-                    .contains("cloudflare");
+                        .as("Public url contains 'cloudflare'")
+                        .contains("cloudflare");
                 String body = readUrl(url);
 
                 assertThat(body.trim())
-                    .as("the index page contains the title 'Hello world'")
-                    .contains("Hello world");
+                        .as("the index page contains the title 'Hello world'")
+                        .contains("Hello world");
             }
 
         }

--- a/modules/cloudflare/src/test/resources/logback-test.xml
+++ b/modules/cloudflare/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+</configuration>


### PR DESCRIPTION
this PR adds a Cloudflare module to programmatically use Cloudflare Quick tunnels for exposing your app to the internet. 

The use cases are: 
* making your app available to hooks from public cloud. 
* showing your local application to other people with ease. 

Creating the cloudflared container and exposing a port on the host machine is now just a few lines of code away. 


