### PR TITLE
openfga.md: fix typo in docker hub link

### DIFF
--- a/docs/modules/openfga.md
+++ b/docs/modules/openfga.md
@@ -1,6 +1,6 @@
 # OpenFGA
 
-Testcontainers module for [OpenFGA](https://hub.docker.com/r/"openfga/openfga).
+Testcontainers module for [OpenFGA](https://hub.docker.com/r/openfga/openfga).
 
 ## OpenFGAContainer's usage examples
 


### PR DESCRIPTION
Small typo in link to openfga docker hub images 