### PR TITLE
Use awaitility in Kafka module

### DIFF
--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -6,4 +6,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
+    testImplementation 'org.awaitility:awaitility:4.2.0'
 }

--- a/modules/kafka/src/test/java/org/testcontainers/AbstractKafka.java
+++ b/modules/kafka/src/test/java/org/testcontainers/AbstractKafka.java
@@ -14,7 +14,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.rnorth.ducttape.unreliables.Unreliables;
+import org.awaitility.Awaitility;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -101,24 +101,17 @@ public class AbstractKafka {
 
             producer.send(new ProducerRecord<>(topicName, "testcontainers", "rulezzz")).get();
 
-            Unreliables.retryUntilTrue(
-                10,
-                TimeUnit.SECONDS,
-                () -> {
+            Awaitility
+                .await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
                     ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
-
-                    if (records.isEmpty()) {
-                        return false;
-                    }
 
                     assertThat(records)
                         .hasSize(1)
                         .extracting(ConsumerRecord::topic, ConsumerRecord::key, ConsumerRecord::value)
                         .containsExactly(tuple(topicName, "testcontainers", "rulezzz"));
-
-                    return true;
-                }
-            );
+                });
 
             consumer.unsubscribe();
         }


### PR DESCRIPTION
Remove usage of `Unreliables` from `duct-tape` lib.
