### PR TITLE
Fix wrong permission setup for HiveMQ container

### DIFF
--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,14 +11,13 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.5")
 
-    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.24.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.14")
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.1")
 }
 
 test {

--- a/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
+++ b/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
@@ -135,6 +135,7 @@ public class HiveMQContainer extends GenericContainer<HiveMQContainer> {
             "-c",
             removeCommand +
             "cp -r '/opt/hivemq/temp-extensions/'* /opt/hivemq/extensions/ ; " +
+            "chmod -R 777 /opt/hivemq/extensions ; " +
             "/opt/docker-entrypoint.sh /opt/hivemq/bin/run.sh"
         );
     }

--- a/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
+++ b/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQContainer.java
@@ -134,9 +134,8 @@ public class HiveMQContainer extends GenericContainer<HiveMQContainer> {
         setCommand(
             "-c",
             removeCommand +
-            "cp -r '/opt/hivemq/temp-extensions/'* /opt/hivemq/extensions/ " +
-            "; chmod -R 777 /opt/hivemq/extensions " +
-            "&& /opt/docker-entrypoint.sh /opt/hivemq/bin/run.sh"
+            "cp -r '/opt/hivemq/temp-extensions/'* /opt/hivemq/extensions/ ; " +
+            "/opt/docker-entrypoint.sh /opt/hivemq/bin/run.sh"
         );
     }
 

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionFromDirectoryIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionFromDirectoryIT.java
@@ -1,7 +1,10 @@
 package org.testcontainers.hivemq;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.event.Level;
 import org.testcontainers.hivemq.util.TestPublishModifiedUtil;
 import org.testcontainers.utility.DockerImageName;
