### PR TITLE
no api scope for junit4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,6 +132,11 @@ subprojects {
 
     dependencies {
         testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+
+        if (project.path != ':testcontainers') {
+            // for compiling classes which extend GenericContainer, etc
+            compileOnly 'junit:junit:4.13.2'
+        }
     }
 
     checkstyle {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -69,7 +69,7 @@ configurations.all {
 }
 
 dependencies {
-    api 'junit:junit:4.13.2'
+    implementation 'junit:junit:4.13.2' // originally had api scope
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:24.1.0'
     testCompileOnly 'org.jetbrains:annotations:24.1.0'


### PR DESCRIPTION
Currently junit4 has api scope, so it will be visible outside
so projects using junit 5 will see 2 `@Test` annotations.