### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/moby-latest.yml
+++ b/.github/workflows/moby-latest.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Notify to Slack on failures
         if: failure()
         id: slack
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v2.1.1
         with:
           payload: |
             {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.gradleup.shadow' version '8.3.0'
+    id 'com.gradleup.shadow' version '8.3.8'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.22.0' apply false
     id 'org.jreleaser' version '1.18.0' apply false

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -111,7 +111,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'redis.clients:jedis:6.0.0'
-    testImplementation 'com.rabbitmq:amqp-client:5.22.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.25.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -86,7 +86,7 @@ dependencies {
         exclude group: 'org.apache.commons', module: 'commons-compress'
     }
 
-    shaded 'org.awaitility:awaitility:4.2.0'
+    shaded 'org.awaitility:awaitility:4.3.0'
 
     api platform('com.github.docker-java:docker-java-bom:3.4.2')
     shaded platform('com.github.docker-java:docker-java-bom:3.4.2')

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -78,7 +78,7 @@ dependencies {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
 
-    provided('com.google.cloud.tools:jib-core:0.23.0') {
+    provided('com.google.cloud.tools:jib-core:0.27.3') {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
@@ -106,7 +106,7 @@ dependencies {
 
     shaded 'org.zeroturnaround:zt-exec:1.12'
 
-    testImplementation('com.google.cloud.tools:jib-core:0.23.0')  {
+    testImplementation('com.google.cloud.tools:jib-core:0.27.3')  {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testImplementation project(":mysql")
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testImplementation "org.seleniumhq.selenium:selenium-api:4.25.0"
+    testImplementation "org.seleniumhq.selenium:selenium-api:4.34.0"
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation "org.apache.activemq:activemq-client:6.1.2"
+    testImplementation "org.apache.activemq:activemq-client:6.1.7"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.37.0"
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'com.ibm.db2:jcc:11.5.9.0'
+    testRuntimeOnly 'com.ibm.db2:jcc:12.1.2.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.15.1"
-    testImplementation "org.elasticsearch.client:transport:7.17.24"
+    testImplementation "org.elasticsearch.client:transport:7.17.29"
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
-    testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.4'
+    testImplementation 'io.micrometer:micrometer-registry-otlp:1.15.1'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
 
     testImplementation platform('io.opentelemetry:opentelemetry-bom:1.51.0')

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.13.4'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
 
-    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.49.0')
+    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.51.0')
     testImplementation 'io.opentelemetry:opentelemetry-api'
     testImplementation 'io.opentelemetry:opentelemetry-sdk'
     testImplementation 'io.opentelemetry:opentelemetry-exporter-otlp'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.32.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.7")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.5.8")
+    testImplementation("ch.qos.logback:logback-classic:1.5.18")
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:26.0.2")
 
     shaded("org.apache.commons:commons-lang3:3.17.0")
-    shaded("commons-io:commons-io:2.17.0")
+    shaded("commons-io:commons-io:2.19.0")
     shaded("org.javassist:javassist:3.30.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testImplementation(project(":junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.32.0")
-    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.3")
+    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.7")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.8")
     testImplementation 'org.assertj:assertj-core:3.27.3'

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -3,10 +3,10 @@ description = "Testcontainers :: InfluxDB"
 dependencies {
     api project(':testcontainers')
 
-    compileOnly 'org.influxdb:influxdb-java:2.24'
+    compileOnly 'org.influxdb:influxdb-java:2.25'
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'org.influxdb:influxdb-java:2.24'
+    testImplementation 'org.influxdb:influxdb-java:2.25'
     testImplementation "com.influxdb:influxdb-client-java:6.12.0"
 }
 

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
-    testImplementation 'com.zaxxer:HikariCP:4.0.3'
+    testImplementation 'com.zaxxer:HikariCP:6.3.0'
     testImplementation 'redis.clients:jedis:6.0.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -9,6 +9,6 @@ dependencies {
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
     testImplementation 'io.fabric8:kubernetes-client:6.13.1'
-    testImplementation 'io.kubernetes:client-java:21.0.1-legacy'
+    testImplementation 'io.kubernetes:client-java:24.0.0-legacy'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/ldap/build.gradle
+++ b/modules/ldap/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'com.unboundid:unboundid-ldapsdk:7.0.2'
+    testImplementation 'com.unboundid:unboundid-ldapsdk:7.0.3'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
-    testImplementation 'software.amazon.awssdk:s3:2.28.6'
+    testImplementation 'software.amazon.awssdk:s3:2.31.77'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:8.5.12")
+    testImplementation("io.minio:minio:8.5.17")
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.18'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.20'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'dev.openfga:openfga-sdk:0.7.0'
+    testImplementation 'dev.openfga:openfga-sdk:0.8.2'
 }
 
 test {

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,11 +3,11 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.33"
+    api "com.orientechnologies:orientdb-client:3.2.42"
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.33"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.42"
 }
 
 tasks.japicmp {

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("org.apache.pulsar:pulsar-bom:3.3.1")
+    testImplementation platform("org.apache.pulsar:pulsar-bom:4.0.5")
     testImplementation 'org.apache.pulsar:pulsar-client'
     testImplementation 'org.apache.pulsar:pulsar-client-admin'
     testImplementation 'org.assertj:assertj-core:3.27.3'

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.22.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.25.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.33'
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
+    testImplementation 'org.apache.kafka:kafka-clients:4.0.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
     testImplementation 'org.awaitility:awaitility:4.3.0'

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: Redpanda"
 
 dependencies {
     api project(':testcontainers')
-    shaded 'org.freemarker:freemarker:2.3.33'
+    shaded 'org.freemarker:freemarker:2.3.34'
 
     testImplementation 'org.apache.kafka:kafka-clients:4.0.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.scylladb:java-driver-core:4.15.0.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'software.amazon.awssdk:dynamodb:2.28.6'
+    testImplementation 'software.amazon.awssdk:dynamodb:2.31.77'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: ScyllaDB"
 dependencies {
     api project(":testcontainers")
 
-    testImplementation 'com.scylladb:java-driver-core:4.15.0.0'
+    testImplementation 'com.scylladb:java-driver-core:4.19.0.1'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'software.amazon.awssdk:dynamodb:2.31.77'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     shaded 'org.awaitility:awaitility:4.3.0'
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'com.solacesystems:sol-jcsmp:10.24.1'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.27.2'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
 
-    testImplementation 'com.zaxxer:HikariCP:4.0.3'
+    testImplementation 'com.zaxxer:HikariCP:6.3.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.7'

--- a/modules/typesense/build.gradle
+++ b/modules/typesense/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.typesense:typesense-java:0.9.0'
+    testImplementation 'org.typesense:typesense-java:1.3.0'
 }

--- a/modules/yugabytedb/build.gradle
+++ b/modules/yugabytedb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':jdbc')
     testImplementation project(':jdbc-test')
     // YCQL driver
-    testImplementation 'com.yugabyte:java-driver-core:4.15.0-yb-2-TESTFIX.0'
+    testImplementation 'com.yugabyte:java-driver-core:4.19.0-yb-1'
     // YSQL driver
     testRuntimeOnly 'com.yugabyte:jdbc-yugabytedb:42.7.3-yb-4'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.awaitility:awaitility from 4.2.0 to 4.3.0 in /core (#10477) @app/dependabot
* Bump slackapi/slack-github-action from 2.1.0 to 2.1.1 (#10476) @app/dependabot
* Bump com.gradleup.shadow from 8.3.0 to 8.3.8 (#10455) @app/dependabot
* Bump com.unboundid:unboundid-ldapsdk from 7.0.2 to 7.0.3 in /modules/ldap (#10448) @app/dependabot
* Bump org.apache.activemq:activemq-client from 6.1.2 to 6.1.7 in /modules/activemq (#10445) @app/dependabot
* Bump org.elasticsearch.client:transport from 7.17.24 to 7.17.29 in /modules/elasticsearch (#10444) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.15.1 to 9.0.3 in /modules/elasticsearch (#10443) @app/dependabot
* Bump com.ibm.db2:jcc from 11.5.9.0 to 12.1.2.0 in /modules/db2 (#10436) @app/dependabot
* Bump io.opentelemetry:opentelemetry-bom from 1.49.0 to 1.51.0 in /modules/grafana (#10429) @app/dependabot
* Bump io.micrometer:micrometer-registry-otlp from 1.13.4 to 1.15.1 in /modules/grafana (#10427) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-api from 4.25.0 to 4.34.0 in /smoke-test (#10414) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.28.6 to 2.31.75 in /modules/localstack (#10406) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.33 to 3.2.41 in /modules/orientdb (#10404) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.33 to 3.2.41 in /modules/orientdb (#10403) @app/dependabot
* Bump software.amazon.awssdk:dynamodb from 2.28.6 to 2.31.75 in /modules/scylladb (#10396) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.24.1 to 10.27.2 in /modules/solace (#10395) @app/dependabot
* Bump com.hivemq:hivemq-mqtt-client from 1.3.3 to 1.3.7 in /modules/hivemq (#10393) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.32.0 to 4.41.0 in /modules/hivemq (#10392) @app/dependabot
* Bump org.apache.pulsar:pulsar-bom from 3.3.1 to 4.0.5 in /modules/pulsar (#10344) @app/dependabot
* Bump io.kubernetes:client-java from 21.0.1-legacy to 24.0.0-legacy in /modules/k3s (#10326) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.13.1 to 7.3.1 in /modules/k3s (#10325) @app/dependabot
* Bump com.yugabyte:java-driver-core from 4.15.0-yb-2-TESTFIX.0 to 4.19.0-yb-1 in /modules/yugabytedb (#10320) @app/dependabot
* Bump uk.org.webcompere:system-stubs-junit4 from 2.1.6 to 2.1.8 in /modules/grafana (#10248) @app/dependabot
* Bump com.scylladb:java-driver-core from 4.15.0.0 to 4.19.0.1 in /modules/scylladb (#10221) @app/dependabot
* Bump commons-io:commons-io from 2.17.0 to 2.19.0 in /modules/hivemq (#10217) @app/dependabot
* Bump org.influxdb:influxdb-java from 2.24 to 2.25 in /modules/influxdb (#10155) @app/dependabot
* Bump com.zaxxer:HikariCP from 4.0.3 to 6.3.0 in /modules/junit-jupiter (#10137) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.5.8 to 1.5.18 in /modules/hivemq (#10133) @app/dependabot
* Bump com.zaxxer:HikariCP from 4.0.3 to 6.3.0 in /modules/spock (#10131) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.8.0 to 4.0.0 in /modules/redpanda (#10129) @app/dependabot
* Bump com.google.cloud.tools:jib-core from 0.23.0 to 0.27.3 in /core (#10118) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.18 to 4.4.20 in /modules/neo4j (#10038) @app/dependabot
* Bump dev.openfga:openfga-sdk from 0.7.0 to 0.8.1 in /modules/openfga (#9992) @app/dependabot
* Bump org.typesense:typesense-java from 0.9.0 to 1.3.0 in /modules/typesense (#9991) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.22.0 to 5.25.0 in /modules/rabbitmq (#9952) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.22.0 to 5.25.0 in /core (#9947) @app/dependabot
* Bump io.minio:minio from 8.5.12 to 8.5.17 in /modules/minio (#9837) @app/dependabot
* Bump org.freemarker:freemarker from 2.3.33 to 2.3.34 in /modules/redpanda (#9702) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.7.2 to 3.7.3 in /modules/orientdb (#9493) @app/dependabot
