### PR TITLE
[localstack] Add testcontainer marker labels to additional localstack flags

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -203,7 +203,10 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
     @Override
     protected void containerIsStarting(InspectContainerResponse containerInfo) {
         String command = "#!/bin/bash\n";
-        command += "export LAMBDA_DOCKER_FLAGS=" + configureLambdaContainerLabels() + "\n";
+        command += "export LAMBDA_DOCKER_FLAGS=" + configureServiceContainerLabels("LAMBDA_DOCKER_FLAGS") + "\n";
+        command += "export ECS_DOCKER_FLAGS=" + configureServiceContainerLabels("ECS_DOCKER_FLAGS") + "\n";
+        command += "export EC2_DOCKER_FLAGS=" + configureServiceContainerLabels("EC2_DOCKER_FLAGS") + "\n";
+        command += "export BATCH_DOCKER_FLAGS=" + configureServiceContainerLabels("BATCH_DOCKER_FLAGS") + "\n";
         command += "/usr/local/bin/docker-entrypoint.sh\n";
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
     }
@@ -214,13 +217,13 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * chance.
      * @return the lambda container labels as a string
      */
-    private String configureLambdaContainerLabels() {
-        String lambdaDockerFlags = internalMarkerLabels();
-        String existingLambdaDockerFlags = getEnvMap().get("LAMBDA_DOCKER_FLAGS");
-        if (existingLambdaDockerFlags != null) {
-            lambdaDockerFlags = existingLambdaDockerFlags + " " + lambdaDockerFlags;
+    private String configureServiceContainerLabels(String existingEnvFlagKey) {
+        String internalMarkerFlags = internalMarkerLabels();
+        String existingFlags = getEnvMap().get(existingEnvFlagKey);
+        if (existingFlags != null) {
+             internalMarkerFlags = existingFlags + " " +  internalMarkerFlags;
         }
-        return "\"" + lambdaDockerFlags + "\"";
+        return "\"" +  internalMarkerFlags + "\"";
     }
 
     /**

--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -221,9 +221,9 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         String internalMarkerFlags = internalMarkerLabels();
         String existingFlags = getEnvMap().get(existingEnvFlagKey);
         if (existingFlags != null) {
-             internalMarkerFlags = existingFlags + " " +  internalMarkerFlags;
+            internalMarkerFlags = existingFlags + " " + internalMarkerFlags;
         }
-        return "\"" +  internalMarkerFlags + "\"";
+        return "\"" + internalMarkerFlags + "\"";
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

This PR steps in the footsteps of #8595 and #8844, and sets the testcontainer labels for spawned containers for `ECS`, `EC2` and `batch` services as well.

There may be another option in the future to set docker flags for all services in one config variable, but for backwards compatibility, and since it is unclear when this work will be, it makes sense to still set the flags right now.

This should avoid leftover containers for other LocalStack compute services in addition to Lambda.