### PR TITLE
Pin OceanBase image

### DIFF
--- a/modules/oceanbase/src/main/java/org/testcontainers/oceanbase/OceanBaseCEContainerProvider.java
+++ b/modules/oceanbase/src/main/java/org/testcontainers/oceanbase/OceanBaseCEContainerProvider.java
@@ -9,7 +9,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class OceanBaseCEContainerProvider extends JdbcDatabaseContainerProvider {
 
-    private static final String DEFAULT_TAG = "4.2.1-lts";
+    private static final String DEFAULT_TAG = "4.2.1.8-108000022024072217";
 
     @Override
     public boolean supports(String databaseType) {


### PR DESCRIPTION
Current version 4.2.1-lts is a mutable image and it has been failing in CI.
We are pinning to tag 4.2.1.8-108000022024072217.
