### PR TITLE
Allow spock tests to be skipped when Docker is unavailable

### DIFF
--- a/modules/spock/src/main/groovy/org/testcontainers/spock/DockerAvailableDetector.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/DockerAvailableDetector.groovy
@@ -1,0 +1,15 @@
+package org.testcontainers.spock
+
+import org.testcontainers.DockerClientFactory
+
+class DockerAvailableDetector {
+
+	boolean isDockerAvailable() {
+		try {
+			DockerClientFactory.instance().client();
+			return true;
+		} catch (Throwable ex) {
+			return false;
+		}
+	}
+}

--- a/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/Testcontainers.groovy
@@ -54,4 +54,11 @@ import java.lang.annotation.Target
 @Target([ElementType.TYPE, ElementType.METHOD])
 @ExtensionAnnotation(TestcontainersExtension)
 @interface Testcontainers {
+
+	/**
+	 * Whether tests should be disabled (rather than failing) when Docker is not available. Defaults to
+	 * {@code false}.
+	 * @return if the tests should be disabled when Docker is not available
+	 */
+	boolean disabledWithoutDocker() default false;
 }

--- a/modules/spock/src/main/groovy/org/testcontainers/spock/TestcontainersExtension.groovy
+++ b/modules/spock/src/main/groovy/org/testcontainers/spock/TestcontainersExtension.groovy
@@ -7,8 +7,23 @@ import org.spockframework.runtime.model.SpecInfo
 
 class TestcontainersExtension extends AbstractAnnotationDrivenExtension<Testcontainers> {
 
+	private final DockerAvailableDetector dockerDetector
+
+	TestcontainersExtension() {
+		this(new DockerAvailableDetector())
+	}
+
+	TestcontainersExtension(DockerAvailableDetector dockerDetector) {
+		this.dockerDetector = dockerDetector
+	}
+
 	@Override
 	void visitSpecAnnotation(Testcontainers annotation, SpecInfo spec) {
+		if (annotation.disabledWithoutDocker()) {
+			if (!dockerDetector.isDockerAvailable()) {
+				spec.skip("disabledWithoutDocker is true and Docker is not available")
+			}
+		}
 		def listener = new ErrorListener()
 		def interceptor = new TestcontainersMethodInterceptor(spec, listener)
 		spec.addSetupSpecInterceptor(interceptor)

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/TestcontainersExtensionTest.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/TestcontainersExtensionTest.groovy
@@ -1,0 +1,39 @@
+package org.testcontainers.spock
+
+import org.spockframework.runtime.model.SpecInfo
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class TestcontainersExtensionTest extends Specification {
+
+	@Unroll
+	def "should handle disabledWithoutDocker=#disabledWithoutDocker and dockerAvailable=#dockerAvailable correctly"() {
+		given:
+		def dockerDetector = Mock(DockerAvailableDetector)
+		dockerDetector.isDockerAvailable() >> dockerAvailable
+		def extension = new TestcontainersExtension(dockerDetector)
+		def specInfo = Mock(SpecInfo)
+		def annotation = disabledWithoutDocker ?
+				TestDisabledWithoutDocker.getAnnotation(Testcontainers) :
+				TestEnabledWithoutDocker.getAnnotation(Testcontainers)
+
+		when:
+		extension.visitSpecAnnotation(annotation, specInfo)
+
+		then:
+		skipCalls * specInfo.skip("disabledWithoutDocker is true and Docker is not available")
+
+		where:
+		disabledWithoutDocker | dockerAvailable | skipCalls
+		true                  | true            | 0
+		true                  | false           | 1
+		false                 | true            | 0
+		false                 | false           | 0
+	}
+
+	@Testcontainers(disabledWithoutDocker = true)
+	static class TestDisabledWithoutDocker {}
+
+	@Testcontainers
+	static class TestEnabledWithoutDocker {}
+}


### PR DESCRIPTION
Fixes #10178
