### PR TITLE
vulnerability fix

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api 'org.apache.commons:commons-compress:1.27.1'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
Fixing the transition vulnerability reported by dependabot. CVE-2024-26308 and CVE-2024-25710 are coming from org.apache.commons:commons-compress:1.24.0 (and CVE-2024-47554 is originated from commons-io:commons-io:2.13.0). It seems like these vulnerabilities are fixed from org.apache.commons:commons-compress:1.26.0. However the latest available version is 1.27.1.