### PR TITLE
Add on-demand execution on windows

### DIFF
--- a/.github/workflows/ci-windows-trigger.yml
+++ b/.github/workflows/ci-windows-trigger.yml
@@ -1,0 +1,27 @@
+name: windows-test command dispatch
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  windows-test-command-trigger:
+    permissions:
+      pull-requests: write  # for peter-evans/slash-command-dispatch to create PR reaction
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger windows-test command
+        uses: peter-evans/slash-command-dispatch@13bc09769d122a64f75aa5037256f6f2d78be8c4 # v4.0.0
+        with:
+          token: ${{ secrets.WINDOWS_WORKERS_TOKEN }}
+          # The command to trigger the pipeline: e.g. /windows-test
+          # The command name must match the name of the repository_dispatch.type in 'ci-windows.yml' workflow, using '-command' as suffix. E.g. 'windows-test-command'
+          commands: windows-test
+          issue-type: pull-request
+          # The user that owns the above token must belong to the elevated role of 'Maintainers'
+          permission: maintain
+          reactions: false

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -32,6 +32,8 @@ on:
       - 'README.md'
       - 'RELEASING.md'
       - '.sdkmanrc'
+  repository_dispatch:
+    types: [windows-test-command]
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.head_ref || github.sha }}"
@@ -42,7 +44,7 @@ permissions:
 
 jobs:
   core:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event.client_payload.slash_command.command == 'windows-test' }}
     runs-on: self-hosted
     permissions:
       checks: write


### PR DESCRIPTION
Test should execute on `main` branch or in PRs if `/windows-test`
is added in comments.
