### PR TITLE
core(wait): add descriptive toString() for HostPortWaitStrategy and test

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
@@ -128,4 +128,10 @@ public class HostPortWaitStrategy extends AbstractWaitStrategy {
         this.ports = ports;
         return this;
     }
+   @Override
+public String toString() {
+    return getClass().getSimpleName() + "{startupTimeout=" + startupTimeout + "}";
+}
+
+
 }

--- a/core/src/test/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategyTest.java
@@ -1,0 +1,22 @@
+package org.testcontainers.containers.wait.strategy;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HostPortWaitStrategyTest {
+
+    @Test
+    public void toStringIncludesStartupTimeout() {
+        WaitStrategy strategy = new HostPortWaitStrategy()
+            .withStartupTimeout(Duration.ofSeconds(60));
+
+        String output = strategy.toString();
+
+        assertThat(output)
+            .contains("HostPortWaitStrategy")
+            .contains("startupTimeout=PT1M");
+    }
+}


### PR DESCRIPTION
Improves developer experience when debugging wait failures.

- Add a concise toString() to HostPortWaitStrategy that includes startupTimeout
- Add a unit test verifying the string contains class name and timeout

This is a small, non-breaking improvement for clearer logs in failing startup scenarios.
