### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -71,8 +71,8 @@ configurations.all {
 dependencies {
     api 'junit:junit:4.13.2'
     api 'org.slf4j:slf4j-api:1.7.36'
-    compileOnly 'org.jetbrains:annotations:24.1.0'
-    testCompileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
+    testCompileOnly 'org.jetbrains:annotations:26.0.2'
     api 'org.apache.commons:commons-compress:1.24.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'org.postgresql:postgresql:42.7.4'
 
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: HiveMQ"
 
 dependencies {
     api(project(":testcontainers"))
-    api("org.jetbrains:annotations:24.1.0")
+    api("org.jetbrains:annotations:26.0.2")
 
     shaded("org.apache.commons:commons-lang3:3.17.0")
     shaded("commons-io:commons-io:2.17.0")

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: JDBC"
 dependencies {
     api project(':database-commons')
 
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.30'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.3.0'
 
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 }
 
 tasks.japicmp {

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.5.0.24.07'
 
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.5.0.24.07'
 
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'

--- a/modules/presto/build.gradle
+++ b/modules/presto/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'io.prestosql:presto-jdbc:350'
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     testImplementation project(':nginx')
     testImplementation 'org.assertj:assertj-core:3.27.3'
 
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.11.0'
 
-    testCompileOnly 'org.jetbrains:annotations:24.1.0'
+    testCompileOnly 'org.jetbrains:annotations:26.0.2'
 }
 
 tasks.withType(GroovyCompile) {

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'io.trino:trino-jdbc:458'
-    compileOnly 'org.jetbrains:annotations:24.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /core (#9905) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/presto (#9906) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/nginx (#9904) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/hivemq (#9900) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/spock (#9895) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/cratedb (#9893) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/rabbitmq (#9890) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/mysql (#9886) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/trino (#9888) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/jdbc (#9880) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/selenium (#9879) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/oracle-xe (#9892) @app/dependabot
* Bump org.jetbrains:annotations from 24.1.0 to 26.0.2 in /modules/oracle-free (#9891) @app/dependabot
