### PR TITLE
feat(oracle): add separate system password and withOraclePassword API…

### DIFF
--- a/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
+++ b/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleContainer.java
@@ -58,6 +58,18 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     private String password = APP_USER_PASSWORD;
 
+    /**
+     * Password for Oracle system user (e.g. SYSTEM/SYS). Defaults to {@link #APP_USER_PASSWORD}
+     * for backwards compatibility, but can be customized independently via {@link #withOraclePassword(String)}.
+     */
+    private String oraclePassword = APP_USER_PASSWORD;
+
+    /**
+     * Tracks whether {@link #withOraclePassword(String)} was called to avoid overriding
+     * the system password when {@link #withPassword(String)} is used for the application user only.
+     */
+    private boolean oraclePasswordExplicitlySet = false;
+
     private boolean usingSid = false;
 
     public OracleContainer(String dockerImageName) {
@@ -112,7 +124,8 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     public String getPassword() {
-        return password;
+        // When connecting via SID we authenticate as SYSTEM. Use the dedicated system password.
+        return isUsingSid() ? oraclePassword : password;
     }
 
     @Override
@@ -142,6 +155,27 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
             throw new IllegalArgumentException("Password cannot be null or empty");
         }
         this.password = password;
+        // Maintain backwards compatibility: if oracle password wasn't set explicitly,
+        // align it with the application user's password.
+        if (!oraclePasswordExplicitlySet) {
+            this.oraclePassword = password;
+        }
+        return self();
+    }
+
+    /**
+     * Sets the password for the Oracle system user (SYSTEM/SYS). This is independent from the
+     * application user password set via {@link #withPassword(String)}.
+     *
+     * @param oraclePassword password for SYSTEM/SYS users inside the container
+     * @return this container instance
+     */
+    public OracleContainer withOraclePassword(String oraclePassword) {
+        if (StringUtils.isEmpty(oraclePassword)) {
+            throw new IllegalArgumentException("Oracle password cannot be null or empty");
+        }
+        this.oraclePassword = oraclePassword;
+        this.oraclePasswordExplicitlySet = true;
         return self();
     }
 
