### PR TITLE
Update redis version

### DIFF
--- a/core/src/test/java/org/testcontainers/TestImages.java
+++ b/core/src/test/java/org/testcontainers/TestImages.java
@@ -3,7 +3,7 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface TestImages {
-    DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:3.0.2");
+    DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:6-alpine");
     DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.5.3");
     DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:3.1.5");
     DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.17");

--- a/core/src/test/java/org/testcontainers/TestImages.java
+++ b/core/src/test/java/org/testcontainers/TestImages.java
@@ -4,7 +4,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public interface TestImages {
     DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:6-alpine");
-    DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.5.3");
+    DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.7.25");
     DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:3.1.5");
     DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.17");
     DockerImageName DOCKER_REGISTRY_IMAGE = DockerImageName.parse("registry:2.7.0");

--- a/core/src/test/java/org/testcontainers/TestImages.java
+++ b/core/src/test/java/org/testcontainers/TestImages.java
@@ -5,7 +5,7 @@ import org.testcontainers.utility.DockerImageName;
 public interface TestImages {
     DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:6-alpine");
     DockerImageName RABBITMQ_IMAGE = DockerImageName.parse("rabbitmq:3.7.25");
-    DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:3.1.5");
+    DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:4.4");
     DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.17");
     DockerImageName DOCKER_REGISTRY_IMAGE = DockerImageName.parse("registry:2.7.0");
     DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.17");

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -227,7 +227,7 @@ public class GenericContainerTest {
     @Test
     public void shouldReturnTheProvidedImage() {
         GenericContainer container = new GenericContainer(TestImages.REDIS_IMAGE);
-        assertThat(container.getImage().get()).isEqualTo("redis:3.0.2");
+        assertThat(container.getImage().get()).isEqualTo("redis:6-alpine");
         container.setImage(new RemoteDockerImage(TestImages.ALPINE_IMAGE));
         assertThat(container.getImage().get()).isEqualTo("alpine:3.17");
     }

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeLocalImageTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeLocalImageTest.java
@@ -12,7 +12,7 @@ public class DockerComposeLocalImageTest {
 
     @Test
     public void usesLocalImageEvenWhenPullFails() throws InterruptedException {
-        tagImage("redis:4.0.10", "redis-local", "latest");
+        tagImage("redis:6-alpine", "redis-local", "latest");
 
         DockerComposeContainer composeContainer = new DockerComposeContainer(
             new File("src/test/resources/local-compose-test.yml")

--- a/core/src/test/resources/compose-options-test/with-deploy-block.yml
+++ b/core/src/test/resources/compose-options-test/with-deploy-block.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   redis:
-      image: redis:2.6.17
+      image: redis:6-alpine
       deploy:
         resources:
           limits:

--- a/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/CmdModifierTest.java
@@ -18,7 +18,7 @@ public class CmdModifierTest {
 
     // hostname {
     @Rule
-    public GenericContainer theCache = new GenericContainer<>(DockerImageName.parse("redis:3.0.2"))
+    public GenericContainer theCache = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
         .withCreateContainerCmdModifier(cmd -> cmd.withHostName("the-cache"));
 
     // }
@@ -30,7 +30,7 @@ public class CmdModifierTest {
     private long memorySwapInBytes = 64l * 1024l * 1024l;
 
     @Rule
-    public GenericContainer memoryLimitedRedis = new GenericContainer<>(DockerImageName.parse("redis:3.0.2"))
+    public GenericContainer memoryLimitedRedis = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
         .withCreateContainerCmdModifier(cmd -> {
             cmd.getHostConfig()
                 .withMemory(memoryInBytes)

--- a/docs/examples/junit4/generic/src/test/java/generic/CommandsTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/CommandsTest.java
@@ -11,7 +11,7 @@ public class CommandsTest {
 
     @Rule
     // startupCommand {
-    public GenericContainer redisWithCustomPort = new GenericContainer(DockerImageName.parse("redis:5.0"))
+    public GenericContainer redisWithCustomPort = new GenericContainer(DockerImageName.parse("redis:6-alpine"))
         .withCommand("redis-server --port 7777")
         // }
         .withExposedPorts(7777);

--- a/docs/examples/junit4/generic/src/test/java/generic/ContainerCreationTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ContainerCreationTest.java
@@ -11,7 +11,7 @@ public class ContainerCreationTest {
 
     // spotless:off
     // simple {
-    public static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:3.0.2");
+    public static final DockerImageName REDIS_IMAGE = DockerImageName.parse("redis:6-alpine");
 
     @ClassRule
     public static GenericContainer<?> redis = new GenericContainer<>(REDIS_IMAGE)

--- a/docs/examples/junit4/generic/src/test/java/generic/DependsOnTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/DependsOnTest.java
@@ -10,7 +10,7 @@ public class DependsOnTest {
 
     @Rule
     // dependsOn {
-    public GenericContainer<?> redis = new GenericContainer<>("redis:3.0.2").withExposedPorts(6379);
+    public GenericContainer<?> redis = new GenericContainer<>("redis:6-alpine").withExposedPorts(6379);
 
     @Rule
     public GenericContainer<?> nginx = new GenericContainer<>("nginx:1.9.4").dependsOn(redis).withExposedPorts(80);

--- a/docs/examples/junit4/generic/src/test/java/generic/WaitStrategiesTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/WaitStrategiesTest.java
@@ -29,7 +29,7 @@ public class WaitStrategiesTest {
 
     @Rule
     // logMessageWait {
-    public GenericContainer containerWithLogWait = new GenericContainer(DockerImageName.parse("redis:5.0.3"))
+    public GenericContainer containerWithLogWait = new GenericContainer(DockerImageName.parse("redis:6-alpine"))
         .withExposedPorts(6379)
         .waitingFor(Wait.forLogMessage(".*Ready to accept connections.*\\n", 1));
 

--- a/docs/examples/junit4/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java
+++ b/docs/examples/junit4/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java
@@ -14,7 +14,7 @@ public class RedisBackedCacheIntTest {
 
     // rule {
     @Rule
-    public GenericContainer redis = new GenericContainer(DockerImageName.parse("redis:5.0.3-alpine"))
+    public GenericContainer redis = new GenericContainer(DockerImageName.parse("redis:6-alpine"))
         .withExposedPorts(6379);
 
     // }

--- a/docs/examples/junit5/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java
+++ b/docs/examples/junit5/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java
@@ -17,7 +17,7 @@ public class RedisBackedCacheIntTest {
 
     // container {
     @Container
-    public GenericContainer redis = new GenericContainer(DockerImageName.parse("redis:5.0.3-alpine"))
+    public GenericContainer redis = new GenericContainer(DockerImageName.parse("redis:6-alpine"))
         .withExposedPorts(6379);
 
     // }

--- a/docs/examples/spock/redis/src/test/groovy/quickstart/RedisBackedCacheIntTest.groovy
+++ b/docs/examples/spock/redis/src/test/groovy/quickstart/RedisBackedCacheIntTest.groovy
@@ -10,7 +10,7 @@ class RedisBackedCacheIntTest extends Specification {
 	private RedisBackedCache underTest
 
 	// init {
-	GenericContainer redis = new GenericContainer<>("redis:5.0.3-alpine")
+	GenericContainer redis = new GenericContainer<>("redis:6-alpine")
 	.withExposedPorts(6379)
 	// }
 

--- a/examples/redis-backed-cache-testng/src/test/java/RedisBackedCacheTest.java
+++ b/examples/redis-backed-cache-testng/src/test/java/RedisBackedCacheTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class RedisBackedCacheTest {
 
-    private static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:3.0.6"))
+    private static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
         .withExposedPorts(6379);
 
     private Cache cache;

--- a/examples/redis-backed-cache/src/test/java/RedisBackedCacheTest.java
+++ b/examples/redis-backed-cache/src/test/java/RedisBackedCacheTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class RedisBackedCacheTest {
 
     @Container
-    public GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:3.0.6"))
+    public GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
         .withExposedPorts(6379);
 
     private Cache cache;

--- a/examples/singleton-container/src/test/java/com/example/AbstractIntegrationTest.java
+++ b/examples/singleton-container/src/test/java/com/example/AbstractIntegrationTest.java
@@ -5,7 +5,7 @@ import org.testcontainers.utility.DockerImageName;
 
 public abstract class AbstractIntegrationTest {
 
-    public static final GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:3.0.6"))
+    public static final GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
         .withExposedPorts(6379);
 
     static {

--- a/examples/spring-boot-kotlin-redis/src/test/kotlin/com/example/redis/AbstractIntegrationTest.kt
+++ b/examples/spring-boot-kotlin-redis/src/test/kotlin/com/example/redis/AbstractIntegrationTest.kt
@@ -16,7 +16,7 @@ import org.testcontainers.containers.GenericContainer
 abstract class AbstractIntegrationTest {
 
     companion object {
-        val redisContainer = GenericContainer<Nothing>("redis:3-alpine")
+        val redisContainer = GenericContainer<Nothing>("redis:6-alpine")
                 .apply { withExposedPorts(6379) }
     }
 

--- a/examples/spring-boot/src/test/java/com/example/AbstractIntegrationTest.java
+++ b/examples/spring-boot/src/test/java/com/example/AbstractIntegrationTest.java
@@ -16,7 +16,7 @@ import org.testcontainers.utility.DockerImageName;
 @ActiveProfiles("test")
 abstract class AbstractIntegrationTest {
 
-    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:3-alpine"))
+    static GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:6-alpine"))
         .withExposedPorts(6379);
 
     @DynamicPropertySource

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/inheritance/RedisContainer.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/inheritance/RedisContainer.java
@@ -7,7 +7,7 @@ import redis.clients.jedis.Jedis;
 public class RedisContainer extends GenericContainer<RedisContainer> {
 
     public RedisContainer() {
-        super(DockerImageName.parse("redis:3.2.11"));
+        super(DockerImageName.parse("redis:6-alpine"));
         withExposedPorts(6379);
     }
 

--- a/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
+++ b/modules/toxiproxy/src/test/java/org/testcontainers/containers/ToxiproxyTest.java
@@ -27,7 +27,7 @@ public class ToxiproxyTest {
 
     // The target container - this could be anything
     @Rule
-    public GenericContainer<?> redis = new GenericContainer<>("redis:5.0.4")
+    public GenericContainer<?> redis = new GenericContainer<>("redis:6-alpine")
         .withExposedPorts(6379)
         .withNetwork(network)
         .withNetworkAliases("redis");
@@ -114,7 +114,7 @@ public class ToxiproxyTest {
     @Test
     public void testMultipleProxiesCanBeCreated() throws IOException {
         try (
-            GenericContainer<?> secondRedis = new GenericContainer<>("redis:5.0.4")
+            GenericContainer<?> secondRedis = new GenericContainer<>("redis:6-alpine")
                 .withExposedPorts(6379)
                 .withNetwork(network)
                 .withNetworkAliases("redis2")


### PR DESCRIPTION
Current tests fail with the following message:
`Could not pull image: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/redis:3.0.2 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/`
