### PR TITLE
Timeout when starting oracle-free

### DIFF
--- a/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
+++ b/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
@@ -31,9 +31,9 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     static final int ORACLE_PORT = 1521;
 
-    private static final int DEFAULT_STARTUP_TIMEOUT_SECONDS = 60;
+    private int startupTimeoutSeconds = 60;
 
-    private static final int DEFAULT_CONNECT_TIMEOUT_SECONDS = 60;
+    private int connectTimeoutSeconds = 60;
 
     // Container defaults
     static final String DEFAULT_DATABASE_NAME = "freepdb1";
@@ -70,9 +70,9 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
         waitingFor(
             Wait
                 .forLogMessage(".*DATABASE IS READY TO USE!.*\\s", 1)
-                .withStartupTimeout(Duration.ofSeconds(DEFAULT_STARTUP_TIMEOUT_SECONDS))
+                .withStartupTimeout(Duration.ofSeconds(startupTimeoutSeconds))
         );
-        withConnectTimeoutSeconds(DEFAULT_CONNECT_TIMEOUT_SECONDS);
+        withConnectTimeoutSeconds(connectTimeoutSeconds);
         addExposedPorts(ORACLE_PORT);
     }
 
@@ -134,6 +134,18 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
         }
         this.username = username;
         return self();
+    }
+
+    @Override
+    public OracleContainer withStartupTimeoutSeconds(int startupTimeoutSeconds) {
+        this.startupTimeoutSeconds = startupTimeoutSeconds;
+        return super.withStartupTimeoutSeconds(startupTimeoutSeconds);
+    }
+
+    @Override
+    public OracleContainer withConnectTimeoutSeconds(int connectTimeoutSeconds) {
+        this.connectTimeoutSeconds = connectTimeoutSeconds;
+        return super.withConnectTimeoutSeconds(connectTimeoutSeconds);
     }
 
     @Override


### PR DESCRIPTION
Replaced the use of the constants DEFAULT_STARTUP_TIMEOUT_SECONDS and DEFAULT_CONNECT_TIMEOUT_SECONDS by parameters set using methods withStartupTimeoutSeconds(int) and withConnectTimeoutSeconds(int).

These two methods were overridden to keep a copy of the value before setting the value in JdbcDatabaseContainer since those values private and the getter methods for those values are deprecated.

<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
