### PR TITLE
Deprecate the typed Neo4j labs plugins

### DIFF
--- a/docs/modules/databases/neo4j.md
+++ b/docs/modules/databases/neo4j.md
@@ -73,13 +73,12 @@ Whole directories work as well:
 
 ### Add Neo4j Docker Labs plugins
 
-Add any Neo4j Labs plugin from the [Neo4j Docker Labs plugin list](https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins).
+Add any Neo4j Labs plugin from the [Neo4j 4.4 Docker Labs plugin list](https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins)
+or [Neo4j 5 plugin list](https://neo4j.com/docs/operations-manual/5/configuration/plugins/).
 
 !!! note
-    At the moment only the plugins available from the list Neo4j Docker 4.4 are supported by type.
-    If you want to register another supported Neo4j Labs plugin, you have to add it manually
-    by using the method `withLabsPlugins(String... neo4jLabsPlugins)`.
-    Please refer to the list of [supported Docker image plugins](https://neo4j.com/docs/operations-manual/current/docker/operations/#docker-neo4jlabs-plugins).
+    The methods `withLabsPlugins(Neo4jLabsPlugin...)` and `withLabsPlugins(String... plugins)` are deprecated.
+    Please the method `withPlugins(String... plugins)`.
 
 <!--codeinclude-->
 [Configure Neo4j Labs Plugins](../../../modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java) inside_block:configureLabsPlugins

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jContainer.java
@@ -318,9 +318,11 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
 
     /**
      * Registers one or more {@link Neo4jLabsPlugin} for download and server startup.
-
+     *
      * @param neo4jLabsPlugins The Neo4j plugins that should get started with the server.
      * @return This container.
+     * @deprecated {@link Neo4jLabsPlugin} were deprecated due to naming changes that cannot be solved by this enumeration.
+     * Please use the {@link Neo4jContainer#withPlugins(String...)} method.
      */
     public S withLabsPlugins(Neo4jLabsPlugin... neo4jLabsPlugins) {
         List<String> pluginNames = Arrays
@@ -333,13 +335,25 @@ public class Neo4jContainer<S extends Neo4jContainer<S>> extends GenericContaine
     }
 
     /**
-     * Registers one or more {@link Neo4jLabsPlugin} for download and server startup.
-
-     * @param neo4jLabsPlugins The Neo4j plugins that should get started with the server.
-     * @return This container.
+     * @deprecated Please use {@link Neo4jContainer#withPlugins(String...)} for named plugins.
      */
     public S withLabsPlugins(String... neo4jLabsPlugins) {
-        this.labsPlugins.addAll(Arrays.asList(neo4jLabsPlugins));
+        return this.withPlugins(neo4jLabsPlugins);
+    }
+
+    /**
+     * Registers one or more Neo4j plugins for server startup.
+     * The plugins are listed here
+     * <ul>
+     *     <li><a href="https://neo4j.com/docs/operations-manual/5/configuration/plugins/">Neo4j 5</a></li>
+     *     <li><a href="https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins">Neo4j 4.4</a></li>
+     * </ul>
+     *
+     * @param plugins The Neo4j plugins that should get started with the server.
+     * @return This container.
+     */
+    public S withPlugins(String... plugins) {
+        this.labsPlugins.addAll(Arrays.asList(plugins));
         return self();
     }
 

--- a/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jLabsPlugin.java
+++ b/modules/neo4j/src/main/java/org/testcontainers/containers/Neo4jLabsPlugin.java
@@ -4,6 +4,14 @@ package org.testcontainers.containers;
  * Reflects a plugin from the official Neo4j 4.4.
  * <a href="https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins">Neo4j Labs Plugin list</a>.
  * There might be plugins not supported by your selected version of Neo4j.
+ *
+ * @deprecated Please use {@link Neo4jContainer#withLabsPlugins(String...)} with the matching plugin name for your Neo4j version.
+ * Due to some renaming of the (Docker image) plugin names, there is no naming consistency across versions.
+ * The plugins are listed here
+ * <ul>
+ *     <li><a href="https://neo4j.com/docs/operations-manual/5/configuration/plugins/">Neo4j 5</a></li>
+ *     <li><a href="https://neo4j.com/docs/operations-manual/4.4/docker/operations/#docker-neo4jlabs-plugins">Neo4j 4.4</a></li>
+ * </ul>
  */
 public enum Neo4jLabsPlugin {
     APOC("apoc"),

--- a/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
+++ b/modules/neo4j/src/test/java/org/testcontainers/containers/Neo4jContainerTest.java
@@ -267,8 +267,9 @@ public class Neo4jContainerTest {
         assertThat(neo4jContainer.getWaitStrategy()).isInstanceOf(CustomDummyWaitStrategy.class);
     }
 
+    // Test for deprecated functionality to be still alive, if `Neo4jLabsPlugin` gets removed, remove this test.
     @Test
-    public void shouldConfigureSingleLabsPlugin() {
+    public void shouldConfigureSingleLabsPluginByType() {
         try (
             Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withLabsPlugins(Neo4jLabsPlugin.APOC)
         ) {
@@ -279,13 +280,12 @@ public class Neo4jContainerTest {
         }
     }
 
+    // Test for deprecated functionality to be still alive, if `Neo4jLabsPlugin` gets removed, remove this test.
     @Test
-    public void shouldConfigureMultipleLabsPlugins() {
+    public void shouldConfigureMultipleLabsPluginsByType() {
         try (
-            // configureLabsPlugins {
             Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4")
                 .withLabsPlugins(Neo4jLabsPlugin.APOC, Neo4jLabsPlugin.BLOOM);
-            // }
         ) {
             // needs to get called explicitly for setup
             neo4jContainer.configure();
@@ -295,26 +295,52 @@ public class Neo4jContainerTest {
         }
     }
 
+    // Test for deprecated functionality to be still alive, if `Neo4jContainer#withLabsPlugins` gets removed, remove this test.
     @Test
-    public void shouldConfigureSingleLabsPluginWithString() {
-        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withLabsPlugins("myApoc")) {
+    public void shouldConfigureSingleLabsPlugin() {
+        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withLabsPlugins("apoc")) {
             // needs to get called explicitly for setup
             neo4jContainer.configure();
 
-            assertThat(neo4jContainer.getEnvMap()).containsEntry("NEO4JLABS_PLUGINS", "[\"myApoc\"]");
+            assertThat(neo4jContainer.getEnvMap()).containsEntry("NEO4JLABS_PLUGINS", "[\"apoc\"]");
+        }
+    }
+
+    // Test for deprecated functionality to be still alive, if `Neo4jContainer#withLabsPlugins` gets removed, remove this test.
+    @Test
+    public void shouldConfigureMultipleLabsPlugins() {
+        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withLabsPlugins("apoc", "bloom");) {
+            // needs to get called explicitly for setup
+            neo4jContainer.configure();
+
+            assertThat(neo4jContainer.getEnvMap().get("NEO4JLABS_PLUGINS"))
+                .containsAnyOf("[\"apoc\",\"bloom\"]", "[\"bloom\",\"apoc\"]");
         }
     }
 
     @Test
-    public void shouldConfigureMultipleLabsPluginsWithString() {
+    public void shouldConfigureSinglePluginByName() {
+        try (Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withPlugins("apoc")) {
+            // needs to get called explicitly for setup
+            neo4jContainer.configure();
+
+            assertThat(neo4jContainer.getEnvMap()).containsEntry("NEO4JLABS_PLUGINS", "[\"apoc\"]");
+        }
+    }
+
+    @Test
+    public void shouldConfigureMultiplePluginsByName() {
         try (
-            Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4").withLabsPlugins("myApoc", "myBloom")
+            // configureLabsPlugins {
+            Neo4jContainer<?> neo4jContainer = new Neo4jContainer<>("neo4j:4.4") //
+                .withPlugins("apoc", "bloom");
+            // }
         ) {
             // needs to get called explicitly for setup
             neo4jContainer.configure();
 
             assertThat(neo4jContainer.getEnvMap().get("NEO4JLABS_PLUGINS"))
-                .containsAnyOf("[\"myApoc\",\"myBloom\"]", "[\"myBloom\",\"myApoc\"]");
+                .containsAnyOf("[\"apoc\",\"bloom\"]", "[\"bloom\",\"apoc\"]");
         }
     }
 


### PR DESCRIPTION
Some user experience improvement.
There were some renaming that makes the whole concept inconsistent. Users should activate the plugin by name from now on.
This commit introduces a new method `withPlugins` to also get rid of the _labs_ part and be in line with the `withPlugins(MountableFile plugins)` method.
