### PR TITLE
Make pgvector available with JDBC syntax (#8633)

### DIFF
--- a/docs/modules/databases/jdbc.md
+++ b/docs/modules/databases/jdbc.md
@@ -79,6 +79,10 @@ Insert `tc:` after `jdbc:` as follows. Note that the hostname, port and database
 
 `jdbc:tc:timescaledb:2.1.0-pg13:///databasename`
 
+#### Using PGVector
+
+`jdbc:tc:pgvector:pg16:///databasename`
+
 #### Using TiDB
 
 `jdbc:tc:tidb:v6.1.0:///databasename`

--- a/modules/jdbc-test/src/main/java/org/testcontainers/jdbc/AbstractJDBCDriverTest.java
+++ b/modules/jdbc-test/src/main/java/org/testcontainers/jdbc/AbstractJDBCDriverTest.java
@@ -130,7 +130,8 @@ public class AbstractJDBCDriverTest {
         if (
             databaseType.equalsIgnoreCase("postgresql") ||
             databaseType.equalsIgnoreCase("postgis") ||
-            databaseType.equalsIgnoreCase("timescaledb")
+            databaseType.equalsIgnoreCase("timescaledb") ||
+            databaseType.equalsIgnoreCase("pgvector")
         ) {
             databaseQuery = "SELECT CURRENT_DATABASE()";
         }

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PgVectorContainerProvider.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PgVectorContainerProvider.java
@@ -1,0 +1,44 @@
+package org.testcontainers.containers;
+
+import org.testcontainers.jdbc.ConnectionUrl;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Factory for PgVector containers.
+ *
+ * @see <a href="https://github.com/pgvector/pgvector">https://github.com/pgvector/pgvector</a>
+ */
+public class PgVectorContainerProvider extends JdbcDatabaseContainerProvider {
+
+    private static final String NAME = "pgvector";
+
+    private static final String DEFAULT_TAG = "pg16";
+
+    private static final DockerImageName DEFAULT_IMAGE = DockerImageName
+        .parse("pgvector/pgvector")
+        .asCompatibleSubstituteFor("postgres");
+
+    public static final String USER_PARAM = "user";
+
+    public static final String PASSWORD_PARAM = "password";
+
+    @Override
+    public boolean supports(String databaseType) {
+        return databaseType.equals(NAME);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance() {
+        return newInstance(DEFAULT_TAG);
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(String tag) {
+        return new PostgreSQLContainer(DEFAULT_IMAGE.withTag(tag));
+    }
+
+    @Override
+    public JdbcDatabaseContainer newInstance(ConnectionUrl connectionUrl) {
+        return newInstanceFromConnectionUrl(connectionUrl, USER_PARAM, PASSWORD_PARAM);
+    }
+}

--- a/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
+++ b/modules/postgresql/src/main/resources/META-INF/services/org.testcontainers.containers.JdbcDatabaseContainerProvider
@@ -1,3 +1,4 @@
 org.testcontainers.containers.PostgreSQLContainerProvider
 org.testcontainers.containers.PostgisContainerProvider
 org.testcontainers.containers.TimescaleDBContainerProvider
+org.testcontainers.containers.PgVectorContainerProvider

--- a/modules/postgresql/src/test/java/org/testcontainers/jdbc/pgvector/PgVectorJDBCDriverTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/jdbc/pgvector/PgVectorJDBCDriverTest.java
@@ -1,0 +1,28 @@
+package org.testcontainers.jdbc.pgvector;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.testcontainers.jdbc.AbstractJDBCDriverTest;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+
+@RunWith(Parameterized.class)
+public class PgVectorJDBCDriverTest extends AbstractJDBCDriverTest {
+
+    @Parameterized.Parameters(name = "{index} - {0}")
+    public static Iterable<Object[]> data() {
+        return Arrays.asList(
+            new Object[][] {
+                {
+                    "jdbc:tc:pgvector://hostname/databasename?user=someuser&password=somepwd",
+                    EnumSet.of(Options.JDBCParams),
+                },
+                {
+                    "jdbc:tc:pgvector:pg14://hostname/databasename?user=someuser&password=somepwd",
+                    EnumSet.of(Options.JDBCParams),
+                },
+            }
+        );
+    }
+}


### PR DESCRIPTION
Add support for pgvector in JDBC urls. Solving #8633
URL's like these are now supported:
`jdbc:tc:pgvector:pg16:///databasename`

This will spin up a `pgvector/pgvector:pg16` container.