### PR TITLE
Remove LinkableContainer from NginxContainer

### DIFF
--- a/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/containers/NginxContainer.java
@@ -1,16 +1,13 @@
 package org.testcontainers.containers;
 
 import org.jetbrains.annotations.NotNull;
-import org.testcontainers.containers.traits.LinkableContainer;
 import org.testcontainers.utility.DockerImageName;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
 
-public class NginxContainer<SELF extends NginxContainer<SELF>>
-    extends GenericContainer<SELF>
-    implements LinkableContainer {
+public class NginxContainer extends GenericContainer<NginxContainer> {
 
     private static final int NGINX_DEFAULT_PORT = 80;
 
@@ -59,7 +56,7 @@ public class NginxContainer<SELF extends NginxContainer<SELF>>
     }
 
     @Deprecated
-    public SELF withCustomContent(String htmlContentPath) {
+    public NginxContainer withCustomContent(String htmlContentPath) {
         this.setCustomContent(htmlContentPath);
         return self();
     }

--- a/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
+++ b/modules/nginx/src/test/java/org/testcontainers/junit/SimpleNginxTest.java
@@ -28,7 +28,7 @@ public class SimpleNginxTest {
 
     // creatingContainer {
     @Rule
-    public NginxContainer<?> nginx = new NginxContainer<>(NGINX_IMAGE)
+    public NginxContainer nginx = new NginxContainer(NGINX_IMAGE)
         .withCopyFileToContainer(MountableFile.forHostPath(tmpDirectory), "/usr/share/nginx/html")
         .waitingFor(new HttpWaitStrategy());
 
@@ -64,7 +64,7 @@ public class SimpleNginxTest {
         assertHasCorrectExposedAndLivenessCheckPorts(nginx);
     }
 
-    private void assertHasCorrectExposedAndLivenessCheckPorts(NginxContainer<?> nginxContainer) throws Exception {
+    private void assertHasCorrectExposedAndLivenessCheckPorts(NginxContainer nginxContainer) {
         assertThat(nginxContainer.getExposedPorts()).containsExactly(80);
         assertThat(nginxContainer.getLivenessCheckPortNumbers()).containsExactly(nginxContainer.getMappedPort(80));
     }


### PR DESCRIPTION
Link containers is deprecated.
