### PR TITLE
[Docs] Add TCI to external integrations

### DIFF
--- a/docs/test_framework_integration/external.md
+++ b/docs/test_framework_integration/external.md
@@ -7,3 +7,4 @@ The following Open Source frameworks add direct integration to Testcontainers
 | jqwik | [jqwik-testcontainers](https://github.com/jqwik-team/jqwik-testcontainers) | [README](https://github.com/jqwik-team/jqwik-testcontainers) |
 | Kotest | [Kotest Extensions Testcontainers](https://github.com/kotest/kotest-extensions-testcontainers) | [kotest.io](https://kotest.io/docs/extensions/test_containers.html) |
 | Synthesized | [Synthesized TDK-Testcontainers integration](https://github.com/synthesized-io/tdk-tc) | [synthesized.io](https://docs.synthesized.io/tdk/latest/user_guide/integrations/testcontainers) |
+| TCI | [Testcontainers Infrastructure (TCI) Framework](https://github.com/xdev-software/tci-base) | [README](https://github.com/xdev-software/tci-base) |


### PR DESCRIPTION
Adds [TCI](https://github.com/xdev-software/tci-base) to external integrations.