@@ -185,7 +219,8 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     protected void configure() {
-        withEnv("ORACLE_PASSWORD", password);
+        // Configure system user password independently from application user's password
+        withEnv("ORACLE_PASSWORD", oraclePassword);
 
         // Only set ORACLE_DATABASE if different than the default.
         if (databaseName != DEFAULT_DATABASE_NAME) {

--- a/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
+++ b/modules/oracle-xe/src/main/java/org/testcontainers/containers/OracleContainer.java
@@ -61,6 +61,18 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     private String password = APP_USER_PASSWORD;
 
+    /**
+     * Password for Oracle system user (e.g. SYSTEM/SYS). Defaults to {@link #APP_USER_PASSWORD}
+     * for backwards compatibility, but can be customized independently via {@link #withOraclePassword(String)}.
+     */
+    private String oraclePassword = APP_USER_PASSWORD;
+
+    /**
+     * Tracks whether {@link #withOraclePassword(String)} was called to avoid overriding
+     * the system password when {@link #withPassword(String)} is used for the application user only.
+     */
+    private boolean oraclePasswordExplicitlySet = false;
+
     private boolean usingSid = false;
 
     public OracleContainer(String dockerImageName) {
@@ -125,7 +137,8 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     public String getPassword() {
-        return password;
+        // When connecting via SID we authenticate as SYSTEM. Use the dedicated system password.
+        return isUsingSid() ? oraclePassword : password;
     }
 
     @Override
@@ -155,6 +168,27 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
             throw new IllegalArgumentException("Password cannot be null or empty");
         }
         this.password = password;
+        // Maintain backwards compatibility: if oracle password wasn't set explicitly,
+        // align it with the application user's password.
+        if (!oraclePasswordExplicitlySet) {
+            this.oraclePassword = password;
+        }
+        return self();
+    }
+
+    /**
+     * Sets the password for the Oracle system user (SYSTEM/SYS). This is independent from the
+     * application user password set via {@link #withPassword(String)}.
+     *
+     * @param oraclePassword password for SYSTEM/SYS users inside the container
+     * @return this container instance
+     */
+    public OracleContainer withOraclePassword(String oraclePassword) {
+        if (StringUtils.isEmpty(oraclePassword)) {
+            throw new IllegalArgumentException("Oracle password cannot be null or empty");
+        }
+        this.oraclePassword = oraclePassword;
+        this.oraclePasswordExplicitlySet = true;
         return self();
     }
 
@@ -203,7 +237,8 @@ public class OracleContainer extends JdbcDatabaseContainer<OracleContainer> {
 
     @Override
     protected void configure() {
-        withEnv("ORACLE_PASSWORD", password);
+        // Configure system user password independently from application user's password
+        withEnv("ORACLE_PASSWORD", oraclePassword);
 
         // Only set ORACLE_DATABASE if different than the default.
         if (databaseName != DEFAULT_DATABASE_NAME) {

--- a/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
+++ b/modules/oracle-xe/src/test/java/org/testcontainers/junit/oracle/SimpleOracleTest.java
@@ -31,6 +31,20 @@ public class SimpleOracleTest extends AbstractContainerDatabaseTest {
         assertThat(resultSetInt).as("A basic SELECT query succeeds").isEqualTo(1);
     }
 
+    private void runTestSystemUser(OracleContainer container, String databaseName, String username, String password)
+        throws SQLException {
+        //Test config was honored
+        assertThat(container.getDatabaseName()).isEqualTo(databaseName);
+        assertThat(container.getUsername()).isEqualTo(username);
+        assertThat(container.getPassword()).isEqualTo(password);
+
+        //Test we can get a connection and execute a system-level command
+        container.start();
+        ResultSet resultSet = performQuery(container, "GRANT DBA TO " + username);
+        int resultSetInt = resultSet.getInt(1);
+        assertThat(resultSetInt).as("A basic system user query succeeds").isEqualTo(1);
+    }
+
     @Test
     public void testDefaultSettings() throws SQLException {
         try (OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME);) {
@@ -77,7 +91,7 @@ public class SimpleOracleTest extends AbstractContainerDatabaseTest {
     @Test
     public void testSID() throws SQLException {
         try (OracleContainer oracle = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME).usingSid();) {
-            runTest(oracle, "xepdb1", "system", "test");
+            runTestSystemUser(oracle, "xepdb1", "system", "test");
 
             // Match against the last ':'
             String urlSuffix = oracle.getJdbcUrl().split("(\\:)(?!.*\\:)", 2)[1];
@@ -92,7 +106,29 @@ public class SimpleOracleTest extends AbstractContainerDatabaseTest {
                 .usingSid()
                 .withPassword("testPassword");
         ) {
-            runTest(oracle, "xepdb1", "system", "testPassword");
+            runTestSystemUser(oracle, "xepdb1", "system", "testPassword");
+        }
+    }
+
+    @Test
+    public void testSeparateSystemAndAppPasswords() throws SQLException {
+        // SID mode should use system password
+        try (
+            OracleContainer oracleSid = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME)
+                .usingSid()
+                .withOraclePassword("SysP@ss1!")
+                .withPassword("AppP@ss1!")
+        ) {
+            runTestSystemUser(oracleSid, "xepdb1", "system", "SysP@ss1!");
+        }
+
+        // Non-SID mode should use application user's password
+        try (
+            OracleContainer oraclePdb = new OracleContainer(ORACLE_DOCKER_IMAGE_NAME)
+                .withOraclePassword("SysP@ss2!")
+                .withPassword("AppP@ss2!")
+        ) {
+            runTest(oraclePdb, "xepdb1", "test", "AppP@ss2!");
         }
     }
 


### PR DESCRIPTION
…; fix ORACLE_PASSWORD mapping

Introduce an independent system user password for Oracle containers and map it correctly to the ORACLE_PASSWORD env.
- Add withOraclePassword(String) to configure SYSTEM/SYS password independently from the app user password
- Use system password in SID connections (getPassword returns system password in SID mode)
- Keep backward compatibility: withPassword also sets system password unless withOraclePassword was called
- Update Oracle XE and Oracle Free containers to use the new internal oraclePassword
- Add OracleContainerTest to verify system vs app password behavior in SID and non-SID modes

This resolves the issue where ORACLE_PASSWORD was effectively bound to the app user password, making it impossible to set the system user password correctly.
### Summary
Fix Oracle container password handling so `ORACLE_PASSWORD` configures the system user (SYSTEM/SYS) password, not the app user’s password. Add `withOraclePassword(String)` to configure it independently while keeping backward compatibility.

### Problem
- `ORACLE_PASSWORD` was populated from the application user password.
- In SID mode, `getUsername()` returns `system`, but `getPassword()` returned the app user’s password, causing authentication mismatches and preventing a distinct system user password.

### Changes
- Add a dedicated system user password field and API:
  - New: `withOraclePassword(String oraclePassword)` for SYSTEM/SYS.
  - Existing: `withPassword(String password)` continues to set the application user password.
- Correct container env mapping:
  - `ORACLE_PASSWORD` ← system user password.
  - `APP_USER_PASSWORD` ← app user password.
- In SID mode, use the system credentials:
  - `getUsername()` returns `system`.
  - `getPassword()` now returns the system password.
- Backward compatibility:
  - If `withOraclePassword(...)` is not used, `withPassword(...)` sets both the app and system passwords (preserving previous behavior).

### Why `getPassword()` changed
```java
return isUsingSid() ? oraclePassword : password;
```
- In SID mode we authenticate as `system`. Returning the app user’s password was incorrect and led to login failures. Now the password matches the user being used.

### Affected modules
- `testcontainers-oracle-xe`
- `testcontainers-oracle-free`

### Tests
- Extended existing `SimpleOracleTest` (no new test classes):
  - SID tests run a system-level statement to validate the system password.
  - Non-SID tests validate the app user password.
  - Added cases verifying independent system vs app passwords.

### Usage examples
```java
// Different passwords for SYSTEM and app user
new OracleContainer(IMAGE)
  .withOraclePassword("SysP@ss1!")
  .withPassword("AppP@ss1!")
  .start();

// SID mode (connects as SYSTEM → uses system password)
new OracleContainer(IMAGE)
  .usingSid()
  .withOraclePassword("SysOnly")
  .start();
```

### Migration / Compatibility
- No breaking change.
- Existing usage of `.withPassword(...)` continues to work (sets both passwords unless `.withOraclePassword(...)` is used).
- Use `.withOraclePassword(...)` to set a distinct system password.

### How to verify locally
- Style and formatting:
  - Unix/macOS: `./gradlew checkstyleMain checkstyleTest spotlessApply`
  - Windows: `.\gradlew.bat checkstyleMain checkstyleTest spotlessApply`
- Run module tests:
  - `./gradlew :testcontainers-oracle-xe:test :testcontainers-oracle-free:test`

### Documentation
- Clarify:
  - `ORACLE_PASSWORD` configures the SYSTEM/SYS password.
  - `APP_USER_PASSWORD` configures the app user’s password.

### Changelog entry
- feat(oracle): add `withOraclePassword` and fix `ORACLE_PASSWORD` mapping to system user; use system password in SID mode; maintain backward compatibility with `withPassword`.

### Related issues
- (If applicable) Fixes: #<issue-number>
