### PR TITLE
Fix Apache Solr link

### DIFF
--- a/docs/modules/solr.md
+++ b/docs/modules/solr.md
@@ -4,7 +4,7 @@
     This module is INCUBATING. While it is ready for use and operational in the current version of Testcontainers, it is possible that it may receive breaking changes in the future. See [our contributing guidelines](/contributing/#incubating-modules) for more information on our incubating modules policy.
 
 
-This module helps running [solr](https://lucene.apache.org/solr/) using Testcontainers.
+This module helps running [solr](https://solr.apache.org/) using Testcontainers.
 
 Note that it's based on the [official Docker image](https://hub.docker.com/_/solr/).
 


### PR DESCRIPTION
Solr is now a top level Apache project at solr.apache.org, so this PR fixes the link.


