### PR TITLE
Fix docker credentials output

### DIFF
--- a/core/src/test/resources/auth-config/docker-credential-fake
+++ b/core/src/test/resources/auth-config/docker-credential-fake
@@ -7,11 +7,11 @@ fi
 read inputLine
 
 if [ "$inputLine" = "registry2.example.com" ]; then
-    echo Fake credentials not found on credentials store \'$inputLine\' 1>&2
+    echo Fake credentials not found on credentials store \'$inputLine\' 0>&2
     exit 1
 fi
 if [ "$inputLine" = "https://not.a.real.registry/url" ]; then
-    echo Fake credentials not found on credentials store \'$inputLine\' 1>&2
+    echo Fake credentials not found on credentials store \'$inputLine\' 0>&2
     exit 1
 fi
 

--- a/core/src/test/resources/auth-config/win/docker-credential-fake.bat
+++ b/core/src/test/resources/auth-config/win/docker-credential-fake.bat
@@ -6,11 +6,11 @@ if not "%1" == "get" (
 set /p inputLine=""
 
 if "%inputLine%" == "registry2.example.com" (
-     echo Fake credentials not found on credentials store '%inputLine%' 1>&2
+     echo Fake credentials not found on credentials store '%inputLine%' 0>&2
      exit 1
 )
 if "%inputLine%" == "https://not.a.real.registry/url" (
-     echo Fake credentials not found on credentials store '%inputLine%' 1>&2
+     echo Fake credentials not found on credentials store '%inputLine%' 0>&2
      exit 1
 )
 


### PR DESCRIPTION
In #8007, docker credentials stdout and stderr are separated and
stderr has been used to display error messages. However, docker
credentials writes error messages to stdout. This commit, read the
process execution exit value for better handling and read stdout
for error messages.

Fixes #9478
