### PR TITLE
Add method for getting Weaviate's gRPC port

### DIFF
--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation 'io.weaviate:client:4.5.1'
+    testImplementation 'io.weaviate:client:4.6.0'
 }

--- a/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
+++ b/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
@@ -33,4 +33,8 @@ public class WeaviateContainer extends GenericContainer<WeaviateContainer> {
     public String getHttpHostAddress() {
         return getHost() + ":" + getMappedPort(8080);
     }
+
+    public String getGrpcHostAddress() {
+        return getHost() + ":" + getMappedPort(50051);
+    }
 }

--- a/modules/weaviate/src/test/java/org/testcontainers/weaviate/WeaviateContainerTest.java
+++ b/modules/weaviate/src/test/java/org/testcontainers/weaviate/WeaviateContainerTest.java
@@ -13,13 +13,15 @@ public class WeaviateContainerTest {
     @Test
     public void test() {
         try ( // container {
-            WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.22.4")
+            WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.24.1")
             // }
         ) {
             weaviate.start();
-            WeaviateClient client = new WeaviateClient(new Config("http", weaviate.getHttpHostAddress()));
+            Config config = new Config("http", weaviate.getHttpHostAddress());
+            config.setGRPCHost(weaviate.getGrpcHostAddress());
+            WeaviateClient client = new WeaviateClient(config);
             Result<Meta> meta = client.misc().metaGetter().run();
-            assertThat(meta.getResult().getVersion()).isEqualTo("1.22.4");
+            assertThat(meta.getResult().getVersion()).isEqualTo("1.24.1");
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
This PR adds a convenience `getGrpcHostAddress()` method to Weaviate module, to get the gRPC host.
It also updates module's test to reflect this change.
