### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,7 +110,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'redis.clients:jedis:5.1.3'
+    testImplementation 'redis.clients:jedis:5.1.5'
     testImplementation 'com.rabbitmq:amqp-client:5.22.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.14.3"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.15.1"
     testImplementation "org.elasticsearch.client:transport:7.17.24"
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api(project(":testcontainers"))
     api("org.jetbrains:annotations:24.1.0")
 
-    shaded("org.apache.commons:commons-lang3:3.15.0")
+    shaded("org.apache.commons:commons-lang3:3.17.0")
     shaded("commons-io:commons-io:2.17.0")
     shaded("org.javassist:javassist:3.30.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(':jdbc')
 
     api 'com.google.guava:guava:33.3.1-jre'
-    api 'org.apache.commons:commons-lang3:3.15.0'
+    api 'org.apache.commons:commons-lang3:3.17.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'
 


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.14.3 to 8.15.1 in /modules/elasticsearch (#9209) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.15.0 to 3.17.0 in /modules/hivemq (#9186) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.15.0 to 3.17.0 in /modules/jdbc-test (#9185) @app/dependabot
* Bump redis.clients:jedis from 5.1.3 to 5.1.5 in /core (#9165) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.3 to 5.11.0 in /examples (#9112) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter-params from 5.10.3 to 5.11.0 in /smoke-test (#9109) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.13.1 to 6.13.3 in /modules/k3s (#9102) @app/dependabot
* Bump org.apache.activemq:activemq-client from 6.1.2 to 6.1.3 in /modules/activemq (#9098) @app/dependabot
* Bump io.qdrant:client from 1.10.0 to 1.11.0 in /modules/qdrant (#9080) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.16 to 4.4.17 in /modules/neo4j (#8749) @app/dependabot
