### PR TITLE
fix LocalStack legacy mode detection for "latest" tag variations

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -147,8 +147,10 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         return true;
     }
 
-    private static boolean shouldRunInLegacyMode(String version) {
-        if (version.equals("latest")) {
+    static boolean shouldRunInLegacyMode(String version) {
+        // assume that the latest images are up-to-date
+        // also consider images with extra packages (like latest-bigdata) and service-specific images (like s3-latest)
+        if (version.equals("latest") || version.startsWith("latest-") || version.endsWith("-latest")) {
             return false;
         }
 

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
@@ -139,4 +139,38 @@ public class LegacyModeTest {
             }
         }
     }
+
+    @RunWith(Parameterized.class)
+    @AllArgsConstructor
+    public static class LegacyModeUnitTest {
+
+        private final String version;
+        private final boolean shouldUseLegacyMode;
+
+        @Parameterized.Parameters(name = "{0} - {1}")
+        public static Iterable<Object[]> constructors() {
+            return Arrays.asList(
+                new Object[][] {
+                    { "latest", false },
+                    { "s3-latest", false },
+                    { "latest-bigdata", false },
+                    { "3.4.0-bigdata", false },
+                    { "3.4.0@sha256:54fcf172f6ff70909e1e26652c3bb4587282890aff0d02c20aa7695469476ac0", false },
+                    { "1.4@sha256:7badf31c550f81151c485980e17542592942d7f05acc09723c5f276d41b5927d", false },
+                    { "3.4.0", false },
+                    { "0.12", false },
+                    { "0.11", false },
+                    { "sha256:8bf0d744fea26603f2b11ef7206edb38375ef954258afaeda96532a6c9c1ab8b", false },
+                    { "0.10.7@sha256:45ef287e29af7285c6e4013fafea1e3567c167cd22d12282f0a5f9c7894b1c5f", true },
+                    { "0.10.7", true },
+                    { "0.9.6", true },
+                }
+            );
+        }
+
+        @Test
+        public void samePortIsExposedForAllServices() {
+            assertThat(LocalStackContainer.shouldRunInLegacyMode(version)).isEqualTo(shouldUseLegacyMode);
+        }
+    }
 }

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
@@ -145,6 +145,7 @@ public class LegacyModeTest {
     public static class LegacyModeUnitTest {
 
         private final String version;
+
         private final boolean shouldUseLegacyMode;
 
         @Parameterized.Parameters(name = "{0} - {1}")


### PR DESCRIPTION
## Motivation
While looking into #7390 and digging into the legacy mode check for LocalStack I stumbled upon an issue when using specific `latest` images, like:
- `localstack/localstack:s3-latest` (a minimal image which basically only contains S3)
- `localstack/localstack-pro:latest-bigdata` (a LocalStack Pro image which contains disk-space heavy packages which would otherwise be downloaded on demand)

If this is the case, the default fallback currently is to jump back to `useLegacyMode=true` which is not compatible with up-to-date images.
In the long run, I would propose to change the default fallback (as mentioned in https://github.com/testcontainers/testcontainers-java/issues/7390#issuecomment-2163055356), but this PR aims at fixing the issue for these specific tags for now.

## Changes
- Extends the "latest check" such that multiple variations of the "latest" tags are possible (see above).
- Adds a unit test which tests various version strings with the `shouldRunInLegacyMode` action (and makes the function package private to allow directly testing it).
