### PR TITLE
Add grafana module

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -27,6 +27,7 @@ body:
         - Dynalite
         - Elasticsearch
         - GCloud
+        - Grafana
         - HiveMQ
         - InfluxDB
         - K3S

--- a/.github/ISSUE_TEMPLATE/enhancement.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yaml
@@ -27,6 +27,7 @@ body:
         - Dynalite
         - Elasticsearch
         - GCloud
+        - Grafana
         - HiveMQ
         - InfluxDB
         - K3S

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -27,6 +27,7 @@ body:
         - Dynalite
         - Elasticsearch
         - GCloud
+        - Grafana
         - HiveMQ
         - InfluxDB
         - K3S

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -107,6 +107,11 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
   - package-ecosystem: "gradle"
+    directory: "/modules/grafana"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gradle"
     directory: "/modules/hivemq"
     schedule:
       interval: "weekly"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -67,6 +67,10 @@
   - changed-files:
     - any-glob-to-any-file:
       - modules/gcloud/**/*
+"modules/grafana":
+  - changed-files:
+    - any-glob-to-any-file:
+      - modules/grafana/**/*
 "modules/hivemq":
   - changed-files:
     - any-glob-to-any-file:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -145,6 +145,9 @@ labels:
   - name: modules/gcloud
     color: '#006b75'
 
+  - name: modules/grafana
+    color: '#006b75'
+
   - name: modules/hivemq
     color: '#006b75'
 

