### PR TITLE
feat: Change the class used by the Oracle database driver

### DIFF
--- a/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
+++ b/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
@@ -89,7 +89,12 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     public String getDriverClassName() {
-        return "oracle.jdbc.driver.OracleDriver";
+        try {
+            Class.forName("oracle.jdbc.OracleDriver");
+            return "oracle.jdbc.OracleDriver";
+        } catch (ClassNotFoundException e) {
+            return "oracle.jdbc.driver.OracleDriver";
+        }
     }
 
     @Override

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -110,7 +110,12 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     public String getDriverClassName() {
-        return "oracle.jdbc.driver.OracleDriver";
+        try {
+            Class.forName("oracle.jdbc.OracleDriver");
+            return "oracle.jdbc.OracleDriver";
+        } catch (ClassNotFoundException e) {
+            return "oracle.jdbc.driver.OracleDriver";
+        }
     }
 
     @Override


### PR DESCRIPTION
HikariCP logs a Warning when using the oracle.jdbc.driver.OracleDriver class. The use of the oracle.jdbc.OracleDriver class is now recommended (see https://stackoverflow.com/questions/6202653/difference-between-oracle-jdbc-driver-classes/6202721#6202721).