### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -99,7 +99,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded 'com.google.guava:guava:33.0.0-jre'
+    shaded 'com.google.guava:guava:33.2.0-jre'
     shaded "org.yaml:snakeyaml:1.33"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation 'com.azure:azure-cosmos:4.54.0'
+    testImplementation 'com.azure:azure-cosmos:4.60.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.13.4"
-    testImplementation "org.elasticsearch.client:transport:7.17.17"
+    testImplementation "org.elasticsearch.client:transport:7.17.21"
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.28.1")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.4.14")
+    testImplementation("ch.qos.logback:logback-classic:1.5.6")
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.3.0.23.09'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.4.0.24.05'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
-    testImplementation 'io.qdrant:client:1.7.1'
+    testImplementation 'io.qdrant:client:1.9.1'
     testImplementation platform('io.grpc:grpc-bom:1.64.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.17.4"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:1.12.1"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.0.1"
         classpath "org.gradle.toolchains:foojay-resolver:0.8.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.azure:azure-cosmos from 4.54.0 to 4.60.0 in /modules/azure (#8647) @app/dependabot
* Bump io.qdrant:client from 1.7.1 to 1.9.1 in /modules/qdrant (#8623) @app/dependabot
* Bump com.google.guava:guava from 33.0.0-jre to 33.2.0-jre in /core (#8611) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.17 to 7.17.21 in /modules/elasticsearch (#8609) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.3.0.23.09 to 23.4.0.24.05 in /modules/oracle-xe (#8606) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 1.12.1 to 2.0.1 (#8570) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.4.14 to 1.5.6 in /modules/hivemq (#8569) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.31.2 to 2.33.0 in /modules/activemq (#8500) @app/dependabot
* Bump io.kubernetes:client-java from 19.0.0 to 20.0.1-legacy in /modules/k3s (#8489) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.1 in /modules/couchbase (#8461) @app/dependabot
* Bump redis.clients:jedis from 5.1.0 to 5.1.2 in /core (#8440) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.26 to 3.2.29 in /modules/orientdb (#8425) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/openfga (#8377) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/milvus (#8356) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/activemq (#8286) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/localstack (#8277) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/solr (#8275) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.1 to 5.10.2 in /examples (#8264) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/neo4j (#8258) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/redpanda (#8255) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/orientdb (#8253) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.1 to 1.10.2 in /modules/spock (#8245) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/kafka (#8235) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/mongodb (#8232) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/pulsar (#8229) @app/dependabot
* Bump peter-evans/create-pull-request from 5.0.2 to 6.0.0 (#8226) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.31.2 to 2.32.0 in /modules/activemq (#8217) @app/dependabot
