### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     testImplementation 'com.azure:azure-data-tables:12.5.0'
     testImplementation 'com.azure:azure-messaging-eventhubs:5.19.2'
     testImplementation 'com.azure:azure-messaging-servicebus:7.17.8'
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.1.0.jre8-preview'
 }

--- a/modules/databend/build.gradle
+++ b/modules/databend/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'com.databend:databend-jdbc:0.3.2'
+    testRuntimeOnly 'com.databend:databend-jdbc:0.3.9'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':jdbc')
 
-    api 'com.google.guava:guava:33.3.1-jre'
+    api 'com.google.guava:guava:33.4.8-jre'
     api 'org.apache.commons:commons-lang3:3.17.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     api 'org.assertj:assertj-core:3.27.3'
 
-    api 'org.apache.tomcat:tomcat-jdbc:10.0.27'
+    api 'org.apache.tomcat:tomcat-jdbc:11.0.9'
     api 'org.vibur:vibur-dbcp:25.0'
     api 'mysql:mysql-connector-java:8.0.33'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:26.0.2'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:25.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:10.1.30'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.9'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.4.1'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.4'
 
     testImplementation testFixtures(project(':r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre8'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.1.0.jre8-preview'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.5.0.24.07'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.8.0.25.04'
 
     compileOnly 'org.jetbrains:annotations:26.0.2'
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.5.0.24.07'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.8.0.25.04'
 
     compileOnly 'org.jetbrains:annotations:26.0.2'
 

--- a/modules/timeplus/build.gradle
+++ b/modules/timeplus/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'com.timeplus:timeplus-native-jdbc:2.0.5'
+    testRuntimeOnly 'com.timeplus:timeplus-native-jdbc:2.0.10'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:458'
+    testRuntimeOnly 'io.trino:trino-jdbc:476'
     compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     // YCQL driver
     testImplementation 'com.yugabyte:java-driver-core:4.15.0-yb-2-TESTFIX.0'
     // YSQL driver
-    testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.3.5-yb-6'
+    testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.7.3-yb-4'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.apache.tomcat:tomcat-jdbc from 10.1.30 to 11.0.8 in /modules/jdbc (#10441) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.0.27 to 11.0.8 in /modules/jdbc-test (#10432) @app/dependabot
* Bump io.trino:trino-jdbc from 458 to 476 in /modules/trino (#10435) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 10.0.27 to 11.0.2 in /modules/jdbc-test (#9616) @app/dependabot
* Bump com.databend:databend-jdbc from 0.3.2 to 0.3.9 in /modules/databend (#10413) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.4.1 to 3.5.4 in /modules/mariadb (#10391) @app/dependabot
* Bump com.timeplus:timeplus-native-jdbc from 2.0.5 to 2.0.10 in /modules/timeplus (#10288) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.8.1.jre8 to 13.1.0.jre8-preview in /modules/mssqlserver (#10446) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 12.8.1.jre8 to 13.1.0.jre8-preview in /modules/azure (#10428) @app/dependabot
* Bump org.vibur:vibur-dbcp from 25.0 to 26.0 in /modules/jdbc (#9785) @app/dependabot
* Bump com.google.guava:guava from 33.3.1-jre to 33.4.8-jre in /modules/jdbc-test (#10244) @app/dependabot
* Bump com.timeplus:timeplus-native-jdbc from 2.0.5 to 2.0.7 in /modules/timeplus (#9567) @app/dependabot
* Bump com.yugabyte:jdbc-yugabytedb from 42.3.5-yb-6 to 42.7.3-yb-4 in /modules/yugabytedb (#10200) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.5.0.24.07 to 23.8.0.25.04 in /modules/oracle-xe (#10318) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.5.0.24.07 to 23.8.0.25.04 in /modules/oracle-free (#10317) @app/dependabot
