### PR TITLE
Expose Tempo in LgtmContainer

### DIFF
--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -7,6 +7,11 @@ dependencies {
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.4'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
+
+    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.49.0')
+    testImplementation 'io.opentelemetry:opentelemetry-api'
+    testImplementation 'io.opentelemetry:opentelemetry-sdk'
+    testImplementation 'io.opentelemetry:opentelemetry-exporter-otlp'
 }
 
 tasks.japicmp {

--- a/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
+++ b/modules/grafana/src/main/java/org/testcontainers/grafana/LgtmStackContainer.java
@@ -14,6 +14,7 @@ import org.testcontainers.utility.DockerImageName;
  * Exposed ports:
  * <ul>
  *     <li>Grafana: 3000</li>
+ *     <li>Tempo: 3200</li>
  *     <li>OTel Http: 4317</li>
  *     <li>OTel Grpc: 4318</li>
  *     <li>Prometheus: 9090</li>
@@ -30,6 +31,8 @@ public class LgtmStackContainer extends GenericContainer<LgtmStackContainer> {
 
     private static final int OTLP_HTTP_PORT = 4318;
 
+    private static final int TEMPO_PORT = 3200;
+
     private static final int PROMETHEUS_PORT = 9090;
 
     public LgtmStackContainer(String image) {
@@ -39,7 +42,7 @@ public class LgtmStackContainer extends GenericContainer<LgtmStackContainer> {
     public LgtmStackContainer(DockerImageName image) {
         super(image);
         image.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-        withExposedPorts(GRAFANA_PORT, OTLP_GRPC_PORT, OTLP_HTTP_PORT, PROMETHEUS_PORT);
+        withExposedPorts(GRAFANA_PORT, TEMPO_PORT, OTLP_GRPC_PORT, OTLP_HTTP_PORT, PROMETHEUS_PORT);
         waitingFor(
             Wait.forLogMessage(".*The OpenTelemetry collector and the Grafana LGTM stack are up and running.*\\s", 1)
         );
@@ -52,6 +55,10 @@ public class LgtmStackContainer extends GenericContainer<LgtmStackContainer> {
 
     public String getOtlpGrpcUrl() {
         return "http://" + getHost() + ":" + getMappedPort(OTLP_GRPC_PORT);
+    }
+
+    public String getTempoUrl() {
+        return "http://" + getHost() + ":" + getMappedPort(TEMPO_PORT);
     }
 
     public String getOtlpHttpUrl() {

--- a/modules/grafana/src/test/java/org/testcontainers/grafana/LgtmStackContainerTest.java
+++ b/modules/grafana/src/test/java/org/testcontainers/grafana/LgtmStackContainerTest.java
@@ -5,6 +5,15 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.registry.otlp.OtlpConfig;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.exporter.otlp.trace.OtlpGrpcSpanExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.awaitility.Awaitility;
@@ -12,15 +21,16 @@ import org.junit.Test;
 import uk.org.webcompere.systemstubs.SystemStubs;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LgtmStackContainerTest {
 
     @Test
-    public void shouldPublishMetric() throws Exception {
+    public void shouldPublishMetricAndTrace() throws Exception {
         try ( // container {
-            LgtmStackContainer lgtm = new LgtmStackContainer("grafana/otel-lgtm:0.6.0")
+            LgtmStackContainer lgtm = new LgtmStackContainer("grafana/otel-lgtm:0.11.0")
             // }
         ) {
             lgtm.start();
@@ -29,7 +39,9 @@ public class LgtmStackContainerTest {
                 .get(String.format("http://%s:%s/api/health", lgtm.getHost(), lgtm.getMappedPort(3000)))
                 .jsonPath()
                 .get("version");
-            assertThat(version).isEqualTo("11.0.0");
+            assertThat(version).isEqualTo("11.6.0");
+
+            generateTrace(lgtm);
 
             OtlpConfig otlpConfig = createOtlpConfig(lgtm);
             MeterRegistry meterRegistry = SystemStubs
@@ -52,7 +64,50 @@ public class LgtmStackContainerTest {
                     assertThat(response.getStatusCode()).isEqualTo(200);
                     assertThat(response.body().jsonPath().getList("data.result[0].value")).contains("2");
                 });
+
+            Awaitility
+                .given()
+                .pollInterval(Duration.ofSeconds(2))
+                .atMost(Duration.ofSeconds(5))
+                .ignoreExceptions()
+                .untilAsserted(() -> {
+                    Response response = RestAssured
+                        .given()
+                        .get(String.format("%s/api/search", lgtm.getTempoUrl()))
+                        .prettyPeek()
+                        .thenReturn();
+                    assertThat(response.getStatusCode()).isEqualTo(200);
+                    assertThat(response.body().jsonPath().getString("traces[0].rootServiceName"))
+                        .isEqualTo("test-service");
+                });
         }
+    }
+
+    private void generateTrace(LgtmStackContainer lgtm) {
+        OtlpGrpcSpanExporter exporter = OtlpGrpcSpanExporter
+            .builder()
+            .setTimeout(Duration.ofSeconds(1))
+            .setEndpoint(lgtm.getOtlpGrpcUrl())
+            .build();
+
+        BatchSpanProcessor spanProcessor = BatchSpanProcessor
+            .builder(exporter)
+            .setScheduleDelay(500, TimeUnit.MILLISECONDS)
+            .build();
+
+        SdkTracerProvider tracerProvider = SdkTracerProvider
+            .builder()
+            .addSpanProcessor(spanProcessor)
+            .setResource(Resource.create(Attributes.of(AttributeKey.stringKey("service.name"), "test-service")))
+            .build();
+
+        OpenTelemetrySdk openTelemetry = OpenTelemetrySdk.builder().setTracerProvider(tracerProvider).build();
+
+        Tracer tracer = openTelemetry.getTracer("test");
+        Span span = tracer.spanBuilder("test").startSpan();
+        span.end();
+
+        openTelemetry.shutdown();
     }
 
     private static OtlpConfig createOtlpConfig(LgtmStackContainer lgtm) {


### PR DESCRIPTION
Exposing the tempo port in the Grafana LGTM container to allow querying traces
