### PR TITLE
Add ConfluentKafkaContainer

### DIFF
--- a/docs/modules/kafka.md
+++ b/docs/modules/kafka.md
@@ -4,9 +4,12 @@ Testcontainers can be used to automatically instantiate and manage [Apache Kafka
 
 Currently, two different Kafka images are supported:
 
-* `org.testcontainers.containers.KafkaContainer` supports 
+* `org.testcontainers.kafka.ConfluentKafkaContainer` supports 
 [confluentinc/cp-kafka](https://hub.docker.com/r/confluentinc/cp-kafka/)
 * `org.testcontainers.kafka.KafkaContainer` supports [apache/kafka](https://hub.docker.com/r/apache/kafka/) and [apache/kafka-native](https://hub.docker.com/r/apache/kafka-native/)
+
+!!! note
+    The `org.testcontainers.containers.KafkaContainer` is deprecated.
 
 ## Benefits
 
@@ -15,7 +18,10 @@ Currently, two different Kafka images are supported:
 
 ## Example
 
+### Using org.testcontainers.containers.KafkaContainer
+
 Create a `KafkaContainer` to use it in your tests:
+
 <!--codeinclude-->
 [Creating a KafkaContainer](../../modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java) inside_block:constructorWithVersion
 <!--/codeinclude-->
@@ -28,12 +34,23 @@ Now your tests or any other process running on your machine can get access to ru
 [Bootstrap Servers](../../modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java) inside_block:getBootstrapServers
 <!--/codeinclude-->
 
-## Options
+### Using org.testcontainers.kafka.ConfluentKafkaContainer
 
-!!! note 
-    The options below are only available for `org.testcontainers.containers.KafkaContainer`
+!!! note
+    Compatible with `confluentinc/cp-kafka` images version `7.4.0` and later.
+
+Create a `ConfluentKafkaContainer` to use it in your tests:
+
+<!--codeinclude-->
+[Creating a ConlfuentKafkaContainer](../../modules/kafka/src/test/java/org/testcontainers/kafka/ConfluentKafkaContainerTest.java) inside_block:constructorWithVersion
+<!--/codeinclude-->
+
+## Options
         
 ### <a name="zookeeper"></a> Using external Zookeeper
+
+!!! note
+    Only available for `org.testcontainers.containers.KafkaContainer`
 
 If for some reason you want to use an externally running Zookeeper, then just pass its location during construction:
 <!--codeinclude-->
@@ -42,19 +59,21 @@ If for some reason you want to use an externally running Zookeeper, then just pa
 
 ### Using Kraft mode
 
-KRaft mode was declared production ready in 3.3.1 (confluentinc/cp-kafka:7.3.x)" 
+!!! note
+    Only available for `org.testcontainers.containers.KafkaContainer`
+
+KRaft mode was declared production ready in 3.3.1 (confluentinc/cp-kafka:7.3.x) 
 
 <!--codeinclude-->
 [Kraft mode](../../modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java) inside_block:withKraftMode
 <!--/codeinclude-->
 
-See the [versions interoperability matrix](https://docs.confluent.io/platform/current/installation/versions-interoperability.html) for more details. 
+See the [versions interoperability matrix](https://docs.confluent.io/platform/current/installation/versions-interoperability.html) for more details.
 
-## Register listeners
+### Register listeners
 
 There are scenarios where additional listeners are needed because the consumer/producer can be in another
-container in the same network or a different process where the port to connect differs from the default 
-exposed port `9093`. E.g [Toxiproxy](../../modules/toxiproxy/).
+container in the same network or a different process where the port to connect differs from the default exposed port. E.g [Toxiproxy](../../modules/toxiproxy/).
 
 <!--codeinclude-->
 [Register additional listener](../../modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java) inside_block:registerListener

--- a/docs/modules/kafka.md
+++ b/docs/modules/kafka.md
@@ -9,7 +9,8 @@ Currently, two different Kafka images are supported:
 * `org.testcontainers.kafka.KafkaContainer` supports [apache/kafka](https://hub.docker.com/r/apache/kafka/) and [apache/kafka-native](https://hub.docker.com/r/apache/kafka-native/)
 
 !!! note
-    The `org.testcontainers.containers.KafkaContainer` is deprecated.
+    `org.testcontainers.containers.KafkaContainer` is deprecated.
+    Please use `org.testcontainers.kafka.ConfluentKafkaContainer` or `org.testcontainers.kafka.KafkaContainer` instead, depending on the used image.
 
 ## Benefits
 

--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -26,7 +26,11 @@ import java.util.stream.Collectors;
  *     <li>Kafka: 9093</li>
  *     <li>Zookeeper: 2181</li>
  * </ul>
+ *
+ * @deprecated use {@link org.testcontainers.kafka.ConfluentKafkaContainer} or
+ * {@link org.testcontainers.kafka.KafkaContainer} instead
  */
+@Deprecated
 public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
@@ -2,7 +2,6 @@ package org.testcontainers.kafka;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
@@ -23,10 +22,6 @@ public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaCont
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
 
-    private static final int KAFKA_PORT = 9092;
-
-    private static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
-
     private final Set<String> listeners = new HashSet<>();
 
     private final Set<Supplier<String>> advertisedListeners = new HashSet<>();
@@ -39,11 +34,11 @@ public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaCont
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        withExposedPorts(KAFKA_PORT);
+        withExposedPorts(KafkaHelper.KAFKA_PORT);
         withEnv(KafkaHelper.envVars());
 
-        withCommand("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
-        waitingFor(Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1));
+        withCommand(KafkaHelper.COMMAND);
+        waitingFor(KafkaHelper.WAIT_STRATEGY);
     }
 
     @Override
@@ -75,7 +70,7 @@ public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaCont
         command += String.format("export KAFKA_ADVERTISED_LISTENERS=%s\n", kafkaAdvertisedListeners);
 
         command += "/etc/confluent/docker/run \n";
-        copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+        copyFileToContainer(Transferable.of(command, 0777), KafkaHelper.STARTER_SCRIPT);
     }
 
     public ConfluentKafkaContainer withListener(String listener) {
@@ -91,6 +86,6 @@ public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaCont
     }
 
     public String getBootstrapServers() {
-        return String.format("%s:%s", getHost(), getMappedPort(KAFKA_PORT));
+        return String.format("%s:%s", getHost(), getMappedPort(KafkaHelper.KAFKA_PORT));
     }
 }

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
@@ -1,0 +1,93 @@
+package org.testcontainers.kafka;
+
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Testcontainers implementation for Confluent Kafka.
+ * <p>
+ * Supported image: {@code confluentinc/cp-kafka}
+ * <p>
+ * Exposed ports: 9092
+ */
+public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaContainer> {
+
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
+
+    private static final int KAFKA_PORT = 9092;
+
+    private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
+
+    private static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
+
+    private static final String DEFAULT_CLUSTER_ID = "4L6g3nShT-eMCtK--X86sw";
+
+    public ConfluentKafkaContainer(String imageName) {
+        this(DockerImageName.parse(imageName));
+    }
+
+    public ConfluentKafkaContainer(DockerImageName dockerImageName) {
+        super(dockerImageName);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+
+        withExposedPorts(KAFKA_PORT);
+        withEnv("CLUSTER_ID", DEFAULT_CLUSTER_ID);
+
+        withEnv(
+            "KAFKA_LISTENERS",
+            "PLAINTEXT://0.0.0.0:" + KAFKA_PORT + ",BROKER://0.0.0.0:9093, CONTROLLER://0.0.0.0:9094"
+        );
+        withEnv("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT");
+        withEnv("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER");
+        withEnv("KAFKA_PROCESS_ROLES", "broker,controller");
+        withEnv("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER");
+
+        withEnv("KAFKA_NODE_ID", "1");
+        withEnv("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF);
+        withEnv("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", DEFAULT_INTERNAL_TOPIC_RF);
+        withEnv("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF);
+        withEnv("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", DEFAULT_INTERNAL_TOPIC_RF);
+        withEnv("KAFKA_LOG_FLUSH_INTERVAL_MESSAGES", Long.MAX_VALUE + "");
+        withEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0");
+
+        withCommand("sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+        waitingFor(Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1));
+    }
+
+    @Override
+    protected void configure() {
+        String firstNetworkAlias = getNetworkAliases().stream().findFirst().orElse(null);
+        String networkAlias = getNetwork() != null ? firstNetworkAlias : "localhost";
+        String controllerQuorumVoters = String.format("%s@%s:9094", getEnvMap().get("KAFKA_NODE_ID"), networkAlias);
+        withEnv("KAFKA_CONTROLLER_QUORUM_VOTERS", controllerQuorumVoters);
+    }
+
+    @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo) {
+        String brokerAdvertisedListener = String.format(
+            "BROKER://%s:%s",
+            containerInfo.getConfig().getHostName(),
+            "9093"
+        );
+        List<String> advertisedListeners = new ArrayList<>();
+        advertisedListeners.add("PLAINTEXT://" + getBootstrapServers());
+        advertisedListeners.add(brokerAdvertisedListener);
+        String kafkaAdvertisedListeners = String.join(",", advertisedListeners);
+        String command = "#!/bin/bash\n";
+        // exporting KAFKA_ADVERTISED_LISTENERS with the container hostname
+        command += String.format("export KAFKA_ADVERTISED_LISTENERS=%s\n", kafkaAdvertisedListeners);
+
+        command += "/etc/confluent/docker/run \n";
+        copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+    }
+
+    public String getBootstrapServers() {
+        return String.format("%s:%s", getHost(), getMappedPort(KAFKA_PORT));
+    }
+}

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
@@ -73,12 +73,63 @@ public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaCont
         copyFileToContainer(Transferable.of(command, 0777), KafkaHelper.STARTER_SCRIPT);
     }
 
+    /**
+     * Add a listener in the format {@code host:port}.
+     * Host will be included as a network alias.
+     * <p>
+     * Use it to register additional connections to the Kafka broker within the same container network.
+     * <p>
+     * The listener will be added to the list of default listeners.
+     * <p>
+     * Default listeners:
+     * <ul>
+     *     <li>0.0.0.0:9092</li>
+     *     <li>0.0.0.0:9093</li>
+     *     <li>0.0.0.0:9094</li>
+     * </ul>
+     * <p>
+     * The listener will be added to the list of default advertised listeners.
+     * <p>
+     * Default advertised listeners:
+     * <ul>
+     *      <li>{@code container.getConfig().getHostName():9092}</li>
+     *      <li>{@code container.getHost():container.getMappedPort(9093)}</li>
+     * </ul>
+     * @param listener a listener with format {@code host:port}
+     * @return this {@link ConfluentKafkaContainer} instance
+     */
     public ConfluentKafkaContainer withListener(String listener) {
         this.listeners.add(listener);
         this.advertisedListeners.add(() -> listener);
         return this;
     }
 
+    /**
+     * Add a listener in the format {@code host:port} and a {@link Supplier} for the advertised listener.
+     * Host from listener will be included as a network alias.
+     * <p>
+     * Use it to register additional connections to the Kafka broker from outside the container network
+     * <p>
+     * The listener will be added to the list of default listeners.
+     * <p>
+     * Default listeners:
+     * <ul>
+     *     <li>0.0.0.0:9092</li>
+     *     <li>0.0.0.0:9093</li>
+     *     <li>0.0.0.0:9094</li>
+     * </ul>
+     * <p>
+     * The {@link Supplier} will be added to the list of default advertised listeners.
+     * <p>
+     * Default advertised listeners:
+     * <ul>
+     *      <li>{@code container.getConfig().getHostName():9092}</li>
+     *      <li>{@code container.getHost():container.getMappedPort(9093)}</li>
+     * </ul>
+     * @param listener a supplier that will provide a listener
+     * @param advertisedListener a supplier that will provide a listener
+     * @return this {@link ConfluentKafkaContainer} instance
+     */
     public ConfluentKafkaContainer withListener(String listener, Supplier<String> advertisedListener) {
         this.listeners.add(listener);
         this.advertisedListeners.add(advertisedListener);

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
@@ -1,6 +1,8 @@
 package org.testcontainers.kafka;
 
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,9 +13,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
-public class KafkaHelper {
-
-    private static final int KAFKA_PORT = 9092;
+class KafkaHelper {
 
     private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
 
@@ -21,7 +21,19 @@ public class KafkaHelper {
 
     private static final String PROTOCOL_PREFIX = "TC";
 
-    public static Map<String, String> envVars() {
+    static final int KAFKA_PORT = 9092;
+
+    static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
+
+    static final String[] COMMAND = {
+        "sh",
+        "-c",
+        "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
+    };
+
+    static final WaitStrategy WAIT_STRATEGY = Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1);
+
+    static Map<String, String> envVars() {
         Map<String, String> envVars = new HashMap<>();
         envVars.put("CLUSTER_ID", DEFAULT_CLUSTER_ID);
 
@@ -47,7 +59,7 @@ public class KafkaHelper {
         return envVars;
     }
 
-    public static void resolveListeners(GenericContainer<?> kafkaContainer, Set<String> listenersSuppliers) {
+    static void resolveListeners(GenericContainer<?> kafkaContainer, Set<String> listenersSuppliers) {
         Set<String> listeners = Arrays
             .stream(kafkaContainer.getEnvMap().get("KAFKA_LISTENERS").split(","))
             .collect(Collectors.toSet());
@@ -76,7 +88,7 @@ public class KafkaHelper {
         kafkaContainer.getEnvMap().put("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", kafkaListenerSecurityProtocolMap);
     }
 
-    public static List<String> resolveAdvertisedListeners(Set<Supplier<String>> listenerSuppliers) {
+    static List<String> resolveAdvertisedListeners(Set<Supplier<String>> listenerSuppliers) {
         List<String> advertisedListeners = new ArrayList<>();
         List<Supplier<String>> listenersToTransform = new ArrayList<>(listenerSuppliers);
         for (int i = 0; i < listenersToTransform.size(); i++) {

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
@@ -1,0 +1,91 @@
+package org.testcontainers.kafka;
+
+import org.testcontainers.containers.GenericContainer;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+public class KafkaHelper {
+
+    private static final int KAFKA_PORT = 9092;
+
+    private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
+
+    private static final String DEFAULT_CLUSTER_ID = "4L6g3nShT-eMCtK--X86sw";
+
+    private static final String PROTOCOL_PREFIX = "TC";
+
+    public static Map<String, String> envVars() {
+        Map<String, String> envVars = new HashMap<>();
+        envVars.put("CLUSTER_ID", DEFAULT_CLUSTER_ID);
+
+        envVars.put(
+            "KAFKA_LISTENERS",
+            "PLAINTEXT://0.0.0.0:" + KAFKA_PORT + ",BROKER://0.0.0.0:9093,CONTROLLER://0.0.0.0:9094"
+        );
+        envVars.put(
+            "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+            "BROKER:PLAINTEXT,PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+        );
+        envVars.put("KAFKA_INTER_BROKER_LISTENER_NAME", "BROKER");
+        envVars.put("KAFKA_PROCESS_ROLES", "broker,controller");
+        envVars.put("KAFKA_CONTROLLER_LISTENER_NAMES", "CONTROLLER");
+
+        envVars.put("KAFKA_NODE_ID", "1");
+        envVars.put("KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_TRANSACTION_STATE_LOG_MIN_ISR", DEFAULT_INTERNAL_TOPIC_RF);
+        envVars.put("KAFKA_LOG_FLUSH_INTERVAL_MESSAGES", Long.MAX_VALUE + "");
+        envVars.put("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0");
+        return envVars;
+    }
+
+    public static void resolveListeners(GenericContainer<?> kafkaContainer, Set<String> listenersSuppliers) {
+        Set<String> listeners = Arrays
+            .stream(kafkaContainer.getEnvMap().get("KAFKA_LISTENERS").split(","))
+            .collect(Collectors.toSet());
+        Set<String> listenerSecurityProtocolMap = Arrays
+            .stream(kafkaContainer.getEnvMap().get("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP").split(","))
+            .collect(Collectors.toSet());
+
+        List<String> listenersToTransform = new ArrayList<>(listenersSuppliers);
+        for (int i = 0; i < listenersToTransform.size(); i++) {
+            String protocol = String.format("%s-%d", PROTOCOL_PREFIX, i);
+            String listener = listenersToTransform.get(i);
+            String listenerPort = listener.split(":")[1];
+            String listenerProtocol = String.format("%s://0.0.0.0:%s", protocol, listenerPort);
+            String protocolMap = String.format("%s:PLAINTEXT", protocol);
+            listeners.add(listenerProtocol);
+            listenerSecurityProtocolMap.add(protocolMap);
+
+            String host = listener.split(":")[0];
+            kafkaContainer.withNetworkAliases(host);
+        }
+
+        String kafkaListeners = String.join(",", listeners);
+        String kafkaListenerSecurityProtocolMap = String.join(",", listenerSecurityProtocolMap);
+
+        kafkaContainer.getEnvMap().put("KAFKA_LISTENERS", kafkaListeners);
+        kafkaContainer.getEnvMap().put("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", kafkaListenerSecurityProtocolMap);
+    }
+
+    public static List<String> resolveAdvertisedListeners(Set<Supplier<String>> listenerSuppliers) {
+        List<String> advertisedListeners = new ArrayList<>();
+        List<Supplier<String>> listenersToTransform = new ArrayList<>(listenerSuppliers);
+        for (int i = 0; i < listenersToTransform.size(); i++) {
+            Supplier<String> listenerSupplier = listenersToTransform.get(i);
+            String protocol = String.format("%s-%d", PROTOCOL_PREFIX, i);
+            String listener = listenerSupplier.get();
+            String listenerProtocol = String.format("%s://%s", protocol, listener);
+            advertisedListeners.add(listenerProtocol);
+        }
+        return advertisedListeners;
+    }
+}

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
@@ -71,8 +71,9 @@ class KafkaHelper {
         for (int i = 0; i < listenersToTransform.size(); i++) {
             String protocol = String.format("%s-%d", PROTOCOL_PREFIX, i);
             String listener = listenersToTransform.get(i);
+            String listenerHost = listener.split(":")[0];
             String listenerPort = listener.split(":")[1];
-            String listenerProtocol = String.format("%s://0.0.0.0:%s", protocol, listenerPort);
+            String listenerProtocol = String.format("%s://%s:%s", protocol, listenerHost, listenerPort);
             String protocolMap = String.format("%s:PLAINTEXT", protocol);
             listeners.add(listenerProtocol);
             listenerSecurityProtocolMap.add(protocolMap);

--- a/modules/kafka/src/test/java/org/testcontainers/KCatContainer.java
+++ b/modules/kafka/src/test/java/org/testcontainers/KCatContainer.java
@@ -1,0 +1,16 @@
+package org.testcontainers;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.images.builder.Transferable;
+
+public class KCatContainer extends GenericContainer<KCatContainer> {
+
+    public KCatContainer() {
+        super("confluentinc/cp-kcat:7.4.1");
+        withCreateContainerCmdModifier(cmd -> {
+            cmd.withEntrypoint("sh");
+        });
+        withCopyToContainer(Transferable.of("Message produced by kcat"), "/data/msgs.txt");
+        withCommand("-c", "tail -f /dev/null");
+    }
+}

--- a/modules/kafka/src/test/java/org/testcontainers/kafka/ConfluentKafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/kafka/ConfluentKafkaContainerTest.java
@@ -1,0 +1,15 @@
+package org.testcontainers.kafka;
+
+import org.junit.Test;
+import org.testcontainers.AbstractKafka;
+
+public class ConfluentKafkaContainerTest extends AbstractKafka {
+
+    @Test
+    public void testUsage() throws Exception {
+        try (ConfluentKafkaContainer kafka = new ConfluentKafkaContainer("confluentinc/cp-kafka:7.4.0")) {
+            kafka.start();
+            testKafkaFunctionality(kafka.getBootstrapServers());
+        }
+    }
+}

--- a/modules/kafka/src/test/java/org/testcontainers/kafka/ConfluentKafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/kafka/ConfluentKafkaContainerTest.java
@@ -2,14 +2,64 @@ package org.testcontainers.kafka;
 
 import org.junit.Test;
 import org.testcontainers.AbstractKafka;
+import org.testcontainers.KCatContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.SocatContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ConfluentKafkaContainerTest extends AbstractKafka {
 
     @Test
     public void testUsage() throws Exception {
-        try (ConfluentKafkaContainer kafka = new ConfluentKafkaContainer("confluentinc/cp-kafka:7.4.0")) {
+        try ( // constructorWithVersion {
+            ConfluentKafkaContainer kafka = new ConfluentKafkaContainer("confluentinc/cp-kafka:7.4.0")
+            // }
+        ) {
             kafka.start();
             testKafkaFunctionality(kafka.getBootstrapServers());
+        }
+    }
+
+    @Test
+    public void testUsageWithListener() throws Exception {
+        try (
+            Network network = Network.newNetwork();
+            // registerListener {
+            ConfluentKafkaContainer kafka = new ConfluentKafkaContainer("confluentinc/cp-kafka:7.4.0")
+                .withListener("kafka:19092")
+                .withNetwork(network);
+            // }
+            KCatContainer kcat = new KCatContainer().withNetwork(network)
+        ) {
+            kafka.start();
+            kcat.start();
+
+            kcat.execInContainer("kcat", "-b", "kafka:19092", "-t", "msgs", "-P", "-l", "/data/msgs.txt");
+            String stdout = kcat
+                .execInContainer("kcat", "-b", "kafka:19092", "-C", "-t", "msgs", "-c", "1")
+                .getStdout();
+
+            assertThat(stdout).contains("Message produced by kcat");
+        }
+    }
+
+    @Test
+    public void testUsageWithListenerFromProxy() throws Exception {
+        try (
+            Network network = Network.newNetwork();
+            // registerListenerFromProxy {
+            SocatContainer socat = new SocatContainer().withNetwork(network).withTarget(2000, "kafka", 19092);
+            ConfluentKafkaContainer kafka = new ConfluentKafkaContainer("confluentinc/cp-kafka:7.4.0")
+                .withListener("kafka:19092", () -> socat.getHost() + ":" + socat.getMappedPort(2000))
+                .withNetwork(network)
+            // }
+        ) {
+            socat.start();
+            kafka.start();
+
+            String bootstrapServers = String.format("%s:%s", socat.getHost(), socat.getMappedPort(2000));
+            testKafkaFunctionality(bootstrapServers);
         }
     }
 }


### PR DESCRIPTION
* Deprecate `org.testcontainers.containers.KafkaContainer`
* Add `org.testcontainers.kafka.ConfluentKafkaContainer` which works with `confluentinc/cp-kafka` images with version `7.4.0` or later.
* `KafkaHelper` container common env vars, command, wait strategy to be shared with `org.testcontainers.kafka.KafkaContainer`
