### PR TITLE
Introduce '@EnabledIfDockerAvailable' JUnit 5 annotation (#8613)

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/DockerAvailableDetector.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/DockerAvailableDetector.java
@@ -1,0 +1,15 @@
+package org.testcontainers.junit.jupiter;
+
+import org.testcontainers.DockerClientFactory;
+
+class DockerAvailableDetector {
+
+    public boolean isDockerAvailable() {
+        try {
+            DockerClientFactory.instance().client();
+            return true;
+        } catch (Throwable ex) {
+            return false;
+        }
+    }
+}

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailable.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailable.java
@@ -1,0 +1,19 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code EnabledIfDockerAvailable} is a JUnit Jupiter extension to enable tests only if Docker is available.
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(EnabledIfDockerAvailableCondition.class)
+public @interface EnabledIfDockerAvailable {
+}

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailableCondition.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailableCondition.java
@@ -20,7 +20,7 @@ public class EnabledIfDockerAvailableCondition implements ExecutionCondition {
     }
 
     boolean isDockerAvailable() {
-        return dockerDetector.isDockerAvailable();
+        return this.dockerDetector.isDockerAvailable();
     }
 
     private ConditionEvaluationResult evaluate(EnabledIfDockerAvailable testcontainers) {

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailableCondition.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailableCondition.java
@@ -1,0 +1,47 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+import java.util.Optional;
+
+public class EnabledIfDockerAvailableCondition implements ExecutionCondition {
+
+    private final DockerAvailableDetector dockerDetector = new DockerAvailableDetector();
+
+    @Override
+    public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+        return findAnnotation(context)
+            .map(this::evaluate)
+            .orElseThrow(() -> new ExtensionConfigurationException("@EnabledIfDockerAvailable not found"));
+    }
+
+    boolean isDockerAvailable() {
+        return dockerDetector.isDockerAvailable();
+    }
+
+    private ConditionEvaluationResult evaluate(EnabledIfDockerAvailable testcontainers) {
+        if (isDockerAvailable()) {
+            return ConditionEvaluationResult.enabled("Docker is available");
+        }
+        return ConditionEvaluationResult.disabled("Docker is not available");
+    }
+
+    private Optional<EnabledIfDockerAvailable> findAnnotation(ExtensionContext context) {
+        Optional<ExtensionContext> current = Optional.of(context);
+        while (current.isPresent()) {
+            Optional<EnabledIfDockerAvailable> enabledIfDockerAvailable = AnnotationSupport.findAnnotation(
+                current.get().getRequiredTestClass(),
+                EnabledIfDockerAvailable.class
+            );
+            if (enabledIfDockerAvailable.isPresent()) {
+                return enabledIfDockerAvailable;
+            }
+            current = current.get().getParent();
+        }
+        return Optional.empty();
+    }
+}

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -16,7 +16,6 @@ import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ModifierSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
-import org.testcontainers.DockerClientFactory;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.lifecycle.TestDescription;
@@ -41,6 +40,8 @@ public class TestcontainersExtension
     private static final String SHARED_LIFECYCLE_AWARE_CONTAINERS = "sharedLifecycleAwareContainers";
 
     private static final String LOCAL_LIFECYCLE_AWARE_CONTAINERS = "localLifecycleAwareContainers";
+
+    private final DockerAvailableDetector dockerDetector = new DockerAvailableDetector();
 
     @Override
     public void beforeAll(ExtensionContext context) {
@@ -192,12 +193,7 @@ public class TestcontainersExtension
     }
 
     boolean isDockerAvailable() {
-        try {
-            DockerClientFactory.instance().client();
-            return true;
-        } catch (Throwable ex) {
-            return false;
-        }
+        return dockerDetector.isDockerAvailable();
     }
 
     private Set<Object> collectParentTestInstances(final ExtensionContext context) {

--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -193,7 +193,7 @@ public class TestcontainersExtension
     }
 
     boolean isDockerAvailable() {
-        return dockerDetector.isDockerAvailable();
+        return this.dockerDetector.isDockerAvailable();
     }
 
     private Set<Object> collectParentTestInstances(final ExtensionContext context) {

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailableTests.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/EnabledIfDockerAvailableTests.java
@@ -1,0 +1,48 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EnabledIfDockerAvailableTests {
+
+    @Test
+    void whenDockerIsAvailableTestsAreEnabled() {
+        ConditionEvaluationResult result = new TestEnabledIfDockerAvailableCondition(true)
+            .evaluateExecutionCondition(extensionContext(DisabledWithoutDocker.class));
+        assertThat(result.isDisabled()).isFalse();
+    }
+
+    @Test
+    void whenDockerIsUnavailableTestsAreDisabled() {
+        ConditionEvaluationResult result = new TestEnabledIfDockerAvailableCondition(false)
+            .evaluateExecutionCondition(extensionContext(DisabledWithoutDocker.class));
+        assertThat(result.isDisabled()).isTrue();
+    }
+
+    private ExtensionContext extensionContext(Class clazz) {
+        ExtensionContext extensionContext = mock(ExtensionContext.class);
+        when(extensionContext.getRequiredTestClass()).thenReturn(clazz);
+        return extensionContext;
+    }
+
+    @EnabledIfDockerAvailable
+    static final class DisabledWithoutDocker {}
+
+    static final class TestEnabledIfDockerAvailableCondition extends EnabledIfDockerAvailableCondition {
+
+        private final boolean dockerAvailable;
+
+        private TestEnabledIfDockerAvailableCondition(boolean dockerAvailable) {
+            this.dockerAvailable = dockerAvailable;
+        }
+
+        boolean isDockerAvailable() {
+            return dockerAvailable;
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Introduces a `@EnabledIfDockerAvailable` annotation to conditionally enable a JUnit 5 test only if Docker is available (as proposed in #8613).

To reuse the same "Docker-available"-detection as in `TestcontainersExtension` this piece was extracted to a new class `DockerAvailableDetector`, which is then used by both.
