### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v5.0.0
+        uses: github/combine-prs@v5.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:32.1.2-jre'
+        classpath 'com.google.guava:guava:33.2.1-jre'
         classpath 'com.github.tjni.captainhook:captain-hook:0.1.5'
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -121,7 +121,7 @@ dependencies {
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(":mysql")
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.21.0"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.22.0"
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }
 

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.2"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.2"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.3"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
     testImplementation 'org.assertj:assertj-core:3.25.3'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'
 
-    testImplementation platform('io.cucumber:cucumber-bom:7.15.0')
+    testImplementation platform('io.cucumber:cucumber-bom:7.18.1')
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit'
     testImplementation 'org.testcontainers:selenium'

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: ActiveMQ"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation "org.apache.activemq:activemq-client:6.1.2"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.33.0"
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.azure:azure-cosmos:4.60.0'
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/chromadb/build.gradle
+++ b/modules/chromadb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ChromaDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.2'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'com.couchbase.client:java-client:3.7.1'
     testImplementation 'org.awaitility:awaitility:4.2.1'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.6.2'
+    testImplementation 'com.couchbase.client:java-client:3.7.1'
     testImplementation 'org.awaitility:awaitility:4.2.1'
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'com.ibm.db2:jcc:11.5.9.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.726'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.726'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.763'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.763'
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.14.3"
     testImplementation "org.elasticsearch.client:transport:7.17.21"
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.13.4"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.14.3"
     testImplementation "org.elasticsearch.client:transport:7.17.21"
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-pubsub'
     testImplementation 'com.google.cloud:google-cloud-spanner'
     testImplementation 'com.google.cloud:google-cloud-bigtable'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.1'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api(project(":testcontainers"))
     api("org.jetbrains:annotations:24.1.0")
 
-    shaded("org.apache.commons:commons-lang3:3.14.0")
+    shaded("org.apache.commons:commons-lang3:3.15.0")
     shaded("commons-io:commons-io:2.16.1")
     shaded("org.javassist:javassist:3.30.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     api 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
 
-    api 'org.assertj:assertj-core:3.25.3'
+    api 'org.assertj:assertj-core:3.26.3'
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(':jdbc')
 
     api 'com.google.guava:guava:33.2.0-jre'
-    api 'org.apache.commons:commons-lang3:3.14.0'
+    api 'org.apache.commons:commons-lang3:3.15.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'
 

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.26'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.24'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.26'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:6.12.1'
     testImplementation 'io.kubernetes:client-java:20.0.1-legacy'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
-    testImplementation 'software.amazon.awssdk:s3:2.25.56'
+    testImplementation 'software.amazon.awssdk:s3:2.26.24'
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.4.0'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.4.1'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation('io.milvus:milvus-sdk-java:2.4.1') {
+    testImplementation('io.milvus:milvus-sdk-java:2.4.2') {
         exclude(group: 'org.testcontainers', module: 'milvus')
         exclude(group: 'org.testcontainers', module: 'junit-jupiter')
     }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("io.minio:minio:8.5.10")
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MongoDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("org.mongodb:mongodb-driver-sync:5.1.0")
+    testImplementation("org.mongodb:mongodb-driver-sync:5.1.2")
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.7.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.7.1.jre8-preview'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.16'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: OpenFGA"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'dev.openfga:openfga-sdk:0.4.2'
 }
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.29"
+    api "com.orientechnologies:orientdb-client:3.2.32"
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.2.32"
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.32"
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.26"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.32"
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client', version: '3.2.3'
-    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.25.3'
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.26.3'
     testImplementation group: 'org.apache.pulsar', name: 'pulsar-client-admin', version: '3.2.3'
 }

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Qdrant"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.qdrant:client:1.9.1'
     testImplementation platform('io.grpc:grpc-bom:1.65.1')
     testImplementation 'io.grpc:grpc-stub'

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
     testImplementation 'io.qdrant:client:1.9.1'
-    testImplementation platform('io.grpc:grpc-bom:1.64.0')
+    testImplementation platform('io.grpc:grpc-bom:1.65.1')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'
     testImplementation 'io.grpc:grpc-netty-shaded'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation 'org.questdb:questdb:7.3.9'
+    testImplementation 'org.questdb:questdb:8.1.0'
     testImplementation 'org.awaitility:awaitility:4.2.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,10 +11,10 @@ dependencies {
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.6.6'
-    testFixturesImplementation 'org.assertj:assertj-core:3.25.3'
+    testFixturesImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.21.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     shaded 'org.freemarker:freemarker:2.3.32'
 
     testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.2.1'
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.solacesystems:sol-jcsmp:10.23.0'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -5,5 +5,5 @@ dependencies {
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.7'
 
     testImplementation 'redis.clients:jedis:3.0.1'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:448'
