### PR TITLE
Combined dependencies PR

### DIFF
--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.13.4')
     testImplementation 'org.junit.platform:junit-platform-suite'
-    testImplementation platform('io.cucumber:cucumber-bom:7.23.0')
+    testImplementation platform('io.cucumber:cucumber-bom:7.27.0')
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit-platform-engine'
     testImplementation 'org.testcontainers:selenium'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit-platform-engine'
     testImplementation 'org.testcontainers:selenium'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
 }
 

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.3.8'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'io.codenotary:immudb4j:1.0.1'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.38"
     testImplementation 'org.testcontainers:kafka'
     testImplementation 'org.apache.kafka:kafka-clients:4.0.0'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
-    testImplementation 'org.awaitility:awaitility:4.2.2'
+    testImplementation 'org.awaitility:awaitility:4.3.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }
 

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.21.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.20'
     testImplementation 'org.testcontainers:neo4j'
     testImplementation 'org.testcontainers:junit-jupiter'

--- a/examples/ollama-hugging-face/build.gradle
+++ b/examples/ollama-hugging-face/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:ollama'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.testng:testng:7.5.1'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 
 test {

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }
 

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:selenium'
     testImplementation 'org.testcontainers:junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.8.2"
 }
 

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'com.github.mwiede:jsch:2.27.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:solr'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.9.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.apache.curator:curator-framework:5.8.0'
+    testImplementation 'org.apache.curator:curator-framework:5.9.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.26.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: elasticsearch"
 
 dependencies {
     api project(':testcontainers')
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.0.4"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.1.0"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.64.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.65.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.4'
     testImplementation(project(":junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.41.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.42.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.7")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.18")

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'com.amazonaws:aws-java-sdk-logs'
     testImplementation 'com.amazonaws:aws-java-sdk-lambda'
     testImplementation 'com.amazonaws:aws-java-sdk-core'
-    testImplementation 'software.amazon.awssdk:s3:2.32.0'
+    testImplementation 'software.amazon.awssdk:s3:2.32.14'
     testImplementation 'org.assertj:assertj-core:3.27.3'
 }
 

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.8.0.25.04'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.9.0.25.07'
 
     compileOnly 'org.jetbrains:annotations:26.0.2'
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.8.0.25.04'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.9.0.25.07'
 
     compileOnly 'org.jetbrains:annotations:26.0.2'
 

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("org.apache.pulsar:pulsar-bom:4.0.5")
+    testImplementation platform("org.apache.pulsar:pulsar-bom:4.0.6")
     testImplementation 'org.apache.pulsar:pulsar-client'
     testImplementation 'org.apache.pulsar:pulsar-client-admin'
     testImplementation 'org.assertj:assertj-core:3.27.3'

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'io.qdrant:client:1.14.1'
+    testImplementation 'io.qdrant:client:1.15.0'
     testImplementation platform('io.grpc:grpc-bom:1.73.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
     testImplementation project(':jdbc-test')
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'org.questdb:questdb:9.0.0'
+    testImplementation 'org.questdb:questdb:9.0.1'
     testImplementation 'org.awaitility:awaitility:4.3.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.scylladb:java-driver-core:4.19.0.1'
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'software.amazon.awssdk:dynamodb:2.32.9'
+    testImplementation 'software.amazon.awssdk:dynamodb:2.32.14'
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.assertj:assertj-core:3.27.3'
-    testImplementation 'io.weaviate:client:5.3.0'
+    testImplementation 'io.weaviate:client:5.4.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump software.amazon.awssdk:dynamodb from 2.32.9 to 2.32.14 in /modules/scylladb (#10585) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.41.0 to 4.42.0 in /modules/hivemq (#10584) @app/dependabot
* Bump io.weaviate:client from 5.3.0 to 5.4.0 in /modules/weaviate (#10580) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.64.0 to 26.65.0 in /modules/gcloud (#10579) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.8.0.25.04 to 23.9.0.25.07 in /modules/oracle-free (#10578) @app/dependabot
* Bump org.apache.pulsar:pulsar-bom from 4.0.5 to 4.0.6 in /modules/pulsar (#10574) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 9.0.4 to 9.1.0 in /modules/elasticsearch (#10573) @app/dependabot
* Bump io.qdrant:client from 1.14.1 to 1.15.0 in /modules/qdrant (#10571) @app/dependabot
* Bump io.cucumber:cucumber-bom from 7.23.0 to 7.27.0 in /examples (#10569) @app/dependabot
* Bump org.awaitility:awaitility from 4.2.2 to 4.3.0 in /examples (#10568) @app/dependabot
* Bump org.apache.curator:curator-framework from 5.8.0 to 5.9.0 in /examples (#10565) @app/dependabot
* Bump software.amazon.awssdk:s3 from 2.32.0 to 2.32.14 in /modules/localstack (#10564) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.8.0.25.04 to 23.9.0.25.07 in /modules/oracle-xe (#10562) @app/dependabot
* Bump org.questdb:questdb from 9.0.0 to 9.0.1 in /modules/questdb (#10561) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.3 in /examples (#10509) @app/dependabot
