### PR TITLE
Update commons-compress to 1.27.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api 'org.apache.commons:commons-compress:1.27.1'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
This is to address https://github.com/advisories/GHSA-4265-ccf5-phj5

while opening the PR the following was mentioned but it seems at least for this lib the process isn't working as the old version of 1.24 is more than a year old now.

> Dependency Upgrades:
> Please do not open a pull request to update only a version dependency. Existing process will perform
> the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
> your pull request is very welcome.
