### PR TITLE
fix: MS SQLServer container does not allow for custom queryString

### DIFF
--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLServerContainer.java
@@ -103,7 +103,20 @@ public class MSSQLServerContainer<SELF extends MSSQLServerContainer<SELF>> exten
         if (urlParameters.keySet().stream().map(String::toLowerCase).noneMatch("encrypt"::equals)) {
             urlParameters.put("encrypt", "false");
         }
-        return super.constructUrlForConnection(queryString);
+
+        // The JDBC driver of MS SQL Server does not use the traditional '?'
+        // as the starting character nor the '&' as the delimiter of additional parameters.
+        String baseUrl = getJdbcUrl();
+
+        if ("".equals(queryString)) {
+            return baseUrl;
+        }
+
+        if (!queryString.startsWith(";")) {
+            throw new IllegalArgumentException("The ';' character must be included");
+        }
+
+        return baseUrl + queryString;
     }
 
     @Override


### PR DESCRIPTION
## Current behavior

If a user attempts to create a connection using the MS SQLServer container with an additional queryString, like:

```java
try (Connection con = myContainer.createConnection(";databaseName=TEST");
    Statement stmt = con.createStatement()) {
      //// execute some query
}
```

Then the JDBCContainer will throw an error because of the following logic:
https://github.com/testcontainers/testcontainers-java/blob/7351b66899fdf1a45e1d31e75727652880a304f8/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java#L315-L317

If the queryString is changed to `?databaseName=TEST" then a malformed JDBC URL is constructed:
```txt
[10/25/2024 15:50:39:255 CDT] [main] DEBUG tc.mcr.microsoft.com/mssql/server:2019-CU18-ubuntu-20.04 - Trying to create JDBC connection using com.microsoft.sqlserver.jdbc.SQLServerDriver to jdbc:sqlserver://myhost:38291;encrypt=false?databaseName=TEST with properties: {password=A_Str0ng_Required_Password, user=sa}
```

## Expected behavior

The MS SQLServer container should override the default behavior of the `constructUrlForConnection` method to allow for the non-standard JDBC URL syntax for MS SQLServer which is to use a starting character ';' and delimiter ';'.

