### PR TITLE
Add support for Weaviate v1.25

### DIFF
--- a/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
+++ b/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
@@ -1,6 +1,9 @@
 package org.testcontainers.weaviate;
 
+import java.time.Duration;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 /**
@@ -32,6 +35,7 @@ public class WeaviateContainer extends GenericContainer<WeaviateContainer> {
         withExposedPorts(8080, 50051);
         withEnv("AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED", "true");
         withEnv("PERSISTENCE_DATA_PATH", "/var/lib/weaviate");
+        waitingFor(Wait.forHttp("/v1/.well-known/ready").forPort(8080).forStatusCode(200));
     }
 
     public String getHttpHostAddress() {

--- a/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
+++ b/modules/weaviate/src/main/java/org/testcontainers/weaviate/WeaviateContainer.java
@@ -1,8 +1,6 @@
 package org.testcontainers.weaviate;
 
-import java.time.Duration;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 

--- a/modules/weaviate/src/test/java/org/testcontainers/weaviate/WeaviateContainerTest.java
+++ b/modules/weaviate/src/test/java/org/testcontainers/weaviate/WeaviateContainerTest.java
@@ -19,7 +19,7 @@ public class WeaviateContainerTest {
     @Test
     public void testWeaviate() {
         try ( // container {
-            WeaviateContainer weaviate = new WeaviateContainer("cr.weaviate.io/semitechnologies/weaviate:1.24.5")
+            WeaviateContainer weaviate = new WeaviateContainer("cr.weaviate.io/semitechnologies/weaviate:1.25.5")
             // }
         ) {
             weaviate.start();
@@ -27,7 +27,7 @@ public class WeaviateContainerTest {
             config.setGRPCHost(weaviate.getGrpcHostAddress());
             WeaviateClient client = new WeaviateClient(config);
             Result<Meta> meta = client.misc().metaGetter().run();
-            assertThat(meta.getResult().getVersion()).isEqualTo("1.24.5");
+            assertThat(meta.getResult().getVersion()).isEqualTo("1.25.5");
         }
     }
 
@@ -43,13 +43,13 @@ public class WeaviateContainerTest {
         Map<String, String> env = new HashMap<>();
         env.put("ENABLE_MODULES", String.join(",", enableModules));
         env.put("BACKUP_FILESYSTEM_PATH", "/tmp/backups");
-        try (WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.24.5").withEnv(env)) {
+        try (WeaviateContainer weaviate = new WeaviateContainer("semitechnologies/weaviate:1.25.5").withEnv(env)) {
             weaviate.start();
             Config config = new Config("http", weaviate.getHttpHostAddress());
             config.setGRPCHost(weaviate.getGrpcHostAddress());
             WeaviateClient client = new WeaviateClient(config);
             Result<Meta> meta = client.misc().metaGetter().run();
-            assertThat(meta.getResult().getVersion()).isEqualTo("1.24.5");
+            assertThat(meta.getResult().getVersion()).isEqualTo("1.25.5");
             Object modules = meta.getResult().getModules();
             assertThat(modules)
                 .isNotNull()


### PR DESCRIPTION
This PR adds support for Weaviate v1.25 in particular it:
- updates tests to use Weaviate `v1.25.5` version
- adds wait for http (`/v1/.well-known/ready`) strategy to container definition