### PR TITLE
Update&replace com.datastax.cassandra:cassandra-driver-core:3.10.0  

### DIFF
--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -8,7 +8,7 @@ configurations.all {
 
 dependencies {
     api project(":database-commons")
-    api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
+    api "com.datastax.oss:java-driver-core:4.17.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'


### PR DESCRIPTION
Phase 1 update and replace driver-core to align with testdep version.
com.datastax.cassandra:cassandra-driver-core:3.10.0 => com.datastax.oss:java-driver-core
This to prevent issues with spring 3.3.x+ (The dependency has been moved again to org.apache.cassandra:java-driver-core.
This must be a next update.
