### PR TITLE
Pass `start` command required in Solr 10

### DIFF
--- a/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
+++ b/modules/solr/src/main/java/org/testcontainers/containers/SolrContainer.java
@@ -111,7 +111,7 @@ public class SolrContainer extends GenericContainer<SolrContainer> {
             throw new IllegalStateException("Solr needs to have a configuration if you want to use a schema");
         }
         // Generate Command Builder
-        String command = "solr -f";
+        String command = "solr start -f";
         // Add Default Ports
         this.addExposedPort(SOLR_PORT);
 


### PR DESCRIPTION
In 10x we removed the short cut that "bin/solr" was a call to "bin/solr start", now we require you to specify what subcommand you want.   This change is backwards compatible with 8x and 9x, and forwards compatible with the upcoming Solr 10 release.