+    testRuntimeOnly 'io.trino:trino-jdbc:452'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.25.3'
-    testImplementation 'io.weaviate:client:4.7.0'
+    testImplementation 'io.weaviate:client:4.8.1'
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // YCQL driver
     testImplementation 'com.yugabyte:java-driver-core:4.15.0-yb-2-TESTFIX.0'
     // YSQL driver
-    testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-4'
+    testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-6'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.17.4"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.17.6"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:2.0.1"
         classpath "org.gradle.toolchains:foojay-resolver:0.8.0"
     }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'
     testImplementation 'org.assertj:assertj-core:3.24.2'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.questdb:questdb from 7.3.9 to 8.1.0 in /modules/questdb (#8995) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.25.56 to 2.26.24 in /modules/localstack (#8992) @app/dependabot
* Bump io.weaviate:client from 4.7.0 to 4.8.1 in /modules/weaviate (#8983) @app/dependabot
* Bump com.couchbase.client:java-client from 3.6.2 to 3.7.1 in /modules/couchbase (#8981) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.26 to 3.2.32 in /modules/orientdb (#8979) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.29 to 3.2.32 in /modules/orientdb (#8978) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.17.4 to 3.17.6 (#8974) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.14.0 to 3.15.0 in /modules/jdbc-test (#8973) @app/dependabot
* Bump com.yugabyte:jdbc-yugabytedb from 42.3.5-yb-4 to 42.3.5-yb-6 in /modules/yugabytedb (#8972) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /core (#8971) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.14.0 to 3.15.0 in /modules/hivemq (#8970) @app/dependabot
* Bump github/combine-prs from 5.0.0 to 5.1.0 (#8969) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.726 to 1.12.763 in /modules/dynalite (#8968) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.4.0 to 3.4.1 in /modules/mariadb (#8967) @app/dependabot
* Bump io.cucumber:cucumber-bom from 7.15.0 to 7.18.1 in /examples (#8966) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.13.4 to 8.14.3 in /modules/elasticsearch (#8956) @app/dependabot
* Bump io.milvus:milvus-sdk-java from 2.4.1 to 2.4.2 in /modules/milvus (#8955) @app/dependabot
* Bump io.grpc:grpc-bom from 1.64.0 to 1.65.1 in /modules/qdrant (#8954) @app/dependabot
* Bump io.trino:trino-jdbc from 448 to 452 in /modules/trino (#8953) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.24 to 10.1.26 in /modules/jdbc (#8952) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.726 to 1.12.761 in /modules/dynalite (#8951) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.10.2 to 5.10.3 in /smoke-test (#8939) @app/dependabot
* Bump com.google.guava:guava from 32.1.2-jre to 33.2.1-jre in /smoke-test (#8938) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.21.0 to 4.22.0 in /smoke-test (#8937) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.10.0 to 5.10.3 in /smoke-test (#8936) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.26.3 in /smoke-test (#8935) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.2 to 5.10.3 in /smoke-test (#8932) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.726 to 1.12.760 in /modules/dynalite (#8929) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/r2dbc (#8925) @app/dependabot
* Bump org.mongodb:mongodb-driver-sync from 5.1.0 to 5.1.2 in /modules/mongodb (#8926) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/gcloud (#8924) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.6.6 to 3.6.8 in /modules/r2dbc (#8923) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/mongodb (#8920) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/pulsar (#8919) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/rabbitmq (#8918) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/elasticsearch (#8917) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.726 to 1.12.759 in /modules/dynalite (#8915) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/k3s (#8914) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/questdb (#8910) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/openfga (#8909) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /examples (#8908) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/jdbc-test (#8905) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/database-commons (#8906) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/consul (#8904) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /core (#8902) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/db2 (#8900) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/minio (#8901) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/kafka (#8899) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/solace (#8898) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/weaviate (#8897) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/vault (#8896) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/junit-jupiter (#8893) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/activemq (#8894) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/azure (#8892) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/orientdb (#8891) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/milvus (#8890) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/couchbase (#8888) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/jdbc (#8887) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/clickhouse (#8886) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/qdrant (#8884) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /modules/grafana (#8885) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/toxiproxy (#8883) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/mockserver (#8882) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/redpanda (#8881) @app/dependabot
* Bump io.micrometer:micrometer-registry-otlp from 1.13.1 to 1.13.2 in /modules/grafana (#8880) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/neo4j (#8878) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/cockroachdb (#8876) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.7.0.jre8-preview to 12.7.1.jre8-preview in /modules/mssqlserver (#8877) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/cassandra (#8875) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/chromadb (#8874) @app/dependabot
