### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.25.1'
     testImplementation "org.apache.activemq:activemq-client:6.1.2"
-    testImplementation "org.apache.activemq:artemis-jakarta-client:2.31.2"
+    testImplementation "org.apache.activemq:artemis-jakarta-client:2.33.0"
 }
 
 test {


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.apache.activemq:artemis-jakarta-client from 2.31.2 to 2.33.0 in /modules/activemq (#8500) @app/dependabot
* Bump io.kubernetes:client-java from 19.0.0 to 20.0.1-legacy in /modules/k3s (#8489) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.1 in /modules/couchbase (#8461) @app/dependabot
* Bump redis.clients:jedis from 5.1.0 to 5.1.2 in /core (#8440) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.26 to 3.2.29 in /modules/orientdb (#8425) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/openfga (#8377) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/milvus (#8356) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/activemq (#8286) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/localstack (#8277) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/solr (#8275) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.1 to 5.10.2 in /examples (#8264) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/neo4j (#8258) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/redpanda (#8255) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/orientdb (#8253) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.1 to 1.10.2 in /modules/spock (#8245) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/kafka (#8235) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/mongodb (#8232) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/pulsar (#8229) @app/dependabot
* Bump peter-evans/create-pull-request from 5.0.2 to 6.0.0 (#8226) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.31.2 to 2.32.0 in /modules/activemq (#8217) @app/dependabot
