### PR TITLE
Fixed bug that allowed configs for Kafka listeners and advertised listeners to come out of sync

### DIFF
--- a/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -22,9 +22,9 @@ public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaCont
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
 
-    private final Set<String> listeners = new HashSet<>();
+    private final Set<String> listeners = new LinkedHashSet<>();
 
-    private final Set<Supplier<String>> advertisedListeners = new HashSet<>();
+    private final Set<Supplier<String>> advertisedListeners = new LinkedHashSet<>();
 
     public ConfluentKafkaContainer(String imageName) {
         this(DockerImageName.parse(imageName));

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaContainer.java
@@ -6,7 +6,7 @@ import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -28,9 +28,9 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
     private static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
 
-    private final Set<String> listeners = new HashSet<>();
+    private final Set<String> listeners = new LinkedHashSet<>();
 
-    private final Set<Supplier<String>> advertisedListeners = new HashSet<>();
+    private final Set<Supplier<String>> advertisedListeners = new LinkedHashSet<>();
 
     public KafkaContainer(String imageName) {
         this(DockerImageName.parse(imageName));


### PR DESCRIPTION
`KafkaContainer` and `ConfluentKafkaContainer` both have a pair of `HashSet` properties: `listeners` and `advertisedListeners`. At some point, these are being fed into `KafkaHelper.resolveListeners(GenericContainer<?>, Set<String>)` and `KafkaHelper.resolveAdvertisedListeners(Set<Supplier<String>>)` to help generate values for `KAFKA_LISTENERS` and `KAFKA_ADVERTISED_LISTENERS`, respectively. Each registered listener will get assigned the protocol `TC-<X>` where `<X>` essentially is the index position of the listener in each `HashSet`, but since `HashSet` doesn't guarantee any such order, a listener might be registered as `TC-0` in the `KAFKA_LISTENERS` env variable and as `TC-1` in `KAFKA_ADVERTISED_LISTENERS`.

The least intrusive solution I could think of was to replace `HashSet` with `LinkedHashSet`, which _does_ guarantee insertion order, and should therefore work better with the way the `KafkaHelper` methods are designed.