### PR TITLE
Fix reuse support for CouchbaseContainer

### DIFF
--- a/modules/couchbase/AUTHORS
+++ b/modules/couchbase/AUTHORS
@@ -1,2 +1,3 @@
 ﻿Tayeb Chlyah <tayebchlyah@gmail.com>
 Tobias Happ <tobias.happ@gmx.de>
+Fredrik Albihn <albihnf@gmail.com>

--- a/modules/couchbase/AUTHORS
+++ b/modules/couchbase/AUTHORS
@@ -1,3 +1,2 @@
 ﻿Tayeb Chlyah <tayebchlyah@gmail.com>
 Tobias Happ <tobias.happ@gmx.de>
-Fredrik Albihn <albihnf@gmail.com>

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -342,6 +342,15 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
     }
 
     @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo, boolean reused) {
+        if (reused) {
+            this.logger().debug("Couchbase container is being reused, assuming correct configuration.");
+        } else {
+            containerIsStarting(containerInfo);
+        }
+    }
+
+    @Override
     protected void containerIsStarting(final InspectContainerResponse containerInfo) {
         logger().debug("Couchbase container is starting, performing configuration.");
 
@@ -356,6 +365,16 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
         if (enabledServices.contains(CouchbaseService.INDEX)) {
             timePhase("configureIndexer", this::configureIndexer);
+        }
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo, boolean reused) {
+        if (reused) {
+            logger()
+                .info("Couchbase container reused and ready! UI available at http://{}:{}", getHost(), getMappedPort(MGMT_PORT));
+        } else {
+            this.containerIsStarted(containerInfo);
         }
     }
 

--- a/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
+++ b/modules/couchbase/src/main/java/org/testcontainers/couchbase/CouchbaseContainer.java
@@ -343,9 +343,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     @Override
     protected void containerIsStarting(InspectContainerResponse containerInfo, boolean reused) {
-        if (reused) {
-            this.logger().debug("Couchbase container is being reused, assuming correct configuration.");
-        } else {
+        if (!reused) {
             containerIsStarting(containerInfo);
         }
     }
@@ -370,10 +368,7 @@ public class CouchbaseContainer extends GenericContainer<CouchbaseContainer> {
 
     @Override
     protected void containerIsStarted(InspectContainerResponse containerInfo, boolean reused) {
-        if (reused) {
-            logger()
-                .info("Couchbase container reused and ready! UI available at http://{}:{}", getHost(), getMappedPort(MGMT_PORT));
-        } else {
+        if (!reused) {
             this.containerIsStarted(containerInfo);
         }
     }


### PR DESCRIPTION
Couchbase test container doesn't support reuse.

When starting it makes several http requests without using credentials and also tries to configure Couchbase again.
https://github.com/testcontainers/testcontainers-java/issues/2794

Solution was to overload appropriate methods and assume all configuration has been made if the container is being reused.

