### PR TITLE
Introduce new property to configure pull.timeout

### DIFF
--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -22,6 +22,7 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.ImageNameSubstitutor;
 import org.testcontainers.utility.LazyFuture;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -35,7 +36,9 @@ import java.util.concurrent.atomic.AtomicReference;
 @AllArgsConstructor(access = AccessLevel.PACKAGE)
 public class RemoteDockerImage extends LazyFuture<String> {
 
-    private static final Duration PULL_RETRY_TIME_LIMIT = Duration.ofMinutes(2);
+    private static final Duration PULL_RETRY_TIME_LIMIT = Duration.ofSeconds(
+        TestcontainersConfiguration.getInstance().getImagePullTimeout()
+    );
 
     @ToString.Exclude
     private Future<DockerImageName> imageNameFuture;

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -208,6 +208,10 @@ public class TestcontainersConfiguration {
         return Integer.parseInt(getEnvVarOrProperty("pull.pause.timeout", "30"));
     }
 
+    public Integer getImagePullTimeout() {
+        return Integer.parseInt(getEnvVarOrProperty("pull.timeout", "120"));
+    }
+
     public String getImageSubstitutorClassName() {
         return getEnvVarOrProperty("image.substitutor", null);
     }

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -90,6 +90,9 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 
 ## Customizing image pull behaviour
 
+> **pull.timeout = 120**
+> By default Testcontainers will timeout if pull takes more than this duration (in seconds)
+
 > **pull.pause.timeout = 30**
 > By default Testcontainers will abort the pull of an image if the pull appears stalled (no data transferred) for longer than this duration (in seconds).
 


### PR DESCRIPTION
Currently, the pull timeout is set to 2 minutes. This commit introduces
a new property `pull.timeout` to be configured in seconds.

Fixes #9191
