### PR TITLE
Bigger max aliases used by ParsedDockerComposeFile

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -82,7 +82,9 @@ class ParsedDockerComposeFile {
                 return;
             }
 
-            servicesMap = (Map<String, ?>) servicesElement;
+            @SuppressWarnings("unchecked")
+            Map<String, ?> temp = (Map<String, ?>) servicesElement;
+            servicesMap = temp;
         } else {
             servicesMap = composeFileContent;
         }
@@ -99,7 +101,8 @@ class ParsedDockerComposeFile {
                 break;
             }
 
-            final Map serviceDefinitionMap = (Map) serviceDefinition;
+            @SuppressWarnings("unchecked")
+            final Map<String, ?> serviceDefinitionMap = (Map<String, ?>) serviceDefinition;
 
             validateNoContainerNameSpecified(serviceName, serviceDefinitionMap);
             findServiceImageName(serviceName, serviceDefinitionMap);
@@ -107,7 +110,7 @@ class ParsedDockerComposeFile {
         }
     }
 
-    private void validateNoContainerNameSpecified(String serviceName, Map serviceDefinitionMap) {
+    private void validateNoContainerNameSpecified(String serviceName, Map<String, ?> serviceDefinitionMap) {
         if (serviceDefinitionMap.containsKey("container_name")) {
             throw new IllegalStateException(
                 String.format(
@@ -127,12 +130,12 @@ class ParsedDockerComposeFile {
         }
     }
 
-    private void findImageNamesInDockerfile(String serviceName, Map serviceDefinitionMap) {
+    private void findImageNamesInDockerfile(String serviceName, Map<String, ?> serviceDefinitionMap) {
         final Object buildNode = serviceDefinitionMap.get("build");
         Path dockerfilePath = null;
 
         if (buildNode instanceof Map) {
-            final Map buildElement = (Map) buildNode;
+            final Map<?, ?> buildElement = (Map<?, ?>) buildNode;
             final Object dockerfileRelativePath = buildElement.get("dockerfile");
             final Object contextRelativePath = buildElement.get("context");
             if (dockerfileRelativePath instanceof String && contextRelativePath instanceof String) {

--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -122,9 +122,10 @@ class ParsedDockerComposeFile {
         }
     }
 
-    private void findServiceImageName(String serviceName, Map serviceDefinitionMap) {
-        if (serviceDefinitionMap.containsKey("image") && serviceDefinitionMap.get("image") instanceof String) {
-            final String imageName = (String) serviceDefinitionMap.get("image");
+    private void findServiceImageName(String serviceName, Map<String, ?> serviceDefinitionMap) {
+        Object result = serviceDefinitionMap.get("image");
+        if (result instanceof String) {
+            final String imageName = (String) result;
             log.debug("Resolved dependency image for Docker Compose in {}: {}", composeFileName, imageName);
             serviceNameToImageNames.put(serviceName, Sets.newHashSet(imageName));
         }

--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -34,7 +34,7 @@ class ParsedDockerComposeFile {
     private final File composeFile;
 
     @Getter
-    private Map<String, Set<String>> serviceNameToImageNames = new HashMap<>();
+    private final Map<String, Set<String>> serviceNameToImageNames = new HashMap<>();
 
     ParsedDockerComposeFile(File composeFile) {
         Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));

--- a/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
@@ -3,16 +3,23 @@ package org.testcontainers.containers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import lombok.SneakyThrows;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
+import java.io.PrintWriter;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 
 public class ParsedDockerComposeFileValidationTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void shouldValidate() {
@@ -128,5 +135,23 @@ public class ParsedDockerComposeFileValidationTest {
                 entry("redis", Sets.newHashSet("redis")),
                 entry("custom", Sets.newHashSet("alpine:3.17"))
             ); // redis, mysql from compose file, alpine:3.17 from Dockerfile build
+    }
+
+    @Test
+    public void shouldSupportALotOfAliases() throws Exception {
+        File file = temporaryFolder.newFile();
+        try (PrintWriter writer = new PrintWriter(file)) {
+            writer.println("x-entry: &entry");
+            writer.println("  key: value");
+            writer.println();
+            writer.println("services:");
+            for (int i = 0; i < 1_000; i++) {
+                writer.println("  service" + i + ":");
+                writer.println("    image: busybox");
+                writer.println("    environment:");
+                writer.println("      <<: *entry");
+            }
+        }
+        assertThatNoException().isThrownBy(() -> new ParsedDockerComposeFile(file));
     }
 }


### PR DESCRIPTION
When a docker-compose.yml file start to rely heavily on aliases, we can go above the default maximum of 50. It happened to me. There is no way to override it. We would need to inject LoaderOptions, ParsedDockerComposeFile, DockerComposeFiles and DockerComposeContainer. I don't want to go there.

So instead, I have set a reasonable threshold. I can't see any harm in having it.

This is all in the last commit.

Other commits are fixing things I wanted to improve in a boy scout style.