### PR TITLE
Fix register listeners in RedpandaContainer

### DIFF
--- a/docs/modules/redpanda.md
+++ b/docs/modules/redpanda.md
@@ -63,6 +63,26 @@ Client using the new registered listener:
 [Produce/Consume via new listener](../../modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java) inside_block:produceConsumeMessage
 <!--/codeinclude-->
 
+The following examples shows how to register a proxy as a new listener in `RedpandaContainer`:
+
+Use `SocatContainer` to create the proxy
+
+<!--codeinclude-->
+[Create Proxy](../../modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java) inside_block:createProxy
+<!--/codeinclude-->
+
+Register the listener and advertised listener
+
+<!--codeinclude-->
+[Register Listener](../../modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java) inside_block:registerListenerAndAdvertisedListener
+<!--/codeinclude-->
+
+Client using the new registered listener:
+
+<!--codeinclude-->
+[Produce/Consume via new listener](../../modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java) inside_block:produceConsumeMessageFromProxy
+<!--/codeinclude-->
+
 ## Adding this module to your project dependencies
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -7,4 +7,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
+++ b/modules/redpanda/src/main/java/org/testcontainers/redpanda/RedpandaContainer.java
@@ -71,7 +71,10 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
 
     private final List<String> superusers = new ArrayList<>();
 
+    @Deprecated
     private final Set<Supplier<Listener>> listenersValueSupplier = new HashSet<>();
+
+    private final Map<String, Supplier<String>> listeners = new HashMap<>();
 
     public RedpandaContainer(String image) {
         this(DockerImageName.parse(image));
@@ -109,6 +112,7 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
             .map(Supplier::get)
             .map(Listener::getAddress)
             .forEach(this::withNetworkAliases);
+        this.listeners.keySet().stream().map(listener -> listener.split(":")[0]).forEach(this::withNetworkAliases);
     }
 
     @SneakyThrows
@@ -212,10 +216,71 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
      * </ul>
      * @param listenerSupplier a supplier that will provide a listener
      * @return this {@link RedpandaContainer} instance
+     * @deprecated use {@link #withListener(String, Supplier)} instead
      */
+    @Deprecated
     public RedpandaContainer withListener(Supplier<String> listenerSupplier) {
         String[] parts = listenerSupplier.get().split(":");
         this.listenersValueSupplier.add(() -> new Listener(parts[0], Integer.parseInt(parts[1])));
+        return this;
+    }
+
+    /**
+     * Add a listener in the format {@code host:port}.
+     * Host will be included as a network alias.
+     * <p>
+     * Use it to register additional connections to the Kafka broker within the same container network.
+     * <p>
+     * The listener will be added to the list of default listeners.
+     * <p>
+     * Default listeners:
+     * <ul>
+     *     <li>0.0.0.0:9092</li>
+     *     <li>0.0.0.0:9093</li>
+     * </ul>
+     * <p>
+     * The listener will be added to the list of default advertised listeners.
+     * <p>
+     * Default advertised listeners:
+     * <ul>
+     *      <li>{@code container.getConfig().getHostName():9092}</li>
+     *      <li>{@code container.getHost():container.getMappedPort(9093)}</li>
+     * </ul>
+     * @param listener a listener with format {@code host:port}
+     * @return this {@link RedpandaContainer} instance
+     */
+    public RedpandaContainer withListener(String listener) {
+        this.listeners.put(listener, () -> listener);
+        return this;
+    }
+
+    /**
+     * Add a listener in the format {@code host:port} and a {@link Supplier} for the advertised listener.
+     * Host from listener will be included as a network alias.
+     * <p>
+     * Use it to register additional connections to the Kafka broker from outside the container network
+     * <p>
+     * The listener will be added to the list of default listeners.
+     * <p>
+     * Default listeners:
+     * <ul>
+     *     <li>0.0.0.0:9092</li>
+     *     <li>0.0.0.0:9093</li>
+     * </ul>
+     * <p>
+     * The {@link Supplier} will be added to the list of default advertised listeners.
+     * <p>
+     * Default advertised listeners:
+     * <ul>
+     *      <li>{@code container.getConfig().getHostName():9092}</li>
+     *      <li>{@code container.getHost():container.getMappedPort(9093)}</li>
+     * </ul>
+     * @param listener a supplier that will provide a listener
+     * @param advertisedListener a supplier that will provide a listener
+     * @return this {@link RedpandaContainer} instance
+     */
+    public RedpandaContainer withListener(String listener, Supplier<String> advertisedListener) {
+        this.listeners.put(listener, advertisedListener);
         return this;
     }
 
@@ -233,6 +298,12 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
     }
 
     private Transferable getRedpandaFile(Configuration cfg) {
+        Map<String, Object> kafkaApi = new HashMap<>();
+        kafkaApi.put("authenticationMethod", this.authenticationMethod);
+        kafkaApi.put("enableAuthorization", this.enableAuthorization);
+        kafkaApi.put("advertisedHost", getHost());
+        kafkaApi.put("advertisedPort", getMappedPort(9092));
+
         List<Map<String, Object>> listeners =
             this.listenersValueSupplier.stream()
                 .map(Supplier::get)
@@ -244,19 +315,44 @@ public class RedpandaContainer extends GenericContainer<RedpandaContainer> {
                     return listenerMap;
                 })
                 .collect(Collectors.toList());
