### PR TITLE
Allow copy specific files to docker compose

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -121,6 +121,7 @@ dependencies {
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -67,6 +67,8 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     private String project;
 
+    private List<String> fileCopyInclusions = new ArrayList<>();
+
     public ComposeContainer(File... composeFiles) {
         this(Arrays.asList(composeFiles));
     }
@@ -134,7 +136,8 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                     this.options,
                     this.services,
                     this.scalingPreferences,
-                    this.env
+                    this.env,
+                    this.fileCopyInclusions
                 );
             this.composeDelegate.startAmbassadorContainer();
             this.composeDelegate.waitUntilServiceStarted(this.tailChildContainers);
@@ -165,7 +168,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env, this.fileCopyInclusions);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }
@@ -349,6 +352,11 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
      */
     public ComposeContainer withStartupTimeout(Duration startupTimeout) {
         this.composeDelegate.setStartupTimeout(startupTimeout);
+        return this;
+    }
+
+    public ComposeContainer withFileCopyInclusions(String... fileCopyInclusions) {
+        this.fileCopyInclusions = Arrays.asList(fileCopyInclusions);
         return this;
     }
 

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -67,7 +67,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     private String project;
 
-    private List<String> fileCopyInclusions = new ArrayList<>();
+    private List<String> filesInDirectory = new ArrayList<>();
 
     public ComposeContainer(File... composeFiles) {
         this(Arrays.asList(composeFiles));
@@ -137,7 +137,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                     this.services,
                     this.scalingPreferences,
                     this.env,
-                    this.fileCopyInclusions
+                    this.filesInDirectory
                 );
             this.composeDelegate.startAmbassadorContainer();
             this.composeDelegate.waitUntilServiceStarted(this.tailChildContainers);
@@ -168,7 +168,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env, this.fileCopyInclusions);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env, this.filesInDirectory);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }
@@ -355,8 +355,8 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
         return this;
     }
 
