### PR TITLE
Combined dependencies PR

### DIFF
--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.3.2.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.3"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.2"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.3"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.3"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'com.hazelcast:hazelcast:5.3.6'
+    testImplementation 'com.hazelcast:hazelcast:5.3.8'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testCompileOnly "org.projectlombok:lombok:1.18.34"
     testAnnotationProcessor "org.projectlombok:lombok:1.18.34"
     testImplementation 'org.testcontainers:kafka'
-    testImplementation 'org.apache.kafka:kafka-clients:3.7.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.18.1'
+    testImplementation 'io.nats:jnats:2.19.1'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'

--- a/examples/ollama-hugging-face/build.gradle
+++ b/examples/ollama-hugging-face/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
-    testImplementation 'io.rest-assured:rest-assured:5.4.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }
 
 test {

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.apache.curator:curator-framework:5.6.0'
+    testImplementation 'org.apache.curator:curator-framework:5.7.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':jdbc')
 
-    api 'com.google.guava:guava:33.2.0-jre'
+    api 'com.google.guava:guava:33.2.1-jre'
     api 'org.apache.commons:commons-lang3:3.15.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.7.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("org.apache.pulsar:pulsar-bom:3.2.3")
+    testImplementation platform("org.apache.pulsar:pulsar-bom:3.3.0")
     testImplementation 'org.apache.pulsar:pulsar-client'
     testImplementation 'org.apache.pulsar:pulsar-client-admin'
     testImplementation 'org.assertj:assertj-core:3.26.3'

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.32'
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.7.1'
+    testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'io.weaviate:client:4.8.1'
+    testImplementation 'io.weaviate:client:4.8.2'
 }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.8'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump ch.qos.logback:logback-classic from 1.3.8 to 1.3.14 in /smoke-test (#9022) @app/dependabot
* Bump io.nats:jnats from 2.18.1 to 2.19.1 in /examples (#9019) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.7.1 to 3.8.0 in /modules/redpanda (#9017) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.4.0 to 5.5.0 in /examples (#9016) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.7.1 to 3.8.0 in /examples (#9015) @app/dependabot
* Bump org.apache.pulsar:pulsar-bom from 3.2.3 to 3.3.0 in /modules/pulsar (#9013) @app/dependabot
* Bump org.apache.curator:curator-framework from 5.6.0 to 5.7.0 in /examples (#9011) @app/dependabot
* Bump io.weaviate:client from 4.8.1 to 4.8.2 in /modules/weaviate (#9012) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.2 to 5.10.3 in /examples (#9010) @app/dependabot
* Bump com.hazelcast:hazelcast from 5.3.6 to 5.3.8 in /examples (#9009) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.7.1 to 3.8.0 in /modules/kafka (#9008) @app/dependabot
* Bump com.azure:azure-cosmos from 4.60.0 to 4.61.1 in /modules/azure (#8748) @app/dependabot
* Bump com.google.guava:guava from 33.2.0-jre to 33.2.1-jre in /modules/jdbc-test (#8741) @app/dependabot
