### PR TITLE
feat: add @ManagedNetwork to /junit-jupiter

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/ManagedNetwork.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/ManagedNetwork.java
@@ -1,0 +1,20 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.AutoClose;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@code @Network} annotation is used in conjunction with the {@link Testcontainers} annotation
+ * to mark networks that should be managed by the Testcontainers extension.
+ *
+ * @see Testcontainers
+ */
+@Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@AutoClose
+public @interface ManagedNetwork {
+}


### PR DESCRIPTION
This enables Testcontainers to manage the network in JUnit Jupiter tests.

With JUnit4, the users had something like @ClassRule Network ... The new annotation enables @ManagedNetwor Network code with JUnit 5
