### PR TITLE
Couchbase: Don't configure external TLS ports if they're not supported

### DIFF
--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -123,6 +123,8 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     private boolean isEnterprise = false;
 
+    private boolean hasTlsPorts = false;
+
     /**
      * Creates a new couchbase container with the default image and version.
      * @deprecated use {@link #CouchbaseContainer(DockerImageName)} instead
@@ -345,6 +347,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
         timePhase("waitUntilNodeIsOnline", this::waitUntilNodeIsOnline);
         timePhase("initializeIsEnterprise", this::initializeIsEnterprise);
+        timePhase("initializeHasTlsPorts", this::initializeHasTlsPorts);
         timePhase("renameNode", this::renameNode);
         timePhase("initializeServices", this::initializeServices);
         timePhase("setMemoryQuotas", this::setMemoryQuotas);
@@ -391,6 +394,24 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
             if (enabledServices.contains(CouchbaseService.EVENTING)) {
                 throw new IllegalStateException("The Eventing Service is only supported with the Enterprise version");
             }
+        }
+    }
+
+    /**
+     * Initializes the {@link #hasTlsPorts} flag.
+     * <p>
+     * Community Edition might support TLS one happy day, so use a "supports TLS" flag separate from
+     * the "enterprise edition" flag.
+     */
+    private void initializeHasTlsPorts() {
+        @Cleanup
+        Response response = doHttpRequest(MGMT_PORT, "/pools/default/nodeServices", "GET", null, true);
+
+        try {
+            String clusterTopology = response.body().string();
+            hasTlsPorts = !MAPPER.readTree(clusterTopology).path("nodesExt").path(0).path("services").path("mgmtSSL").isMissingNode();
+        } catch (IOException e) {
+            throw new IllegalStateException("Couchbase /pools/default/nodeServices did not return valid JSON");
         }
     }
 
@@ -503,33 +524,45 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
         final FormBody.Builder builder = new FormBody.Builder();
         builder.add("hostname", getHost());
         builder.add("mgmt", Integer.toString(getMappedPort(MGMT_PORT)));
