### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
-    id 'me.champeau.gradle.japicmp' version '0.4.2' apply false
+    id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -120,13 +120,13 @@ dependencies {
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
     jarFileTestImplementation 'junit:junit:4.13.2'
-    jarFileTestImplementation 'org.assertj:assertj-core:3.25.3'
+    jarFileTestImplementation 'org.assertj:assertj-core:3.26.3'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'
 }
 

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testImplementation "org.seleniumhq.selenium:selenium-api:4.22.0"
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 
 test {

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.3.1.RELEASE"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.3"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.2"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.3"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.3"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 
 test {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit'
     testImplementation 'org.testcontainers:selenium'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 
 test {

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.3.6'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'io.codenotary:immudb4j:1.0.1'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:postgresql'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.18.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.13'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/examples/ollama-hugging-face/build.gradle
+++ b/examples/ollama-hugging-face/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:ollama'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'io.rest-assured:rest-assured:5.4.0'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testng:testng:7.5.1'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 
 test {

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 
 test {

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'com.jcraft:jsch:0.1.55'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }
 

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.6.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'com.azure:azure-cosmos:4.60.0'
+    testImplementation 'com.azure:azure-cosmos:4.62.0'
 }

--- a/modules/chromadb/build.gradle
+++ b/modules/chromadb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.763'
     testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.763'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.39.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.43.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
-    testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.1'
+    testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.2'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
 }
 

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Grafana"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.1'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.28.1")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.30.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.6")
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 
 test {

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.5")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.30.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'org.influxdb:influxdb-java:2.24'
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.influxdb:influxdb-java:2.24'
     testImplementation "com.influxdb:influxdb-client-java:6.12.0"
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    implementation platform('org.junit:junit-bom:5.10.2')
+    implementation platform('org.junit:junit-bom:5.10.3')
     implementation 'org.junit.jupiter:junit-jupiter-api'
 
     testImplementation project(':mysql')

--- a/modules/k6/build.gradle
+++ b/modules/k6/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: k6"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.7.1'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
-    testImplementation 'software.amazon.awssdk:s3:2.26.24'
+    testImplementation 'software.amazon.awssdk:s3:2.26.25'
     testImplementation 'org.assertj:assertj-core:3.25.3'
 }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:8.5.10")
+    testImplementation("io.minio:minio:8.5.11")
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("org.mongodb:mongodb-driver-sync:5.1.2")
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.16'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.18'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Nginx"
 dependencies {
     api project(':testcontainers')
     compileOnly 'org.jetbrains:annotations:24.1.0'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/ollama/build.gradle
+++ b/modules/ollama/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'io.qdrant:client:1.9.1'
+    testImplementation 'io.qdrant:client:1.10.0'
     testImplementation platform('io.grpc:grpc-bom:1.65.1')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.6.6'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.6.8'
     testFixturesImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.32'
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.7.0'
+    testImplementation 'org.apache.kafka:kafka-clients:3.7.1'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'
     testImplementation project(':nginx')
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     shaded 'org.awaitility:awaitility:4.2.1'
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'com.solacesystems:sol-jcsmp:10.23.0'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.24.1'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.3'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.3'
 
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Weaviate"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.weaviate:client:4.8.1'
 }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.8'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 
 test {

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'org.slf4j:slf4j-api:1.7.36'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump software.amazon.awssdk:s3 from 2.26.24 to 2.26.25 in /modules/localstack (#8999) @app/dependabot
* Bump me.champeau.gradle.japicmp from 0.4.2 to 0.4.3 in /smoke-test (#8940) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.26.3 in /smoke-test (#8935) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.10.2 to 5.10.3 in /smoke-test (#8933) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.2 to 5.10.3 in /smoke-test (#8932) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/selenium (#8927) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.6.6 to 3.6.8 in /modules/r2dbc (#8923) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/solr (#8922) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/hivemq (#8921) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/mongodb (#8920) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/k6 (#8913) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /examples (#8908) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/nginx (#8907) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /core (#8902) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/dynalite (#8903) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/weaviate (#8897) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/localstack (#8895) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/grafana (#8889) @app/dependabot
* Bump io.micrometer:micrometer-registry-otlp from 1.13.1 to 1.13.2 in /modules/grafana (#8880) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/influxdb (#8879) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /modules/ollama (#8865) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.39.0 to 26.43.0 in /modules/gcloud (#8864) @app/dependabot
* Bump org.junit:junit-bom from 5.10.2 to 5.10.3 in /modules/junit-jupiter (#8863) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /modules/redpanda (#8860) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /modules/vault (#8859) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /modules/chromadb (#8858) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /modules/consul (#8857) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.23.0 to 10.24.1 in /modules/solace (#8856) @app/dependabot
* Bump com.azure:azure-cosmos from 4.60.0 to 4.62.0 in /modules/azure (#8855) @app/dependabot
* Bump io.qdrant:client from 1.9.1 to 1.10.0 in /modules/qdrant (#8839) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.10.2 to 1.10.3 in /modules/spock (#8838) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.2 to 1.10.3 in /modules/spock (#8837) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.1 to 3.7.1 in /examples (#8835) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.28.1 to 4.30.0 in /modules/hivemq (#8833) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.10.2 to 5.10.3 in /modules/hivemq (#8832) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.7.0 to 3.7.1 in /modules/kafka (#8829) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.7.0 to 3.7.1 in /modules/redpanda (#8827) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.16 to 4.4.18 in /modules/neo4j (#8826) @app/dependabot
* Bump io.minio:minio from 8.5.10 to 8.5.11 in /modules/minio (#8825) @app/dependabot
