### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'redis.clients:jedis:6.0.0'
-    testImplementation 'com.rabbitmq:amqp-client:5.25.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.26.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.3.8'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'org.apache.kafka:kafka-clients:4.0.0'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'com.google.guava:guava:23.0'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testImplementation 'org.awaitility:awaitility:4.2.2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.21.4'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/ollama-hugging-face/build.gradle
+++ b/examples/ollama-hugging-face/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.testcontainers:ollama'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/ollama-hugging-face/build.gradle
+++ b/examples/ollama-hugging-face/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testImplementation 'io.rest-assured:rest-assured:5.5.0'
+    testImplementation 'io.rest-assured:rest-assured:5.5.5'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }
 

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.testng:testng:7.5.1'
     testImplementation 'org.assertj:assertj-core:3.26.3'
 }

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:6.0.0'
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.google.code.gson:gson:2.13.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
     implementation 'redis.clients:jedis:6.0.0'
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.google.code.gson:gson:2.13.1'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'com.github.mwiede:jsch:2.27.2'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'com.github.mwiede:jsch:2.27.0'
+    testImplementation 'com.github.mwiede:jsch:2.27.2'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.14'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
 
     implementation 'redis.clients:jedis:6.0.0'
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.google.code.gson:gson:2.13.1'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
 
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.8.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
-    testImplementation 'ch.qos.logback:logback-classic:1.3.14'
+    testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation "org.apache.activemq:activemq-client:6.1.7"
-    testImplementation "org.apache.activemq:artemis-jakarta-client:2.41.0"
+    testImplementation "org.apache.activemq:artemis-jakarta-client:2.42.0"
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -14,5 +14,5 @@ dependencies {
     testImplementation 'com.azure:azure-data-tables'
     testImplementation 'com.azure:azure-messaging-eventhubs'
     testImplementation 'com.azure:azure-messaging-servicebus'
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.1.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.1.1.jre8-preview'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.0.3"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.0.4"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.63.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.64.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api("org.jetbrains:annotations:26.0.2")
 
     shaded("org.apache.commons:commons-lang3:3.18.0")
-    shaded("commons-io:commons-io:2.19.0")
+    shaded("commons-io:commons-io:2.20.0")
     shaded("org.javassist:javassist:3.30.2-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.1.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.1.1.jre8-preview'
 
     testImplementation project(':r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: RabbitMQ"
 
 dependencies {
     api project(":testcontainers")
-    testImplementation 'com.rabbitmq:amqp-client:5.25.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.26.0'
     testImplementation 'org.assertj:assertj-core:3.27.3'
     compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.scylladb:java-driver-core:4.19.0.1'
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'software.amazon.awssdk:dynamodb:2.32.0'
+    testImplementation 'software.amazon.awssdk:dynamodb:2.32.9'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     shaded 'org.awaitility:awaitility:4.3.0'
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'com.solacesystems:sol-jcsmp:10.27.2'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.27.3'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':mysql')
     testImplementation project(':postgresql')
 
-    testImplementation 'com.zaxxer:HikariCP:6.3.0'
+    testImplementation 'com.zaxxer:HikariCP:7.0.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.7'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.rest-assured:rest-assured from 5.5.0 to 5.5.5 in /examples (#10557) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.41.0 to 2.42.0 in /modules/activemq (#10555) @app/dependabot
* Bump com.github.mwiede:jsch from 2.27.0 to 2.27.2 in /examples (#10553) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.14 to 1.3.15 in /examples (#10552) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.63.0 to 26.64.0 in /modules/gcloud (#10548) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 13.1.0.jre8-preview to 13.1.1.jre8-preview in /modules/azure (#10546) @app/dependabot
* Bump com.zaxxer:HikariCP from 6.3.0 to 7.0.0 in /modules/spock (#10544) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.27.2 to 10.27.3 in /modules/solace (#10543) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 9.0.3 to 9.0.4 in /modules/elasticsearch (#10540) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 13.1.0.jre8-preview to 13.1.1.jre8-preview in /modules/mssqlserver (#10539) @app/dependabot
* Bump commons-io:commons-io from 2.19.0 to 2.20.0 in /modules/hivemq (#10536) @app/dependabot
* Bump software.amazon.awssdk:dynamodb from 2.32.0 to 2.32.9 in /modules/scylladb (#10535) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.25.0 to 5.26.0 in /modules/rabbitmq (#10534) @app/dependabot
* Bump com.google.code.gson:gson from 2.11.0 to 2.13.1 in /examples (#10532) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.25.0 to 5.26.0 in /core (#10531) @app/dependabot
