### PR TITLE
Feat/update compose container

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -62,7 +62,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker.exe" : "docker";
 
-    public static final String DEFAULT_DOCKER_IMAGE = "docker:24.0.2";
+    public static final String DEFAULT_DOCKER_IMAGE = "docker:27.5.0";
 
     private final ComposeDelegate composeDelegate;
 
@@ -70,32 +70,70 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     private List<String> filesInDirectory = new ArrayList<>();
 
-    public ComposeContainer(File... composeFiles) {
-        this(Arrays.asList(composeFiles));
+    public ComposeContainer(DockerImageName image, File... composeFiles) {
+        this(image, Arrays.asList(composeFiles));
     }
 
-    public ComposeContainer(List<File> composeFiles) {
-        this(Base58.randomString(6).toLowerCase(), composeFiles);
+    public ComposeContainer(DockerImageName image, List<File> composeFiles) {
+        this(image,Base58.randomString(6).toLowerCase(),composeFiles);
     }
 
-    public ComposeContainer(String identifier, File... composeFiles) {
-        this(identifier, Arrays.asList(composeFiles));
+    public ComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
+        this(image,identifier, Arrays.asList(composeFiles));
     }
 
-    public ComposeContainer(String identifier, List<File> composeFiles) {
+    public ComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(
                 ComposeDelegate.ComposeVersion.V2,
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DockerImageName.parse(
-                    TestcontainersConfiguration
-                        .getInstance()
-                        .getEnvVarOrUserProperty("compose.container.image", DEFAULT_DOCKER_IMAGE)
-                )
+                image
             );
         this.project = this.composeDelegate.getProject();
+    }
+
+    /**
+     * @deprecated
+     *  Use the new constructor ComposeContainer(DockerImageName image, File... composeFiles)
+     */
+    @Deprecated
+    public ComposeContainer(File... composeFiles) {
+        this(getDockerImageName(),Arrays.asList(composeFiles));
+    }
+    /**
+     * @deprecated
+     *  Use the new constructor ComposeContainer(DockerImageName image,List<File> composeFiles)
+     */
+    @Deprecated
+    public ComposeContainer(List<File> composeFiles) {
+        this(getDockerImageName(), composeFiles);
+    }
+    /**
+     * @deprecated
+     *  Use the new constructor ComposeContainer(DockerImageName image, String identifier, File... composeFile)
+     */
+    @Deprecated
+    public ComposeContainer(String identifier, File... composeFiles) {
+        this(getDockerImageName(),identifier, Arrays.asList(composeFiles));
+    }
+
+    /**
+     * @deprecated
+     * Use the new constructor ComposeContainer(DockerImageName image,String identifier, List<File> composeFiles)
+     */
+    @Deprecated
+    public ComposeContainer(String identifier, List<File> composeFiles) {
+       this(getDockerImageName(),identifier, composeFiles);
+    }
+
+    public static DockerImageName getDockerImageName() {
+        return DockerImageName.parse(
+            TestcontainersConfiguration
+                .getInstance()
+                .getEnvVarOrUserProperty("compose.container.image", DEFAULT_DOCKER_IMAGE)
+        );
     }
 
     @Override

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -13,6 +13,7 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.time.Duration;
@@ -61,7 +62,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker.exe" : "docker";
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker:24.0.2");
+    public static final String DEFAULT_DOCKER_IMAGE = "docker:24.0.2";
 
     private final ComposeDelegate composeDelegate;
 
@@ -88,7 +89,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DEFAULT_IMAGE_NAME
+                DockerImageName.parse(TestcontainersConfiguration.getInstance().getEnvVarOrUserProperty("compose.container.image",DEFAULT_DOCKER_IMAGE))
             );
         this.project = this.composeDelegate.getProject();
     }

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -62,7 +62,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker.exe" : "docker";
 
