### PR TITLE
Fixes #3998 and allows per test method screen recording

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -181,11 +181,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
                 withNetwork(Network.SHARED);
             }
 
-            vncRecordingContainer =
-                new VncRecordingContainer(this)
-                    .withVncPassword(DEFAULT_PASSWORD)
-                    .withVncPort(VNC_PORT)
-                    .withVideoFormat(recordingFormat);
+            configureVncRecorderContainer();
         }
 
         if (customImageName != null) {
@@ -228,6 +224,21 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         setStartupAttempts(3);
     }
 
+    private void configureVncRecorderContainer() {
+        vncRecordingContainer =
+            new VncRecordingContainer(this)
+                .withVncPassword(DEFAULT_PASSWORD)
+                .withVncPort(VNC_PORT)
+                .withVideoFormat(recordingFormat);
+    }
+
+    protected void reinitializeVncRecorderContainer() {
+        if (vncRecordingContainer != null) {
+            vncRecordingContainer.close();
+        }
+        configureVncRecorderContainer();
+        vncRecordingContainer.start();
+    }
     /**
      * @param capabilities a {@link Capabilities} object for either Chrome or Firefox
      * @param seleniumVersion the version of selenium in use


### PR DESCRIPTION
This pull request is related to issue #3998. 

BrowserWebDriverContainer is designed to execute each test in a fresh container. 
However this is slow and not an option especially when test execution can't be parallelized.

Instead of recreating a fresh BrowserWebDriverContainer instance it may be sufficient to just re-create the VncRecorderContainer for each test.

This pull request offers a new method `reinitializeVncRecorderContainer` that tears down the vncRecordingContainer and creates a fresh instance. So it comes with out side effects of breaking existing functions.

With that update it is fairly simple to create a subclass of `BrowserWebDriverContainer` to take care of re-creating the vnc recorder by overriding the `afterTest` method.

```
class VncRecordingPerTestMethodBrowserWebDriverContainer<T extends VncRecordingPerTestMethodBrowserWebDriverContainer<T>>
		extends BrowserWebDriverContainer<T> {
	@Override
	public void afterTest(TestDescription description, Optional<Throwable> throwable) {
		super.afterTest(description, throwable);
		reinitializeVncRecorderContainer();
	}
}
```