-    public ComposeContainer withFileCopyInclusions(String... fileCopyInclusions) {
-        this.fileCopyInclusions = Arrays.asList(fileCopyInclusions);
+    public ComposeContainer withCopyFilesInContainer(String... fileCopyInclusions) {
+        this.filesInDirectory = Arrays.asList(fileCopyInclusions);
         return this;
     }
 

--- a/core/src/main/java/org/testcontainers/containers/ComposeDelegate.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeDelegate.java
@@ -126,7 +126,8 @@ class ComposeDelegate {
         final Set<String> options,
         final List<String> services,
         final Map<String, Integer> scalingPreferences,
-        Map<String, String> env
+        Map<String, String> env,
+        List<String> fileCopyInclusions
     ) {
         // services that have been explicitly requested to be started. If empty, all services should be started.
         final String serviceNameArgs = Stream
@@ -160,7 +161,7 @@ class ComposeDelegate {
         }
 
         // Run the docker compose container, which starts up the services
-        runWithCompose(localCompose, command, env);
+        runWithCompose(localCompose, command, env, fileCopyInclusions);
     }
 
     private String getUpCommand(String options) {
@@ -237,10 +238,15 @@ class ComposeDelegate {
     }
 
     public void runWithCompose(boolean localCompose, String cmd) {
-        runWithCompose(localCompose, cmd, Collections.emptyMap());
+        runWithCompose(localCompose, cmd, Collections.emptyMap(), Collections.emptyList());
     }
 
-    public void runWithCompose(boolean localCompose, String cmd, Map<String, String> env) {
+    public void runWithCompose(
+        boolean localCompose,
+        String cmd,
+        Map<String, String> env,
+        List<String> fileCopyInclusions
+    ) {
         Preconditions.checkNotNull(composeFiles);
         Preconditions.checkArgument(!composeFiles.isEmpty(), "No docker compose file have been provided");
 
@@ -248,7 +254,8 @@ class ComposeDelegate {
         if (localCompose) {
             dockerCompose = new LocalDockerCompose(this.executable, composeFiles, project);
         } else {
-            dockerCompose = new ContainerisedDockerCompose(this.defaultImageName, composeFiles, project);
+            dockerCompose =
+                new ContainerisedDockerCompose(this.defaultImageName, composeFiles, project, fileCopyInclusions);
         }
 
         dockerCompose.withCommand(cmd).withEnv(env).invoke();

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -68,7 +68,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     private String project;
 
-    private List<String> fileCopyInclusions = new ArrayList<>();
+    private List<String> filesInDirectory = new ArrayList<>();
 
     @Deprecated
     public DockerComposeContainer(File composeFile, String identifier) {
@@ -143,7 +143,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                     this.services,
                     this.scalingPreferences,
                     this.env,
-                    this.fileCopyInclusions
+                    this.filesInDirectory
                 );
             this.composeDelegate.startAmbassadorContainer();
             this.composeDelegate.waitUntilServiceStarted(this.tailChildContainers);
@@ -175,7 +175,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env, this.fileCopyInclusions);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env, this.filesInDirectory);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }
@@ -358,8 +358,8 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
         return self();
     }
 
-    public SELF withFileCopyInclusions(String... fileCopyInclusions) {
-        this.fileCopyInclusions = Arrays.asList(fileCopyInclusions);
+    public SELF withCopyFilesInContainer(String... fileCopyInclusions) {
+        this.filesInDirectory = Arrays.asList(fileCopyInclusions);
         return self();
     }
 

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -68,6 +68,8 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     private String project;
 
+    private List<String> fileCopyInclusions = new ArrayList<>();
+
     @Deprecated
     public DockerComposeContainer(File composeFile, String identifier) {
         this(identifier, composeFile);
@@ -140,7 +142,8 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                     this.options,
                     this.services,
                     this.scalingPreferences,
-                    this.env
+                    this.env,
+                    this.fileCopyInclusions
                 );
             this.composeDelegate.startAmbassadorContainer();
             this.composeDelegate.waitUntilServiceStarted(this.tailChildContainers);
@@ -172,7 +175,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 if (removeImages != null) {
                     cmd += " --rmi " + removeImages.dockerRemoveImagesType();
                 }
-                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env);
+                this.composeDelegate.runWithCompose(this.localCompose, cmd, this.env, this.fileCopyInclusions);
             } finally {
                 this.project = this.composeDelegate.randomProjectId();
             }
@@ -352,6 +355,11 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
      */
     public SELF withStartupTimeout(Duration startupTimeout) {
         this.composeDelegate.setStartupTimeout(startupTimeout);
+        return self();
+    }
+
+    public SELF withFileCopyInclusions(String... fileCopyInclusions) {
+        this.fileCopyInclusions = Arrays.asList(fileCopyInclusions);
         return self();
     }
 

