### PR TITLE
Make ParsedDockerComposeFile public to use it out of the project, since it's a useful class

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 @Slf4j
 @EqualsAndHashCode
-class ParsedDockerComposeFile {
+public class ParsedDockerComposeFile {
 
     private final Map<String, Object> composeFileContent;
 


### PR DESCRIPTION
I have found this class really useful so I currently have a copy of it.
It allows me to gather information from the `docker-compose.yml` file before calling testcontainers.
