### PR TITLE
Pass options to compose down command

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ComposeCommand.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeCommand.java
@@ -1,0 +1,37 @@
+package org.testcontainers.containers;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Set;
+
+class ComposeCommand {
+
+    static String getDownCommand(ComposeDelegate.ComposeVersion composeVersion, Set<String> options) {
+        String composeOptions = optionsAsString(options);
+        if (composeOptions == null || composeOptions.equals("")) {
+            return composeVersion == ComposeDelegate.ComposeVersion.V1 ? "down" : "compose down";
+        }
+        String cmd = composeVersion == ComposeDelegate.ComposeVersion.V1 ? "%s down" : "compose %s down";
+        return String.format(cmd, composeOptions);
+    }
+
+    static String getUpCommand(ComposeDelegate.ComposeVersion composeVersion, Set<String> options) {
+        String composeOptions = optionsAsString(options);
+        if (composeOptions == null || composeOptions.equals("")) {
+            return composeVersion == ComposeDelegate.ComposeVersion.V1 ? "up -d" : "compose up -d";
+        }
+        String cmd = composeVersion == ComposeDelegate.ComposeVersion.V1 ? "%s up -d" : "compose %s up -d";
+        return String.format(cmd, composeOptions);
+    }
+
+    private static String optionsAsString(final Set<String> options) {
+        String optionsString = String.join(" ", options);
+        if (!optionsString.isEmpty()) {
+            // ensures that there is a space between the options and 'up' if options are passed.
+            return optionsString;
+        } else {
+            // otherwise two spaces would appear between 'docker-compose' and 'up'
+            return StringUtils.EMPTY;
+        }
+    }
+}

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -161,7 +161,8 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 this.composeDelegate.getAmbassadorContainer().stop();
 
                 // Kill the services using docker
-                String cmd = "compose down";
+                String cmd = ComposeCommand.getDownCommand(ComposeDelegate.ComposeVersion.V2, this.options);
+
                 if (removeVolumes) {
                     cmd += " -v";
                 }

--- a/core/src/main/java/org/testcontainers/containers/ComposeDelegate.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeDelegate.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.output.OutputFrame;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
@@ -146,7 +145,7 @@ class ComposeDelegate {
             .distinct()
             .collect(Collectors.joining(" "));
 
-        String command = getUpCommand(optionsAsString(options));
+        String command = ComposeCommand.getUpCommand(this.composeVersion, options);
 
         if (build) {
             command += " --build";
@@ -162,25 +161,6 @@ class ComposeDelegate {
 
         // Run the docker compose container, which starts up the services
         runWithCompose(localCompose, command, env, fileCopyInclusions);
-    }
-
-    private String getUpCommand(String options) {
-        if (options == null || options.equals("")) {
-            return this.composeVersion == ComposeVersion.V1 ? "up -d" : "compose up -d";
-        }
-        String cmd = this.composeVersion == ComposeVersion.V1 ? "%s up -d" : "compose %s up -d";
-        return String.format(cmd, options);
-    }
-
-    private String optionsAsString(final Set<String> options) {
-        String optionsString = options.stream().collect(Collectors.joining(" "));
-        if (optionsString.length() != 0) {
-            // ensures that there is a space between the options and 'up' if options are passed.
-            return optionsString;
-        } else {
-            // otherwise two spaces would appear between 'docker-compose' and 'up'
-            return StringUtils.EMPTY;
-        }
     }
 
     void waitUntilServiceStarted(boolean tailChildContainers) {

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -167,7 +167,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 this.composeDelegate.getAmbassadorContainer().stop();
 
                 // Kill the services using docker-compose
-                String cmd = "down";
+                String cmd = ComposeCommand.getDownCommand(ComposeDelegate.ComposeVersion.V1, this.options);
 
                 if (removeVolumes) {
                     cmd += " -v";

--- a/core/src/test/java/org/testcontainers/containers/ComposeProfilesOptionTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeProfilesOptionTest.java
@@ -1,0 +1,35 @@
+package org.testcontainers.containers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class ComposeProfilesOptionTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Boolean[] local() {
+        return new Boolean[] { Boolean.TRUE, Boolean.FALSE };
+    }
+
+    @Parameterized.Parameter
+    public boolean local;
+
+    public static final File COMPOSE_FILE = new File("src/test/resources/compose-profile-option/compose-test.yml");
+
+    @Test
+    public void testProfileOption() {
+        try (
+            ComposeContainer compose = new ComposeContainer(COMPOSE_FILE)
+                .withOptions("--profile=cache")
+                .withLocalCompose(true)
+        ) {
+            compose.start();
+            assertThat(compose.listChildContainers()).hasSize(1);
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/containers/DockerComposeProfilesOptionTest.java
+++ b/core/src/test/java/org/testcontainers/containers/DockerComposeProfilesOptionTest.java
@@ -1,0 +1,35 @@
+package org.testcontainers.containers;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(Parameterized.class)
+public class DockerComposeProfilesOptionTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Boolean[] local() {
+        return new Boolean[] { Boolean.TRUE, Boolean.FALSE };
+    }
+
+    @Parameterized.Parameter
+    public boolean local;
+
+    public static final File COMPOSE_FILE = new File("src/test/resources/compose-profile-option/compose-test.yml");
+
+    @Test
+    public void testProfileOption() {
+        try (
+            DockerComposeContainer<?> compose = new DockerComposeContainer<>(COMPOSE_FILE)
+                .withOptions("--profile=cache")
+                .withLocalCompose(this.local)
+        ) {
+            compose.start();
+            assertThat(compose.listChildContainers()).hasSize(1);
+        }
+    }
+}

--- a/core/src/test/resources/compose-profile-option/compose-test.yml
+++ b/core/src/test/resources/compose-profile-option/compose-test.yml
@@ -1,0 +1,11 @@
+services:
+  redis:
+    image: redis
+    profiles:
+      - cache
+  db:
+    image: mysql:8.0.36
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: "true"
+    profiles:
+      - db


### PR DESCRIPTION
Currently, setting options are supported for the `up` command. But, the same are not passed to the `down` command. Support for this has been added. Also, adding an example using `--profiles`.

Fixes #5041
