### PR TITLE
Bump org.apache.commons:commons-compress to 1.27.1

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api 'org.apache.commons:commons-compress:1.27.1'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
As per the pull request template 

> Please do not open a pull request to update only a version dependency. Existing process will perform
> the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
> your pull request is very welcome.
> 

That however does not seem to be true for this component as it is quite outdated and is poisoning the project with various vulnerabilities such as 

CVE-2024-26308
CVE-2024-25710

If this pull request is deemed as invalid even with the context above, I'd appreciate that the "process" is triggered and that this dependency is updated to fix the CVEs above

