### PR TITLE
Skip starting zookeeper when using a Kafka container with the provided Zookeeper

### DIFF
--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -182,15 +182,14 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
         // exporting KAFKA_ADVERTISED_LISTENERS with the container hostname
         command += String.format("export KAFKA_ADVERTISED_LISTENERS=%s\n", kafkaAdvertisedListeners);
 
-        if (this.kraftEnabled && isLessThanCP740()) {
+        if (!this.kraftEnabled || isLessThanCP740()) {
             // Optimization: skip the checks
             command += "echo '' > /etc/confluent/docker/ensure \n";
-            command += commandKraft();
         }
 
-        if (!this.kraftEnabled) {
-            // Optimization: skip the checks
-            command += "echo '' > /etc/confluent/docker/ensure \n";
+        if (this.kraftEnabled) {
+            command += commandKraft();
+        } else if (this.externalZookeeperConnect == null) {
             command += commandZookeeper();
         }
 


### PR DESCRIPTION
Currently Kafka container always starts embedded Zookeeper in non-kraft mode even if external Zookeeper is provided.
It's not necessary to do that and this PR adds an additional check to only start and embedded Zookeeper when no kraft mode is specified and no external zookeeper is provided.