### PR TITLE
bugfix: rootless container provider not available on macOS

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/RootlessDockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/RootlessDockerClientProviderStrategy.java
@@ -79,7 +79,7 @@ public final class RootlessDockerClientProviderStrategy extends DockerClientProv
 
     @Override
     protected boolean isApplicable() {
-        return SystemUtils.IS_OS_LINUX && getSocketPath() != null && Files.exists(getSocketPath());
+        return (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) && getSocketPath() != null && Files.exists(getSocketPath());
     }
 
     @Override


### PR DESCRIPTION
Allows rootless container provider on macOS.