-
-        Map<String, Object> kafkaApi = new HashMap<>();
-        kafkaApi.put("authenticationMethod", this.authenticationMethod);
-        kafkaApi.put("enableAuthorization", this.enableAuthorization);
-        kafkaApi.put("advertisedHost", getHost());
-        kafkaApi.put("advertisedPort", getMappedPort(9092));
         kafkaApi.put("listeners", listeners);
+
+        List<Map<String, Object>> kafkaListeners =
+            this.listeners.keySet()
+                .stream()
+                .map(listener -> {
+                    Map<String, Object> listenerMap = new HashMap<>();
+                    listenerMap.put("name", listener.split(":")[0]);
+                    listenerMap.put("address", listener.split(":")[0]);
+                    listenerMap.put("port", listener.split(":")[1]);
+                    listenerMap.put("authentication_method", this.authenticationMethod);
+                    return listenerMap;
+                })
+                .collect(Collectors.toList());
+
+        List<Map<String, Object>> kafkaAdvertisedListeners =
+            this.listeners.entrySet()
+                .stream()
+                .map(entry -> {
+                    String advertisedListener = entry.getValue().get();
+                    Map<String, Object> listenerMap = new HashMap<>();
+                    listenerMap.put("name", entry.getKey().split(":")[0]);
+                    listenerMap.put("address", advertisedListener.split(":")[0]);
+                    listenerMap.put("port", advertisedListener.split(":")[1]);
+                    return listenerMap;
+                })
+                .collect(Collectors.toList());
+
+        Map<String, Object> kafka = new HashMap<>();
+        kafka.put("listeners", kafkaListeners);
+        kafka.put("advertisedListeners", kafkaAdvertisedListeners);
 
         Map<String, Object> schemaRegistry = new HashMap<>();
         schemaRegistry.put("authenticationMethod", this.schemaRegistryAuthenticationMethod);
 
         Map<String, Object> root = new HashMap<>();
         root.put("kafkaApi", kafkaApi);
+        root.put("kafka", kafka);
         root.put("schemaRegistry", schemaRegistry);
 
         String file = resolveTemplate(cfg, "redpanda.yaml.ftl", root);

--- a/modules/redpanda/src/main/resources/testcontainers/redpanda.yaml.ftl
+++ b/modules/redpanda/src/main/resources/testcontainers/redpanda.yaml.ftl
@@ -27,6 +27,12 @@ redpanda:
       port: ${listener.port}
       authentication_method: ${listener.authentication_method}
 </#list>
+<#list kafka.listeners as listener>
+    - address: ${listener.address}
+      name: ${listener.name}
+      port: ${listener.port}
+      authentication_method: ${listener.authentication_method}
+</#list>
 
   advertised_kafka_api:
     - address: ${ kafkaApi.advertisedHost }
@@ -38,6 +44,11 @@ redpanda:
 <#list kafkaApi.listeners as listener>
     - address: ${listener.address}
       name: ${listener.address}
+      port: ${listener.port}
+</#list>
+<#list kafka.advertisedListeners as listener>
+    - address: ${listener.address}
+      name: ${listener.name}
       port: ${listener.port}
 </#list>
 


### PR DESCRIPTION
Previously, RedpandaContainer allowed to register a new listener
using a Supplier and the new listener's host was also added as a network
alias. However, if the listener's host was an IP the listener configuration
was wrong and didn't allow to connect to the broker.
