### PR TITLE
Fix URI decode.

### DIFF
--- a/core/src/jarFileTest/java/org/testcontainers/AbstractJarFileTest.java
+++ b/core/src/jarFileTest/java/org/testcontainers/AbstractJarFileTest.java
@@ -1,6 +1,8 @@
 package org.testcontainers;
 
 import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -14,7 +16,8 @@ public abstract class AbstractJarFileTest {
     static {
         try {
             Path jarFilePath = Paths.get(System.getProperty("jarFile"));
-            URI jarFileUri = new URI("jar", jarFilePath.toUri().toString(), null);
+            String decodedPath = URLDecoder.decode(jarFilePath.toUri().toString(), StandardCharsets.UTF_8.name());
+            URI jarFileUri = new URI("jar", decodedPath, null);
             FileSystem fileSystem = FileSystems.newFileSystem(jarFileUri, Collections.emptyMap());
             root = fileSystem.getPath("/");
         } catch (Exception e) {


### PR DESCRIPTION
Fix URI decode of the created jar file when the directory on the path contains spaces.
Example of the URI string producing error:
`C:\Users\Krunoslav%20Magazin\projects\testcontainers-java\core\build\libs\testcontainers.jar`

After decode fix resulting URI is:
`C:\Users\Krunoslav Magazin\projects\testcontainers-java\core\build\libs\testcontainers.jar`
-> with space and jar file can be found.

#9025 bug report