### PR TITLE
[servicebus] Skip waiting for sql to be ready

### DIFF
--- a/modules/azure/src/main/java/org/testcontainers/azure/ServiceBusEmulatorContainer.java
+++ b/modules/azure/src/main/java/org/testcontainers/azure/ServiceBusEmulatorContainer.java
@@ -41,6 +41,7 @@ public class ServiceBusEmulatorContainer extends GenericContainer<ServiceBusEmul
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
         withExposedPorts(DEFAULT_PORT);
+        withEnv("SQL_WAIT_INTERVAL", "0");
         waitingFor(Wait.forLogMessage(".*Emulator Service is Successfully Up!.*", 1));
     }
 

--- a/modules/azure/src/test/java/org/testcontainers/azure/ServiceBusEmulatorContainerTest.java
+++ b/modules/azure/src/test/java/org/testcontainers/azure/ServiceBusEmulatorContainerTest.java
@@ -48,7 +48,7 @@ public class ServiceBusEmulatorContainerTest {
     @Rule
     // emulatorContainer {
     public ServiceBusEmulatorContainer emulator = new ServiceBusEmulatorContainer(
-        "mcr.microsoft.com/azure-messaging/servicebus-emulator:1.0.1"
+        "mcr.microsoft.com/azure-messaging/servicebus-emulator:1.1.2"
     )
         .acceptLicense()
         .withConfig(MountableFile.forClasspathResource("/service-bus-config.json"))


### PR DESCRIPTION
By default, Azure ServiceBus emulator waits 15 seconds for sql to
be ready. Testcontainers is in charge of service readiness, so,
the emulator should skip waiting for sql.
