### PR TITLE
Combined dependencies PR

### DIFF
--- a/docs/examples/junit4/generic/build.gradle
+++ b/docs/examples/junit4/generic/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     testRuntimeOnly 'mysql:mysql-connector-java:8.0.33'
     testImplementation "org.seleniumhq.selenium:selenium-api:4.34.0"
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/docs/examples/junit4/redis/build.gradle
+++ b/docs/examples/junit4/redis/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":testcontainers")
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testImplementation project(":testcontainers")
     testImplementation project(":testcontainers-junit-jupiter")
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 test {

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit-platform-engine'
     testImplementation 'org.testcontainers:testcontainers-selenium'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
 }
 

--- a/examples/hazelcast/build.gradle
+++ b/examples/hazelcast/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'com.hazelcast:hazelcast:5.3.8'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/immudb/build.gradle
+++ b/examples/immudb/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation 'io.codenotary:immudb4j:1.0.1'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testAnnotationProcessor "org.projectlombok:lombok:1.18.38"
     testImplementation 'org.testcontainers:testcontainers-kafka'
     testImplementation 'org.apache.kafka:kafka-clients:4.0.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'

--- a/examples/nats/build.gradle
+++ b/examples/nats/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'io.nats:jnats:2.21.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/examples/neo4j-container/build.gradle
+++ b/examples/neo4j-container/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.20'
     testImplementation 'org.testcontainers:testcontainers-neo4j'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'

--- a/examples/ollama-hugging-face/build.gradle
+++ b/examples/ollama-hugging-face/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers-ollama'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.testng:testng:7.5.1'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 test {

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }
 

--- a/examples/selenium-container/build.gradle
+++ b/examples/selenium-container/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.testcontainers:testcontainers-selenium'
     testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.8.2"
 }
 

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'com.github.mwiede:jsch:2.27.2'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.testcontainers:testcontainers-solr'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
 }

--- a/examples/zookeeper/build.gradle
+++ b/examples/zookeeper/build.gradle
@@ -9,7 +9,7 @@ repositories {
 dependencies {
     testImplementation 'org.apache.curator:curator-framework:5.9.0'
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: ActiveMQ"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation "org.apache.activemq:activemq-client:6.1.7"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.42.0"
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:5.1.0'
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation platform("com.azure:azure-sdk-bom:1.2.32")
     testImplementation 'com.azure:azure-cosmos'
     testImplementation 'com.azure:azure-storage-blob'

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/chromadb/build.gradle
+++ b/modules/chromadb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ChromaDB"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
 }

--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     testImplementation project(':testcontainers-jdbc-test')
     testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-jdbc', version: '0.9.1', classifier: 'all')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'com.clickhouse:client-v2:0.9.1'
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
     testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-r2dbc', version: '0.9.1', classifier: 'http')

--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation project(':testcontainers-jdbc-test')
     testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/consul/build.gradle
+++ b/modules/consul/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation 'com.ecwid.consul:consul-api:1.4.5'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
     testImplementation 'com.couchbase.client:java-client:3.8.3'
     testImplementation 'org.awaitility:awaitility:4.3.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/database-commons/build.gradle
+++ b/modules/database-commons/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Database-Commons"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/databend/build.gradle
+++ b/modules/databend/build.gradle
@@ -5,5 +5,5 @@ dependencies {
 
     testImplementation project(':testcontainers-jdbc-test')
     testRuntimeOnly 'com.databend:databend-jdbc:0.4.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     testImplementation project(':testcontainers-jdbc-test')
     testRuntimeOnly 'com.ibm.db2:jcc:12.1.2.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.1.0"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -10,5 +10,5 @@ dependencies {
     testImplementation 'com.google.cloud:google-cloud-pubsub'
     testImplementation 'com.google.cloud:google-cloud-spanner'
     testImplementation 'com.google.cloud:google-cloud-bigtable'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Grafana"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.15.2'
     testImplementation 'uk.org.webcompere:system-stubs-junit4:2.1.8'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.7")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.18")
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 test {

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     compileOnly 'org.influxdb:influxdb-java:2.25'
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.influxdb:influxdb-java:2.25'
     testImplementation "com.influxdb:influxdb-client-java:7.3.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'
 
-    api 'org.assertj:assertj-core:3.27.3'
+    api 'org.assertj:assertj-core:3.27.4'
 
     api 'org.apache.tomcat:tomcat-jdbc:11.0.9'
     api 'org.vibur:vibur-dbcp:26.0'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'org.vibur:vibur-dbcp:26.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.9'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')
     }
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.junit.jupiter:junit-jupiter'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.4'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -8,5 +8,5 @@ dependencies {
 
     testImplementation 'io.fabric8:kubernetes-client:7.3.1'
     testImplementation 'io.kubernetes:client-java:24.0.0-legacy'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/k6/build.gradle
+++ b/modules/k6/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: k6"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/ldap/build.gradle
+++ b/modules/ldap/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: LDAP"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'com.unboundid:unboundid-ldapsdk:7.0.3'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation 'software.amazon.awssdk:cloudwatchlogs'
     testImplementation 'software.amazon.awssdk:lambda'
     testImplementation 'software.amazon.awssdk:kms'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Milvus"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.milvus:milvus-sdk-java:2.6.1'
 }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("io.minio:minio:8.5.17")
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
 }
 

