### PR TITLE
Set MariaDB user when is not root

### DIFF
--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -75,7 +75,10 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         );
 
         addEnv("MYSQL_DATABASE", databaseName);
-        addEnv("MYSQL_USER", username);
+
+        if (!MARIADB_ROOT_USER.equalsIgnoreCase(this.username)) {
+            addEnv("MYSQL_USER", username);
+        }
         if (password != null && !password.isEmpty()) {
             addEnv("MYSQL_PASSWORD", password);
             addEnv("MYSQL_ROOT_PASSWORD", password);

--- a/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
@@ -132,6 +132,18 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
         }
     }
 
+    @Test
+    public void testEmptyPasswordWithRootUser() throws SQLException {
+        try (MariaDBContainer<?> mysql = new MariaDBContainer<>("mariadb:11.2.4").withUsername("root")) {
+            mysql.start();
+
+            ResultSet resultSet = performQuery(mysql, "SELECT 1");
+            int resultSetInt = resultSet.getInt(1);
+
+            assertThat(resultSetInt).isEqualTo(1);
+        }
+    }
+
     private void assertThatCustomIniFileWasUsed(MariaDBContainer<?> mariadb) throws SQLException {
         try (ResultSet resultSet = performQuery(mariadb, "SELECT @@GLOBAL.innodb_max_undo_log_size")) {
             long result = resultSet.getLong(1);


### PR DESCRIPTION
Currently, setting MYSQL_USER with root won't start the container.
