### PR TITLE
Move ollama port to a constant and provide new `getPort` method

### DIFF
--- a/modules/ollama/src/main/java/org/testcontainers/ollama/OllamaContainer.java
+++ b/modules/ollama/src/main/java/org/testcontainers/ollama/OllamaContainer.java
@@ -23,6 +23,7 @@ import java.util.Map;
 public class OllamaContainer extends GenericContainer<OllamaContainer> {
 
     private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("ollama/ollama");
+
     private static final int OLLAMA_PORT = 11434;
 
     public OllamaContainer(String image) {

--- a/modules/ollama/src/main/java/org/testcontainers/ollama/OllamaContainer.java
+++ b/modules/ollama/src/main/java/org/testcontainers/ollama/OllamaContainer.java
@@ -23,6 +23,7 @@ import java.util.Map;
 public class OllamaContainer extends GenericContainer<OllamaContainer> {
 
     private static final DockerImageName DOCKER_IMAGE_NAME = DockerImageName.parse("ollama/ollama");
+    private static final int OLLAMA_PORT = 11434;
 
     public OllamaContainer(String image) {
         this(DockerImageName.parse(image));
@@ -49,7 +50,7 @@ public class OllamaContainer extends GenericContainer<OllamaContainer> {
                 });
             }
         }
-        withExposedPorts(11434);
+        withExposedPorts(OLLAMA_PORT);
     }
 
     /**
@@ -74,7 +75,11 @@ public class OllamaContainer extends GenericContainer<OllamaContainer> {
         }
     }
 
+    public int getPort() {
+        return getMappedPort(OLLAMA_PORT);
+    }
+
     public String getEndpoint() {
-        return "http://" + getHost() + ":" + getMappedPort(11434);
+        return "http://" + getHost() + ":" + getPort();
     }
 }


### PR DESCRIPTION
Slight refactoring to `OllamaContainer` to use a constant for the port number, as well as introducing an overridable method for determining the port Ollama is running on.

I'm working on something that uses this (see https://github.com/quarkiverse/quarkus-langchain4j/pull/1148) and would be nice to have this built-in.