### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v3.10.1
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v3.10.1
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v3.10.1
         with:
           title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    implementation 'org.json:json:20231013'
+    implementation 'org.json:json:20240303'
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:postgresql'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:5.1.3'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:5.1.3'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:5.1.3'
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.14.3"
-    testImplementation "org.elasticsearch.client:transport:7.17.21"
+    testImplementation "org.elasticsearch.client:transport:7.17.22"
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:5.1.2'
+    testImplementation 'redis.clients:jedis:5.1.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.13.1'
-    testImplementation 'io.kubernetes:client-java:20.0.1-legacy'
+    testImplementation 'io.kubernetes:client-java:21.0.0-legacy'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'dev.openfga:openfga-sdk:0.4.2'
+    testImplementation 'dev.openfga:openfga-sdk:0.5.0'
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.17.6"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.0.1"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.0.2"
         classpath "org.gradle.toolchains:foojay-resolver:0.8.0"
     }
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.kubernetes:client-java from 20.0.1-legacy to 21.0.0-legacy in /modules/k3s (#8811) @app/dependabot
* Bump peter-evans/create-pull-request from 6.0.5 to 6.1.0 (#8803) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 2.0.1 to 2.0.2 (#8788) @app/dependabot
* Bump dev.openfga:openfga-sdk from 0.4.2 to 0.5.0 in /modules/openfga (#8783) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.21 to 7.17.22 in /modules/elasticsearch (#8781) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.13 to 4.4.17 in /examples (#8755) @app/dependabot
* Bump com.azure:azure-cosmos from 4.60.0 to 4.61.1 in /modules/azure (#8748) @app/dependabot
* Bump redis.clients:jedis from 5.1.2 to 5.1.3 in /modules/junit-jupiter (#8726) @app/dependabot
* Bump com.google.code.gson:gson from 2.10.1 to 2.11.0 in /examples (#8710) @app/dependabot
* Bump org.assertj:assertj-core from 3.25.3 to 3.26.0 in /modules/milvus (#8682) @app/dependabot
* Bump org.json:json from 20231013 to 20240303 in /examples (#8419) @app/dependabot
