### PR TITLE
Improve GitLab docs

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
@@ -24,13 +24,10 @@ See below for an example runner configuration:
 Please also include the following in your GitlabCI pipeline definitions (`.gitlab-ci.yml`) that use Testcontainers:
 ```yml
 variables:
-  # Windows and MacOS
-  TESTCONTAINERS_HOST_OVERRIDE: "host.docker.internal"
-  # Linux
-  TESTCONTAINERS_HOST_OVERRIDE: "172.17.0.1"
+  TESTCONTAINERS_HOST_OVERRIDE: "<ip-docker-host>"
 ```
 
-The environment variable `TESTCONTAINERS_HOST_OVERRIDE` needs to be configured, otherwise, a wrong IP address would be used to resolve the Docker host, which will likely lead to failing tests.
+The environment variable `TESTCONTAINERS_HOST_OVERRIDE` needs to be configured, otherwise, a wrong IP address would be used to resolve the Docker host, which will likely lead to failing tests. For Windows and MacOS, use `host.docker.internal`.
 
 ## Example using DinD (Docker-in-Docker)
 

--- a/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/gitlab_ci.md
@@ -24,7 +24,10 @@ See below for an example runner configuration:
 Please also include the following in your GitlabCI pipeline definitions (`.gitlab-ci.yml`) that use Testcontainers:
 ```yml
 variables:
+  # Windows and MacOS
   TESTCONTAINERS_HOST_OVERRIDE: "host.docker.internal"
+  # Linux
+  TESTCONTAINERS_HOST_OVERRIDE: "172.17.0.1"
 ```
 
 The environment variable `TESTCONTAINERS_HOST_OVERRIDE` needs to be configured, otherwise, a wrong IP address would be used to resolve the Docker host, which will likely lead to failing tests.


### PR DESCRIPTION
Small documentation update, which caused me a headache, because I forgot, that devices not relying on Docker Desktop won't be able to resolve `host.docker.internal`.

See also https://stackoverflow.com/questions/48546124/what-is-the-linux-equivalent-of-host-docker-internal for a discussion on that topic