### PR TITLE
upgrade to fix commons-compress CVEs

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -73,7 +73,9 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testCompileOnly 'org.jetbrains:annotations:24.1.0'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api ('org.apache.commons:commons-compress:1.27.1') {
+        exclude(group: 'org.apache.commons', module: 'commons-lang3')
+    }
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }


### PR DESCRIPTION
I've had troubles with upgrading testcontainers dependencies in my projects to the latest version. Nexus is blocking it because of transitive vulnerabilities detected from commons-compress. Maven Repository is also indicating [CVE-2024-26308](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-26308) and [CVE-2024-25710](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-25710).

I decided to get on the bottom of it and resolve the issues around upgrading. I am aware you have Dependabot configured to perform upgrading weekly. However commons-compress is on the ignore list - I guess because of the runtime issues. I managed to resolve those relatively simply. Please find the fix in my PR. You may consider even removing the Dependabot ignore but I leave it up to your decision.