### PR TITLE
Use Awaitility to Poll the Image Pull

### DIFF
--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -1,6 +1,5 @@
 package org.testcontainers.images;
 
-import static org.awaitility.pollinterval.FibonacciPollInterval.fibonacci;
 import static org.awaitility.pollinterval.IterativePollInterval.iterative;
 
 import com.github.dockerjava.api.DockerClient;
@@ -17,7 +16,6 @@ import lombok.SneakyThrows;
 import lombok.ToString;
 import lombok.With;
 import org.awaitility.Awaitility;
-import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.ContainerFetchException;
@@ -37,7 +35,6 @@ import java.util.concurrent.Future;
 public class RemoteDockerImage extends LazyFuture<String> {
 
     private static final Duration PULL_RETRY_TIME_LIMIT = Duration.ofMinutes(2);
-    private static final int PULL_RETRY_ATTEMPT_LIMIT = 100;
 
     @ToString.Exclude
     private Future<DockerImageName> imageNameFuture;

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -135,7 +135,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
     ) {
         return () -> {
             try {
-                pullWithX86Fallback(pullImageCmd, logger);
+                pullImage(pullImageCmd, logger);
                 dockerImageName.set(imageName.asCanonicalNameString());
                 return true;
             } catch (InterruptedException | InternalServerErrorException e) {
@@ -151,7 +151,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
         };
     }
 
-    private TimeLimitedLoggedPullImageResultCallback pullWithX86Fallback(PullImageCmd pullImageCmd, Logger logger)
+    private TimeLimitedLoggedPullImageResultCallback pullImage(PullImageCmd pullImageCmd, Logger logger)
         throws InterruptedException {
         try {
             return pullImageCmd.exec(new TimeLimitedLoggedPullImageResultCallback(logger)).awaitCompletion();


### PR DESCRIPTION
Puts an interval between Image Pull attempts during the allowed pull duration. Without an interval attempt limit, thousands of docker pull requests can be attempted the default 2 minute time limit.

Fixes https://github.com/testcontainers/testcontainers-java/issues/8454

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
