### PR TITLE
[localstack] Fix reuse mode

### DIFF
--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LegacyModeTest.java
@@ -37,8 +37,8 @@ public class LegacyModeTest {
                     { "0.12", new LocalStackContainer(LocalstackTestImages.LOCALSTACK_0_12_IMAGE) },
                     { "0.11", new LocalStackContainer(LocalstackTestImages.LOCALSTACK_0_11_IMAGE) },
                     {
-                        "0.7 with legacy = off",
-                        new LocalStackContainer(LocalstackTestImages.LOCALSTACK_0_7_IMAGE, false),
+                        "0.11 with legacy = off",
+                        new LocalStackContainer(LocalstackTestImages.LOCALSTACK_0_11_IMAGE, false),
                     },
                 }
             );

--- a/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
+++ b/modules/localstack/src/test/java/org/testcontainers/containers/localstack/LocalstackTestImages.java
@@ -4,7 +4,6 @@ import org.testcontainers.utility.DockerImageName;
 
 public interface LocalstackTestImages {
     DockerImageName LOCALSTACK_IMAGE = DockerImageName.parse("localstack/localstack:0.12.8");
-    DockerImageName LOCALSTACK_0_7_IMAGE = LOCALSTACK_IMAGE.withTag("0.7.0");
     DockerImageName LOCALSTACK_0_10_IMAGE = LOCALSTACK_IMAGE.withTag("0.10.7");
     DockerImageName LOCALSTACK_0_11_IMAGE = LOCALSTACK_IMAGE.withTag("0.11.3");
     DockerImageName LOCALSTACK_0_12_IMAGE = LOCALSTACK_IMAGE.withTag("0.12.8");


### PR DESCRIPTION
2195610 allows to copy all `org.testcontainers.*` labels to `LAMBDA_DOCKER_FLAGS` and it generates a `session-id` breaking reuse mode. This commit waits until the container is starting with the right labels and then read the labels to set `LAMBDA_DOCKER_FLAGS`.

Fixes #8814
