### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v3.10.1
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v3.10.1
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v3.10.1
         with:
           title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'redis.clients:jedis:5.1.0'
-    testImplementation 'com.rabbitmq:amqp-client:5.20.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.21.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -120,12 +120,12 @@ dependencies {
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
     jarFileTestImplementation 'junit:junit:4.13.2'
-    jarFileTestImplementation 'org.assertj:assertj-core:3.25.1'
+    jarFileTestImplementation 'org.assertj:assertj-core:3.25.3'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'
 }
 

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.1"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.1"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.1"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
     testImplementation 'org.assertj:assertj-core:3.25.2'

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.3.1.RELEASE"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.1"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.1"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
     testImplementation project(":testcontainers")

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'com.hazelcast:hazelcast:5.3.6'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.25.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation 'io.nats:jnats:2.18.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.13'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.25.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.25.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'
     testImplementation 'org.assertj:assertj-core:3.25.2'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly "org.projectlombok:lombok:1.18.30"
     annotationProcessor "org.projectlombok:lombok:1.18.30"
 
-    implementation 'org.apache.solr:solr-solrj:8.11.2'
+    implementation 'org.apache.solr:solr-solrj:8.11.3'
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:postgresql'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 
 test {

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation "org.apache.activemq:activemq-client:6.0.1"
+    testImplementation "org.apache.activemq:activemq-client:6.1.2"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.31.2"
 }
 

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/chromadb/build.gradle
+++ b/modules/chromadb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ChromaDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.2'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'com.couchbase.client:java-client:3.5.2'
-    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.awaitility:awaitility:4.2.1'
     testImplementation 'org.assertj:assertj-core:3.25.1'
 }

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'com.ibm.db2:jcc:11.5.9.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.643'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.643'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.726'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.726'
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.12.0"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.13.4"
     testImplementation "org.elasticsearch.client:transport:7.17.17"
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.13.4"
     testImplementation "org.elasticsearch.client:transport:7.17.17"
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.30.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.39.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-pubsub'
     testImplementation 'com.google.cloud:google-cloud-spanner'
     testImplementation 'com.google.cloud:google-cloud-bigtable'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.24.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.28.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.4.14")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:24.1.0")
 
     shaded("org.apache.commons:commons-lang3:3.14.0")
-    shaded("commons-io:commons-io:2.15.1")
+    shaded("commons-io:commons-io:2.16.1")
     shaded("org.javassist:javassist:3.30.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.5")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.28.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.28.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.4.14")
+    testImplementation("ch.qos.logback:logback-classic:1.5.6")
     testImplementation 'org.assertj:assertj-core:3.25.1'
 }
 

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'org.influxdb:influxdb-java:2.24'
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.influxdb:influxdb-java:2.24'
     testImplementation "com.influxdb:influxdb-client-java:7.1.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     api 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
 
-    api 'org.assertj:assertj-core:3.25.1'
+    api 'org.assertj:assertj-core:3.25.3'
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':jdbc')
 
-    api 'com.google.guava:guava:33.0.0-jre'
+    api 'com.google.guava:guava:33.2.0-jre'
     api 'org.apache.commons:commons-lang3:3.14.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.18'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.24'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.24'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:6.12.1'
     testImplementation 'io.kubernetes:client-java:19.0.0'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.10.0'
+    testImplementation 'io.fabric8:kubernetes-client:6.12.1'
     testImplementation 'io.kubernetes:client-java:19.0.0'
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/k6/build.gradle
+++ b/modules/k6/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: k6"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
     testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
-    testImplementation 'software.amazon.awssdk:s3:2.23.9'
+    testImplementation 'software.amazon.awssdk:s3:2.25.56'
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.3.2'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.4.0'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation 'io.milvus:milvus-sdk-java:2.3.4'
+    testImplementation 'io.milvus:milvus-sdk-java:2.4.1'
 }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:8.5.7")
+    testImplementation("io.minio:minio:8.5.10")
     testImplementation 'org.assertj:assertj-core:3.25.1'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:4.11.1")
+    testImplementation("org.mongodb:mongodb-driver-sync:5.1.0")
     testImplementation 'org.assertj:assertj-core:3.25.1'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.5.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.7.0.jre8-preview'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.asyncer:r2dbc-mysql:1.0.6'
+    compileOnly 'io.asyncer:r2dbc-mysql:1.1.3'
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.0.6'
+    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.1.3'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.13'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.16'
     testImplementation 'org.assertj:assertj-core:3.25.2'
 }