--- a/modules/mongodb/build.gradle
+++ b/modules/mongodb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation("org.mongodb:mongodb-driver-sync:5.1.4")
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.20'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/nginx/build.gradle
+++ b/modules/nginx/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Nginx"
 dependencies {
     api project(':testcontainers')
     compileOnly 'org.jetbrains:annotations:26.0.2'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/ollama/build.gradle
+++ b/modules/ollama/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Ollama"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: OpenFGA"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'dev.openfga:openfga-sdk:0.8.3'
 }
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.2.42"
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.3'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.42"
 }

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation platform("org.apache.pulsar:pulsar-bom:4.0.5")
     testImplementation 'org.apache.pulsar:pulsar-client'
     testImplementation 'org.apache.pulsar:pulsar-client-admin'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Qdrant"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.qdrant:client:1.15.0'
     testImplementation platform('io.grpc:grpc-bom:1.73.0')
     testImplementation 'io.grpc:grpc-stub'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.questdb:questdb:9.0.1'
     testImplementation 'org.awaitility:awaitility:4.3.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -8,10 +8,10 @@ dependencies {
     api project(':testcontainers')
     api 'io.r2dbc:r2dbc-spi:0.9.0.RELEASE'
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':testcontainers-postgresql')
 
     testFixturesImplementation 'io.projectreactor:reactor-core:3.7.8'
-    testFixturesImplementation 'org.assertj:assertj-core:3.27.3'
+    testFixturesImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
     testImplementation 'com.rabbitmq:amqp-client:5.26.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     compileOnly 'org.jetbrains:annotations:26.0.2'
 }
 

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     shaded 'org.freemarker:freemarker:2.3.34'
 
     testImplementation 'org.apache.kafka:kafka-clients:4.0.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'com.scylladb:java-driver-core:4.19.0.1'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'software.amazon.awssdk:dynamodb:2.32.14'
 }

--- a/modules/selenium/build.gradle
+++ b/modules/selenium/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation 'org.mortbay.jetty:jetty:6.1.26'
     testImplementation project(':testcontainers-nginx')
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 
     compileOnly 'org.jetbrains:annotations:26.0.2'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.3.0'
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'com.solacesystems:sol-jcsmp:10.27.3'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     shaded 'com.squareup.okhttp3:okhttp:5.1.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.4'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/timeplus/build.gradle
+++ b/modules/timeplus/build.gradle
@@ -6,5 +6,5 @@ dependencies {
 
     testImplementation project(':testcontainers-jdbc-test')
     testRuntimeOnly 'com.timeplus:timeplus-native-jdbc:2.0.10'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.7'
 
     testImplementation 'redis.clients:jedis:6.0.0'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }
 
 tasks.japicmp {

--- a/modules/typesense/build.gradle
+++ b/modules/typesense/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Typesense"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'org.typesense:typesense-java:1.3.0'
 }

--- a/modules/vault/build.gradle
+++ b/modules/vault/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testImplementation 'com.bettercloud:vault-java-driver:5.1.0'
     testImplementation 'io.rest-assured:rest-assured:5.5.5'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: Weaviate"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.weaviate:client:5.4.0'
 }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.3'
 }
 

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'org.slf4j:slf4j-api:2.0.17'
-    testImplementation 'org.assertj:assertj-core:3.27.3'
+    testImplementation 'org.assertj:assertj-core:3.27.4'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /examples (#10688) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/r2dbc (#10707) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/redpanda (#10695) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/pulsar (#10692) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /smoke-test (#10684) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/timeplus (#10685) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/solace (#10686) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/milvus (#10706) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/databend (#10653) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/kafka (#10665) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/k6 (#10666) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/selenium (#10668) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/qdrant (#10667) @app/dependabot
* Bump org.assertj:assertj-core from 3.26.3 to 3.27.4 in /modules/typesense (#10671) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/questdb (#10670) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/neo4j (#10655) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/hivemq (#10702) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/cassandra (#10643) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/grafana (#10649) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/mockserver (#10645) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/db2 (#10644) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/orientdb (#10647) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/scylladb (#10623) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/minio (#10699) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/rabbitmq (#10616) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/jdbc (#10697) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/ollama (#10694) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/nginx (#10636) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/couchbase (#10683) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/chromadb (#10682) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/openfga (#10614) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/toxiproxy (#10679) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/localstack (#10678) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/influxdb (#10677) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/k3s (#10676) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/cockroachdb (#10675) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/vault (#10663) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/consul (#10660) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/mongodb (#10658) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/ldap (#10657) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/activemq (#10656) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/elasticsearch (#10651) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/gcloud (#10639) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/clickhouse (#10632) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/azure (#10630) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/weaviate (#10618) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/solr (#10617) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/database-commons (#10654) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/jdbc-test (#10650) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.3 to 3.27.4 in /modules/junit-jupiter (#10625) @app/dependabot
