### PR TITLE
Weaviate: Support new project container registry

### DIFF
--- a/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
+++ b/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.utility.DockerImageName;
 /**
  * Testcontainers implementation of Weaviate.
  * <p>
- * Supported image: {@code semitechnologies/weaviate}
+ * Supported images: {@code cr.weaviate.io/semitechnologies/weaviate}, {@code semitechnologies/weaviate}
  * <p>
  * Exposed ports:
  * <ul>
@@ -16,7 +16,11 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class WeaviateContainer extends GenericContainer<WeaviateContainer> {
 
-    private static final String WEAVIATE_IMAGE = "semitechnologies/weaviate";
+    private static final DockerImageName DEFAULT_WEAVIATE_IMAGE = DockerImageName.parse(
+        "cr.weaviate.io/semitechnologies/weaviate"
+    );
+
+    private static final DockerImageName DOCKER_HUB_WEAVIATE_IMAGE = DockerImageName.parse("semitechnologies/weaviate");
 
     public WeaviateContainer(String dockerImageName) {
         this(DockerImageName.parse(dockerImageName));
@@ -24,7 +28,7 @@ public class WeaviateContainer extends GenericContainer<WeaviateContainer> {
 
     public WeaviateContainer(DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DockerImageName.parse(WEAVIATE_IMAGE));
+        dockerImageName.assertCompatibleWith(DEFAULT_WEAVIATE_IMAGE, DOCKER_HUB_WEAVIATE_IMAGE);
         withExposedPorts(8080, 50051);
         withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true");
         withEnv("PERSISTENCE_DATA_PATH", "/var/lib/weaviate");

--- a/modules/weaviate/src/test/java/org/testcontainers/weaviate/WeaviateContainerTest.java
+++ b/modules/weaviate/src/test/java/org/testcontainers/weaviate/WeaviateContainerTest.java
@@ -19,7 +19,7 @@ public class WeaviateContainerTest {
     @Test
     public void testWeaviate() {
         try ( // container {
-            WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.24.5")
+            WeaviateContainer weaviate = new WeaviateContainer("cr.weaviate.io/semitechnologies/weaviate:1.24.5")
             // }
         ) {
             weaviate.start();


### PR DESCRIPTION
The Testcontainers Weaviate module now supports both the Weaviate own container registry (default) and Docker Hub (alternative for backward compatibility).

Fixes gh-8511
