### PR TITLE
Fix missing null check for JDBC init script

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -360,9 +361,11 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     /**
      * Load init script content and apply it to the database if initScriptPath is set
      */
-    protected void runInitScriptIfRequired() {
-        initScriptPaths.forEach(path -> ScriptUtils.runInitScript(getDatabaseDelegate(), path));
-    }
+protected void runInitScriptIfRequired() {
+    initScriptPaths.stream()
+        .filter(Objects::nonNull)
+        .forEach(path -> ScriptUtils.runInitScript(getDatabaseDelegate(), path));
+}
 
     public void setParameters(Map<String, String> parameters) {
         this.parameters = parameters;

--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -361,11 +361,12 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     /**
      * Load init script content and apply it to the database if initScriptPath is set
      */
-protected void runInitScriptIfRequired() {
-    initScriptPaths.stream()
-        .filter(Objects::nonNull)
-        .forEach(path -> ScriptUtils.runInitScript(getDatabaseDelegate(), path));
-}
+    protected void runInitScriptIfRequired() {
+        initScriptPaths
+            .stream()
+            .filter(Objects::nonNull)
+            .forEach(path -> ScriptUtils.runInitScript(getDatabaseDelegate(), path));
+    }
 
     public void setParameters(Map<String, String> parameters) {
         this.parameters = parameters;

--- a/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
@@ -11,6 +11,7 @@ import java.util.logging.Level;
 import java.util.logging.LogManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
     static {
@@ -56,6 +57,16 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
             ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
             String result = resultSet.getString(1);
             assertThat(result).as("max_connections should not be overriden").isNotEqualTo("42");
+        }
+    }
+
+    @Test
+    public void testMissingInitScript() {
+        try (
+            PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(PostgreSQLTestImages.POSTGRES_TEST_IMAGE)
+                .withInitScript(null)
+        ) {
+            assertThatNoException().isThrownBy(postgres::start);
         }
     }
 


### PR DESCRIPTION
In PR https://github.com/testcontainers/testcontainers-java/pull/7680, a new feature was introduced to support multiple init scripts in JdbcDatabaseContainer. However, during this update, a critical null check was inadvertently removed from the `JdbcDatabaseContainer.runInitScriptIfRequired` method. This check was responsible for ignoring null values for the `initScript` parameter.

As a result, when no init script is defined, a null value is passed to `ScriptUtils.runInitScript`, leading to an exception being thrown and preventing the database container from starting.

This commit reinstates the missing null check, ensuring that undefined init scripts are properly handled. Additionally, a test has been added to verify that the issue is resolved and the database container can start without an init script.
