### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/moby-latest.yml
+++ b/.github/workflows/moby-latest.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Notify to Slack on failures
         if: failure()
         id: slack
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v1.27.0
         with:
           payload: |
             {

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v3.10.1
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Update Gradle Wrapper
-        uses: gradle-update/update-gradle-wrapper-action@0407394b9d173dfc9cf5695f9f560fef6d61a5fe # v1.0.13
+        uses: gradle-update/update-gradle-wrapper-action@9268373d69bd0974b6318eb3b512b8e025060bbe # v1.0.13
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels: dependencies

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v3.10.1
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v3.10.1
         with:
           title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:33.2.1-jre'
+        classpath 'com.google.guava:guava:33.3.1-jre'
         classpath 'com.github.tjni.captainhook:captain-hook:0.1.5'
     }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'redis.clients:jedis:5.1.3'
-    testImplementation 'com.rabbitmq:amqp-client:5.21.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.22.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -99,7 +99,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded 'com.google.guava:guava:33.2.1-jre'
+    shaded 'com.google.guava:guava:33.3.1-jre'
     shaded "org.yaml:snakeyaml:1.33"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation project(":mysql")
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.22.0"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.25.0"
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.3.2.RELEASE"
+    api "io.lettuce:lettuce-core:6.4.0.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.3"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.3"
-    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.10.3"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.0"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
     testImplementation 'org.assertj:assertj-core:3.26.3'

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.3.2.RELEASE"
+    api "io.lettuce:lettuce-core:6.4.0.RELEASE"
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.0"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.3"

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.3.2.RELEASE"
 
-    testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.3"
+    testImplementation "org.junit.jupiter:junit-jupiter-api:5.11.0"
     testImplementation "org.junit.jupiter:junit-jupiter-params:5.10.3"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.0"
     testImplementation project(":testcontainers")

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.3.2.RELEASE"
+    api "io.lettuce:lettuce-core:6.4.0.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('org.seleniumhq.selenium:selenium-bom:4.21.0')
+    implementation platform('org.seleniumhq.selenium:selenium-bom:4.25.0')
     implementation 'org.seleniumhq.selenium:selenium-remote-driver'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'com.hazelcast:hazelcast:5.3.8'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/linked-container/build.gradle
+++ b/examples/linked-container/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'org.json:json:20240303'
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:postgresql'
     testImplementation 'org.assertj:assertj-core:3.26.3'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.19.1'
+    testImplementation 'io.nats:jnats:2.20.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation 'io.nats:jnats:2.20.2'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.18'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }

--- a/examples/ollama-hugging-face/build.gradle
+++ b/examples/ollama-hugging-face/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.testcontainers:ollama'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }
 

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.1.3'
+    implementation 'redis.clients:jedis:5.1.5'
     implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:5.1.3'
+    implementation 'redis.clients:jedis:5.1.5'
     implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:5.1.3'
+    implementation 'redis.clients:jedis:5.1.5'
     implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:postgresql'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
 }
 
 test {

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation "org.apache.activemq:activemq-client:6.1.2"
-    testImplementation "org.apache.activemq:artemis-jakarta-client:2.35.0"
+    testImplementation "org.apache.activemq:artemis-jakarta-client:2.37.0"
 }
 
 test {

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'com.azure:azure-cosmos:4.62.0'
+    testImplementation 'com.azure:azure-cosmos:4.63.3'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.7.1'
+    testImplementation 'com.couchbase.client:java-client:3.7.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/databend/build.gradle
+++ b/modules/databend/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'com.databend:databend-jdbc:0.2.9'
+    testRuntimeOnly 'com.databend:databend-jdbc:0.3.2'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/dynalite/build.gradle
+++ b/modules/dynalite/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Dynalite (deprecated)"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.765'
-    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.765'
+    compileOnly 'com.amazonaws:aws-java-sdk-dynamodb:1.12.772'
+    testImplementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.772'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.14.3"
-    testImplementation "org.elasticsearch.client:transport:7.17.22"
+    testImplementation "org.elasticsearch.client:transport:7.17.24"
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
-    testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.2'
+    testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.4'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
 }
 

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.3")
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.30.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.32.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.8")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:24.1.0")
 
     shaded("org.apache.commons:commons-lang3:3.15.0")
-    shaded("commons-io:commons-io:2.16.1")
+    shaded("commons-io:commons-io:2.17.0")
     shaded("org.javassist:javassist:3.30.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.30.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.5.6")
+    testImplementation("ch.qos.logback:logback-classic:1.5.8")
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }
 

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':jdbc')
 
