### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@09c613e259eb8d4e7c81c2cb00618eb5fc4575a7 # v5.19.0
+      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -86,7 +86,7 @@ dependencies {
         exclude group: 'org.apache.commons', module: 'commons-compress'
     }
 
-    shaded 'org.awaitility:awaitility:4.2.0'
+    shaded 'org.awaitility:awaitility:4.2.1'
 
     api platform('com.github.docker-java:docker-java-bom:3.3.6')
     shaded platform('com.github.docker-java:docker-java-bom:3.3.6')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,7 +110,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'redis.clients:jedis:5.1.0'
+    testImplementation 'redis.clients:jedis:5.1.3'
     testImplementation 'com.rabbitmq:amqp-client:5.21.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testImplementation "org.seleniumhq.selenium:selenium-api:4.21.0"
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 
 test {

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.3.1.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.1"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 
 test {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit'
     testImplementation 'org.testcontainers:selenium'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 
 test {

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.3.6'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'io.codenotary:immudb4j:1.0.1'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:postgresql'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.18.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.13'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testng:testng:7.5.1'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 
 test {

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 
 test {

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'com.jcraft:jsch:0.1.55'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.6.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: ActiveMQ"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation "org.apache.activemq:activemq-client:6.1.2"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.31.2"
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'com.couchbase.client:java-client:3.6.2'
-    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.awaitility:awaitility:4.2.1'
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.726'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.726'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    implementation platform('org.junit:junit-bom:5.10.1')
+    implementation platform('org.junit:junit-bom:5.10.2')
     implementation 'org.junit.jupiter:junit-jupiter-api'
 
     testImplementation project(':mysql')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:5.1.0'
+    testImplementation 'redis.clients:jedis:5.1.2'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.12.1'
-    testImplementation 'io.kubernetes:client-java:19.0.0'
+    testImplementation 'io.kubernetes:client-java:20.0.1-legacy'
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
     testImplementation 'software.amazon.awssdk:s3:2.25.56'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Milvus"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.milvus:milvus-sdk-java:2.4.1'
 }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("io.minio:minio:8.5.10")
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("org.mongodb:mongodb-driver-sync:5.1.0")
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.16'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Nginx"
 dependencies {
     api project(':testcontainers')
     compileOnly 'org.jetbrains:annotations:24.1.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: OpenFGA"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'dev.openfga:openfga-sdk:0.4.2'
 }
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.2.29"
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.26"
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.2.3'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.1'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.3'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.2.3'
 }

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Qdrant"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.qdrant:client:1.9.1'
     testImplementation platform('io.grpc:grpc-bom:1.64.0')
     testImplementation 'io.grpc:grpc-stub'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,10 +11,10 @@ dependencies {
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'
 
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.6.6'
-    testFixturesImplementation 'org.assertj:assertj-core:3.25.2'
+    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.21.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     shaded 'org.freemarker:freemarker:2.3.32'
 
     testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.3'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.2'
 
     testCompileOnly 'org.jetbrains:annotations:24.1.0'

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -5,5 +5,5 @@ dependencies {
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.7'
 
     testImplementation 'redis.clients:jedis:3.0.1'
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Weaviate"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.1'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.weaviate:client:4.7.0'
 }

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'org.slf4j:slf4j-api:1.7.36'
-    testImplementation 'org.assertj:assertj-core:3.25.2'
+    testImplementation 'org.assertj:assertj-core:3.25.3'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump redis.clients:jedis from 5.1.0 to 5.1.3 in /core (#8662) @app/dependabot
* Bump io.kubernetes:client-java from 19.0.0 to 20.0.1-legacy in /modules/k3s (#8489) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.1 in /core (#8474) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.1 in /modules/couchbase (#8461) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.1 to 42.7.3 in /modules/cratedb (#8459) @app/dependabot
* Bump redis.clients:jedis from 5.1.0 to 5.1.2 in /modules/junit-jupiter (#8439) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.26 to 3.2.29 in /modules/orientdb (#8425) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/openfga (#8377) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/qdrant (#8363) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/milvus (#8356) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/weaviate (#8351) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/activemq (#8286) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/minio (#8280) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/localstack (#8277) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/nginx (#8276) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/solr (#8275) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/consul (#8274) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.1 to 5.10.2 in /examples (#8264) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /examples (#8263) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/neo4j (#8258) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/dynalite (#8257) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/redpanda (#8255) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/rabbitmq (#8254) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/orientdb (#8253) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.2 to 3.25.3 in /modules/r2dbc (#8252) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.1 to 1.10.2 in /modules/spock (#8245) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/cockroachdb (#8243) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/kafka (#8235) @app/dependabot
* Bump org.junit:junit-bom from 5.10.1 to 5.10.2 in /modules/junit-jupiter (#8234) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/mongodb (#8232) @app/dependabot
* Bump org.apache.pulsar:pulsar-client from 3.1.2 to 3.2.0 in /modules/pulsar (#8231) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/pulsar (#8229) @app/dependabot
* Bump release-drafter/release-drafter from 5.25.0 to 6.0.0 (#8228) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.1 to 3.25.3 in /modules/toxiproxy (#8225) @app/dependabot
