### PR TITLE
Automatically add LAMBDA_DOCKER_FLAGS with testcontainer labels

### DIFF
--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-s3'
     testImplementation 'com.amazonaws:aws-java-sdk-sqs'
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
+    testImplementation 'com.amazonaws:aws-java-sdk-lambda'
+    testImplementation 'com.amazonaws:aws-java-sdk-core'
     testImplementation 'software.amazon.awssdk:s3:2.23.9'
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

## Motivation
We have been seeing issues (like localstack/localstack#8616) where the Lambda containers spawned by LocalStack were not removed after the testcontainer session finished.
This can happen if the LocalStack container is killed before it can finish cleaning up all spawned resources.

Using `LAMBDA_DOCKER_FLAGS` we can, for example, add labels to all spawned lambda containers. Using this mechanism, we can add the same labels testcontainers sets on spawned containers on the lambda containers created by LocalStack, and let testcontainers handle the termination after the test session finishes.

## Changes
* Add internal testcontainer marker labels to `LAMBDA_DOCKER_FLAGS`
* Add test asserting the labels on the spawned lambda container