### PR TITLE
Add GenericContainer.withPortBindings() method

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1114,6 +1114,17 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     }
 
     /**
+    * Sets the port bindings for the container
+    *
+    * @param portBindings the list of port bindings to set. Each entry should be in the format "hostPort:containerPort".
+    * @return this
+    */
+    public SELF withPortBindings(List<String> portBindings) {
+        this.setPortBindings(portBindings);
+        return self();
+    }
+
+    /**
      * Add a TCP container port that should be bound to a fixed port on the docker host.
      * <p>
      * Note that this method is protected scope to discourage use, as clashes or instability are more likely when


### PR DESCRIPTION
This PR simply adds `withPortBindings` method to `GenericContainer.java`.

The main interest is to be able to define port bindings in a fluent way like this:
``` java
Container c = new GenericContainer("httpd:2.4.58")
    .withPortBindings("80:80");
```
