### PR TITLE
Parse docker compose file correctly when version is not declared

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -78,16 +78,16 @@ class ParsedDockerComposeFile {
 
     private void parseAndValidate() {
         final Map<String, ?> servicesMap;
-        if (composeFileContent.containsKey("version")) {
-            if ("2.0".equals(composeFileContent.get("version"))) {
-                log.warn(
-                    "Testcontainers may not be able to clean up networks spawned using Docker Compose v2.0 files. " +
-                    "Please see https://github.com/testcontainers/moby-ryuk/issues/2, and specify 'version: \"2.1\"' or " +
-                    "higher in {}",
-                    composeFileName
-                );
-            }
+        if (composeFileContent.containsKey("version") && "2.0".equals(composeFileContent.get("version"))) {
+            log.warn(
+                "Testcontainers may not be able to clean up networks spawned using Docker Compose v2.0 files. " +
+                "Please see https://github.com/testcontainers/moby-ryuk/issues/2, and specify 'version: \"2.1\"' or " +
+                "higher in {}",
+                composeFileName
+            );
+        }
 
+        if (composeFileContent.containsKey("services")) {
             final Object servicesElement = composeFileContent.get("services");
             if (servicesElement == null) {
                 log.debug(

--- a/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
@@ -112,6 +112,19 @@ public class ParsedDockerComposeFileValidationTest {
     }
 
     @Test
+    public void shouldObtainImageNamesV2WithNoVersionTag() {
+        File file = new File("src/test/resources/docker-compose-imagename-parsing-v2-no-version.yml");
+        ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file);
+        assertThat(parsedFile.getServiceNameToImageNames())
+            .as("all defined images are found")
+            .contains(
+                entry("mysql", Sets.newHashSet("mysql")),
+                entry("redis", Sets.newHashSet("redis")),
+                entry("custom", Sets.newHashSet("postgres"))
+            );
+    }
+
+    @Test
     public void shouldObtainImageFromDockerfileBuild() {
         File file = new File("src/test/resources/docker-compose-imagename-parsing-dockerfile.yml");
         ParsedDockerComposeFile parsedFile = new ParsedDockerComposeFile(file);

--- a/core/src/test/resources/docker-compose-imagename-parsing-v2-no-version.yml
+++ b/core/src/test/resources/docker-compose-imagename-parsing-v2-no-version.yml
@@ -1,0 +1,9 @@
+services:
+    redis:
+        image: redis
+    mysql:
+        image: mysql
+    custom:
+        build: .
+networks:
+    custom_network: {}


### PR DESCRIPTION
`version` is optional in compose file.

Supported compose files:

Example 1:

```yaml
redis:
  image: redis:7-alpine
```

Example 2:

```yaml
version: 2.0
services:
  redis:
    image: redis:7-alpine
```

Example 3:

```yaml
services:
  redis:
    image: redis:7-alpine
```

Fixes #8109