### PR TITLE
Combined dependencies PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ subprojects {
     }
 
     dependencies {
-        testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+        testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     }
 
     checkstyle {

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.4.0.RELEASE"
+    api "io.lettuce:lettuce-core:6.7.1.RELEASE"
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.4.0.RELEASE"
+    api "io.lettuce:lettuce-core:6.7.1.RELEASE"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.13.3'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.13.3'

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.4.0.RELEASE"
+    api "io.lettuce:lettuce-core:6.7.1.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     api "io.lettuce:lettuce-core:6.7.1.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":spock")
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
 }
 
 test {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    implementation platform('org.seleniumhq.selenium:selenium-bom:4.25.0')
+    implementation platform('org.seleniumhq.selenium:selenium-bom:4.34.0')
     implementation 'org.seleniumhq.selenium:selenium-remote-driver'
     implementation 'org.seleniumhq.selenium:selenium-firefox-driver'
     implementation 'org.seleniumhq.selenium:selenium-chrome-driver'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.34"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.34"
+    testCompileOnly "org.projectlombok:lombok:1.18.38"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.38"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:4.0.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'io.nats:jnats:2.20.2'
+    testImplementation 'io.nats:jnats:2.21.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.18'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.20'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.34"
-    annotationProcessor "org.projectlombok:lombok:1.18.34"
+    compileOnly "org.projectlombok:lombok:1.18.38"
+    annotationProcessor "org.projectlombok:lombok:1.18.38"
 
     implementation 'org.apache.solr:solr-solrj:8.11.4'
 

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':mssqlserver')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.12.0'
+    shaded 'com.squareup.okhttp3:okhttp:5.1.0'
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation platform("com.azure:azure-sdk-bom:1.2.32")

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.12.0'
+    shaded 'com.squareup.okhttp3:okhttp:5.1.0'
 
     testImplementation 'com.couchbase.client:java-client:3.8.3'
     testImplementation 'org.awaitility:awaitility:4.3.0'

--- a/modules/databend/build.gradle
+++ b/modules/databend/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':jdbc')
 
     testImplementation project(':jdbc-test')
-    testRuntimeOnly 'com.databend:databend-jdbc:0.3.9'
+    testRuntimeOnly 'com.databend:databend-jdbc:0.4.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.15.1'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.8'
 
-    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.51.0')
+    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.52.0')
     testImplementation 'io.opentelemetry:opentelemetry-api'
     testImplementation 'io.opentelemetry:opentelemetry-sdk'
     testImplementation 'io.opentelemetry:opentelemetry-exporter-otlp'

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
-    testImplementation 'io.micrometer:micrometer-registry-otlp:1.15.1'
+    testImplementation 'io.micrometer:micrometer-registry-otlp:1.15.2'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.8'
 
     testImplementation platform('io.opentelemetry:opentelemetry-bom:1.52.0')

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api(project(":testcontainers"))
     api("org.jetbrains:annotations:26.0.2")
 
-    shaded("org.apache.commons:commons-lang3:3.17.0")
+    shaded("org.apache.commons:commons-lang3:3.18.0")
     shaded("commons-io:commons-io:2.19.0")
     shaded("org.javassist:javassist:3.30.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     api project(':jdbc')
 
     api 'com.google.guava:guava:33.4.8-jre'
-    api 'org.apache.commons:commons-lang3:3.17.0'
+    api 'org.apache.commons:commons-lang3:3.18.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'
 

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
-    testImplementation 'software.amazon.awssdk:s3:2.31.77'
+    testImplementation 'software.amazon.awssdk:s3:2.32.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'io.milvus:milvus-sdk-java:2.6.0'
+    testImplementation 'io.milvus:milvus-sdk-java:2.6.1'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'dev.openfga:openfga-sdk:0.8.2'
+    testImplementation 'dev.openfga:openfga-sdk:0.8.3'
 }
 
 test {

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.scylladb:java-driver-core:4.19.0.1'
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'software.amazon.awssdk:dynamodb:2.31.77'
+    testImplementation 'software.amazon.awssdk:dynamodb:2.32.0'
 }

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Solr"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:4.12.0'
+    shaded 'com.squareup.okhttp3:okhttp:5.1.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.4'
     testImplementation 'org.assertj:assertj-core:3.27.3'

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.3'
 }

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
-    implementation 'org.slf4j:slf4j-api:2.0.16'
+    implementation 'org.slf4j:slf4j-api:2.0.17'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.lettuce:lettuce-core from 6.4.0.RELEASE to 6.7.1.RELEASE in /examples (#10517) @app/dependabot
* Bump org.seleniumhq.selenium:selenium-bom from 4.25.0 to 4.34.0 in /examples (#10515) @app/dependabot
* Bump io.nats:jnats from 2.20.2 to 2.21.4 in /examples (#10513) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.18 to 4.4.20 in /examples (#10512) @app/dependabot
* Bump org.projectlombok:lombok from 1.18.34 to 1.18.38 in /examples (#10510) @app/dependabot
* Bump org.slf4j:slf4j-api from 2.0.16 to 2.0.17 in /smoke-test (#10508) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.14 to 1.3.15 in /smoke-test (#10505) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.12.0 to 5.1.0 in /modules/solr (#10503) @app/dependabot
* Bump software.amazon.awssdk:dynamodb from 2.31.77 to 2.32.0 in /modules/scylladb (#10502) @app/dependabot
* Bump dev.openfga:openfga-sdk from 0.8.2 to 0.8.3 in /modules/openfga (#10501) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.31.77 to 2.32.0 in /modules/localstack (#10500) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.17.0 to 3.18.0 in /modules/jdbc-test (#10498) @app/dependabot
* Bump io.milvus:milvus-sdk-java from 2.6.0 to 2.6.1 in /modules/milvus (#10497) @app/dependabot
* Bump io.opentelemetry:opentelemetry-bom from 1.51.0 to 1.52.0 in /modules/grafana (#10496) @app/dependabot
* Bump org.apache.commons:commons-lang3 from 3.17.0 to 3.18.0 in /modules/hivemq (#10495) @app/dependabot
* Bump io.micrometer:micrometer-registry-otlp from 1.15.1 to 1.15.2 in /modules/grafana (#10494) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.12.0 to 5.1.0 in /modules/azure (#10491) @app/dependabot
* Bump com.databend:databend-jdbc from 0.3.9 to 0.4.0 in /modules/databend (#10489) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 4.12.0 to 5.1.0 in /modules/couchbase (#10488) @app/dependabot
