### PR TITLE
Added newNetwork method

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Network.java
+++ b/core/src/main/java/org/testcontainers/containers/Network.java
@@ -34,6 +34,14 @@ public interface Network extends AutoCloseable, TestRule {
         return builder().build();
     }
 
+    static Network newNetwork(boolean initialize) {
+        Network network = newNetwork();
+        if (initialize) {
+            network.getId();
+        }
+        return network;
+    }
+
     static NetworkImpl.NetworkImplBuilder builder() {
         return NetworkImpl.builder();
     }


### PR DESCRIPTION
# Summary

Added `Network.newNetwork(boolean initialize)` method to force initialization on creation.

# Purpose

When writing integration tests, I want to confirm that the network has been created before proceeding.

The current API requires two method calls:

```java
Network network = Network.newNetwork();
network.getId();
```

The new method would allow a single method call:

```java
Network network = Network.newNetwork(true);
```

# Real-world example

## Prometheus JMX Exporter integration tests

Using the existing `netNetwork` method:

```java
    @Verifyica.Prepare
    public static void prepare(ClassContext classContext) {
        if (classContext.testArgumentParallelism() == 1) {
            // Create the network at the test class scope
            // Get the id to force the network creation
            Network network = Network.newNetwork();
            network.getId();

            classContext.map().put(NETWORK, network);
        }
    }
```

Reference: 

https://github.com/prometheus/jmx_exporter/blob/89949413148adcfbc8ded41a2d931c8ef608ab2d/integration_test_suite/integration_tests/src/test/java/io/prometheus/jmx/test/common/AbstractExporterTest.java#L65-L75

---

Using the new `newNetwork(boolean initialize)` method:

```java
    @Verifyica.Prepare
    public static void prepare(ClassContext classContext) {
        if (classContext.testArgumentParallelism() == 1) {
            // Create the network at the test class scope
            classContext.map().put(NETWORK, Network.newNetwork(true);
        }
    }
```