-    api 'com.google.guava:guava:33.2.1-jre'
+    api 'com.google.guava:guava:33.3.1-jre'
     api 'org.apache.commons:commons-lang3:3.15.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.26'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.30'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 }
 

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
-    testImplementation 'redis.clients:jedis:5.1.3'
+    testImplementation 'redis.clients:jedis:5.1.5'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.13.1'
-    testImplementation 'io.kubernetes:client-java:21.0.0-legacy'
+    testImplementation 'io.kubernetes:client-java:21.0.1-legacy'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.awaitility:awaitility:4.2.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
-    testImplementation 'software.amazon.awssdk:s3:2.26.25'
+    testImplementation 'software.amazon.awssdk:s3:2.28.6'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation('io.milvus:milvus-sdk-java:2.4.2') {
+    testImplementation('io.milvus:milvus-sdk-java:2.4.4') {
         exclude(group: 'org.testcontainers', module: 'milvus')
         exclude(group: 'org.testcontainers', module: 'junit-jupiter')
     }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:8.5.11")
+    testImplementation("io.minio:minio:8.5.12")
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.7.1.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre8'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -7,13 +7,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.asyncer:r2dbc-mysql:1.1.3'
+    compileOnly 'io.asyncer:r2dbc-mysql:1.3.0'
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.1.3'
+    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.3.0'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'dev.openfga:openfga-sdk:0.5.0'
+    testImplementation 'dev.openfga:openfga-sdk:0.7.0'
 }
 
 test {

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.4.0.24.05'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.5.0.24.07'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.4.0.24.05'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.5.0.24.07'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.32"
+    api "com.orientechnologies:orientdb-client:3.2.33"
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -7,5 +7,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.32"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.33"
 }

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("org.apache.pulsar:pulsar-bom:3.3.0")
+    testImplementation platform("org.apache.pulsar:pulsar-bom:3.3.1")
     testImplementation 'org.apache.pulsar:pulsar-client'
     testImplementation 'org.apache.pulsar:pulsar-client-admin'
     testImplementation 'org.assertj:assertj-core:3.26.3'

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.qdrant:client:1.10.0'
-    testImplementation platform('io.grpc:grpc-bom:1.65.1')
+    testImplementation platform('io.grpc:grpc-bom:1.68.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'
     testImplementation 'io.grpc:grpc-netty-shaded'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.questdb:questdb:8.1.1'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.questdb:questdb:7.3.9'
+    testImplementation 'org.questdb:questdb:8.1.1'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -15,6 +15,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.6.8'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.6.10'
     testFixturesImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.21.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.22.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -7,5 +7,5 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
-    testImplementation 'org.awaitility:awaitility:4.2.0'
+    testImplementation 'org.awaitility:awaitility:4.2.2'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
-    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.11.0'
 
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:4.0.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.3'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.10.3'

--- a/modules/timeplus/build.gradle
+++ b/modules/timeplus/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'com.timeplus:timeplus-native-jdbc:2.0.4'
+    testRuntimeOnly 'com.timeplus:timeplus-native-jdbc:2.0.5'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.7'
 
-    testImplementation 'redis.clients:jedis:5.1.3'
+    testImplementation 'redis.clients:jedis:5.1.5'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:453'
+    testRuntimeOnly 'io.trino:trino-jdbc:458'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'io.weaviate:client:4.8.2'
+    testImplementation 'io.weaviate:client:4.8.3'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.17.6"
+        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.18.1"
         classpath "com.gradle:common-custom-user-data-gradle-plugin:2.0.2"
         classpath "org.gradle.toolchains:foojay-resolver:0.8.0"
     }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