--- a/modules/ollama/build.gradle
+++ b/modules/ollama/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Ollama"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation 'dev.openfga:openfga-sdk:0.3.2'
+    testImplementation 'dev.openfga:openfga-sdk:0.4.2'
 }
 
 test {

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.4.0.24.05'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.26"
+    api "com.orientechnologies:orientdb-client:3.2.29"
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     api "com.orientechnologies:orientdb-client:3.2.26"
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.1'
+    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.26"
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.1'
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.1.2'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.2.3'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.1.2'
+    testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.2.3'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.1'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.2.3'
 }

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation 'io.qdrant:client:1.7.1'
-    testImplementation platform('io.grpc:grpc-bom:1.61.1')
+    testImplementation platform('io.grpc:grpc-bom:1.64.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'
     testImplementation 'io.grpc:grpc-netty-shaded'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.25.2'
     testImplementation 'org.questdb:questdb:7.4.2'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.25.2'
-    testImplementation 'org.questdb:questdb:7.3.9'
+    testImplementation 'org.questdb:questdb:7.4.2'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.20.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.21.0'
     testImplementation 'org.assertj:assertj-core:3.25.1'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.32'
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
     testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'
     testImplementation project(':nginx')
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.2.0'
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'com.solacesystems:sol-jcsmp:10.22.0'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'org.apache.solr:solr-solrj:8.11.2'
+    testImplementation 'org.apache.solr:solr-solrj:8.11.3'
     testImplementation 'org.assertj:assertj-core:3.25.1'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.2'
 
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.1'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:436'
+    testRuntimeOnly 'io.trino:trino-jdbc:448'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation 'io.weaviate:client:4.6.0'
+    testImplementation 'io.weaviate:client:4.7.0'
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
     testImplementation project(':jdbc-test')
     // YCQL driver
-    testImplementation 'com.yugabyte:java-driver-core:4.15.0-yb-1'
+    testImplementation 'com.yugabyte:java-driver-core:4.15.0-yb-2-TESTFIX.0'
     // YSQL driver
     testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-4'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.projectreactor:reactor-core from 3.6.2 to 3.6.6 in /modules/r2dbc (#8656) @app/dependabot
* Bump io.nats:jnats from 2.17.2 to 2.18.1 in /examples (#8655) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.17.0 to 4.21.0 in /examples (#8654) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-bom from 4.17.0 to 4.21.0 in /examples (#8653) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.16.1 to 3.17.4 (#8652) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.12.0 to 7.1.0 in /modules/influxdb (#8651) @app/dependabot
* Bump io.trino:trino-jdbc from 436 to 448 in /modules/trino (#8650) @app/dependabot
* Bump org.apache.pulsar:pulsar-client-admin from 3.1.2 to 3.2.3 in /modules/pulsar (#8649) @app/dependabot
* Bump org.apache.pulsar:pulsar-client from 3.1.2 to 3.2.3 in /modules/pulsar (#8648) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.643 to 1.12.726 in /modules/dynalite (#8646) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.3.2 to 3.4.0 in /modules/mariadb (#8645) @app/dependabot
* Bump io.grpc:grpc-bom from 1.61.1 to 1.64.0 in /modules/qdrant (#8644) @app/dependabot
* Bump io.weaviate:client from 4.6.0 to 4.7.0 in /modules/weaviate (#8643) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.23.9 to 2.25.56 in /modules/localstack (#8641) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.12.0 to 8.13.4 in /modules/elasticsearch (#8632) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.30.0 to 26.39.0 in /modules/gcloud (#8629) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.24.0 to 4.28.1 in /modules/hivemq (#8628) @app/dependabot
* Bump io.milvus:milvus-sdk-java from 2.3.4 to 2.4.1 in /modules/milvus (#8627) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.18 to 10.1.24 in /modules/jdbc (#8626) @app/dependabot
* Bump io.qdrant:client from 1.7.1 to 1.9.1 in /modules/qdrant (#8623) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.17 to 7.17.21 in /modules/elasticsearch (#8609) @app/dependabot
* Bump com.google.guava:guava from 33.0.0-jre to 33.2.0-jre in /modules/jdbc-test (#8605) @app/dependabot
* Bump dev.openfga:openfga-sdk from 0.3.2 to 0.4.2 in /modules/openfga (#8603) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.3.0.23.09 to 23.4.0.24.05 in /modules/oracle-free (#8599) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 4.11.1 to 5.1.0 in /modules/mongodb (#8598) @app/dependabot
* Bump org.apache.activemq:activemq-client from 6.0.1 to 6.1.2 in /modules/activemq (#8591) @app/dependabot
* Bump peter-evans/create-pull-request from 5.0.2 to 6.0.5 (#8589) @app/dependabot
* Bump io.minio:minio from 8.5.7 to 8.5.10 in /modules/minio (#8585) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.13 to 4.4.16 in /modules/neo4j (#8584) @app/dependabot
* Bump com.couchbase.client:java-client from 3.5.2 to 3.6.2 in /modules/couchbase (#8583) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.4.14 to 1.5.6 in /modules/hivemq (#8569) @app/dependabot
* Bump org.questdb:questdb from 7.3.9 to 7.4.2 in /modules/questdb (#8562) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.10.0 to 6.12.1 in /modules/k3s (#8561) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.7.1 to 3.7.2 in /modules/orientdb (#8549) @app/dependabot
* Bump io.asyncer:r2dbc-mysql from 1.0.6 to 1.1.3 in /modules/mysql (#8533) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.5.0.jre8-preview to 12.7.0.jre8-preview in /modules/mssqlserver (#8527) @app/dependabot
* Bump commons-io:commons-io from 2.15.1 to 2.16.1 in /modules/hivemq (#8525) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.20.0 to 5.21.0 in /core (#8523) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.20.0 to 5.21.0 in /modules/rabbitmq (#8521) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.31.2 to 2.33.0 in /modules/activemq (#8500) @app/dependabot
* Bump io.kubernetes:client-java from 19.0.0 to 20.0.1-legacy in /modules/k3s (#8489) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.1 to 42.7.3 in /modules/spock (#8471) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.1 to 42.7.3 in /modules/junit-jupiter (#8470) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.1 to 42.7.3 in /modules/questdb (#8467) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.1 in /modules/questdb (#8466) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.1 in /modules/couchbase (#8461) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.1 to 42.7.3 in /modules/cratedb (#8459) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.1 to 42.7.3 in /modules/postgresql (#8455) @app/dependabot
* Bump redis.clients:jedis from 5.1.0 to 5.1.2 in /core (#8440) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.26 to 3.2.29 in /modules/orientdb (#8426) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.26 to 3.2.29 in /modules/orientdb (#8425) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/ollama (#8411) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.10.1 to 5.10.2 in /modules/hivemq (#8407) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.1 to 3.7.0 in /modules/redpanda (#8390) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/k6 (#8389) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.1 to 3.7.0 in /modules/kafka (#8387) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/openfga (#8377) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/milvus (#8356) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/chromadb (#8349) @app/dependabot
* Bump org.apache.solr:solr-solrj from 8.11.2 to 8.11.3 in /examples (#8311) @app/dependabot
* Bump org.apache.solr:solr-solrj from 8.11.2 to 8.11.3 in /modules/solr (#8307) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/activemq (#8286) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/localstack (#8277) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/solr (#8275) @app/dependabot
* Bump com.yugabyte:java-driver-core from 4.15.0-yb-1 to 4.15.0-yb-2-TESTFIX.0 in /modules/yugabytedb (#8273) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/database-commons (#8272) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/influxdb (#8270) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/selenium (#8269) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/cassandra (#8268) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/clickhouse (#8267) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.10.1 to 5.10.2 in /examples (#8266) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.10.1 to 5.10.2 in /examples (#8265) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.1 to 5.10.2 in /examples (#8264) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.10.1 to 5.10.2 in /examples (#8261) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/jdbc-test (#8260) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/neo4j (#8258) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/solace (#8256) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/redpanda (#8255) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/orientdb (#8253) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/jdbc (#8251) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/couchbase (#8250) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/db2 (#8248) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/gcloud (#8247) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.10.1 to 1.10.2 in /modules/spock (#8246) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.1 to 1.10.2 in /modules/spock (#8245) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/vault (#8242) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/k3s (#8241) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/questdb (#8240) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/elasticsearch (#8238) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /core (#8237) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/kafka (#8235) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/junit-jupiter (#8233) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/mongodb (#8232) @app/dependabot
* Bump org.apache.pulsar:pulsar-client-admin from 3.1.2 to 3.2.0 in /modules/pulsar (#8230) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/pulsar (#8229) @app/dependabot
* Bump peter-evans/create-pull-request from 5.0.2 to 6.0.0 (#8226) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/hivemq (#8223) @app/dependabot
