### PR TITLE
Upgrade docker-java to 3.5.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -88,8 +88,8 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.2.0'
 
-    api platform('com.github.docker-java:docker-java-bom:3.4.2')
-    shaded platform('com.github.docker-java:docker-java-bom:3.4.2')
+    api platform('com.github.docker-java:docker-java-bom:3.5.0')
+    shaded platform('com.github.docker-java:docker-java-bom:3.5.0')
 
     api "com.github.docker-java:docker-java-api"
 


### PR DESCRIPTION
I noticed that dependabot wasn't proposing a docker-java upgrade, and that this one is always manually proposed. We would really like this upgrade so thought I would propose it.

The reason we care about this is because we use Quarkus, and in Quarkus docker-java is always enforced to have the same version as testcontainers-java's docker-java version. So we can't upgrade docker-java until testcontainers-java upgrades to the new version.