### PR TITLE
Add DockerImageName constructors to ComposeContainer

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -62,7 +62,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker.exe" : "docker";
 
-    public static final String DEFAULT_DOCKER_IMAGE = "docker:24.0.2";
+    public static final String DEFAULT_DOCKER_IMAGE = "docker:27.5.0";
 
     private final ComposeDelegate composeDelegate;
 
@@ -70,32 +70,70 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     private List<String> filesInDirectory = new ArrayList<>();
 
-    public ComposeContainer(File... composeFiles) {
-        this(Arrays.asList(composeFiles));
+    public ComposeContainer(DockerImageName image, File... composeFiles) {
+        this(image, Arrays.asList(composeFiles));
     }
 
-    public ComposeContainer(List<File> composeFiles) {
-        this(Base58.randomString(6).toLowerCase(), composeFiles);
+    public ComposeContainer(DockerImageName image, List<File> composeFiles) {
+        this(image,Base58.randomString(6).toLowerCase(),composeFiles);
     }
 
-    public ComposeContainer(String identifier, File... composeFiles) {
-        this(identifier, Arrays.asList(composeFiles));
+    public ComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
+        this(image,identifier, Arrays.asList(composeFiles));
     }
 
-    public ComposeContainer(String identifier, List<File> composeFiles) {
+    public ComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(
                 ComposeDelegate.ComposeVersion.V2,
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DockerImageName.parse(
-                    TestcontainersConfiguration
-                        .getInstance()
-                        .getEnvVarOrUserProperty("compose.container.image", DEFAULT_DOCKER_IMAGE)
-                )
+                image
             );
         this.project = this.composeDelegate.getProject();
+    }
+
+    /**
+     * @deprecated
+     *  Use the new constructor ComposeContainer(DockerImageName image, File... composeFiles)
+     */
+    @Deprecated
+    public ComposeContainer(File... composeFiles) {
+        this(getDockerImageName(),Arrays.asList(composeFiles));
+    }
+    /**
+     * @deprecated
+     *  Use the new constructor ComposeContainer(DockerImageName image,List<File> composeFiles)
+     */
+    @Deprecated
+    public ComposeContainer(List<File> composeFiles) {
+        this(getDockerImageName(), composeFiles);
+    }
+    /**
+     * @deprecated
+     *  Use the new constructor ComposeContainer(DockerImageName image, String identifier, File... composeFile)
+     */
+    @Deprecated
+    public ComposeContainer(String identifier, File... composeFiles) {
+        this(getDockerImageName(),identifier, Arrays.asList(composeFiles));
+    }
+
+    /**
+     * @deprecated
+     * Use the new constructor ComposeContainer(DockerImageName image,String identifier, List<File> composeFiles)
+     */
+    @Deprecated
+    public ComposeContainer(String identifier, List<File> composeFiles) {
+       this(getDockerImageName(),identifier, composeFiles);
+    }
+
+    public static DockerImageName getDockerImageName() {
+        return DockerImageName.parse(
+            TestcontainersConfiguration
+                .getInstance()
+                .getEnvVarOrUserProperty("compose.container.image", DEFAULT_DOCKER_IMAGE)
+        );
     }
 
     @Override

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -62,7 +62,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker.exe" : "docker";
 
-    private static final String DEFAULT_DOCKER_IMAGE = "docker:27.5.0";
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker:24.0.2");
 
     private final ComposeDelegate composeDelegate;
 
@@ -94,7 +94,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
      */
     @Deprecated
     public ComposeContainer(File... composeFiles) {
-        this(getDockerImageName(), Arrays.asList(composeFiles));
+        this(DEFAULT_IMAGE_NAME, Arrays.asList(composeFiles));
     }
 
     /**
@@ -103,7 +103,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
      */
     @Deprecated
     public ComposeContainer(List<File> composeFiles) {
-        this(getDockerImageName(), composeFiles);
+        this(DEFAULT_IMAGE_NAME, composeFiles);
     }
 
     /**
@@ -112,7 +112,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
      */
     @Deprecated
     public ComposeContainer(String identifier, File... composeFiles) {
-        this(getDockerImageName(), identifier, Arrays.asList(composeFiles));
+        this(DEFAULT_IMAGE_NAME, identifier, Arrays.asList(composeFiles));
     }
 
     /**
@@ -121,15 +121,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
      */
     @Deprecated
     public ComposeContainer(String identifier, List<File> composeFiles) {
-        this(getDockerImageName(), identifier, composeFiles);
-    }
-
-    public static DockerImageName getDockerImageName() {
-        return DockerImageName.parse(
-            TestcontainersConfiguration
-                .getInstance()
-                .getEnvVarOrUserProperty("compose.container.image", DEFAULT_DOCKER_IMAGE)
-        );
+        this(DEFAULT_IMAGE_NAME, identifier, composeFiles);
     }
 
     @Override

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -99,7 +99,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     /**
      * @deprecated
-     *  Use the new constructor ComposeContainer(DockerImageName image,List<File> composeFiles)
+     *  Use the new constructor ComposeContainer(DockerImageName image,List composeFiles)
      */
     @Deprecated
     public ComposeContainer(List<File> composeFiles) {
@@ -117,7 +117,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     /**
      * @deprecated
-     * Use the new constructor ComposeContainer(DockerImageName image,String identifier, List<File> composeFiles)
+     * Use the new constructor ComposeContainer(DockerImageName image,String identifier, List composeFiles)
      */
     @Deprecated
     public ComposeContainer(String identifier, List<File> composeFiles) {

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -13,6 +13,7 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.time.Duration;
@@ -61,7 +62,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker.exe" : "docker";
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker:24.0.2");
+    public static final String DEFAULT_DOCKER_IMAGE = "docker:24.0.2";
 
     private final ComposeDelegate composeDelegate;
 
@@ -88,7 +89,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DEFAULT_IMAGE_NAME
+                DockerImageName.parse(TestcontainersConfiguration.getInstance().getEnvVarOrUserProperty("compose.container.image",DEFAULT_DOCKER_IMAGE))
             );
         this.project = this.composeDelegate.getProject();
     }

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -75,22 +75,16 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
     }
 
     public ComposeContainer(DockerImageName image, List<File> composeFiles) {
-        this(image,Base58.randomString(6).toLowerCase(),composeFiles);
+        this(image, Base58.randomString(6).toLowerCase(), composeFiles);
     }
 
     public ComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
-        this(image,identifier, Arrays.asList(composeFiles));
+        this(image, identifier, Arrays.asList(composeFiles));
     }
 
     public ComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
         this.composeDelegate =
