### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -119,13 +119,13 @@ dependencies {
     // Synthetic JAR used for MountableFileTest and DirectoryTarResourceTest
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
-    testImplementation 'org.assertj:assertj-core:3.27.4'
+    testImplementation 'org.assertj:assertj-core:3.27.6'
     testImplementation 'io.rest-assured:rest-assured:5.5.6'
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
     jarFileTestImplementation 'junit:junit:4.13.2'
-    jarFileTestImplementation 'org.assertj:assertj-core:3.27.4'
+    jarFileTestImplementation 'org.assertj:assertj-core:3.27.6'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -109,7 +109,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
-    testImplementation 'redis.clients:jedis:6.1.0'
+    testImplementation 'redis.clients:jedis:6.2.0'
     testImplementation 'com.rabbitmq:amqp-client:5.26.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -72,7 +72,7 @@ dependencies {
     api 'org.slf4j:slf4j-api:1.7.36'
     compileOnly 'org.jetbrains:annotations:26.0.2-1'
     testCompileOnly 'org.jetbrains:annotations:26.0.2-1'
-    api 'org.apache.commons:commons-compress:1.24.0'
+    api 'org.apache.commons:commons-compress:1.28.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'io.qdrant:client:1.15.0'
-    testImplementation platform('io.grpc:grpc-bom:1.73.0')
+    testImplementation platform('io.grpc:grpc-bom:1.75.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'
     testImplementation 'io.grpc:grpc-netty-shaded'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.assertj:assertj-core from 3.27.4 to 3.27.6 in /core (#10794) @app/dependabot
* Bump redis.clients:jedis from 6.1.0 to 6.2.0 in /core (#10729) @app/dependabot
* Bump org.apache.commons:commons-compress from 1.24.0 to 1.28.0 in /core (#10590) @app/dependabot
* Bump io.grpc:grpc-bom from 1.73.0 to 1.74.0 in /modules/qdrant (#10572) @app/dependabot