-    implementation 'org.slf4j:slf4j-api:1.7.36'
+    implementation 'org.slf4j:slf4j-api:2.0.16'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.weaviate:client from 4.8.2 to 4.8.3 in /modules/weaviate (#9278) @app/dependabot
* Bump commons-io:commons-io from 2.16.1 to 2.17.0 in /modules/hivemq (#9275) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.2 in /modules/kafka (#9274) @app/dependabot
* Bump io.milvus:milvus-sdk-java from 2.4.2 to 2.4.4 in /modules/milvus (#9273) @app/dependabot
* Bump com.google.guava:guava from 33.2.1-jre to 33.3.1-jre in /core (#9272) @app/dependabot
* Bump com.databend:databend-jdbc from 0.2.9 to 0.3.2 in /modules/databend (#9271) @app/dependabot
* Bump peter-evans/create-pull-request from 6.1.0 to 7.0.5 (#9270) @app/dependabot
* Bump io.trino:trino-jdbc from 453 to 458 in /modules/trino (#9268) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.26.25 to 2.28.6 in /modules/localstack (#9267) @app/dependabot
* Bump com.google.guava:guava from 33.2.1-jre to 33.3.1-jre in /modules/jdbc-test (#9266) @app/dependabot
* Bump com.google.guava:guava from 33.2.1-jre to 33.3.1-jre in /smoke-test (#9265) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.22.0 to 4.25.0 in /smoke-test (#9264) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.22.0 to 4.25.0 in /examples (#9263) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-bom from 4.21.0 to 4.25.0 in /examples (#9262) @app/dependabot
* Bump com.couchbase.client:java-client from 3.7.1 to 3.7.3 in /modules/couchbase (#9261) @app/dependabot
* Bump io.grpc:grpc-bom from 1.65.1 to 1.68.0 in /modules/qdrant (#9260) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.0 to 4.2.2 in /modules/redpanda (#9259) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.1.26 to 10.1.30 in /modules/jdbc (#9244) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.6.8 to 3.6.10 in /modules/r2dbc (#9240) @app/dependabot
* Bump com.gradle.enterprise:com.gradle.enterprise.gradle.plugin from 3.17.6 to 3.18.1 (#9239) @app/dependabot
* Bump com.azure:azure-cosmos from 4.62.0 to 4.63.3 in /modules/azure (#9238) @app/dependabot
* Bump com.amazonaws:aws-java-sdk-dynamodb from 1.12.765 to 1.12.772 in /modules/dynalite (#9237) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.21.0 to 5.22.0 in /modules/rabbitmq (#9236) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.22 to 7.17.24 in /modules/elasticsearch (#9233) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.21.0 to 5.22.0 in /core (#9232) @app/dependabot
* Bump gradle-update/update-gradle-wrapper-action from 1.0.20 to 2.0.0 (#9229) @app/dependabot
* Bump io.micrometer:micrometer-registry-otlp from 1.13.2 to 1.13.4 in /modules/grafana (#9211) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.14.3 to 8.15.1 in /modules/elasticsearch (#9209) @app/dependabot
* Bump com.timeplus:timeplus-native-jdbc from 2.0.4 to 2.0.5 in /modules/timeplus (#9203) @app/dependabot
* Bump org.questdb:questdb from 7.3.9 to 8.1.1 in /modules/questdb (#9202) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.5.6 to 1.5.8 in /modules/hivemq (#9201) @app/dependabot
* Bump dev.openfga:openfga-sdk from 0.5.0 to 0.7.0 in /modules/openfga (#9188) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.30.0 to 4.32.0 in /modules/hivemq (#9187) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.15.0 to 3.17.0 in /modules/hivemq (#9186) @app/dependabot
* Bump slackapi/slack-github-action from 1.26.0 to 1.27.0 (#9184) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.32 to 3.2.33 in /modules/orientdb (#9181) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.32 to 3.2.33 in /modules/orientdb (#9180) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.3 to 42.7.4 in /examples (#9177) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.35.0 to 2.37.0 in /modules/activemq (#9174) @app/dependabot
* Bump redis.clients:jedis from 5.1.3 to 5.1.5 in /core (#9165) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.3 to 42.7.4 in /modules/postgresql (#9163) @app/dependabot
* Bump redis.clients:jedis from 3.0.1 to 5.1.5 in /modules/toxiproxy (#9162) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.3 to 42.7.4 in /modules/cockroachdb (#9161) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.7.1.jre8-preview to 12.8.1.jre8 in /modules/mssqlserver (#9160) @app/dependabot
* Bump io.nats:jnats from 2.19.1 to 2.20.2 in /examples (#9159) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.3 to 42.7.4 in /modules/questdb (#9158) @app/dependabot
* Bump io.kubernetes:client-java from 21.0.0-legacy to 21.0.1-legacy in /modules/k3s (#9157) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.3 to 42.7.4 in /modules/spock (#9153) @app/dependabot
* Bump redis.clients:jedis from 5.1.3 to 5.1.5 in /modules/junit-jupiter (#9151) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.3 to 42.7.4 in /modules/junit-jupiter (#9150) @app/dependabot
* Bump redis.clients:jedis from 5.1.3 to 5.1.5 in /examples (#9146) @app/dependabot
* Bump io.minio:minio from 8.5.11 to 8.5.12 in /modules/minio (#9124) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-engine from 5.10.3 to 5.11.0 in /examples (#9115) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.10.3 to 5.11.0 in /smoke-test (#9114) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.10.3 to 5.11.0 in /smoke-test (#9113) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.3 to 5.11.0 in /examples (#9112) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-api from 5.10.3 to 5.11.0 in /examples (#9111) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.3 to 5.11.0 in /smoke-test (#9109) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.10.3 to 5.11.0 in /examples (#9108) @app/dependabot
* Bump org.junit.platform:junit-platform-testkit from 1.10.3 to 1.11.0 in /modules/spock (#9104) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.13.1 to 6.13.3 in /modules/k3s (#9102) @app/dependabot
* Bump org.apache.activemq:activemq-client from 6.1.2 to 6.1.3 in /modules/activemq (#9098) @app/dependabot
* Bump org.slf4j:slf4j-api from 1.7.36 to 2.0.16 in /smoke-test (#9092) @app/dependabot
* Bump io.qdrant:client from 1.10.0 to 1.11.0 in /modules/qdrant (#9080) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.4.0.24.05 to 23.5.0.24.07 in /modules/oracle-xe (#9065) @app/dependabot
* Bump io.asyncer:r2dbc-mysql from 1.1.3 to 1.3.0 in /modules/mysql (#9063) @app/dependabot
* Bump org.apache.pulsar:pulsar-bom from 3.3.0 to 3.3.1 in /modules/pulsar (#9062) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.4.0.24.05 to 23.5.0.24.07 in /modules/oracle-free (#9061) @app/dependabot
* Bump io.lettuce:lettuce-core from 6.3.2.RELEASE to 6.4.0.RELEASE in /smoke-test (#9038) @app/dependabot
* Bump io.lettuce:lettuce-core from 6.3.2.RELEASE to 6.4.0.RELEASE in /examples (#9030) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.16 to 4.4.17 in /modules/neo4j (#8749) @app/dependabot
