### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/combine-prs.yml
+++ b/.github/workflows/combine-prs.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - name: combine-prs
         id: combine-prs
-        uses: github/combine-prs@v5.1.0
+        uses: github/combine-prs@v5.2.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/moby-latest.yml
+++ b/.github/workflows/moby-latest.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Notify to Slack on failures
         if: failure()
         id: slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v2.1.0
         with:
           payload: |
             {

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v5.19.0
+      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v3.10.1
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v3.10.1
         with:
           title: Update docs version to ${GITHUB_REF##*/}
           body: |

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -23,7 +23,7 @@ jobs:
           sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
           git diff
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # v3.10.1
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v3.10.1
         with:
           title: Update testcontainers version to ${GITHUB_REF##*/}
           body: |


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump slackapi/slack-github-action from 1.27.0 to 2.1.0 (#10261) @app/dependabot
* Bump peter-evans/create-pull-request from 7.0.5 to 7.0.8 (#10061) @app/dependabot
* Bump release-drafter/release-drafter from 6.0.0 to 6.1.0 (#9820) @app/dependabot
* Bump github/combine-prs from 5.1.0 to 5.2.0 (#9388) @app/dependabot
