### PR TITLE
Bump confluentinc/cp-kcat from 7.4.1 to 7.9.0

### DIFF
--- a/modules/kafka/src/test/java/org/testcontainers/KCatContainer.java
+++ b/modules/kafka/src/test/java/org/testcontainers/KCatContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.images.builder.Transferable;
 public class KCatContainer extends GenericContainer<KCatContainer> {
 
     public KCatContainer() {
-        super("confluentinc/cp-kcat:7.4.1");
+        super("confluentinc/cp-kcat:7.9.0");
         withCreateContainerCmdModifier(cmd -> {
             cmd.withEntrypoint("sh");
         });

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -195,7 +195,7 @@ public class KafkaContainerTest extends AbstractKafka {
                 .withNetwork(network);
             // }
             // createKCatContainer {
-            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.4.1")
+            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.9.0")
                 .withCreateContainerCmdModifier(cmd -> {
                     cmd.withEntrypoint("sh");
                 })

--- a/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
+++ b/modules/redpanda/src/test/java/org/testcontainers/redpanda/RedpandaContainerTest.java
@@ -111,7 +111,7 @@ public class RedpandaContainerTest extends AbstractRedpanda {
             RedpandaContainer redpanda = new RedpandaContainer("docker.redpanda.com/redpandadata/redpanda:v23.1.7")
                 .withListener(() -> "redpanda:19092")
                 .withNetwork(network);
-            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.4.1")
+            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.9.0")
                 .withCreateContainerCmdModifier(cmd -> {
                     cmd.withEntrypoint("sh");
                 })
@@ -141,7 +141,7 @@ public class RedpandaContainerTest extends AbstractRedpanda {
                 .withNetwork(network);
             // }
             // createKCatContainer {
-            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.4.1")
+            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.9.0")
                 .withCreateContainerCmdModifier(cmd -> {
                     cmd.withEntrypoint("sh");
                 })
@@ -200,7 +200,7 @@ public class RedpandaContainerTest extends AbstractRedpanda {
                 .withSuperuser("panda")
                 .withListener("my-panda:29092")
                 .withNetwork(network);
-            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.4.1")
+            GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.9.0")
                 .withCreateContainerCmdModifier(cmd -> {
                     cmd.withEntrypoint("sh");
                 })


### PR DESCRIPTION
Bump confluentinc/cp-kcat from 7.4.1 to 7.9.0. The new version has much smaller image size:
* 7.4.1 has 327 MB: https://hub.docker.com/r/confluentinc/cp-kcat/tags?name=7.4.1
* 7.9.0 has 83 MB: https://hub.docker.com/r/confluentinc/cp-kcat/tags?name=7.9.0