### PR TITLE
Expose parent-cgroup option

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -376,6 +376,13 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     SELF withWorkingDirectory(String workDir);
 
     /**
+     * Set the cgroup parent that the container should use on startup.
+     *
+     * @param cgroupParent the cgroup parent for the container
+     */
+    SELF withCgroupParent(String cgroupParent);
+
+    /**
      * <b>Resolve</b> Docker image and set it.
      *
      * @param dockerImageName image name

--- a/core/src/main/java/org/testcontainers/containers/ContainerDef.java
+++ b/core/src/main/java/org/testcontainers/containers/ContainerDef.java
@@ -60,6 +60,8 @@ class ContainerDef {
     @Getter
     private WaitStrategy waitStrategy = GenericContainer.DEFAULT_WAIT_STRATEGY;
 
+    @Getter String cgroupParent;
+
     public ContainerDef() {}
 
     protected void applyTo(CreateContainerCmd createCommand) {
@@ -135,6 +137,10 @@ class ContainerDef {
         }
 
         createCommand.withLabels(combinedLabels);
+
+        if (cgroupParent != null) {
+            hostConfig.withCgroupParent(cgroupParent);
+        }
     }
 
     protected void setImage(RemoteDockerImage image) {
@@ -301,4 +307,9 @@ class ContainerDef {
     protected void setWaitStrategy(WaitStrategy waitStrategy) {
         this.waitStrategy = waitStrategy;
     }
+
+    protected void setCgroupParent(String cgroupParent) {
+        this.cgroupParent = cgroupParent;
+    }
+
 }

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1316,6 +1316,15 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * {@inheritDoc}
      */
     @Override
+    public SELF withCgroupParent(String cgroupParent) {
+        this.containerDef.setCgroupParent(cgroupParent);
+        return self();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public SELF withCopyFileToContainer(MountableFile mountableFile, String containerPath) {
         if (copyToFileContainerPathMap.containsKey(mountableFile)) {
             throw new IllegalStateException("Path already configured for copy: " + mountableFile);
@@ -1575,6 +1584,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     public void setNetworkMode(String networkMode) {
         this.containerDef.setNetworkMode(networkMode);
+    }
+
+    public void setCgroupParent(String cgroupParent) {
+        this.containerDef.setCgroupParent(cgroupParent);
     }
 
     public void setNetwork(Network network) {


### PR DESCRIPTION
Simply exposes the cgroup-parent option from the underlying Docker API. Syntax similar to the other options exposed.