### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -120,13 +120,13 @@ dependencies {
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
     jarFileTestImplementation 'junit:junit:4.13.2'
-    jarFileTestImplementation 'org.assertj:assertj-core:3.26.3'
+    jarFileTestImplementation 'org.assertj:assertj-core:3.27.3'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'
 }
 

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testImplementation "org.seleniumhq.selenium:selenium-api:4.25.0"
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.11.0"
     testImplementation project(":testcontainers")
     testImplementation project(":junit-jupiter")
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 test {

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: ActiveMQ"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation "org.apache.activemq:activemq-client:6.1.2"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.37.0"
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'com.azure:azure-cosmos:4.63.3'
     testImplementation 'com.azure:azure-storage-blob:12.29.0'
     testImplementation 'com.azure:azure-storage-queue:12.24.0'

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/chromadb/build.gradle
+++ b/modules/chromadb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ChromaDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     testImplementation 'com.couchbase.client:java-client:3.7.3'
     testImplementation 'org.awaitility:awaitility:4.2.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/databend/build.gradle
+++ b/modules/databend/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'com.databend:databend-jdbc:0.3.2'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'com.ibm.db2:jcc:11.5.9.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.15.1"
     testImplementation "org.elasticsearch.client:transport:7.17.24"
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-pubsub'
     testImplementation 'com.google.cloud:google-cloud-spanner'
     testImplementation 'com.google.cloud:google-cloud-bigtable'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Grafana"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.4'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.8")
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 test {

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'org.influxdb:influxdb-java:2.24'
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.influxdb:influxdb-java:2.24'
     testImplementation "com.influxdb:influxdb-client-java:6.12.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     api 'com.googlecode.junit-toolbox:junit-toolbox:2.4'
 
-    api 'org.assertj:assertj-core:3.26.3'
+    api 'org.assertj:assertj-core:3.27.3'
 
     api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
     api 'org.vibur:vibur-dbcp:25.0'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.30'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.4'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -10,5 +10,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:6.13.1'
     testImplementation 'io.kubernetes:client-java:21.0.1-legacy'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/k6/build.gradle
+++ b/modules/k6/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: k6"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'org.awaitility:awaitility:4.2.2'
 }

--- a/modules/ldap/build.gradle
+++ b/modules/ldap/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: LDAP"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'com.unboundid:unboundid-ldapsdk:7.0.2'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
     testImplementation 'software.amazon.awssdk:s3:2.28.6'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Milvus"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.milvus:milvus-sdk-java:2.4.4'
 }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("io.minio:minio:8.5.12")
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("org.mongodb:mongodb-driver-sync:5.1.4")
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.18'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Nginx"
 dependencies {
     api project(':testcontainers')
     compileOnly 'org.jetbrains:annotations:24.1.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/ollama/build.gradle
+++ b/modules/ollama/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Ollama"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.2.33"
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.33"
 }

--- a/modules/pinecone/build.gradle
+++ b/modules/pinecone/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ActiveMQ"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.pinecone:pinecone-client:3.1.0'
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation platform("org.apache.pulsar:pulsar-bom:3.3.1")
     testImplementation 'org.apache.pulsar:pulsar-client'
     testImplementation 'org.apache.pulsar:pulsar-client-admin'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Qdrant"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.qdrant:client:1.10.0'
     testImplementation platform('io.grpc:grpc-bom:1.68.0')
     testImplementation 'io.grpc:grpc-stub'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
     testImplementation project(':jdbc-test')
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.questdb:questdb:7.3.9'
     testImplementation 'org.awaitility:awaitility:4.2.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -8,10 +8,10 @@ dependencies {
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.6.10'
-    testFixturesImplementation 'org.assertj:assertj-core:3.26.3'
+    testFixturesImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.22.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }
 

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     shaded 'org.freemarker:freemarker:2.3.33'
 
     testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testImplementation 'org.awaitility:awaitility:4.2.2'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'com.scylladb:java-driver-core:4.15.0.0'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'software.amazon.awssdk:dynamodb:2.28.6'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'
     testImplementation project(':nginx')
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 
     compileOnly 'org.jetbrains:annotations:24.1.0'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.2.0'
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'com.solacesystems:sol-jcsmp:10.24.1'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.3'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/timeplus/build.gradle
+++ b/modules/timeplus/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'com.timeplus:timeplus-native-jdbc:2.0.5'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.7'
 
     testImplementation 'redis.clients:jedis:5.1.5'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 tasks.japicmp {

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Weaviate"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.weaviate:client:4.8.3'
 }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.11.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 test {

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'org.slf4j:slf4j-api:2.0.16'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/rabbitmq (#9862) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/pulsar (#9859) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/mockserver (#9851) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/mongodb (#9850) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/solr (#9849) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/neo4j (#9848) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/couchbase (#9841) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/cockroachdb (#9833) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/db2 (#9826) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/influxdb (#9822) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/elasticsearch (#9818) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/localstack (#9813) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/toxiproxy (#9811) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/nginx (#9809) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/orientdb (#9803) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /core (#9856) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /smoke-test (#9847) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/grafana (#9865) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/ldap (#9989) @app/dependabot
* Bump org.assertj:assertj-core from 3.24.2 to 3.27.3 in /modules/scylladb (#9929) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/pinecone (#9918) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/activemq (#9912) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/clickhouse (#9852) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/jdbc (#9863) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/selenium (#9861) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/vault (#9858) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/milvus (#9857) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/timeplus (#9854) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/hivemq (#9845) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/r2dbc (#9843) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/qdrant (#9839) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/minio (#9836) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/k6 (#9834) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/kafka (#9829) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/chromadb (#9828) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/ollama (#9827) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/gcloud (#9824) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/weaviate (#9823) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/databend (#9821) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/solace (#9817) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/k3s (#9815) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/cassandra (#9810) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/questdb (#9807) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/redpanda (#9806) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/azure (#9804) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/consul (#9802) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/junit-jupiter (#9831) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/database-commons (#9816) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /modules/jdbc-test (#9814) @app/dependabot