-        builder.add("mgmtSSL", Integer.toString(getMappedPort(MGMT_SSL_PORT)));
+        if (hasTlsPorts) {
+            builder.add("mgmtSSL", Integer.toString(getMappedPort(MGMT_SSL_PORT)));
+        }
 
         if (enabledServices.contains(CouchbaseService.KV)) {
             builder.add("kv", Integer.toString(getMappedPort(KV_PORT)));
-            builder.add("kvSSL", Integer.toString(getMappedPort(KV_SSL_PORT)));
             builder.add("capi", Integer.toString(getMappedPort(VIEW_PORT)));
-            builder.add("capiSSL", Integer.toString(getMappedPort(VIEW_SSL_PORT)));
+            if (hasTlsPorts) {
+                builder.add("kvSSL", Integer.toString(getMappedPort(KV_SSL_PORT)));
+                builder.add("capiSSL", Integer.toString(getMappedPort(VIEW_SSL_PORT)));
+            }
         }
 
         if (enabledServices.contains(CouchbaseService.QUERY)) {
             builder.add("n1ql", Integer.toString(getMappedPort(QUERY_PORT)));
-            builder.add("n1qlSSL", Integer.toString(getMappedPort(QUERY_SSL_PORT)));
+            if (hasTlsPorts) {
+                builder.add("n1qlSSL", Integer.toString(getMappedPort(QUERY_SSL_PORT)));
+            }
         }
 
         if (enabledServices.contains(CouchbaseService.SEARCH)) {
             builder.add("fts", Integer.toString(getMappedPort(SEARCH_PORT)));
-            builder.add("ftsSSL", Integer.toString(getMappedPort(SEARCH_SSL_PORT)));
+            if (hasTlsPorts) {
+                builder.add("ftsSSL", Integer.toString(getMappedPort(SEARCH_SSL_PORT)));
+            }
         }
 
         if (enabledServices.contains(CouchbaseService.ANALYTICS)) {
             builder.add("cbas", Integer.toString(getMappedPort(ANALYTICS_PORT)));
-            builder.add("cbasSSL", Integer.toString(getMappedPort(ANALYTICS_SSL_PORT)));
+            if (hasTlsPorts) {
+                builder.add("cbasSSL", Integer.toString(getMappedPort(ANALYTICS_SSL_PORT)));
+            }
         }
 
         if (enabledServices.contains(CouchbaseService.EVENTING)) {
             builder.add("eventingAdminPort", Integer.toString(getMappedPort(EVENTING_PORT)));
-            builder.add("eventingSSL", Integer.toString(getMappedPort(EVENTING_SSL_PORT)));
+            if (hasTlsPorts) {
+                builder.add("eventingSSL", Integer.toString(getMappedPort(EVENTING_SSL_PORT)));
+            }
         }
 
         @Cleanup

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -409,7 +409,14 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
         try {
             String clusterTopology = response.body().string();
-            hasTlsPorts = !MAPPER.readTree(clusterTopology).path("nodesExt").path(0).path("services").path("mgmtSSL").isMissingNode();
+            hasTlsPorts =
+                !MAPPER
+                    .readTree(clusterTopology)
+                    .path("nodesExt")
+                    .path(0)
+                    .path("services")
+                    .path("mgmtSSL")
+                    .isMissingNode();
         } catch (IOException e) {
             throw new IllegalStateException("Couchbase /pools/default/nodeServices did not return valid JSON");
         }

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
@@ -33,51 +33,44 @@ import static org.awaitility.Awaitility.await;
 
 public class CouchbaseContainerTest {
 
-    private static final DockerImageName COUCHBASE_IMAGE_ENTERPRISE = DockerImageName.parse(
-        "couchbase/server:enterprise-7.0.3"
-    );
+    private static final String COUCHBASE_IMAGE_ENTERPRISE = "couchbase/server:enterprise-7.0.3";
 
-    private static final DockerImageName COUCHBASE_IMAGE_COMMUNITY = DockerImageName.parse(
-        "couchbase/server:community-7.0.2"
-    );
+    private static final String COUCHBASE_IMAGE_ENTERPRISE_RECENT = "couchbase/server:enterprise-7.6.2";
+
+    private static final String COUCHBASE_IMAGE_COMMUNITY = "couchbase/server:community-7.0.2";
+
+    private static final String COUCHBASE_IMAGE_COMMUNITY_RECENT = "couchbase/server:community-7.6.2";
 
     @Test
     public void testBasicContainerUsageForEnterpriseContainer() {
+        testBasicContainerUsage(COUCHBASE_IMAGE_ENTERPRISE);
+    }
+
+    @Test
+    public void testBasicContainerUsageForEnterpriseContainerRecent() {
+        testBasicContainerUsage(COUCHBASE_IMAGE_ENTERPRISE_RECENT);
+    }
+
+    @Test
+    public void testBasicContainerUsageForCommunityContainer() {
+        testBasicContainerUsage(COUCHBASE_IMAGE_COMMUNITY);
+    }
+
+    @Test
+    public void testBasicContainerUsageForCommunityContainerRecent() {
+        testBasicContainerUsage(COUCHBASE_IMAGE_COMMUNITY_RECENT);
+    }
+
+    private void testBasicContainerUsage(String couchbaseImage) {
         // bucket_definition {
         BucketDefinition bucketDefinition = new BucketDefinition("mybucket");
         // }
 
         try (
             // container_definition {
-            CouchbaseContainer container = new CouchbaseContainer(COUCHBASE_IMAGE_ENTERPRISE)
+            CouchbaseContainer container = new CouchbaseContainer(couchbaseImage)
                 .withBucket(bucketDefinition)
             // }
-        ) {
-            setUpClient(
-                container,
-                cluster -> {
-                    Bucket bucket = cluster.bucket(bucketDefinition.getName());
-                    bucket.waitUntilReady(Duration.ofSeconds(10L));
-
-                    Collection collection = bucket.defaultCollection();
-
-                    collection.upsert("foo", JsonObject.create().put("key", "value"));
-
-                    JsonObject fooObject = collection.get("foo").contentAsObject();
-
-                    assertThat(fooObject.getString("key")).isEqualTo("value");
-                }
-            );
-        }
-    }
-
-    @Test
-    public void testBasicContainerUsageForCommunityContainer() {
-        BucketDefinition bucketDefinition = new BucketDefinition("mybucket");
-
-        try (
-            CouchbaseContainer container = new CouchbaseContainer(COUCHBASE_IMAGE_COMMUNITY)
-                .withBucket(bucketDefinition)
         ) {
             setUpClient(
                 container,

--- a/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
+++ b/modules/couchbase/src/test/java/org/testcontainers/couchbase/CouchbaseContainerTest.java
@@ -22,7 +22,6 @@ import com.couchbase.client.java.Collection;
 import com.couchbase.client.java.json.JsonObject;
 import org.junit.Test;
 import org.testcontainers.containers.ContainerLaunchException;
-import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 import java.util.function.Consumer;
@@ -68,8 +67,7 @@ public class CouchbaseContainerTest {
 
         try (
             // container_definition {
-            CouchbaseContainer container = new CouchbaseContainer(couchbaseImage)
-                .withBucket(bucketDefinition)
+            CouchbaseContainer container = new CouchbaseContainer(couchbaseImage).withBucket(bucketDefinition)
             // }
         ) {
             setUpClient(


### PR DESCRIPTION
Couchbase: Don't configure external TLS ports if they're not supported.

Test recent Couchbase Server versions as well as the old ones.

Fixes "Couchbase Community Edition 7.6 fails to start" (#8989)