-            new ComposeDelegate(
-                ComposeDelegate.ComposeVersion.V2,
-                composeFiles,
-                identifier,
-                COMPOSE_EXECUTABLE,
-                image
-            );
+            new ComposeDelegate(ComposeDelegate.ComposeVersion.V2, composeFiles, identifier, COMPOSE_EXECUTABLE, image);
         this.project = this.composeDelegate.getProject();
     }
 
@@ -100,8 +94,9 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
      */
     @Deprecated
     public ComposeContainer(File... composeFiles) {
-        this(getDockerImageName(),Arrays.asList(composeFiles));
+        this(getDockerImageName(), Arrays.asList(composeFiles));
     }
+
     /**
      * @deprecated
      *  Use the new constructor ComposeContainer(DockerImageName image,List<File> composeFiles)
@@ -110,13 +105,14 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
     public ComposeContainer(List<File> composeFiles) {
         this(getDockerImageName(), composeFiles);
     }
+
     /**
      * @deprecated
      *  Use the new constructor ComposeContainer(DockerImageName image, String identifier, File... composeFile)
      */
     @Deprecated
     public ComposeContainer(String identifier, File... composeFiles) {
-        this(getDockerImageName(),identifier, Arrays.asList(composeFiles));
+        this(getDockerImageName(), identifier, Arrays.asList(composeFiles));
     }
 
     /**
@@ -125,7 +121,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
      */
     @Deprecated
     public ComposeContainer(String identifier, List<File> composeFiles) {
-       this(getDockerImageName(),identifier, composeFiles);
+        this(getDockerImageName(), identifier, composeFiles);
     }
 
     public static DockerImageName getDockerImageName() {

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -62,7 +62,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker.exe" : "docker";
 
-    public static final String DEFAULT_DOCKER_IMAGE = "docker:27.5.0";
+    private static final String DEFAULT_DOCKER_IMAGE = "docker:27.5.0";
 
     private final ComposeDelegate composeDelegate;
 

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -89,7 +89,11 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DockerImageName.parse(TestcontainersConfiguration.getInstance().getEnvVarOrUserProperty("compose.container.image",DEFAULT_DOCKER_IMAGE))
+                DockerImageName.parse(
+                    TestcontainersConfiguration
+                        .getInstance()
+                        .getEnvVarOrUserProperty("compose.container.image", DEFAULT_DOCKER_IMAGE)
+                )
             );
         this.project = this.composeDelegate.getProject();
     }

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -69,19 +69,45 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
     private String project;
 
     private List<String> filesInDirectory = new ArrayList<>();
