### PR TITLE
Update MariaDB containers

### DIFF
--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -4,11 +4,11 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
+    compileOnly 'org.mariadb:r2dbc-mariadb:1.3.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.4.1'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.1'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
+    testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.3.0'
 }

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -17,8 +17,10 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mariadb");
 
+    private static final DockerImageName FOUNDATION_IMAGE_NAME = DockerImageName.parse("quay.io/repository/mariadb-foundation/mariadb-devel");
+
     @Deprecated
-    public static final String DEFAULT_TAG = "10.3.6";
+    public static final String DEFAULT_TAG = "10.11.10";
 
     public static final String NAME = "mariadb";
 
@@ -55,7 +57,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
 
     public MariaDBContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, FOUNDATION_IMAGE_NAME);
 
         addExposedPort(MARIADB_PORT);
     }

--- a/modules/mariadb/src/test/java/org/testcontainers/MariaDBTestImages.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/MariaDBTestImages.java
@@ -3,5 +3,5 @@ package org.testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 public interface MariaDBTestImages {
-    DockerImageName MARIADB_IMAGE = DockerImageName.parse("mariadb:10.3.39");
+    DockerImageName MARIADB_IMAGE = DockerImageName.parse("mariadb:10.11.10");
 }

--- a/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
@@ -13,7 +13,7 @@ public class MariaDBR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseCont
 
     @Override
     protected String createR2DBCUrl() {
-        return "r2dbc:tc:mariadb:///db?TC_IMAGE_TAG=10.3.39";
+        return "r2dbc:tc:mariadb:///db?TC_IMAGE_TAG=10.11.10";
     }
 
     @Override

--- a/modules/mariadb/src/test/java/org/testcontainers/jdbc/mariadb/MariaDBJDBCDriverTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/jdbc/mariadb/MariaDBJDBCDriverTest.java
@@ -19,29 +19,29 @@ public class MariaDBJDBCDriverTest extends AbstractJDBCDriverTest {
                     "jdbc:tc:mariadb://hostname/databasename?user=someuser&TC_INITSCRIPT=somepath/init_mariadb.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
-                { "jdbc:tc:mariadb:10.3.39://hostname/databasename", EnumSet.noneOf(Options.class) },
+                { "jdbc:tc:mariadb:10.11.10://hostname/databasename", EnumSet.noneOf(Options.class) },
                 {
-                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mariadb.sql&useUnicode=yes&characterEncoding=utf8",
+                    "jdbc:tc:mariadb:10.11.10://hostname/databasename?TC_INITSCRIPT=somepath/init_unicode_mariadb.sql&useUnicode=yes&characterEncoding=utf8",
                     EnumSet.of(Options.CharacterSet),
                 },
                 {
-                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&TC_INITSCRIPT=somepath/init_mariadb.sql",
+                    "jdbc:tc:mariadb:10.11.10://hostname/databasename?user=someuser&TC_INITSCRIPT=somepath/init_mariadb.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
+                    "jdbc:tc:mariadb:10.11.10://hostname/databasename?user=someuser&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mariadb.sql",
+                    "jdbc:tc:mariadb:10.11.10://hostname/databasename?user=someuser&password=somepwd&TC_INITSCRIPT=somepath/init_mariadb.sql",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
+                    "jdbc:tc:mariadb:10.11.10://hostname/databasename?user=someuser&password=somepwd&TC_INITFUNCTION=org.testcontainers.jdbc.AbstractJDBCDriverTest::sampleInitFunction",
                     EnumSet.of(Options.ScriptedSchema, Options.JDBCParams),
                 },
                 {
-                    "jdbc:tc:mariadb:10.3.39://hostname/databasename?TC_MY_CNF=somepath/mariadb_conf_override",
+                    "jdbc:tc:mariadb:10.11.10://hostname/databasename?TC_MY_CNF=somepath/mariadb_conf_override",
                     EnumSet.of(Options.CustomIniFile),
                 },
             }

--- a/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/junit/mariadb/SimpleMariaDBTest.java
@@ -39,7 +39,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
     public void testSpecificVersion() throws SQLException {
         try (
             MariaDBContainer<?> mariadbOldVersion = new MariaDBContainer<>(
-                MariaDBTestImages.MARIADB_IMAGE.withTag("10.3.39")
+                MariaDBTestImages.MARIADB_IMAGE.withTag("10.11.10")
             )
         ) {
             mariadbOldVersion.start();
@@ -49,7 +49,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
             assertThat(resultSetString)
                 .as("The database version can be set using a container rule parameter")
-                .startsWith("10.3.39");
+                .startsWith("10.11.10");
         }
     }
 
@@ -59,7 +59,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
         try (
             MariaDBContainer<?> mariadbCustomConfig = new MariaDBContainer<>(
-                MariaDBTestImages.MARIADB_IMAGE.withTag("10.3.39")
+                MariaDBTestImages.MARIADB_IMAGE.withTag("10.11.10")
             )
                 .withConfigurationOverride("somepath/mariadb_conf_override")
         ) {
@@ -107,7 +107,7 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
 
         try (
             MariaDBContainer<?> mariadbCustomConfig = new MariaDBContainer<>(
-                MariaDBTestImages.MARIADB_IMAGE.withTag("10.3.39")
+                MariaDBTestImages.MARIADB_IMAGE.withTag("10.11.10")
             )
                 .withConfigurationOverride("somepath/mariadb_conf_override")
         ) {
@@ -135,6 +135,18 @@ public class SimpleMariaDBTest extends AbstractContainerDatabaseTest {
     @Test
     public void testEmptyPasswordWithRootUser() throws SQLException {
         try (MariaDBContainer<?> mysql = new MariaDBContainer<>("mariadb:11.2.4").withUsername("root")) {
+            mysql.start();
+
+            ResultSet resultSet = performQuery(mysql, "SELECT 1");
+            int resultSetInt = resultSet.getInt(1);
+
+            assertThat(resultSetInt).isEqualTo(1);
+        }
+    }
+
+    @Test
+    public void testFondationImages() throws SQLException {
+        try (MariaDBContainer<?> mysql = new MariaDBContainer<>("quay.io/repository/mariadb-foundation/mariadb-devel?tab=tags&tag=11.7").withUsername("root")) {
             mysql.start();
 
             ResultSet resultSet = performQuery(mysql, "SELECT 1");


### PR DESCRIPTION
* update connector to recent version
* set default image to current LTS (10.3 is EOL)
* add Foundation image from quay.io: these permit testing preview mariadb images, available 6 months before official release, like new authentication, vector, ...

