### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     api 'org.assertj:assertj-core:3.27.3'
 
     api 'org.apache.tomcat:tomcat-jdbc:11.0.9'
-    api 'org.vibur:vibur-dbcp:25.0'
+    api 'org.vibur:vibur-dbcp:26.0'
     api 'mysql:mysql-connector-java:8.0.33'
 }

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'org.jetbrains:annotations:26.0.2'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
-    testImplementation 'org.vibur:vibur-dbcp:25.0'
+    testImplementation 'org.vibur:vibur-dbcp:26.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.9'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation 'org.assertj:assertj-core:3.27.3'

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -4,13 +4,13 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'io.asyncer:r2dbc-mysql:1.3.0'
+    compileOnly 'io.asyncer:r2dbc-mysql:1.4.1'
 
     testImplementation project(':jdbc-test')
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.3.0'
+    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.4.1'
 
     compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
+    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.8.0.25.04'
@@ -12,5 +12,5 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:26.0.2'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
+    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 }

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     compileOnly project(':r2dbc')
-    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
+    compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':jdbc-test')
     testImplementation 'com.oracle.database.jdbc:ojdbc11:23.8.0.25.04'
@@ -12,7 +12,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:26.0.2'
 
     testImplementation testFixtures(project(':r2dbc'))
-    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.2.0'
+    testRuntimeOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 }
 
 tasks.japicmp {

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -12,6 +12,6 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.6.10'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.7.8'
     testFixturesImplementation 'org.assertj:assertj-core:3.27.3'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump com.oracle.database.r2dbc:oracle-r2dbc from 1.2.0 to 1.3.0 in /modules/oracle-free (#9596) @app/dependabot
* Bump com.oracle.database.r2dbc:oracle-r2dbc from 1.2.0 to 1.3.0 in /modules/oracle-xe (#9586) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.6.10 to 3.7.7 in /modules/r2dbc (#10442) @app/dependabot
* Bump io.asyncer:r2dbc-mysql from 1.3.0 to 1.4.1 in /modules/mysql (#10215) @app/dependabot
* Bump org.vibur:vibur-dbcp from 25.0 to 26.0 in /modules/jdbc (#9785) @app/dependabot
* Bump org.vibur:vibur-dbcp from 25.0 to 26.0 in /modules/jdbc-test (#9789) @app/dependabot