-
+    /**
+     * Creates a new ComposeContainer with a random identifier using the specified Docker image and compose files.
+     *
+     * @param image        The Docker image to use for the container
+     * @param composeFiles One or more Docker Compose configuration files
+     */
     public ComposeContainer(DockerImageName image, File... composeFiles) {
         this(image, Arrays.asList(composeFiles));
     }
 
+    /**
+     * Creates a new ComposeContainer with a random identifier using the specified Docker image and compose files.
+     *
+     * @param image        The Docker image to use for the container
+     * @param composeFiles A list of Docker Compose configuration files
+     */
     public ComposeContainer(DockerImageName image, List<File> composeFiles) {
         this(image, Base58.randomString(6).toLowerCase(), composeFiles);
     }
 
+    /**
+     * Creates a new ComposeContainer with the specified Docker image, identifier, and compose files.
+     *
+     * @param image        The Docker image to use for the container
+     * @param identifier   A unique identifier for this compose environment
+     * @param composeFiles One or more Docker Compose configuration files
+     */
     public ComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
         this(image, identifier, Arrays.asList(composeFiles));
     }
 
+    /**
+     * Creates a new ComposeContainer with the specified Docker image, identifier, and compose files.
+     * This is the primary constructor that all other constructors delegate to.
+     *
+     * @param image        The Docker image to use for the container
+     * @param identifier   A unique identifier for this compose environment
+     * @param composeFiles A list of Docker Compose configuration files
+     */
     public ComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(ComposeDelegate.ComposeVersion.V2, composeFiles, identifier, COMPOSE_EXECUTABLE, image);

--- a/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/ComposeContainer.java
@@ -13,7 +13,6 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.time.Duration;
@@ -69,6 +68,7 @@ public class ComposeContainer extends FailureDetectingExternalResource implement
     private String project;
 
     private List<String> filesInDirectory = new ArrayList<>();