@@ -11,12 +14,16 @@ import java.util.concurrent.TimeUnit;
 
 class ContainerWithExtensionFromDirectoryIT {
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "2020.1", // first version that provided a container image
+        "2024.3" // version that runs the image as a non-root user by default
+    })
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
-    void test() throws Exception {
+    void test(final @NotNull String hivemqCeTag) throws Exception {
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag(hivemqCeTag)
             )
                 .withExtension(MountableFile.forClasspathResource("/modifier-extension"))
                 .waitForExtension("Modifier Extension")
@@ -33,7 +40,7 @@ class ContainerWithExtensionFromDirectoryIT {
     void test_wrongDirectoryName() throws Exception {
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
             )
                 .withExtension(MountableFile.forClasspathResource("/modifier-extension-wrong-name"))
                 .waitForExtension("Modifier Extension")

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionFromDirectoryIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionFromDirectoryIT.java
@@ -15,10 +15,12 @@ import java.util.concurrent.TimeUnit;
 class ContainerWithExtensionFromDirectoryIT {
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "2020.1", // first version that provided a container image
-        "2024.3" // version that runs the image as a non-root user by default
-    })
+    @ValueSource(
+        strings = {
+            "2020.1", // first version that provided a container image
+            "2024.3", // version that runs the image as a non-root user by default
+        }
+    )
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
     void test(final @NotNull String hivemqCeTag) throws Exception {
         try (

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionIT.java
@@ -1,7 +1,9 @@
 package org.testcontainers.hivemq;
 
-import org.junit.jupiter.api.Test;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.hivemq.util.MyExtension;
 import org.testcontainers.hivemq.util.TestPublishModifiedUtil;
 import org.testcontainers.utility.DockerImageName;
@@ -11,9 +13,13 @@ import java.util.concurrent.TimeUnit;
 
 class ContainerWithExtensionIT {
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "2020.1", // first version that provided a container image
+        "2024.3" // version that runs the image as a non-root user by default
+    })
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
-    void test() throws Exception {
+    void test(final @NotNull String hivemqCeTag) throws Exception {
         final HiveMQExtension hiveMQExtension = HiveMQExtension
             .builder()
             .id("extension-1")
@@ -24,7 +30,7 @@ class ContainerWithExtensionIT {
 
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag(hivemqCeTag)
             )
                 .withHiveMQConfig(MountableFile.forClasspathResource("/inMemoryConfig.xml"))
                 .waitForExtension(hiveMQExtension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionIT.java
@@ -14,10 +14,12 @@ import java.util.concurrent.TimeUnit;
 class ContainerWithExtensionIT {
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "2020.1", // first version that provided a container image
-        "2024.3" // version that runs the image as a non-root user by default
-    })
+    @ValueSource(
+        strings = {
+            "2020.1", // first version that provided a container image
+            "2024.3", // version that runs the image as a non-root user by default
+        }
+    )
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
     void test(final @NotNull String hivemqCeTag) throws Exception {
         final HiveMQExtension hiveMQExtension = HiveMQExtension

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionSubclassIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionSubclassIT.java
@@ -25,7 +25,7 @@ class ContainerWithExtensionSubclassIT {
 
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
             )
                 .waitForExtension(hiveMQExtension)
                 .withExtension(hiveMQExtension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithFileInExtensionHomeIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithFileInExtensionHomeIT.java
@@ -24,10 +24,12 @@ import java.util.concurrent.TimeUnit;
 class ContainerWithFileInExtensionHomeIT {
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "2020.1", // first version that provided a container image
-        "2024.3" // version that runs the image as a non-root user by default
-    })
+    @ValueSource(
+        strings = {
+            "2020.1", // first version that provided a container image
+            "2024.3", // version that runs the image as a non-root user by default
+        }
+    )
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
     void test(final @NotNull String hivemqCeTag) throws Exception {
         final HiveMQExtension hiveMQExtension = HiveMQExtension

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithFileInExtensionHomeIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithFileInExtensionHomeIT.java
@@ -9,8 +9,9 @@ import com.hivemq.extension.sdk.api.parameter.ExtensionStopOutput;
 import com.hivemq.extension.sdk.api.services.Services;
 import com.hivemq.extension.sdk.api.services.intializer.ClientInitializer;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.hivemq.util.TestPublishModifiedUtil;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -22,9 +23,13 @@ import java.util.concurrent.TimeUnit;
 
 class ContainerWithFileInExtensionHomeIT {
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "2020.1", // first version that provided a container image
+        "2024.3" // version that runs the image as a non-root user by default
+    })
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
-    void test() throws Exception {
+    void test(final @NotNull String hivemqCeTag) throws Exception {
         final HiveMQExtension hiveMQExtension = HiveMQExtension
             .builder()
             .id("extension-1")
@@ -35,7 +40,7 @@ class ContainerWithFileInExtensionHomeIT {
 
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag(hivemqCeTag)
             )
                 .withHiveMQConfig(MountableFile.forClasspathResource("/inMemoryConfig.xml"))
                 .withExtension(hiveMQExtension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithFileInHomeIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithFileInHomeIT.java
@@ -35,7 +35,7 @@ class ContainerWithFileInHomeIT {
 
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
             )
                 .withHiveMQConfig(MountableFile.forClasspathResource("/inMemoryConfig.xml"))
                 .withExtension(hiveMQExtension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithLicenseIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithLicenseIT.java
@@ -35,7 +35,7 @@ class ContainerWithLicenseIT {
 
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
             )
                 .withHiveMQConfig(MountableFile.forClasspathResource("/inMemoryConfig.xml"))
                 .withExtension(hiveMQExtension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/CreateFileInCopiedDirectoryIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/CreateFileInCopiedDirectoryIT.java
@@ -47,7 +47,7 @@ class CreateFileInCopiedDirectoryIT {
 
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
             )
                 .withHiveMQConfig(MountableFile.forClasspathResource("/inMemoryConfig.xml"))
                 .withExtension(extension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/CreateFileInExtensionDirectoryIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/CreateFileInExtensionDirectoryIT.java
@@ -9,8 +9,9 @@ import com.hivemq.extension.sdk.api.parameter.ExtensionStopOutput;
 import com.hivemq.extension.sdk.api.services.Services;
 import com.hivemq.extension.sdk.api.services.intializer.ClientInitializer;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.hivemq.util.TestPublishModifiedUtil;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -23,9 +24,13 @@ import java.util.concurrent.TimeUnit;
 
 class CreateFileInExtensionDirectoryIT {
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "2020.1", // first version that provided a container image
+        "2024.3" // version that runs the image as a non-root user by default
+    })
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
-    void test() throws Exception {
+    void test(final @NotNull String hivemqCeTag) throws Exception {
         final HiveMQExtension hiveMQExtension = HiveMQExtension
             .builder()
             .id("extension-1")
@@ -36,7 +41,7 @@ class CreateFileInExtensionDirectoryIT {
 
         try (
             final HiveMQContainer hivemq = new HiveMQContainer(
-                DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+                DockerImageName.parse("hivemq/hivemq-ce").withTag(hivemqCeTag)
             )
                 .withHiveMQConfig(MountableFile.forClasspathResource("/inMemoryConfig.xml"))
                 .waitForExtension(hiveMQExtension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/CreateFileInExtensionDirectoryIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/CreateFileInExtensionDirectoryIT.java
@@ -25,10 +25,12 @@ import java.util.concurrent.TimeUnit;
 class CreateFileInExtensionDirectoryIT {
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "2020.1", // first version that provided a container image
-        "2024.3" // version that runs the image as a non-root user by default
-    })
+    @ValueSource(
+        strings = {
+            "2020.1", // first version that provided a container image
+            "2024.3", // version that runs the image as a non-root user by default
+        }
+    )
     @Timeout(value = 3, unit = TimeUnit.MINUTES)
     void test(final @NotNull String hivemqCeTag) throws Exception {
         final HiveMQExtension hiveMQExtension = HiveMQExtension

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/HiveMQTestContainerCore.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/HiveMQTestContainerCore.java
@@ -16,7 +16,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class HiveMQTestContainerCore {
 
     @NotNull
-    final HiveMQContainer container = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3"));
+    final HiveMQContainer container = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3"));
 
     @TempDir
     File tempDir;

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoExtensionTestsIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoExtensionTestsIT.java
@@ -38,7 +38,7 @@ class DemoExtensionTestsIT {
 
     @Container
     final HiveMQContainer hivemqWithClasspathExtension = new HiveMQContainer(
-        DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+        DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
     )
         .waitForExtension(hiveMQEClasspathxtension)
         .withExtension(hiveMQEClasspathxtension)

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoFilesIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoFilesIT.java
@@ -19,7 +19,7 @@ class DemoFilesIT {
 
     // hivemqHome {
     final HiveMQContainer hivemqFileInHome = new HiveMQContainer(
-        DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+        DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
     )
         .withFileInHomeFolder(
             MountableFile.forHostPath("src/test/resources/additionalFile.txt"),
@@ -31,7 +31,7 @@ class DemoFilesIT {
     // extensionHome {
     @Container
     final HiveMQContainer hivemqFileInExtensionHome = new HiveMQContainer(
-        DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3")
+        DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3")
     )
         .withExtension(
             HiveMQExtension
@@ -52,7 +52,7 @@ class DemoFilesIT {
 
     // withLicenses {
     @Container
-    final HiveMQContainer hivemq = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3"))
+    final HiveMQContainer hivemq = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3"))
         .withLicense(MountableFile.forHostPath("src/test/resources/myLicense.lic"))
         .withLicense(MountableFile.forHostPath("src/test/resources/myExtensionLicense.elic"));
 

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoHiveMQContainerIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/docs/DemoHiveMQContainerIT.java
@@ -18,7 +18,7 @@ class DemoHiveMQContainerIT {
 
     // ceVersion {
     @Container
-    final HiveMQContainer hivemqCe = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2021.3"))
+    final HiveMQContainer hivemqCe = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce").withTag("2024.3"))
         .withLogLevel(Level.DEBUG);
 
     // }
@@ -43,7 +43,7 @@ class DemoHiveMQContainerIT {
 
     // specificVersion {
     @Container
-    final HiveMQContainer hivemqSpecificVersion = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce:2021.3"));
+    final HiveMQContainer hivemqSpecificVersion = new HiveMQContainer(DockerImageName.parse("hivemq/hivemq-ce:2024.3"));
 
     // }
 


### PR DESCRIPTION
The line `chmod -R 777 /opt/hivemq/extensions` is problematic when running the HiveMQ container with a non-root user.
It is now made optional (removing it completely is not possible because older HiveMQ container images still need to be supported).