### PR TITLE
Making R2DBCDatabaseContainer extend GenericContainer

### DIFF
--- a/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseR2DBCDatabaseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseR2DBCDatabaseContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 /**
  * ClickHouse R2DBC support
  */
-public class ClickHouseR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
+public class ClickHouseR2DBCDatabaseContainer extends R2DBCDatabaseContainer<ClickHouseR2DBCDatabaseContainer> {
 
     private final ClickHouseContainer container;
 

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
 @RequiredArgsConstructor
-public class MariaDBR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
+public class MariaDBR2DBCDatabaseContainer extends R2DBCDatabaseContainer<MariaDBR2DBCDatabaseContainer> {
 
     @Delegate(types = Startable.class)
     private final MariaDBContainer<?> container;

--- a/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/containers/MSSQLR2DBCDatabaseContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
 @RequiredArgsConstructor
-public class MSSQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
+public class MSSQLR2DBCDatabaseContainer extends R2DBCDatabaseContainer<MSSQLR2DBCDatabaseContainer> {
 
     @Delegate(types = Startable.class)
     private final MSSQLServerContainer<?> container;

--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLR2DBCDatabaseContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
 @RequiredArgsConstructor
-public class MySQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
+public class MySQLR2DBCDatabaseContainer extends R2DBCDatabaseContainer<MySQLR2DBCDatabaseContainer> {
 
     @Delegate(types = Startable.class)
     private final MySQLContainer<?> container;

--- a/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/containers/PostgreSQLR2DBCDatabaseContainer.java
@@ -7,7 +7,7 @@ import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
 @RequiredArgsConstructor
-public final class PostgreSQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
+public final class PostgreSQLR2DBCDatabaseContainer extends R2DBCDatabaseContainer<PostgreSQLR2DBCDatabaseContainer> {
 
     @Delegate(types = Startable.class)
     private final PostgreSQLContainer<?> container;

--- a/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/R2DBCDatabaseContainer.java
+++ b/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/R2DBCDatabaseContainer.java
@@ -1,8 +1,9 @@
 package org.testcontainers.r2dbc;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import org.testcontainers.lifecycle.Startable;
+import org.testcontainers.containers.GenericContainer;
 
-public interface R2DBCDatabaseContainer extends Startable {
-    ConnectionFactoryOptions configure(ConnectionFactoryOptions options);
+public abstract class R2DBCDatabaseContainer<SELF extends R2DBCDatabaseContainer<SELF>>
+    extends GenericContainer<SELF> {
+    public abstract ConnectionFactoryOptions configure(ConnectionFactoryOptions options);
 }


### PR DESCRIPTION
R2DBCDatabaseContainer seemed a bit neglected. For instance, it's currently not possible to query a R2DBCDatabaseContainers state, etc.

This should bring it more in line with JDBC containers.
