### PR TITLE
Bump org.apache.commons.commons-compress from 1.24.0 to 1.26.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api 'org.apache.commons:commons-compress:1.26.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
I understand the instructions ask not to open a pull request to update only a version dependency. However, I don't see a PR opened for this specific dependency, and there is a serious vulnerability in the current version used.

**Fixed in Apache Commons Compress 1.26.0**
**Important: Denial of Service** [CVE-2024-25710](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25710)
This affects version 1.3 through 1.25.0.
This denial of service is caused by an infinite loop reading a corrupted DUMP file.
**Users are recommended to upgrade to version 1.26.0 which fixes the issue.**

**Moderate: Denial of Service** [CVE-2024-26308](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26308)
You can get an OutOfMemoryError unpacking a broken Pack200 file.
This issue affects Commons Compress 1.21 before 1.26.0.
**Users are recommended to upgrade to version 1.26.0 which fixes the issue.**