### PR TITLE
Adjust shadow gradle plugin coordinates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.0'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'com.gradleup.shadow'
 
 description = "Testcontainers Core"
 

--- a/gradle/shading.gradle
+++ b/gradle/shading.gradle
@@ -1,6 +1,6 @@
 import java.util.jar.JarFile
 
-apply plugin: 'com.github.johnrengelman.shadow'
+apply plugin: 'com.gradleup.shadow'
 
 configurations {
     shaded
@@ -30,7 +30,7 @@ project.afterEvaluate {
         return it.dependencyProject.tasks.findByName("shadowJar")?.relocators ?: []
     }
 
-    // See https://github.com/johnrengelman/shadow/blob/5.0.0/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ConfigureShadowRelocation.groovy
+    // See https://github.com/GradleUp/shadow/blob/5.0.0/src/main/groovy/com/github/jengelman/gradle/plugins/shadow/tasks/ConfigureShadowRelocation.groovy
     Set<String> packages = []
 
     for (artifact in project.configurations.shaded.resolvedConfiguration.resolvedArtifacts) {


### PR DESCRIPTION
As noted [here](https://github.com/testcontainers/testcontainers-java/issues/9576) I would like to add publishing for the gradle module metadata.

First, the shadow plugin needs to updated.
Since the plugin has been relocated, dependabot most likely needs a little help.
Version 8.3 is identical to 8.1.1
