### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -99,7 +99,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded 'com.google.guava:guava:33.2.0-jre'
+    shaded 'com.google.guava:guava:33.2.1-jre'
     shaded "org.yaml:snakeyaml:1.33"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.3.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.3.2.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.3.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.3.2.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.3"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.2"

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.3.1.RELEASE"
+    api "io.lettuce:lettuce-core:6.3.2.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.30"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.6.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.7.1'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.30"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.30"
+    testCompileOnly "org.projectlombok:lombok:1.18.34"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.34"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:3.7.1'
     testImplementation 'org.assertj:assertj-core:3.26.3'

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.json:json:20231013'
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.1'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.26.3'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.13'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.18'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.1.0'
+    implementation 'redis.clients:jedis:5.1.3'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.1.0'
+    implementation 'redis.clients:jedis:5.1.3'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:5.1.0'
+    implementation 'redis.clients:jedis:5.1.3'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.30"
-    annotationProcessor "org.projectlombok:lombok:1.18.30"
+    compileOnly "org.projectlombok:lombok:1.18.34"
+    annotationProcessor "org.projectlombok:lombok:1.18.34"
 
     implementation 'org.apache.solr:solr-solrj:8.11.3'
 

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation "org.apache.activemq:activemq-client:6.1.2"
-    testImplementation "org.apache.activemq:artemis-jakarta-client:2.33.0"
+    testImplementation "org.apache.activemq:artemis-jakarta-client:2.35.0"
 }
 
 test {

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.763'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.763'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.765'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.765'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.influxdb:influxdb-java:2.24'
-    testImplementation "com.influxdb:influxdb-client-java:6.12.0"
+    testImplementation "com.influxdb:influxdb-client-java:7.1.0"
 }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.12.1'
+    testImplementation 'io.fabric8:kubernetes-client:6.13.1'
     testImplementation 'io.kubernetes:client-java:20.0.1-legacy'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
     testImplementation 'software.amazon.awssdk:s3:2.26.25'
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Milvus"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.25.3'
+    testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation('io.milvus:milvus-sdk-java:2.4.2') {
         exclude(group: 'org.testcontainers', module: 'milvus')
         exclude(group: 'org.testcontainers', module: 'junit-jupiter')

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.3'
 
     testCompileOnly 'org.jetbrains:annotations:24.1.0'

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:452'
+    testRuntimeOnly 'io.trino:trino-jdbc:453'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.trino:trino-jdbc from 452 to 453 in /modules/trino (#9003) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.763 to 1.12.765 in /modules/dynalite (#9001) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/localstack (#8895) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.3 in /modules/milvus (#8890) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.2 to 1.10.3 in /modules/spock (#8837) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.33.0 to 2.35.0 in /modules/activemq (#8836) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.1 to 3.7.1 in /examples (#8835) @app/dependabot
* Bump org.projectlombok:lombok from 1.18.30 to 1.18.34 in /examples (#8834) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.13 to 4.4.18 in /examples (#8819) @app/dependabot
* Bump io.kubernetes:client-java from 20.0.1-legacy to 21.0.0-legacy in /modules/k3s (#8811) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 2.0.1 to 2.0.2 (#8788) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.21 to 7.17.22 in /modules/elasticsearch (#8781) @app/dependabot
* Bump org.apache.pulsar:pulsar-client from 3.2.3 to 3.3.0 in /modules/pulsar (#8769) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.12.1 to 6.13.0 in /modules/k3s (#8754) @app/dependabot
* Bump com.google.guava:guava from 33.2.0-jre to 33.2.1-jre in /core (#8752) @app/dependabot
* Bump com.azure:azure-cosmos from 4.60.0 to 4.61.1 in /modules/azure (#8748) @app/dependabot
* Bump com.google.guava:guava from 33.2.0-jre to 33.2.1-jre in /modules/jdbc-test (#8741) @app/dependabot
* Bump io.lettuce:lettuce-core from 6.3.1.RELEASE to 6.3.2.RELEASE in /examples (#8717) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.6.1 to 3.7.0 in /examples (#8716) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.1 to 42.7.3 in /examples (#8712) @app/dependabot
* Bump redis.clients:jedis from 5.1.0 to 5.1.3 in /examples (#8711) @app/dependabot
* Bump com.google.code.gson:gson from 2.10.1 to 2.11.0 in /examples (#8710) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.0 in /modules/vault (#8695) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.0 in /modules/localstack (#8677) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.12.0 to 7.1.0 in /modules/influxdb (#8651) @app/dependabot
* Bump org.json:json from 20231013 to 20240303 in /examples (#8419) @app/dependabot
