### PR TITLE
Move from com.jcraft:jsch to com.github.mwiede:jsch

### DIFF
--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'com.jcraft:jsch:0.1.55'
+    testImplementation 'com.github.mwiede:jsch:2.27.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'


### PR DESCRIPTION
Upgrade testImplementation dependency from
`com.jcraft:jsch:0.1.55`
to
`com.github.mwiede:jsch:2.27.0`

The artifact was moved, see
* https://mvnrepository.com/artifact/com.jcraft/jsch
* https://github.com/mwiede/jsch

> Dependency Upgrades:
> Please do not open a pull request to update only a version dependency. Existing process will perform
> the upgrade every week.

Sorry, I've waited two months (since 2025-03-17 #10096) but the existing process failed to do the upgrade.