### PR TITLE
Remove incubator note from Solr docs

### DIFF
--- a/docs/modules/solr.md
+++ b/docs/modules/solr.md
@@ -1,9 +1,5 @@
 # Solr Container
 
-!!! note
-    This module is INCUBATING. While it is ready for use and operational in the current version of Testcontainers, it is possible that it may receive breaking changes in the future. See [our contributing guidelines](/contributing/#incubating-modules) for more information on our incubating modules policy.
-
-
 This module helps running [solr](https://lucene.apache.org/solr/) using Testcontainers.
 
 Note that it's based on the [official Docker image](https://hub.docker.com/_/solr/).


### PR DESCRIPTION
Wasn't sure the best way to start this discussion.

Solr has been part of testcontainers for a number of years, and I see it used.   It's had steady upgrades for recent versions of Solr.   

I'd like to remove the incubating tag ;-).   If there are specific things that need to happen (docs? tests?) etc I'd love to hear more about that.