### PR TITLE
Update shadow gradle plugin to 8.3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.gradleup.shadow' version '8.3.0'
+    id 'com.gradleup.shadow' version '8.3.5'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.13.0' apply false
 }


### PR DESCRIPTION
As noted [here](https://github.com/testcontainers/testcontainers-java/issues/9576) I would like to add publishing for the gradle module metadata.
For that I need shadow 8.3.2 or later.

I know you use dependabot, since I wanted to make sure all publications and testclasspaths are unchanged I thought I could aswell make a PR with a commit describing that.
So no hard feelings if we simply close this PR.