--- a/docs/modules/grafana.md
+++ b/docs/modules/grafana.md
@@ -1,0 +1,28 @@
+# Grafana
+
+Testcontainers module for [Grafana Otel LGTM](https://hub.docker.com/r/grafana/otel-lgtm).
+
+## LGTM's usage examples
+
+You can start a Grafana Otel LGTM container instance from any Java application by using:
+
+<!--codeinclude-->
+[Grafana Otel LGTM container](../../modules/grafana/src/test/java/org/testcontainers/grafana/LgtmStackContainerTest.java) inside_block:container
+<!--/codeinclude-->
+
+Add the following dependency to your `pom.xml`/`build.gradle` file:
+
+=== "Gradle"
+    ```groovy
+    testImplementation "org.testcontainers:grafana:{{latest_version}}"
+    ```
+
+=== "Maven"
+    ```xml
+    <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>grafana</artifactId>
+        <version>{{latest_version}}</version>
+        <scope>test</scope>
+    </dependency>
+    ```

--- a/docs/modules/grafana.md
+++ b/docs/modules/grafana.md
@@ -1,10 +1,10 @@
 # Grafana
 
-Testcontainers module for [Grafana Otel LGTM](https://hub.docker.com/r/grafana/otel-lgtm).
+Testcontainers module for [Grafana OTel LGTM](https://hub.docker.com/r/grafana/otel-lgtm).
 
 ## LGTM's usage examples
 
-You can start a Grafana Otel LGTM container instance from any Java application by using:
+You can start a Grafana OTel LGTM container instance from any Java application by using:
 
 <!--codeinclude-->
 [Grafana Otel LGTM container](../../modules/grafana/src/test/java/org/testcontainers/grafana/LgtmStackContainerTest.java) inside_block:container

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
           - modules/docker_compose.md
           - modules/elasticsearch.md
           - modules/gcloud.md
+          - modules/grafana.md
           - modules/hivemq.md
           - modules/k3s.md
           - modules/k6.md

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -1,0 +1,23 @@
+description = "Testcontainers :: Grafana"
+
+dependencies {
+    api project(':testcontainers')
+
+    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.1'
+    testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
+}
+
+test {
+    javaLauncher = javaToolchains.launcherFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+
+compileTestJava {
+    javaCompiler = javaToolchains.compilerFor {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+    options.release.set(11)
+}

--- a/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
+++ b/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
@@ -1,0 +1,56 @@
+package org.testcontainers.grafana;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Testcontainers implementation for Grafana Otel LGTM.
+ * <p>
+ * Supported image: {@code grafana/otel-lgtm}
+ * <p>
+ * Exposed ports:
+ * <ul>
+ *     <li>Grafana: 3000</li>
+ *     <li>Otel Http: 4317</li>
+ *     <li>Otel Grpc: 4318</li>
+ *     <li>Prometheus: 9090</li>
+ * </ul>
+ */
+public class LgtmStackContainer extends GenericContainer<LgtmStackContainer> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("grafana/otel-lgtm");
+
+    private static final int GRAFANA_PORT = 3000;
+
+    private static final int OTLP_GRPC_PORT = 4317;
+
+    private static final int OTLP_HTTP_PORT = 4318;
+
+    private static final int PROMETHEUS_PORT = 9090;
+
+    public LgtmStackContainer(String image) {
+        this(DockerImageName.parse(image));
+    }
+
+    public LgtmStackContainer(DockerImageName image) {
+        super(image);
+        image.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        withExposedPorts(GRAFANA_PORT, OTLP_GRPC_PORT, OTLP_HTTP_PORT, PROMETHEUS_PORT);
+        waitingFor(
+            Wait.forLogMessage(".*The OpenTelemetry collector and the Grafana LGTM stack are up and running.*\\s", 1)
+        );
+    }
+
+    public String getOtlpGrpcUrl() {
+        return "http://" + getHost() + ":" + getMappedPort(OTLP_GRPC_PORT);
+    }
+
+    public String getOtlpHttpUrl() {
+        return "http://" + getHost() + ":" + getMappedPort(OTLP_HTTP_PORT);
+    }
+
+    public String getPromehteusHttpUrl() {
+        return "http://" + getHost() + ":" + getMappedPort(PROMETHEUS_PORT);
+    }
+}

--- a/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
+++ b/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
@@ -5,15 +5,15 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * Testcontainers implementation for Grafana Otel LGTM.
+ * Testcontainers implementation for Grafana OTel LGTM.
  * <p>
  * Supported image: {@code grafana/otel-lgtm}
  * <p>
  * Exposed ports:
  * <ul>
  *     <li>Grafana: 3000</li>
- *     <li>Otel Http: 4317</li>
- *     <li>Otel Grpc: 4318</li>
+ *     <li>OTel Http: 4317</li>
+ *     <li>OTel Grpc: 4318</li>
  *     <li>Prometheus: 9090</li>
  * </ul>
  */

--- a/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
+++ b/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
@@ -1,5 +1,7 @@
 package org.testcontainers.grafana;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
@@ -17,6 +19,7 @@ import org.testcontainers.utility.DockerImageName;
  *     <li>Prometheus: 9090</li>
  * </ul>
  */
+@Slf4j
 public class LgtmStackContainer extends GenericContainer<LgtmStackContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("grafana/otel-lgtm");
@@ -40,6 +43,11 @@ public class LgtmStackContainer extends GenericContainer<LgtmStackContainer> {
         waitingFor(
             Wait.forLogMessage(".*The OpenTelemetry collector and the Grafana LGTM stack are up and running.*\\s", 1)
         );
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        log.info("Access to the Grafana dashboard: {}", getOtlpHttpUrl());
     }
 
     public String getOtlpGrpcUrl() {

--- a/modules/grafana/src/test/java/org/testcontainers/grafana/LgtmStackContainerTest.java
+++ b/modules/grafana/src/test/java/org/testcontainers/grafana/LgtmStackContainerTest.java
@@ -1,0 +1,76 @@
+package org.testcontainers.grafana;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.registry.otlp.OtlpConfig;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.awaitility.Awaitility;
+import org.junit.Test;
+import uk.org.webcompere.systemstubs.SystemStubs;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LgtmStackContainerTest {
+
+    @Test
+    public void shouldPublishMetric() throws Exception {
+        try ( // container {
+            LgtmStackContainer lgtm = new LgtmStackContainer("grafana/otel-lgtm:0.6.0")
+            // }
+        ) {
+            lgtm.start();
+
+            String version = RestAssured
+                .get(String.format("http://%s:%s/api/health", lgtm.getHost(), lgtm.getMappedPort(3000)))
+                .jsonPath()
+                .get("version");
+            assertThat(version).isEqualTo("11.0.0");
+
+            OtlpConfig otlpConfig = createOtlpConfig(lgtm);
+            MeterRegistry meterRegistry = SystemStubs
+                .withEnvironmentVariable("OTEL_SERVICE_NAME", "testcontainers")
+                .execute(() -> new OtlpMeterRegistry(otlpConfig, Clock.SYSTEM));
+            Counter.builder("test.counter").register(meterRegistry).increment(2);
+
+            Awaitility
+                .given()
+                .pollInterval(Duration.ofSeconds(2))
+                .atMost(Duration.ofSeconds(5))
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    Response response = RestAssured
+                        .given()
+                        .queryParam("query", "test_counter_total{job=\"testcontainers\"}")
+                        .get(String.format("%s/api/v1/query", lgtm.getPromehteusHttpUrl()))
+                        .prettyPeek()
+                        .thenReturn();
+                    assertThat(response.getStatusCode()).isEqualTo(200);
+                    assertThat(response.body().jsonPath().getList("data.result[0].value")).contains("2");
+                });
+        }
+    }
+
+    private static OtlpConfig createOtlpConfig(LgtmStackContainer lgtm) {
+        return new OtlpConfig() {
+            @Override
+            public String url() {
+                return String.format("%s/v1/metrics", lgtm.getOtlpHttpUrl());
+            }
+
+            @Override
+            public Duration step() {
+                return Duration.ofSeconds(1);
+            }
+
+            @Override
+            public String get(String s) {
+                return null;
+            }
+        };
+    }
+}

--- a/modules/grafana/src/test/resources/logback-test.xml
+++ b/modules/grafana/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.testcontainers" level="INFO"/>
+</configuration>


### PR DESCRIPTION
Add Grafana Otel LGTM container implementation.

Expose ports for Grafana (3000), OTLP GRPC (4317), OTLP HTTP (4318)
and Prometheus (9090). Also, utility methods to get URLs.
