### PR TITLE
Update jackson, snakeyaml and docker-java versions

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,8 +62,8 @@ tasks.japicmp {
 
 configurations.all {
     resolutionStrategy {
-        force 'com.fasterxml.jackson.core:jackson-databind:2.19.0'
-        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.18.4'
+        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.4'
     }
 }
 
@@ -87,8 +87,8 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.2.0'
 
-    api platform('com.github.docker-java:docker-java-bom:3.4.2')
-    shaded platform('com.github.docker-java:docker-java-bom:3.4.2')
+    api platform('com.github.docker-java:docker-java-bom:3.5.3')
+    shaded platform('com.github.docker-java:docker-java-bom:3.5.3')
 
     api "com.github.docker-java:docker-java-api"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,9 +62,8 @@ tasks.japicmp {
 
 configurations.all {
     resolutionStrategy {
-        // use lower Jackson version
-        force 'com.fasterxml.jackson.core:jackson-databind:2.8.8'
-        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.8'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.19.0'
+        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0'
     }
 }
 
@@ -100,7 +99,7 @@ dependencies {
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
     shaded 'com.google.guava:guava:33.3.1-jre'
-    shaded "org.yaml:snakeyaml:1.33"
+    shaded "org.yaml:snakeyaml:2.4"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'
 

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -3,10 +3,8 @@ description = "Testcontainers :: K3S"
 dependencies {
     api project(":testcontainers")
 
-    // https://youtu.be/otCpCn0l4Wo
-    // The core module depends on jackson-databind 2.8.x for backward compatibility.
-    // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
-    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
+    // Synchronize with the jackson version, must match major and minor version
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.0'
 
     testImplementation 'io.fabric8:kubernetes-client:6.13.1'
     testImplementation 'io.kubernetes:client-java:21.0.1-legacy'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(":testcontainers")
 
     // Synchronize with the jackson version, must match major and minor version
-    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.19.0'
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.4'
 
     testImplementation 'io.fabric8:kubernetes-client:6.13.1'
     testImplementation 'io.kubernetes:client-java:21.0.1-legacy'


### PR DESCRIPTION
Code hygene and clearing falsely flagged CVEs

Upgrade jackson and snakeyaml to the latest version. Aside from providing code hygene, these two dependencies are flagged by FOSS scanning tools as having critical severity CVEs. Although not exploitable in testcontainers, this causes a headache for developers.

This is to address Issue #9289 