-    public static final String DEFAULT_DOCKER_IMAGE = "docker:27.5.0";
+    private static final String DEFAULT_DOCKER_IMAGE = "docker:27.5.0";
 
     private final ComposeDelegate composeDelegate;
 

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -89,7 +89,11 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DockerImageName.parse(TestcontainersConfiguration.getInstance().getEnvVarOrUserProperty("compose.container.image",DEFAULT_DOCKER_IMAGE))
+                DockerImageName.parse(
+                    TestcontainersConfiguration
+                        .getInstance()
+                        .getEnvVarOrUserProperty("compose.container.image", DEFAULT_DOCKER_IMAGE)
+                )
             );
         this.project = this.composeDelegate.getProject();
     }

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -13,11 +13,13 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +27,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import static org.testcontainers.containers.ComposeContainer.getDockerImageName;
 
 /**
  * Container which launches Docker Compose, for the purposes of launching a defined set of containers.
@@ -62,31 +66,59 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker-compose.exe" : "docker-compose";
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker/compose:1.29.2");
-
     private final ComposeDelegate composeDelegate;
 
     private String project;
 
     private List<String> filesInDirectory = new ArrayList<>();
 
+
+
+    public DockerComposeContainer(DockerImageName image, String identifier, File composeFile) {
+        this(image, identifier, Collections.singletonList(composeFile));
+    }
+
+    public DockerComposeContainer(DockerImageName image, List<File> composeFiles) {
+        this(image,Base58.randomString(6).toLowerCase(),composeFiles);
+    }
+
+    public DockerComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
+        this(image,identifier, Arrays.asList(composeFiles));
+    }
+    public DockerComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
+        this.composeDelegate =
+            new ComposeDelegate(
+                ComposeDelegate.ComposeVersion.V2,
+                composeFiles,
+                identifier,
+                COMPOSE_EXECUTABLE,
+                image
+            );
+        this.project = this.composeDelegate.getProject();
+    }
+
+
     @Deprecated
     public DockerComposeContainer(File composeFile, String identifier) {
         this(identifier, composeFile);
     }
 
+    @Deprecated
     public DockerComposeContainer(File... composeFiles) {
         this(Arrays.asList(composeFiles));
     }
 
+    @Deprecated
     public DockerComposeContainer(List<File> composeFiles) {
         this(Base58.randomString(6).toLowerCase(), composeFiles);
     }
 
+    @Deprecated
     public DockerComposeContainer(String identifier, File... composeFiles) {
         this(identifier, Arrays.asList(composeFiles));
     }
 
+    @Deprecated
     public DockerComposeContainer(String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(
@@ -94,10 +126,12 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DEFAULT_IMAGE_NAME
+                getDockerImageName()
             );
         this.project = this.composeDelegate.getProject();
     }
+
+
 
     @Override
     @Deprecated

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -88,7 +88,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
     public DockerComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(
-                ComposeDelegate.ComposeVersion.V2,
+                ComposeDelegate.ComposeVersion.V1,
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
@@ -126,7 +126,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                getDockerImageName()
+                DockerImageName.parse("docker/compose:1.29.2")
             );
         this.project = this.composeDelegate.getProject();
     }

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -244,7 +244,7 @@ public class TestcontainersConfiguration {
         }
 
         for (final Properties properties : propertiesSources) {
-            if (properties.get(propertyName) != null) {
+            if (properties.get(propertyName) != null && !properties.get(propertyName).toString().trim().isEmpty()) {
                 return (String) properties.get(propertyName);
             }
         }

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -1,0 +1,69 @@
+package org.testcontainers.containers;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class ComposeContainerTest {
+    private TestLogAppender testLogAppender;
+    private Logger rootLogger;
+
+    @Before
+    public void setup() {
+        testLogAppender = new TestLogAppender();
+        testLogAppender.start();
+        rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        rootLogger.addAppender(testLogAppender);
+    }
+
+    @After
+    public void tearDown() {
+        rootLogger.detachAppender(testLogAppender);
+    }
+
+    @Test
+    public void testWithCustomDockerImage() throws IOException {
+        TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "docker:25.0.2");
+        ComposeContainer composeContainer = new ComposeContainer(Lists.newArrayList(new File("src/test/resources/docker-compose-imagename-parsing-v2.yml")));
+        composeContainer.start();
+        System.clearProperty("compose.container.image");
+        List<String> logs = testLogAppender.getLogs();
+        composeContainer.stop();
+        assertNotNull(logs);
+        Optional<String> verification = logs.stream().filter(line -> line.contains("Creating container for image: docker:25.0.2")).findFirst();
+        assertTrue(verification.isPresent());
+        TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
+    }
+
+    private static class TestLogAppender extends AppenderBase<ILoggingEvent> {
+        private final List<String> logs = new ArrayList<>();
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            logs.add(eventObject.getFormattedMessage());
+        }
+
+        public List<String> getLogs() {
+            return logs;
+        }
+
+        public void clearLogs() {
+            logs.clear();
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -12,15 +12,17 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ComposeContainerTest {
+
     private TestLogAppender testLogAppender;
+
     private Logger rootLogger;
 
     @Before
@@ -44,9 +46,9 @@ public class ComposeContainerTest {
         System.clearProperty("compose.container.image");
         List<String> logs = testLogAppender.getLogs();
         composeContainer.stop();
-        assertNotNull(logs);
+        assertThat(logs).isNotNull();
         Optional<String> verification = logs.stream().filter(line -> line.contains("Creating container for image: docker:25.0.2")).findFirst();
-        assertTrue(verification.isPresent());
+        assertThat(verification.isPresent()).isTrue();
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
     }
 

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class ComposeContainerTest {
 
     private TestLogAppender testLogAppender;
@@ -41,18 +40,24 @@ public class ComposeContainerTest {
     @Test
     public void testWithCustomDockerImage() throws IOException {
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "docker:25.0.2");
-        ComposeContainer composeContainer = new ComposeContainer(Lists.newArrayList(new File("src/test/resources/docker-compose-imagename-parsing-v2.yml")));
+        ComposeContainer composeContainer = new ComposeContainer(
+            Lists.newArrayList(new File("src/test/resources/docker-compose-imagename-parsing-v2.yml"))
+        );
         composeContainer.start();
         System.clearProperty("compose.container.image");
         List<String> logs = testLogAppender.getLogs();
         composeContainer.stop();
         assertThat(logs).isNotNull();
-        Optional<String> verification = logs.stream().filter(line -> line.contains("Creating container for image: docker:25.0.2")).findFirst();
+        Optional<String> verification = logs
+            .stream()
+            .filter(line -> line.contains("Creating container for image: docker:25.0.2"))
+            .findFirst();
         assertThat(verification.isPresent()).isTrue();
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
     }
 
     private static class TestLogAppender extends AppenderBase<ILoggingEvent> {
+
         private final List<String> logs = new ArrayList<>();
 
         @Override


### PR DESCRIPTION
In the #9222 a user is specifying a property with the field name `compose.container.image` and the `ComposeContainer` when it creates the `composeDelegate` variable is always picking the `24.0.2` version of docker. The change that I am proposing is to use the `TestcontainersConfiguration` in order to parse the property `compose.container.image` if it exists otherwise continue as it was in the past. Updated the constructors based on the feedback.