### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/cockroachdb/build.gradle
+++ b/modules/cockroachdb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: JDBC :: CockroachDB"
 dependencies {
     api project(':testcontainers-jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.8'
 
     testImplementation project(':testcontainers-jdbc-test')
 }

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: JDBC :: CrateDB"
 dependencies {
     api project(':testcontainers-jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.8'
 
     testImplementation project(':testcontainers-jdbc-test')
 

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.1.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.1.4"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
 }
 

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Milvus"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.milvus:milvus-sdk-java:2.6.3'
+    testImplementation 'io.milvus:milvus-sdk-java:2.6.5'
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -4,13 +4,13 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     compileOnly project(':testcontainers-r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.3.RELEASE'
 
     testImplementation project(':testcontainers-jdbc-test')
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.2.0.jre8'
 
     testImplementation project(':testcontainers-r2dbc')
-    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.2.RELEASE'
+    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.3.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':testcontainers-r2dbc'))

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.20'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.21'
 }
 
 tasks.japicmp {

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,10 +3,10 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.43"
+    api "com.orientechnologies:orientdb-client:3.2.44"
 
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.7.4'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.43"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.44"
 }
 
 tasks.japicmp {

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.8'
 
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
     testRuntimeOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'org.questdb:questdb:9.0.2'
+    testImplementation 'org.questdb:questdb:9.0.3'
     testImplementation 'org.awaitility:awaitility:4.3.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':testcontainers-jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.7'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.8'
 
     testImplementation project(':testcontainers-jdbc-test')
     testImplementation 'org.questdb:questdb:9.0.3'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':testcontainers-postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.7.9'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.7.11'
     testFixturesImplementation 'org.assertj:assertj-core:3.27.4'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'com.scylladb:java-driver-core:4.19.0.1'
-    testImplementation 'software.amazon.awssdk:dynamodb:2.32.30'
+    testImplementation 'software.amazon.awssdk:dynamodb:2.34.8'
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Weaviate"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.weaviate:client:5.4.0'
+    testImplementation 'io.weaviate:client:5.5.0'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump software.amazon.awssdk:dynamodb from 2.32.30 to 2.34.8 in /modules/scylladb (#11066) @app/dependabot
* Bump io.milvus:milvus-sdk-java from 2.6.3 to 2.6.5 in /modules/milvus (#11031) @app/dependabot
* Bump io.weaviate:client from 5.4.0 to 5.5.0 in /modules/weaviate (#11024) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.7 to 42.7.8 in /modules/cratedb (#11002) @app/dependabot
* Bump org.questdb:questdb from 9.0.2 to 9.0.3 in /modules/questdb (#10986) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.7 to 42.7.8 in /modules/questdb (#10984) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.43 to 3.2.44 in /modules/orientdb (#10951) @app/dependabot
* Bump com.orientechnologies:orientdb-gremlin from 3.2.43 to 3.2.44 in /modules/orientdb (#10949) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.7 to 42.7.8 in /modules/cockroachdb (#10947) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.7.9 to 3.7.11 in /modules/r2dbc (#10941) @app/dependabot
* Bump io.r2dbc:r2dbc-mssql from 1.0.2.RELEASE to 1.0.3.RELEASE in /modules/mssqlserver (#10912) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 9.1.2 to 9.1.4 in /modules/elasticsearch (#10872) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.7 to 42.7.8 in /modules/postgresql (#10869) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.20 to 4.4.21 in /modules/neo4j (#10823) @app/dependabot
