### PR TITLE
Remove privilegedMode in Db2Container

### DIFF
--- a/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
+++ b/modules/db2/src/main/java/org/testcontainers/containers/Db2Container.java
@@ -1,5 +1,6 @@
 package org.testcontainers.containers;
 
+import com.github.dockerjava.api.model.Capability;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.LicenseAcceptance;
@@ -57,7 +58,7 @@ public class Db2Container extends JdbcDatabaseContainer<Db2Container> {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_NEW_IMAGE_NAME, DEFAULT_IMAGE_NAME);
 
-        withPrivilegedMode(true);
+        withCreateContainerCmdModifier(cmd -> cmd.withCapAdd(Capability.IPC_LOCK).withCapAdd(Capability.IPC_OWNER));
         this.waitStrategy =
             new LogMessageWaitStrategy()
                 .withRegEx(".*Setup has completed\\..*")


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

Currently, the DB2 container uses the privilegedMode, as mentioned in the official IBM docs. But this mode should be avoided. DB2 needs the privilegedMode due larger shared memory segments. But this behavior can be archived by setting the capabilities IPC_LOCK and IPC_OWNER.

Source: https://db2indocker.blogspot.com