+
     /**
      * Creates a new ComposeContainer with a random identifier using the specified Docker image and compose files.
      *

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -13,11 +13,13 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +27,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import static org.testcontainers.containers.ComposeContainer.getDockerImageName;
 
 /**
  * Container which launches Docker Compose, for the purposes of launching a defined set of containers.
@@ -62,31 +66,59 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     public static final String COMPOSE_EXECUTABLE = SystemUtils.IS_OS_WINDOWS ? "docker-compose.exe" : "docker-compose";
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker/compose:1.29.2");
-
     private final ComposeDelegate composeDelegate;
 
     private String project;
 
     private List<String> filesInDirectory = new ArrayList<>();
 
+
+
+    public DockerComposeContainer(DockerImageName image, String identifier, File composeFile) {
+        this(image, identifier, Collections.singletonList(composeFile));
+    }
+
+    public DockerComposeContainer(DockerImageName image, List<File> composeFiles) {
+        this(image,Base58.randomString(6).toLowerCase(),composeFiles);
+    }
+
+    public DockerComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
+        this(image,identifier, Arrays.asList(composeFiles));
+    }
+    public DockerComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
+        this.composeDelegate =
+            new ComposeDelegate(
+                ComposeDelegate.ComposeVersion.V2,
+                composeFiles,
+                identifier,
+                COMPOSE_EXECUTABLE,
+                image
+            );
+        this.project = this.composeDelegate.getProject();
+    }
+
+
     @Deprecated
     public DockerComposeContainer(File composeFile, String identifier) {
         this(identifier, composeFile);
     }
 
+    @Deprecated
     public DockerComposeContainer(File... composeFiles) {
         this(Arrays.asList(composeFiles));
     }
 
+    @Deprecated
     public DockerComposeContainer(List<File> composeFiles) {
         this(Base58.randomString(6).toLowerCase(), composeFiles);
     }
 
+    @Deprecated
     public DockerComposeContainer(String identifier, File... composeFiles) {
         this(identifier, Arrays.asList(composeFiles));
     }
 
+    @Deprecated
     public DockerComposeContainer(String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(
@@ -94,10 +126,12 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                DEFAULT_IMAGE_NAME
+                getDockerImageName()
             );
         this.project = this.composeDelegate.getProject();
     }
+
+
 
     @Override
     @Deprecated

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -88,7 +88,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
     public DockerComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(
-                ComposeDelegate.ComposeVersion.V2,
+                ComposeDelegate.ComposeVersion.V1,
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
@@ -126,7 +126,7 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
                 composeFiles,
                 identifier,
                 COMPOSE_EXECUTABLE,
-                getDockerImageName()
+                DockerImageName.parse("docker/compose:1.29.2")
             );
         this.project = this.composeDelegate.getProject();
     }

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -13,7 +13,6 @@ import org.testcontainers.containers.wait.strategy.WaitStrategy;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.time.Duration;
@@ -27,8 +26,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
-
-import static org.testcontainers.containers.ComposeContainer.getDockerImageName;
 
 /**
  * Container which launches Docker Compose, for the purposes of launching a defined set of containers.
@@ -72,31 +69,23 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     private List<String> filesInDirectory = new ArrayList<>();
 
-
-
     public DockerComposeContainer(DockerImageName image, String identifier, File composeFile) {
         this(image, identifier, Collections.singletonList(composeFile));
     }
 
     public DockerComposeContainer(DockerImageName image, List<File> composeFiles) {
-        this(image,Base58.randomString(6).toLowerCase(),composeFiles);
+        this(image, Base58.randomString(6).toLowerCase(), composeFiles);
     }
 
     public DockerComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
-        this(image,identifier, Arrays.asList(composeFiles));
-    }
-    public DockerComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
-        this.composeDelegate =
-            new ComposeDelegate(
-                ComposeDelegate.ComposeVersion.V1,
-                composeFiles,
-                identifier,
-                COMPOSE_EXECUTABLE,
-                image
-            );
-        this.project = this.composeDelegate.getProject();
+        this(image, identifier, Arrays.asList(composeFiles));
     }
 
+    public DockerComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
+        this.composeDelegate =
+            new ComposeDelegate(ComposeDelegate.ComposeVersion.V1, composeFiles, identifier, COMPOSE_EXECUTABLE, image);
+        this.project = this.composeDelegate.getProject();
+    }
 
     @Deprecated
     public DockerComposeContainer(File composeFile, String identifier) {
@@ -130,8 +119,6 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
             );
         this.project = this.composeDelegate.getProject();
     }
-
-
 
     @Override
     @Deprecated

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -87,26 +87,47 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
         this.project = this.composeDelegate.getProject();
     }
 
+    /**
+     * @deprecated
+     *  Use the new constructor DockerComposeContainer(File composeFile, String identifier)
+     */
     @Deprecated
     public DockerComposeContainer(File composeFile, String identifier) {
         this(identifier, composeFile);
     }
 
+    /**
+     * @deprecated
+     *  Use the new constructor DockerComposeContainer(File... composeFiles)
+     */
     @Deprecated
     public DockerComposeContainer(File... composeFiles) {
         this(Arrays.asList(composeFiles));
     }
 
