### PR TITLE
Dead links in CircleCI reference documentation

### DIFF
--- a/docs/supported_docker_environment/continuous_integration/circle_ci.md
+++ b/docs/supported_docker_environment/continuous_integration/circle_ci.md
@@ -1,7 +1,7 @@
 # CircleCI (Cloud, Server v2.x, and Server v3.x)
 
 Your CircleCI configuration should use a dedicated VM for Testcontainers to work. You can achieve this by specifying the 
-executor type in your `.circleci/config.yml` to be `machine` instead of the default `docker` executor (see [Choosing an Executor Type](https://circleci.com/docs/guides/execution-managed/executor-intro/) for more info).  
+executor type in your `.circleci/config.yml` to be `machine` instead of the default `docker` executor (see [Choosing an Executor Type](https://circleci.com/docs/executor-intro) for more info).  
 
 Here is a sample CircleCI configuration that does a checkout of a project and runs Maven:
 


### PR DESCRIPTION
### Context
The CircleCI reference documentation at https://java.testcontainers.org/supported_docker_environment/continuous_integration/circle_ci/ contained dead links. 
These referenced pages have been moved in CircleCI’s documentation.

### Change
- Updated links to CircleCI’s new documentation:
  - Executor intro: https://circleci.com/docs/executor-intro/
 
### Related Issue
Fixes https://github.com/testcontainers/testcontainers-java/issues/10711.