### PR TITLE
add system property support to configure Oracle Free container

### DIFF
--- a/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
+++ b/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
@@ -32,7 +32,11 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     static final int ORACLE_PORT = 1521;
 
+    private static final String STARTUP_TIMEOUT_SECONDS_PROPERTY = "org.testcontainers.oracle.timeout.startup.seconds";
+
     private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 60;
+
+    private static final String CONNECT_TIMEOUT_SECONDS_PROPERTY = "org.testcontainers.oracle.timeout.connect.seconds";
 
     private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 60;
 
@@ -72,8 +76,15 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
             new LogMessageWaitStrategy()
                 .withRegEx(".*DATABASE IS READY TO USE!.*\\s")
                 .withTimes(1)
-                .withStartupTimeout(Duration.of(DEFAULT_STARTUP_TIMEOUT_SECONDS, ChronoUnit.SECONDS));
-        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+                .withStartupTimeout(
+                    Duration.of(
+                        Long.getLong(STARTUP_TIMEOUT_SECONDS_PROPERTY, DEFAULT_STARTUP_TIMEOUT_SECONDS),
+                        ChronoUnit.SECONDS
+                    )
+                );
+        withConnectTimeoutSeconds(
+            Integer.getInteger(CONNECT_TIMEOUT_SECONDS_PROPERTY, DEFAULT_CONNECT_TIMEOUT_SECONDS)
+        );
         addExposedPorts(ORACLE_PORT);
     }
 


### PR DESCRIPTION
The proposed support for configuring the Oracle Free Container via system properties should help to run tests on machines/VMs with lower CPU performance.

Configure the startup timeout of the Oracle Free container by the system property `org.testcontainers.oracle.timeout.startup.seconds`. If it's not present or an invalid value, the default value of 60 (seconds) will be used.

For the connect timeout use the system property `org.testcontainers.oracle.timeout.connect.seconds`. The default value of 60 (seconds) will be used if the value is not present or invalid.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