+    /**
+     * @deprecated
+     *  Use the new constructor DockerComposeContainer(List composeFiles)
+     */
     @Deprecated
     public DockerComposeContainer(List<File> composeFiles) {
         this(Base58.randomString(6).toLowerCase(), composeFiles);
     }
 
+    /**
+     * @deprecated
+     *  Use the new constructor DockerComposeContainer(String identifier,File... composeFiles)
+     */
     @Deprecated
     public DockerComposeContainer(String identifier, File... composeFiles) {
         this(identifier, Arrays.asList(composeFiles));
     }
 
+
+    /**
+     * @deprecated
+     *  Use the new constructor DockerComposeContainer(String identifier,List composeFiles)
+     */
     @Deprecated
     public DockerComposeContainer(String identifier, List<File> composeFiles) {
         this.composeDelegate =

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -69,18 +69,46 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
 
     private List<String> filesInDirectory = new ArrayList<>();
 
+    /**
+     * Creates a new DockerComposeContainer with the specified Docker image, identifier, and a single compose file.
+     *
+     * @param image        The Docker image to use for the container
+     * @param identifier   A unique identifier for this compose environment
+     * @param composeFile  A Docker Compose configuration file
+     */
     public DockerComposeContainer(DockerImageName image, String identifier, File composeFile) {
         this(image, identifier, Collections.singletonList(composeFile));
     }
 
+    /**
+     * Creates a new DockerComposeContainer with a random identifier using the specified Docker image and compose files.
+     *
+     * @param image        The Docker image to use for the container
+     * @param composeFiles A list of Docker Compose configuration files
+     */
     public DockerComposeContainer(DockerImageName image, List<File> composeFiles) {
         this(image, Base58.randomString(6).toLowerCase(), composeFiles);
     }
 
+    /**
+     * Creates a new DockerComposeContainer with the specified Docker image, identifier, and compose files.
+     *
+     * @param image        The Docker image to use for the container
+     * @param identifier   A unique identifier for this compose environment
+     * @param composeFiles One or more Docker Compose configuration files
+     */
     public DockerComposeContainer(DockerImageName image, String identifier, File... composeFiles) {
         this(image, identifier, Arrays.asList(composeFiles));
     }
 
+    /**
+     * Creates a new DockerComposeContainer with the specified Docker image, identifier, and compose files.
+     * This is the primary constructor that all other constructors delegate to.
+     *
+     * @param image        The Docker image to use for the container
+     * @param identifier   A unique identifier for this compose environment
+     * @param composeFiles A list of Docker Compose configuration files
+     */
     public DockerComposeContainer(DockerImageName image, String identifier, List<File> composeFiles) {
         this.composeDelegate =
             new ComposeDelegate(ComposeDelegate.ComposeVersion.V1, composeFiles, identifier, COMPOSE_EXECUTABLE, image);

--- a/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/DockerComposeContainer.java
@@ -151,7 +151,6 @@ public class DockerComposeContainer<SELF extends DockerComposeContainer<SELF>>
         this(identifier, Arrays.asList(composeFiles));
     }
 
-
     /**
      * @deprecated
      *  Use the new constructor DockerComposeContainer(String identifier,List composeFiles)

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -244,7 +244,7 @@ public class TestcontainersConfiguration {
         }
 
         for (final Properties properties : propertiesSources) {
-            if (properties.get(propertyName) != null) {
+            if (properties.get(propertyName) != null && !properties.get(propertyName).toString().trim().isEmpty()) {
                 return (String) properties.get(propertyName);
             }
         }

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -1,0 +1,69 @@
+package org.testcontainers.containers;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import com.google.common.collect.Lists;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.*;
+
+public class ComposeContainerTest {
+    private TestLogAppender testLogAppender;
+    private Logger rootLogger;
+
+    @Before
+    public void setup() {
+        testLogAppender = new TestLogAppender();
+        testLogAppender.start();
+        rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        rootLogger.addAppender(testLogAppender);
+    }
+
+    @After
+    public void tearDown() {
+        rootLogger.detachAppender(testLogAppender);
+    }
+
+    @Test
+    public void testWithCustomDockerImage() throws IOException {
+        TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "docker:25.0.2");
+        ComposeContainer composeContainer = new ComposeContainer(Lists.newArrayList(new File("src/test/resources/docker-compose-imagename-parsing-v2.yml")));
+        composeContainer.start();
+        System.clearProperty("compose.container.image");
+        List<String> logs = testLogAppender.getLogs();
+        composeContainer.stop();
+        assertNotNull(logs);
+        Optional<String> verification = logs.stream().filter(line -> line.contains("Creating container for image: docker:25.0.2")).findFirst();
+        assertTrue(verification.isPresent());
+        TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
+    }
+
+    private static class TestLogAppender extends AppenderBase<ILoggingEvent> {
+        private final List<String> logs = new ArrayList<>();
+
+        @Override
+        protected void append(ILoggingEvent eventObject) {
+            logs.add(eventObject.getFormattedMessage());
+        }
+
+        public List<String> getLogs() {
+            return logs;
+        }
+
+        public void clearLogs() {
+            logs.clear();
+        }
+    }
+}

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -12,15 +12,17 @@ import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class ComposeContainerTest {
+
     private TestLogAppender testLogAppender;
+
     private Logger rootLogger;
 
     @Before
@@ -44,9 +46,9 @@ public class ComposeContainerTest {
         System.clearProperty("compose.container.image");
         List<String> logs = testLogAppender.getLogs();
         composeContainer.stop();
-        assertNotNull(logs);
+        assertThat(logs).isNotNull();
         Optional<String> verification = logs.stream().filter(line -> line.contains("Creating container for image: docker:25.0.2")).findFirst();
-        assertTrue(verification.isPresent());
+        assertThat(verification.isPresent()).isTrue();
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
     }
 

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ComposeContainerTest {
 
     public static final String DOCKER_IMAGE = "docker:25.0.2";
+
     private TestLogAppender testLogAppender;
 
     private Logger rootLogger;
@@ -53,7 +54,7 @@ public class ComposeContainerTest {
         assertThat(logs).isNotNull();
         Optional<String> verification = logs
             .stream()
-            .filter(line -> line.contains("Creating container for image: "+DOCKER_IMAGE))
+            .filter(line -> line.contains("Creating container for image: " + DOCKER_IMAGE))
             .findFirst();
         assertThat(verification.isPresent()).isTrue();
     }

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -18,7 +18,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 public class ComposeContainerTest {
 
     private TestLogAppender testLogAppender;
@@ -41,18 +40,24 @@ public class ComposeContainerTest {
     @Test
     public void testWithCustomDockerImage() throws IOException {
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "docker:25.0.2");
-        ComposeContainer composeContainer = new ComposeContainer(Lists.newArrayList(new File("src/test/resources/docker-compose-imagename-parsing-v2.yml")));
+        ComposeContainer composeContainer = new ComposeContainer(
+            Lists.newArrayList(new File("src/test/resources/docker-compose-imagename-parsing-v2.yml"))
+        );
         composeContainer.start();
         System.clearProperty("compose.container.image");
         List<String> logs = testLogAppender.getLogs();
         composeContainer.stop();
         assertThat(logs).isNotNull();
-        Optional<String> verification = logs.stream().filter(line -> line.contains("Creating container for image: docker:25.0.2")).findFirst();
+        Optional<String> verification = logs
+            .stream()
+            .filter(line -> line.contains("Creating container for image: docker:25.0.2"))
+            .findFirst();
         assertThat(verification.isPresent()).isTrue();
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
     }
 
     private static class TestLogAppender extends AppenderBase<ILoggingEvent> {
+
         private final List<String> logs = new ArrayList<>();
 
         @Override

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -3,7 +3,6 @@ package org.testcontainers.containers;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,10 +11,8 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -33,11 +33,11 @@ public class ComposeContainerTest {
         rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         rootLogger.addAppender(testLogAppender);
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", DOCKER_IMAGE);
-        composeContainer.stop();
     }
 
     @After
     public void tearDown() {
+        composeContainer.stop();
         rootLogger.detachAppender(testLogAppender);
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
         System.clearProperty("compose.container.image");
@@ -45,18 +45,15 @@ public class ComposeContainerTest {
 
     @Test
     public void testWithCustomDockerImage() {
-        composeContainer = new ComposeContainer(
-            DockerImageName.parse(DOCKER_IMAGE), new File(COMPOSE_FILE_PATH)
-        );
+        composeContainer = new ComposeContainer(DockerImageName.parse(DOCKER_IMAGE), new File(COMPOSE_FILE_PATH));
         composeContainer.start();
         verifyContainerCreation();
     }
 
     @Test
     public void testWithCustomDockerImageAndIdentifier() {
-        composeContainer = new ComposeContainer(
-            DockerImageName.parse(DOCKER_IMAGE), "myidentifier", new File(COMPOSE_FILE_PATH)
-        );
+        composeContainer =
+            new ComposeContainer(DockerImageName.parse(DOCKER_IMAGE), "myidentifier", new File(COMPOSE_FILE_PATH));
         composeContainer.start();
         verifyContainerCreation();
     }
@@ -64,11 +61,8 @@ public class ComposeContainerTest {
     private void verifyContainerCreation() {
         List<String> logs = testLogAppender.getLogs();
 
-        assertThat(logs)
-            .isNotNull()
-            .anyMatch(line -> line.contains("Creating container for image: " + DOCKER_IMAGE));
+        assertThat(logs).isNotNull().anyMatch(line -> line.contains("Creating container for image: " + DOCKER_IMAGE));
     }
-
 
     private static class TestLogAppender extends AppenderBase<ILoggingEvent> {
 

--- a/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ComposeContainerTest.java
@@ -19,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ComposeContainerTest {
 
     public static final String DOCKER_IMAGE = "docker:25.0.2";
+
     private static final String COMPOSE_FILE_PATH = "src/test/resources/docker-compose-imagename-parsing-v2.yml";
 
     private ComposeContainer composeContainer;
+
     private TestLogAppender testLogAppender;
 
     private Logger rootLogger;

--- a/core/src/test/java/org/testcontainers/containers/DockerComposeContainerCustomImageTest.java
+++ b/core/src/test/java/org/testcontainers/containers/DockerComposeContainerCustomImageTest.java
@@ -19,10 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class DockerComposeContainerCustomImageTest {
 
     public static final String DOCKER_IMAGE = "docker/compose:debian-1.29.2";
+
     private static final String COMPOSE_FILE_PATH = "src/test/resources/docker-compose-imagename-parsing-v1.yml";
 
     private DockerComposeContainer composeContainer;
+
     private TestLogAppender testLogAppender;
+
     private Logger rootLogger;
 
     @Before

--- a/core/src/test/java/org/testcontainers/containers/DockerComposeContainerCustomImageTest.java
+++ b/core/src/test/java/org/testcontainers/containers/DockerComposeContainerCustomImageTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DockerComposeContainerCustomImageTest {
+
     public static final String DOCKER_IMAGE = "docker/compose:debian-1.29.2";
     private static final String COMPOSE_FILE_PATH = "src/test/resources/docker-compose-imagename-parsing-v1.yml";
 
@@ -43,14 +44,20 @@ public class DockerComposeContainerCustomImageTest {
 
     @Test
     public void testWithCustomDockerImage() {
-        composeContainer = new DockerComposeContainer(DockerImageName.parse(DOCKER_IMAGE),"testing", new File(COMPOSE_FILE_PATH));
+        composeContainer =
+            new DockerComposeContainer(DockerImageName.parse(DOCKER_IMAGE), "testing", new File(COMPOSE_FILE_PATH));
         composeContainer.start();
         verifyContainerCreation();
     }
 
     @Test
     public void testWithCustomDockerImageAndIdentifier() {
-        composeContainer = new DockerComposeContainer(DockerImageName.parse(DOCKER_IMAGE), "myidentifier", new File(COMPOSE_FILE_PATH));
+        composeContainer =
+            new DockerComposeContainer(
+                DockerImageName.parse(DOCKER_IMAGE),
+                "myidentifier",
+                new File(COMPOSE_FILE_PATH)
+            );
         composeContainer.start();
         verifyContainerCreation();
     }
@@ -58,9 +65,7 @@ public class DockerComposeContainerCustomImageTest {
     private void verifyContainerCreation() {
         List<String> logs = testLogAppender.getLogs();
 
-        assertThat(logs)
-            .isNotNull()
-            .anyMatch(line -> line.contains("Creating container for image: " + DOCKER_IMAGE));
+        assertThat(logs).isNotNull().anyMatch(line -> line.contains("Creating container for image: " + DOCKER_IMAGE));
     }
 
     private static class TestLogAppender extends AppenderBase<ILoggingEvent> {

--- a/core/src/test/java/org/testcontainers/containers/DockerComposeContainerCustomImageTest.java
+++ b/core/src/test/java/org/testcontainers/containers/DockerComposeContainerCustomImageTest.java
@@ -3,7 +3,6 @@ package org.testcontainers.containers;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
-import com.google.common.collect.Lists;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,21 +11,17 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ComposeContainerTest {
+public class DockerComposeContainerCustomImageTest {
+    public static final String DOCKER_IMAGE = "docker/compose:debian-1.29.2";
+    private static final String COMPOSE_FILE_PATH = "src/test/resources/docker-compose-imagename-parsing-v1.yml";
 
-    public static final String DOCKER_IMAGE = "docker:25.0.2";
-    private static final String COMPOSE_FILE_PATH = "src/test/resources/docker-compose-imagename-parsing-v2.yml";
-
-    private ComposeContainer composeContainer;
+    private DockerComposeContainer composeContainer;
     private TestLogAppender testLogAppender;
-
     private Logger rootLogger;
 
     @Before
@@ -36,7 +31,6 @@ public class ComposeContainerTest {
         rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         rootLogger.addAppender(testLogAppender);
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", DOCKER_IMAGE);
-        composeContainer.stop();
     }
 
     @After
@@ -44,22 +38,19 @@ public class ComposeContainerTest {
         rootLogger.detachAppender(testLogAppender);
         TestcontainersConfiguration.getInstance().updateUserConfig("compose.container.image", "");
         System.clearProperty("compose.container.image");
+        composeContainer.stop();
     }
 
     @Test
     public void testWithCustomDockerImage() {
-        composeContainer = new ComposeContainer(
-            DockerImageName.parse(DOCKER_IMAGE), new File(COMPOSE_FILE_PATH)
-        );
+        composeContainer = new DockerComposeContainer(DockerImageName.parse(DOCKER_IMAGE),"testing", new File(COMPOSE_FILE_PATH));
         composeContainer.start();
         verifyContainerCreation();
     }
 
     @Test
     public void testWithCustomDockerImageAndIdentifier() {
-        composeContainer = new ComposeContainer(
-            DockerImageName.parse(DOCKER_IMAGE), "myidentifier", new File(COMPOSE_FILE_PATH)
-        );
+        composeContainer = new DockerComposeContainer(DockerImageName.parse(DOCKER_IMAGE), "myidentifier", new File(COMPOSE_FILE_PATH));
         composeContainer.start();
         verifyContainerCreation();
     }
@@ -71,7 +62,6 @@ public class ComposeContainerTest {
             .isNotNull()
             .anyMatch(line -> line.contains("Creating container for image: " + DOCKER_IMAGE));
     }
-
 
     private static class TestLogAppender extends AppenderBase<ILoggingEvent> {
 


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

In the https://github.com/testcontainers/testcontainers-java/issues/9222 a user is specifying a property with the field name compose.container.image and the ComposeContainer when it creates the composeDelegate variable is always picking the 24.0.2 version of docker. The change that I am proposing is to use the TestcontainersConfiguration in order to parse the property compose.container.image if it exists otherwise continue as it was in the past. Updated the constructors based on the feedback.

@fokion I've rebased your branch.