### PR TITLE
enhancement: Easier configuration of the `postgres` command

### DIFF
--- a/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/junit/postgresql/SimplePostgreSQLTest.java
@@ -61,6 +61,25 @@ public class SimplePostgreSQLTest extends AbstractContainerDatabaseTest {
     }
 
     @Test
+    public void testWithConfigOption() throws SQLException {
+        try (
+            PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(PostgreSQLTestImages.POSTGRES_TEST_IMAGE)
+                .withConfigOption("max_connections", "42")
+        ) {
+            postgres.start();
+
+            ResultSet resultSet = performQuery(postgres, "SELECT current_setting('max_connections')");
+            String result = resultSet.getString(1);
+            assertThat(result).as("max_connections should be overriden").isEqualTo("42");
+
+            // Ensure default config
+            resultSet = performQuery(postgres, "SELECT current_setting('fsync')");
+            result = resultSet.getString(1);
+            assertThat(result).as("fsync should not overriden").isEqualTo("off");
+        }
+    }
+
+    @Test
     public void testMissingInitScript() {
         try (
             PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>(PostgreSQLTestImages.POSTGRES_TEST_IMAGE)


### PR DESCRIPTION
Currently, the PostgreSQLContainer configures `fync=off` during initialization of the container class.
This setting can be accidentally overwritten by using the `withCommand()` or `setCommand()` methods.
It would be more extensible to keep a list of configuration options for the postgres command, and instead configure a command during the configure lifecycle step. 

Opening this PR because this is how I use the PostgreSQL container and thought maybe others might find this useful.
If there is no interest feel free to close this PR.
