### PR TITLE
fix: no match for platform in manifest when containerd is enabled

### DIFF
--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.exception.DockerClientException;
 import com.github.dockerjava.api.exception.InternalServerErrorException;
+import com.github.dockerjava.api.exception.NotFoundException;
 import com.google.common.util.concurrent.Futures;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -155,7 +156,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
         throws InterruptedException {
         try {
             return pullImageCmd.exec(new TimeLimitedLoggedPullImageResultCallback(logger)).awaitCompletion();
-        } catch (DockerClientException e) {
+        } catch (DockerClientException | NotFoundException e) {
             // Try to fallback to x86
             return pullImageCmd
                 .withPlatform("linux/amd64")


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

**Given** a Docker image that only has `linux/amd64` as a platform

**When** I try to pull it with testcontainers on an ARM Mac

**Then** I should be able to pull it without any problem

Current behavior:
Trying to pull such an image causes `com.github.dockerjava.api.exception.NotFoundException`.
If the image manifest in the registry doesn't contain the platform it is pulled for, the registry will return 404 with the following body: `{"message":"no match for platform in manifest: not found"}`. Docker-java will throw `com.github.dockerjava.api.exception.NotFoundException` in such case (instead of `DockerClientException`), so the fallback to x86 will never be attempted.


This change fixes that. I didn't dig into how to write a proper test for that and I didn't find any tests covering the exception scenario, unfortunately. Nevertheless, this will make the fallback actually work, I built it locally with the patch and confirmed it works.

Fixes #9214