### PR TITLE
Pass env to ComposeDelegate in DockerComposeContainer#stop

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -165,7 +165,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd, env);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -165,7 +165,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, env);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -172,7 +172,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, env);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -172,7 +172,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd, env);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }

--- a/core/src/test/java/org/testcontainers/junit/ComposeContainerPortViaEnvTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ComposeContainerPortViaEnvTest.java
@@ -1,0 +1,21 @@
+package org.testcontainers.junit;
+
+import org.junit.Rule;
+import org.testcontainers.containers.ComposeContainer;
+
+import java.io.File;
+
+public class ComposeContainerPortViaEnvTest extends BaseComposeTest {
+
+    @Rule
+    public ComposeContainer environment = new ComposeContainer(
+        new File("src/test/resources/v2-compose-test-port-via-env.yml")
+    )
+        .withExposedService("redis-1", REDIS_PORT)
+        .withEnv("REDIS_PORT", String.valueOf(REDIS_PORT));
+
+    @Override
+    protected ComposeContainer getEnvironment() {
+        return environment;
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeContainerPortViaEnvTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeContainerPortViaEnvTest.java
@@ -1,0 +1,21 @@
+package org.testcontainers.junit;
+
+import org.junit.Rule;
+import org.testcontainers.containers.DockerComposeContainer;
+
+import java.io.File;
+
+public class DockerComposeContainerPortViaEnvTest extends BaseDockerComposeTest {
+
+    @Rule
+    public DockerComposeContainer environment = new DockerComposeContainer(
+        new File("src/test/resources/v2-compose-test-port-via-env.yml")
+    )
+        .withExposedService("redis_1", REDIS_PORT)
+        .withEnv("REDIS_PORT", String.valueOf(REDIS_PORT));
+
+    @Override
+    protected DockerComposeContainer getEnvironment() {
+        return environment;
+    }
+}

--- a/core/src/test/resources/v2-compose-test-port-via-env.yml
+++ b/core/src/test/resources/v2-compose-test-port-via-env.yml
@@ -1,0 +1,5 @@
+services:
+  redis:
+    image: redis
+    ports:
+      - ${REDIS_PORT}


### PR DESCRIPTION
This fixes issues on stopping when ENV-Variables are used inside the compose file. Issue was introduced in 7112db5.

Fixes #8492
