### PR TITLE
Improve docs for Elasticsearch 8

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -10,9 +10,9 @@ Note that it's based on the [official Docker image](https://www.elastic.co/guide
 You can start an elasticsearch container instance from any Java application by using:
 
 <!--codeinclude-->
-[HttpClient](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainer
+[HttpClient](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainer7
 [HttpClient with Elasticsearch 8](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainer8
-[HttpClient with Elasticsearch 8 and SSL disabled](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainer8NoSSL
+[HttpClient with Elasticsearch 8 and SSL disabled](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainerNoSSL8
 [TransportClient](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:transportClientContainer
 <!--/codeinclude-->
 

--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -11,6 +11,8 @@ You can start an elasticsearch container instance from any Java application by u
 
 <!--codeinclude-->
 [HttpClient](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainer
+[HttpClient with Elasticsearch 8](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainer8
+[HttpClient with Elasticsearch 8 and SSL disabled](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientContainer8NoSSL
 [TransportClient](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:transportClientContainer
 <!--/codeinclude-->
 

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -183,7 +183,7 @@ public class ElasticsearchContainerTest {
 
     @Test
     public void restClientClusterHealth() throws IOException {
-        // httpClientContainer {
+        // httpClientContainer7 {
         // Create the elasticsearch container.
         try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE)) {
             // Start the container. This step might take some time...
@@ -208,7 +208,7 @@ public class ElasticsearchContainerTest {
             // }}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer {{
+            // httpClientContainer7 {{
         }
         // }
     }
@@ -245,17 +245,17 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}
+            // }
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8 {{{
+            // httpClientContainer8 {
         }
         // }
     }
 
     @Test
     public void restClientClusterHealthElasticsearch8WithoutSSL() throws IOException {
-        // httpClientContainer8NoSSL {
+        // httpClientContainerNoSSL8 {
         // Create the elasticsearch container.
         try (
             ElasticsearchContainer container = new ElasticsearchContainer(
@@ -284,10 +284,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}
+            // }
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8NoSSL {{{
+            // httpClientContainerNoSSL8 {
         }
         // }
     }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -245,10 +245,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}
+            // }
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8 {{
+            // httpClientContainer8 {
         }
         // }
     }
@@ -284,10 +284,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}
+            // }
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8NoSSL {{
+            // httpClientContainer8NoSSL {
         }
         // }
     }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -238,7 +238,7 @@ public class ElasticsearchContainerTest {
                     .builder(HttpHost.create("https://" + container.getHttpHostAddress()))
                     .setHttpClientConfigCallback(httpClientBuilder -> {
                         httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
-                        // SSL is activated by default in Elasticseach 8
+                        // SSL is activated by default in Elasticsearch 8
                         httpClientBuilder.setSSLContext(container.createSslContextFromCa());
                         return httpClientBuilder;
                     })

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -369,20 +369,6 @@ public class ElasticsearchContainerTest {
     }
 
     @Test
-    public void testElasticsearch8SecureByDefault() throws Exception {
-        try (
-            ElasticsearchContainer container = new ElasticsearchContainer(
-                "docker.elastic.co/elasticsearch/elasticsearch:8.1.2"
-            )
-        ) {
-            // Start the container. This step might take some time...
-            container.start();
-
-            assertClusterHealthResponse(container);
-        }
-    }
-
-    @Test
     public void testDockerHubElasticsearch8ImageSecureByDefault() throws Exception {
         try (ElasticsearchContainer container = new ElasticsearchContainer("elasticsearch:8.1.2")) {
             container.start();

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -245,10 +245,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }
+            // }}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8 {
+            // httpClientContainer8 {{
         }
         // }
     }
@@ -284,10 +284,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }
+            // }}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainerNoSSL8 {
+            // httpClientContainerNoSSL8 {{
         }
         // }
     }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -245,10 +245,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}}}
+            // }}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8 {{{{{
+            // httpClientContainer8 {{{
         }
         // }
     }
@@ -284,10 +284,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}}
+            // }}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8NoSSL {{{{
+            // httpClientContainer8NoSSL {{{
         }
         // }
     }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -245,10 +245,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }
+            // }}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8 {
+            // httpClientContainer8 {{
         }
         // }
     }
@@ -284,10 +284,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }
+            // }}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8NoSSL {
+            // httpClientContainer8NoSSL {{
         }
         // }
     }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -261,9 +261,9 @@ public class ElasticsearchContainerTest {
             ElasticsearchContainer container = new ElasticsearchContainer(
                 "docker.elastic.co/elasticsearch/elasticsearch:8.1.2"
             )
-                    // disable SSL
-                    .withEnv("xpack.security.transport.ssl.enabled", "false")
-                    .withEnv("xpack.security.http.ssl.enabled", "false")
+                // disable SSL
+                .withEnv("xpack.security.transport.ssl.enabled", "false")
+                .withEnv("xpack.security.http.ssl.enabled", "false")
         ) {
             // Start the container. This step might take some time...
             container.start();

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -205,10 +205,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}
+            // }}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer {{
+            // httpClientContainer {{{
         }
         // }
     }
@@ -245,10 +245,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}
+            // }}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8 {{
+            // httpClientContainer8 {{{
         }
         // }
     }
@@ -284,10 +284,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}
+            // }}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8NoSSL {{
+            // httpClientContainer8NoSSL {{{
         }
         // }
     }
@@ -320,10 +320,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}
+            // }}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientSecuredContainer {{
+            // httpClientSecuredContainer {{{
         }
         // }
     }

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -205,10 +205,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}
+            // }}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer {{{
+            // httpClientContainer {{
         }
         // }
     }
@@ -245,10 +245,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}
+            // }}}}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8 {{{
+            // httpClientContainer8 {{{{{
         }
         // }
     }
@@ -284,10 +284,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}
+            // }}}}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientContainer8NoSSL {{{
+            // httpClientContainer8NoSSL {{{{
         }
         // }
     }
@@ -320,10 +320,10 @@ public class ElasticsearchContainerTest {
                     .build();
 
             Response response = client.performRequest(new Request("GET", "/_cluster/health"));
-            // }}}
+            // }}
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
-            // httpClientSecuredContainer {{{
+            // httpClientSecuredContainer {{
         }
         // }
     }


### PR DESCRIPTION
The docs for connecting to Elasticsearch container only work for Elasticsearch v7. For Elasticsearch v8 either the SSLContext has to be configured for the HTTPClient or SSL needs to be disabled. This PR adds according documentation
