### PR TITLE
Remove ru.yandex image & jdbc driver support

### DIFF
--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'ru.yandex.clickhouse:clickhouse-jdbc:0.3.2'
+    testRuntimeOnly 'com.clickhouse:clickhouse-jdbc:0.6.4:all'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/clickhouse/src/test/java/org/testcontainers/junit/clickhouse/SimpleClickhouseTest.java
+++ b/modules/clickhouse/src/test/java/org/testcontainers/junit/clickhouse/SimpleClickhouseTest.java
@@ -26,7 +26,6 @@ public class SimpleClickhouseTest extends AbstractContainerDatabaseTest {
     public static Object[][] data() {
         return new Object[][] { //
             { ClickhouseTestImages.CLICKHOUSE_IMAGE },
-            { ClickhouseTestImages.YANDEX_CLICKHOUSE_IMAGE },
         };
     }
 


### PR DESCRIPTION
We are updating the ClickHouse module with a new ClickHouse image and removing the `ru.yandex` image and old JDBC driver.