### PR TITLE
support backtick enquoting in SQL script splitter

### DIFF
--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptScanner.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptScanner.java
@@ -141,7 +141,7 @@ class ScriptScanner {
                 return Lexem.SEPARATOR;
             } else if (matchesSingleLineComment() || matchesMultilineComment()) {
                 return Lexem.COMMENT;
-            } else if (matchesQuotedString('\'') || matchesQuotedString('"') || matchesDollarQuotedString()) {
+            } else if (matchesQuotedString('\'') || matchesQuotedString('"') || matchesQuotedString('`') || matchesDollarQuotedString()) {
                 return Lexem.QUOTED_STRING;
             } else if (matches(identifier)) {
                 return Lexem.IDENTIFIER;

--- a/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptScanner.java
+++ b/modules/database-commons/src/main/java/org/testcontainers/ext/ScriptScanner.java
@@ -141,7 +141,12 @@ class ScriptScanner {
                 return Lexem.SEPARATOR;
             } else if (matchesSingleLineComment() || matchesMultilineComment()) {
                 return Lexem.COMMENT;
-            } else if (matchesQuotedString('\'') || matchesQuotedString('"') || matchesQuotedString('`') || matchesDollarQuotedString()) {
+            } else if (
+                matchesQuotedString('\'') ||
+                matchesQuotedString('"') ||
+                matchesQuotedString('`') ||
+                matchesDollarQuotedString()
+            ) {
                 return Lexem.QUOTED_STRING;
             } else if (matches(identifier)) {
                 return Lexem.IDENTIFIER;

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptSplittingTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptSplittingTest.java
@@ -69,6 +69,20 @@ public class ScriptSplittingTest {
     }
 
     @Test
+    public void testSplittingEnquotedSemicolon() {
+        String script =
+            "CREATE TABLE `bar;bar` (\n" +
+            "  end_time VARCHAR(255)\n" +
+            ");";
+
+        List<String> expected = Arrays.asList(
+            "CREATE TABLE `bar;bar` ( end_time VARCHAR(255) )"
+        );
+
+        splitAndCompare(script, expected);
+    }
+
+    @Test
     public void testUnusualSemicolonPlacement() {
         String script = "SELECT 1;;;;;SELECT 2;\n;SELECT 3\n; SELECT 4;\n SELECT 5";
 

--- a/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptSplittingTest.java
+++ b/modules/database-commons/src/test/java/org/testcontainers/ext/ScriptSplittingTest.java
@@ -70,14 +70,9 @@ public class ScriptSplittingTest {
 
     @Test
     public void testSplittingEnquotedSemicolon() {
-        String script =
-            "CREATE TABLE `bar;bar` (\n" +
-            "  end_time VARCHAR(255)\n" +
-            ");";
+        String script = "CREATE TABLE `bar;bar` (\n" + "  end_time VARCHAR(255)\n" + ");";
 
-        List<String> expected = Arrays.asList(
-            "CREATE TABLE `bar;bar` ( end_time VARCHAR(255) )"
-        );
+        List<String> expected = Arrays.asList("CREATE TABLE `bar;bar` ( end_time VARCHAR(255) )");
 
         splitAndCompare(script, expected);
     }


### PR DESCRIPTION
This adds support for splitting SQL scripts that contain backtick-enquoted strings. See https://github.com/testcontainers/testcontainers-java/issues/8592