### PR TITLE
Change Ryuk connection failure log from WARN to INFO (#10713)

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/RyukResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/RyukResourceReaper.java
@@ -117,7 +117,7 @@ class RyukResourceReaper extends ResourceReaper {
                                 }
                             }
                         } catch (IOException e) {
-                            log.warn("Can not connect to Ryuk at {}:{}", host, ryukPort, e);
+                            log.info("Attempt failed: Cannot connect to Ryuk at {}:{}. Will retry", host, ryukPort);
                         }
                     });
                 }


### PR DESCRIPTION
This PR addresses issue #10713.

### Context
Currently, `RyukResourceReaper` logs a warning when it cannot connect to Ryuk during startup.

This is misleading, since the situation is expected and self-heals within a few hundred milliseconds on most systems.

### Changes
- Changed the log level from `WARN` to `INFO`.
- Removed the exception stack trace from the log, as it does not provide actionable information for users.
- Updated the log message to clarify that the connection attempt will be retried automatically.

### Why
- Avoids confusing users with unnecessary warnings and stack traces.
- Keeps logs cleaner while still providing visibility at `INFO` level.
- Better reflects the expected and transient nature of this event.

### Related Issue
Fixes #10713.

