### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation "org.apache.activemq:activemq-client:6.1.7"
-    testImplementation "org.apache.activemq:artemis-jakarta-client:2.37.0"
+    testImplementation "org.apache.activemq:artemis-jakarta-client:2.41.0"
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'com.couchbase.client:java-client:3.7.3'
+    testImplementation 'com.couchbase.client:java-client:3.8.3'
     testImplementation 'org.awaitility:awaitility:4.3.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:8.15.1"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.0.3"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.15.1'
-    testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.6'
+    testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.8'
 
     testImplementation platform('io.opentelemetry:opentelemetry-bom:1.51.0')
     testImplementation 'io.opentelemetry:opentelemetry-api'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.32.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.41.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.7")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.18")

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.influxdb:influxdb-java:2.25'
-    testImplementation "com.influxdb:influxdb-client-java:6.12.0"
+    testImplementation "com.influxdb:influxdb-client-java:7.3.0"
 }
 
 tasks.japicmp {

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     // Any >2.8 version here is not compatible with jackson-databind 2.8.x.
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.8'
 
-    testImplementation 'io.fabric8:kubernetes-client:6.13.1'
+    testImplementation 'io.fabric8:kubernetes-client:7.3.1'
     testImplementation 'io.kubernetes:client-java:24.0.0-legacy'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api "com.orientechnologies:orientdb-client:3.2.42"
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.2'
+    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.3'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.42"
 }
 

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:4.12.0'
 
-    testImplementation 'org.apache.solr:solr-solrj:8.11.3'
+    testImplementation 'org.apache.solr:solr-solrj:8.11.4'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit:1.13.3'
 
     testCompileOnly 'org.jetbrains:annotations:26.0.2'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.elasticsearch.client:elasticsearch-rest-client from 8.15.1 to 9.0.3 in /modules/elasticsearch (#10443) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.3 to 1.13.2 in /modules/spock (#10437) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.32.0 to 4.41.0 in /modules/hivemq (#10392) @app/dependabot
* Bump com.couchbase.client:java-client from 3.7.3 to 3.8.2 in /modules/couchbase (#10389) @app/dependabot
* Bump io.fabric8:kubernetes-client from 6.13.1 to 7.3.1 in /modules/k3s (#10325) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 6.12.0 to 7.3.0 in /modules/influxdb (#10323) @app/dependabot
* Bump uk.org.webcompere:system-stubs-junit4 from 2.1.6 to 2.1.8 in /modules/grafana (#10248) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.37.0 to 2.41.0 in /modules/activemq (#10238) @app/dependabot
* Bump org.apache.tinkerpop:gremlin-driver from 3.7.2 to 3.7.3 in /modules/orientdb (#9493) @app/dependabot
* Bump org.apache.solr:solr-solrj from 8.11.3 to 8.11.4 in /modules/solr (#9329) @app/dependabot
