### PR TITLE
Fix default client.ping.timeout value in docs

### DIFF
--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -98,7 +98,7 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 
 ## Customizing client ping behaviour
 
-> **client.ping.timeout = 5**
+> **client.ping.timeout = 10**
 > Specifies for how long Testcontainers will try to connect to the Docker client to obtain valid info about the client before giving up and trying next strategy, if applicable (in seconds).
 
 ## Customizing Docker host detection


### PR DESCRIPTION
Docs were never updated when the default value of `client.ping.timeout` was updated from 5 to 10 seconds.

https://github.com/testcontainers/testcontainers-java/blob/7351b66899fdf1a45e1d31e75727652880a304f8/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java#L223-L225
