### PR TITLE
Fix wait strategy definition

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -893,7 +893,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @Override
     public void setWaitStrategy(WaitStrategy waitStrategy) {
-        this.containerDef.setWaitStrategy(waitStrategy);
+        this.waitStrategy = waitStrategy;
     }
 
     /**


### PR DESCRIPTION
Currently, `waitingFor` takes precedence over `setWaitStrategy`. This was introduced with ContainerDef in 1dba8d1. This commit  uses `waitStrategy` defined in GenericContainer for both methods `waitingFor` and `setWaitStrategy`.

Fixes #8578
