### PR TITLE
[solr] Replace "create_core" with "create" command

### DIFF
--- a/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
+++ b/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
@@ -143,7 +143,7 @@ public class SolrContainer extends GenericContainer<SolrContainer> {
     @SneakyThrows
     protected void containerIsStarted(InspectContainerResponse containerInfo) {
         if (!configuration.isZookeeper()) {
-            ExecResult result = execInContainer("solr", "create_core", "-c", configuration.getCollectionName());
+            ExecResult result = execInContainer("solr", "create", "-c", configuration.getCollectionName());
             if (result.getExitCode() != 0) {
                 throw new IllegalStateException(
                     "Unable to create solr core:\nStdout: " + result.getStdout() + "\nStderr:" + result.getStderr()


### PR DESCRIPTION
Solr 10x will be out soon.  In 10, we removed support for "create_core", replacing it with "create".  Create works in Solr 8x, 9x, and the upcoming 10x.

Existing tests pass.