### PR TITLE
Normalize image names in prefix substitutor

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -26,7 +26,7 @@ public final class DockerImageName {
 
     private static final Pattern REPO_NAME = Pattern.compile(REPO_NAME_PART + "(/" + REPO_NAME_PART + ")*");
 
-    private static final String LIBRARY_PREFIX = "library/";
+    static final String LIBRARY_PREFIX = "library/";
 
     private final String rawName;
 

--- a/core/src/test/java/org/testcontainers/utility/PrefixingImageNameSubstitutorTest.java
+++ b/core/src/test/java/org/testcontainers/utility/PrefixingImageNameSubstitutorTest.java
@@ -34,6 +34,21 @@ public class PrefixingImageNameSubstitutorTest {
     }
 
     @Test
+    public void testNormalizeToLibraryPath() {
+        when(mockConfiguration.getEnvVarOrProperty(eq(PrefixingImageNameSubstitutor.PREFIX_PROPERTY_KEY), any()))
+            .thenReturn("someregistry.com/our-mirror/");
+        when(mockConfiguration.getEnvVarOrProperty(eq(PrefixingImageNameSubstitutor.NORMALIZE_PROPERTY_KEY), any()))
+            .thenReturn("true");
+
+        final DockerImageName result = underTest.apply(DockerImageName.parse("image:tag"));
+
+        assertThat(result.asCanonicalNameString())
+            .as("The prefix is applied")
+            .isEqualTo("someregistry.com/our-mirror/library/image:tag");
+        result.assertCompatibleWith(DockerImageName.parse("image:tag"));
+    }
+
+    @Test
     public void hubIoRegistryIsNotChanged() {
         when(mockConfiguration.getEnvVarOrProperty(eq(PrefixingImageNameSubstitutor.PREFIX_PROPERTY_KEY), any()))
             .thenReturn("someregistry.com/our-mirror/");

--- a/docs/features/image_name_substitution.md
+++ b/docs/features/image_name_substitution.md
@@ -77,6 +77,13 @@ Testcontainers will not apply the prefix to:
 * non-Hub image names (e.g. where another registry is set)
 * Docker Hub image names where the hub registry is explicitly part of the name (i.e. anything with a `docker.io` or `registry.hub.docker.com` host part)
 
+If you want your registry to handle both official Docker Hub images (e.g `postgres`)
+as well as images from other registries (e.g `mycompany/postgres`), you can use the
+`TESTCONTAINERS_HUB_IMAGE_NAME_NORMALIZE` environment variable or the `hub.image.name.normalize`
+configuration option. When set to `true`, Testcontainers will normalize the official Docker Hub
+image names to start with `library/`. When this option is used, Testcontainers will additionally
+disable image compatibility checks done by some containers, so it the compatibility responsibility
+is on the user.
 
 
 ## Developing a custom function for transforming image names on the fly


### PR DESCRIPTION
Optionally normalize docker image names to use `library/` prefix when they don't have any namespace at all. This allows for the `PrefixingImageNameSubstitutor` to be used to redirect Docker Hub requests to a private registry without having to apply otherwise redundant changes to the test code.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
