### PR TITLE
Increased Timeout

### DIFF
--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public class RemoteDockerImage extends LazyFuture<String> {
 
-    private static final Duration PULL_RETRY_TIME_LIMIT = Duration.ofMinutes(2);
+    private static final Duration PULL_RETRY_TIME_LIMIT = Duration.ofMinutes(3);
 
     @ToString.Exclude
     private Future<DockerImageName> imageNameFuture;

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -152,7 +152,7 @@ public class TestcontainersConfiguration {
     }
 
     public Integer getRyukTimeout() {
-        return Integer.parseInt(getEnvVarOrProperty("ryuk.container.timeout", "30"));
+        return Integer.parseInt(getEnvVarOrProperty("ryuk.container.timeout", "60"));
     }
 
     @Deprecated

--- a/docs/examples/junit4/generic/src/test/resources/testcontainers.properties
+++ b/docs/examples/junit4/generic/src/test/resources/testcontainers.properties
@@ -1,1 +1,2 @@
 image.substitutor=generic.support.TestSpecificImageNameSubstitutor
+ryuk.container.timeout=60


### PR DESCRIPTION
Fixes #9191 
I have increased the Pull TimeOut Configuration  by 3 mins.
PULL_RETRY_TIME_LIMIT = 3 in RemoteDockerImage.java



<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:



-->
