### PR TITLE
Fix register listener for kafka docs

### DIFF
--- a/docs/modules/kafka.md
+++ b/docs/modules/kafka.md
@@ -85,7 +85,7 @@ There are scenarios where additional listeners are needed because the consumer/p
 container in the same network or a different process where the port to connect differs from the default exposed port. E.g [Toxiproxy](../../modules/toxiproxy/).
 
 <!--codeinclude-->
-[Register additional listener](../../modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java) inside_block:registerListener
+[Register additional listener](../../modules/kafka/src/test/java/org/testcontainers/kafka/KafkaContainerTest.java) inside_block:registerListener
 <!--/codeinclude-->
 
 Container defined in the same network:

--- a/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/containers/KafkaContainerTest.java
@@ -189,11 +189,9 @@ public class KafkaContainerTest extends AbstractKafka {
     public void testUsageWithListener() throws Exception {
         try (
             Network network = Network.newNetwork();
-            // registerListener {
             KafkaContainer kafka = new KafkaContainer(KAFKA_KRAFT_TEST_IMAGE)
                 .withListener(() -> "kafka:19092")
                 .withNetwork(network);
-            // }
             // createKCatContainer {
             GenericContainer<?> kcat = new GenericContainer<>("confluentinc/cp-kcat:7.9.0")
                 .withCreateContainerCmdModifier(cmd -> {

--- a/modules/kafka/src/test/java/org/testcontainers/kafka/KafkaContainerTest.java
+++ b/modules/kafka/src/test/java/org/testcontainers/kafka/KafkaContainerTest.java
@@ -25,9 +25,11 @@ public class KafkaContainerTest extends AbstractKafka {
     public void testUsageWithListener() throws Exception {
         try (
             Network network = Network.newNetwork();
+            // registerListener {
             KafkaContainer kafka = new KafkaContainer("apache/kafka-native:3.8.0")
                 .withListener("kafka:19092")
                 .withNetwork(network);
+            // }
             KCatContainer kcat = new KCatContainer().withNetwork(network)
         ) {
             kafka.start();


### PR DESCRIPTION
The withListener method of the deprecated KafkaContainer takes `Supplier<String>`, whereas the withListener method of the current KafkaContainer takes a `String`.

Show the new syntax in the documentation.