--- a/core/src/test/java/org/testcontainers/junit/ComposeContainerFileCopyInclusionsTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ComposeContainerFileCopyInclusionsTest.java
@@ -1,0 +1,95 @@
+package org.testcontainers.junit;
+
+import org.junit.Test;
+import org.testcontainers.containers.ComposeContainer;
+import org.testcontainers.containers.ContainerLaunchException;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Scanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class ComposeContainerFileCopyInclusionsTest {
+
+    @Test
+    public void testShouldCopyAllFilesByDefault() throws IOException {
+        try (
+            ComposeContainer environment = new ComposeContainer(
+                new File("src/test/resources/compose-file-copy-inclusions/compose.yml")
+            )
+                .withExposedService("app", 8080)
+        ) {
+            environment.start();
+
+            Integer servicePort = environment.getServicePort("app-1", 8080);
+            String serviceHost = environment.getServiceHost("app-1", 8080);
+            String response = readStringFromURL("http://" + serviceHost + ":" + servicePort + "/env");
+            assertThat(response).isEqualTo("MY_ENV_VARIABLE: override");
+        }
+    }
+
+    @Test
+    public void testWithFileCopyInclusionUsingFilePath() throws IOException {
+        try (
+            ComposeContainer environment = new ComposeContainer(
+                new File("src/test/resources/compose-file-copy-inclusions/compose-root-only.yml")
+            )
+                .withExposedService("app", 8080)
+                .withFileCopyInclusions("Dockerfile", "EnvVariableRestEndpoint.java", ".env")
+        ) {
+            environment.start();
+
+            Integer servicePort = environment.getServicePort("app-1", 8080);
+            String serviceHost = environment.getServiceHost("app-1", 8080);
+            String response = readStringFromURL("http://" + serviceHost + ":" + servicePort + "/env");
+
+            // The `test/.env` file is not copied, now so we get the original value
+            assertThat(response).isEqualTo("MY_ENV_VARIABLE: original");
+        }
+    }
+
+    @Test
+    public void testWithFileCopyInclusionUsingDirectoryPath() throws IOException {
+        try (
+            ComposeContainer environment = new ComposeContainer(
+                new File("src/test/resources/compose-file-copy-inclusions/compose-test-only.yml")
+            )
+                .withExposedService("app", 8080)
+                .withFileCopyInclusions("Dockerfile", "EnvVariableRestEndpoint.java", "test")
+        ) {
+            environment.start();
+
+            Integer servicePort = environment.getServicePort("app-1", 8080);
+            String serviceHost = environment.getServiceHost("app-1", 8080);
+            String response = readStringFromURL("http://" + serviceHost + ":" + servicePort + "/env");
+            // The test directory (with its contents) is copied, so we get the override
+            assertThat(response).isEqualTo("MY_ENV_VARIABLE: override");
+        }
+    }
+
+    @Test
+    public void testShouldNotBeAbleToStartIfNeededEnvFileIsNotCopied() {
+        try (
+            ComposeContainer environment = new ComposeContainer(
+                new File("src/test/resources/compose-file-copy-inclusions/compose-test-only.yml")
+            )
+                .withExposedService("app", 8080)
+                .withFileCopyInclusions("Dockerfile", "EnvVariableRestEndpoint.java")
+        ) {
+            assertThatExceptionOfType(ContainerLaunchException.class)
+                .isThrownBy(environment::start)
+                .withMessage("Container startup failed for image docker:24.0.2");
+        }
+    }
+
+    private static String readStringFromURL(String requestURL) throws IOException {
+        try (Scanner scanner = new Scanner(new URL(requestURL).openStream(), StandardCharsets.UTF_8.toString())) {
+            scanner.useDelimiter("\\A");
+            return scanner.hasNext() ? scanner.next() : "";
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/junit/DockerComposeContainerWithCopyFilesTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerComposeContainerWithCopyFilesTest.java
@@ -1,0 +1,70 @@
+package org.testcontainers.junit;
+
+import io.restassured.RestAssured;
+import org.junit.Test;
+import org.testcontainers.containers.DockerComposeContainer;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DockerComposeContainerWithCopyFilesTest {
+
+    @Test
+    public void testShouldCopyAllFilesByDefault() throws IOException {
+        try (
+            DockerComposeContainer environment = new DockerComposeContainer(
+                new File("src/test/resources/compose-file-copy-inclusions/compose.yml")
+            )
+                .withExposedService("app", 8080)
+        ) {
+            environment.start();
+
+            String response = readStringFromURL(environment);
+            assertThat(response).isEqualTo("MY_ENV_VARIABLE: override");
+        }
+    }
+
+    @Test
+    public void testWithFileCopyInclusionUsingFilePath() throws IOException {
+        try (
+            DockerComposeContainer environment = new DockerComposeContainer(
+                new File("src/test/resources/compose-file-copy-inclusions/compose-root-only.yml")
+            )
+                .withExposedService("app", 8080)
+                .withCopyFilesInContainer("Dockerfile", "EnvVariableRestEndpoint.java", ".env")
+        ) {
+            environment.start();
+
+            String response = readStringFromURL(environment);
+
+            // The `test/.env` file is not copied, now so we get the original value
+            assertThat(response).isEqualTo("MY_ENV_VARIABLE: original");
+        }
+    }
+
+    @Test
+    public void testWithFileCopyInclusionUsingDirectoryPath() throws IOException {
+        try (
+            DockerComposeContainer environment = new DockerComposeContainer(
+                new File("src/test/resources/compose-file-copy-inclusions/compose-test-only.yml")
+            )
+                .withExposedService("app", 8080)
+                .withCopyFilesInContainer("Dockerfile", "EnvVariableRestEndpoint.java", "test")
+        ) {
+            environment.start();
+
+            String response = readStringFromURL(environment);
+            // The test directory (with its contents) is copied, so we get the override
+            assertThat(response).isEqualTo("MY_ENV_VARIABLE: override");
+        }
+    }
+
+    private static String readStringFromURL(DockerComposeContainer container) throws IOException {
+        Integer servicePort = container.getServicePort("app_1", 8080);
+        String serviceHost = container.getServiceHost("app_1", 8080);
+        String requestURL = "http://" + serviceHost + ":" + servicePort + "/env";
+        return RestAssured.get(requestURL).thenReturn().body().asString();
+    }
+}

--- a/core/src/test/resources/compose-file-copy-inclusions/.env
+++ b/core/src/test/resources/compose-file-copy-inclusions/.env
@@ -1,0 +1,1 @@
+MY_ENV_VARIABLE=original

--- a/core/src/test/resources/compose-file-copy-inclusions/Dockerfile
+++ b/core/src/test/resources/compose-file-copy-inclusions/Dockerfile
@@ -1,0 +1,9 @@
+FROM jbangdev/jbang-action
+
+WORKDIR /app
+COPY EnvVariableRestEndpoint.java .
+
+RUN jbang export portable --force EnvVariableRestEndpoint.java
+
+EXPOSE 8080
+CMD ["./EnvVariableRestEndpoint.java"]

--- a/core/src/test/resources/compose-file-copy-inclusions/EnvVariableRestEndpoint.java
+++ b/core/src/test/resources/compose-file-copy-inclusions/EnvVariableRestEndpoint.java
@@ -1,0 +1,45 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+
+import com.sun.net.httpserver.HttpServer;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpExchange;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class EnvVariableRestEndpoint {
+    private static final String ENV_VARIABLE_NAME = "MY_ENV_VARIABLE";
+    private static final int PORT = 8080;
+
+    public static void main(String[] args) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(PORT), 0);
+        server.createContext("/env", new EnvVariableHandler());
+        server.setExecutor(null);
+        server.start();
+        System.out.println("Server started on port " + PORT);
+    }
+
+    static class EnvVariableHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            if ("GET".equals(exchange.getRequestMethod())) {
+                String envValue = System.getenv(ENV_VARIABLE_NAME);
+                String response = envValue != null
+                    ? ENV_VARIABLE_NAME + ": " + envValue
+                    : "Environment variable " + ENV_VARIABLE_NAME + " not found";
+
+                exchange.sendResponseHeaders(200, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes());
+                }
+            } else {
+                String response = "Method not allowed";
+                exchange.sendResponseHeaders(405, response.length());
+                try (OutputStream os = exchange.getResponseBody()) {
+                    os.write(response.getBytes());
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/resources/compose-file-copy-inclusions/compose-root-only.yml
+++ b/core/src/test/resources/compose-file-copy-inclusions/compose-root-only.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    env_file:
+      - '.env'

--- a/core/src/test/resources/compose-file-copy-inclusions/compose-test-only.yml
+++ b/core/src/test/resources/compose-file-copy-inclusions/compose-test-only.yml
@@ -1,0 +1,7 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    env_file:
+      - './test/.env'

--- a/core/src/test/resources/compose-file-copy-inclusions/compose.yml
+++ b/core/src/test/resources/compose-file-copy-inclusions/compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build: .
+    ports:
+      - "8080:8080"
+    env_file:
+      - '.env'
+      - './test/.env'

--- a/core/src/test/resources/compose-file-copy-inclusions/test/.env
+++ b/core/src/test/resources/compose-file-copy-inclusions/test/.env
@@ -1,0 +1,1 @@
+MY_ENV_VARIABLE=override

--- a/docs/modules/docker_compose.md
+++ b/docs/modules/docker_compose.md
@@ -135,6 +135,26 @@ public static ComposeContainer environment =
 !!! note
     Make sure the service name use a `-` instead of `_` as separator using `ComposeContainer`.
 
+## Limiting files that are copied
+
+Testcontainers runs the compose file on a new container.
+To make that possible, it needs to copy over your compose file along with any file inside the directory that the file is in, as the compose file might reference some of those files.
+If the compose file is on the root folder of the project, this means copying over all files of the whole project, including any temporary files that have been created during the build.
+
+To avoid unnecessary copying of files, you can indicate what files should be copied only via `withFileCopyInclusions`:
+
+```java
+public static ComposeContainer environment =
+    new ComposeContainer(new File("compose.yml"))
+        .withFileCopyInclusions(".env");
+```
+
+In this example, only `compose.yml` and `.env` are copied over into the container that will run the Docker Compose file.
+
+This can be used with `DockerComposeContainer` and `ComposeContainer`.
+You can use file and directory references.
+They are always resolved relative to the directory where the compose file resides.
+
 ## Using private repositories in Docker compose
 When Docker Compose is used in container mode (not local), it's needs to be made aware of Docker settings for private repositories. 
 By default, those setting are located in `$HOME/.docker/config.json`. 

--- a/docs/modules/docker_compose.md
+++ b/docs/modules/docker_compose.md
@@ -135,25 +135,25 @@ public static ComposeContainer environment =
 !!! note
     Make sure the service name use a `-` instead of `_` as separator using `ComposeContainer`.
 
-## Limiting files that are copied
+## Build working directory
 
-Testcontainers runs the compose file on a new container.
-To make that possible, it needs to copy over your compose file along with any file inside the directory that the file is in, as the compose file might reference some of those files.
-If the compose file is on the root folder of the project, this means copying over all files of the whole project, including any temporary files that have been created during the build.
-
-To avoid unnecessary copying of files, you can indicate what files should be copied only via `withFileCopyInclusions`:
+You can select what files should be copied only via `withCopyFilesInContainer`:
 
 ```java
 public static ComposeContainer environment =
     new ComposeContainer(new File("compose.yml"))
-        .withFileCopyInclusions(".env");
+        .withCopyFilesInContainer(".env");
 ```
 
-In this example, only `compose.yml` and `.env` are copied over into the container that will run the Docker Compose file.
+In this example, only `compose.yml` and `.env` are copied over into the container that will run the Docker Compose file.  
+By default, all files in the same directory as the compose file are copied over.
 
 This can be used with `DockerComposeContainer` and `ComposeContainer`.
 You can use file and directory references.
 They are always resolved relative to the directory where the compose file resides.
+
+!!! note
+    This only work with containarized Compose, not with `Local Compose` mode.
 
 ## Using private repositories in Docker compose
 When Docker Compose is used in container mode (not local), it's needs to be made aware of Docker settings for private repositories. 


### PR DESCRIPTION
This commit adds support for a `withFileCopyInclusions` method on `ComposeContainer` and `DockerComposeContainer`. It allows to specify what files or directories should be copied, instead of just copying all files. If not used, the current behaviour is preserved.
