### PR TITLE
fix: await during DockerClientProviderStrategy test method

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -31,7 +31,6 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
@@ -207,14 +206,12 @@ public abstract class DockerClientProviderStrategy {
         }
 
         try (Socket socket = socketProvider.call()) {
-            Duration timeout = Duration.ofMillis(200);
             Awaitility
                 .await()
-                .atMost(TestcontainersConfiguration.getInstance().getClientPingTimeout(), TimeUnit.SECONDS)
-                .pollInterval(timeout)
+                .atMost(TestcontainersConfiguration.getInstance().getClientPingTimeout(), TimeUnit.SECONDS) // timeout after configured duration
+                .pollInterval(Duration.ofMillis(200)) // check state every 200ms
                 .pollDelay(Duration.ofSeconds(0)) // start checking immediately
-                .ignoreExceptionsInstanceOf(SocketTimeoutException.class)
-                .untilAsserted(() -> socket.connect(socketAddress, (int) timeout.toMillis()));
+                .untilAsserted(() -> socket.connect(socketAddress));
             return true;
         } catch (Exception e) {
             log.warn("DOCKER_HOST {} is not listening", dockerHost);


### PR DESCRIPTION
## Current behavior

The current test method performs the following socket test:
https://github.com/testcontainers/testcontainers-java/blob/e35705bd373bed4c9dd54643e89f71af1ef20e48/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java#L209-L223

Using the config `client.ping.timeout`

```txt
client.ping.timeout = 5 Specifies for how long Testcontainers will try to connect to the Docker client to obtain valid info about the client before giving up and trying next strategy, if applicable (in seconds).
```

Consider the following scenario where I set `client.ping.timeout=60` because my docker host and local machine are in different locales and I expect a network lag.

```java
Duration timeout = Duration.ofMillis(200);
Awaitility
    .await()
    .atMost(TestcontainersConfiguration.getInstance().getClientPingTimeout(), TimeUnit.SECONDS) // do not wait more than 60 seconds
    .pollInterval(timeout) // check status every 200ms
    .pollDelay(Duration.ofSeconds(0)) // start checking immediately
    .ignoreExceptionsInstanceOf(SocketTimeoutException.class) // Ignore the expected timeout
    .untilAsserted(() -> socket.connect(socketAddress, (int) timeout.toMillis())); // Try to connect and timeout after 200ms
```

Currently, the `client.ping.timeout` configuration is essentially ignored because the socket will always timeout before `atMost` is ever reached.

## Proposed Behavior

Instead, we should not provide a timeout to socket.connect.
If we take the same example as previously mentioned:

```java
Awaitility
    .await()
    .atMost(TestcontainersConfiguration.getInstance().getClientPingTimeout(), TimeUnit.SECONDS)  // do not wait more than 60 seconds
    .pollInterval(Duration.ofMillis(200)) // check state every 200ms
    .pollDelay(Duration.ofSeconds(0)) // start checking immediately
    .untilAsserted(() -> socket.connect(socketAddress)); // Try to connect with an unlimited timeout
```

If the `client.ping.timeout` is reached, then Awaitility will interrupt the Runnable and still throw a ConditionTimeoutException.