### PR TITLE
fixes 1112

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -82,7 +82,7 @@ and then use dependencies without specifying a version:
     ```xml
     <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>mysql</artifactId>
+        <artifactId>testcontainers-mysql</artifactId>
         <scope>test</scope>
     </dependency>
     ```
@@ -92,7 +92,7 @@ Using Gradle 5.0 or higher, you can add the following to the `dependencies` sect
 === "Gradle"
     ```groovy
     implementation platform('org.testcontainers:testcontainers-bom:{{latest_version}}') //import bom
-    testImplementation('org.testcontainers:mysql') //no version specified
+    testImplementation('org.testcontainers:testcontainers-mysql') //no version specified
     ```
 
 

--- a/docs/quickstart/junit_5_quickstart.md
+++ b/docs/quickstart/junit_5_quickstart.md
@@ -25,7 +25,7 @@ First, add Testcontainers as a dependency as follows:
     ```groovy
     testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
     testImplementation "org.testcontainers:testcontainers:{{latest_version}}"
-    testImplementation "org.testcontainers:junit-jupiter:{{latest_version}}"
+    testImplementation "org.testcontainers:testcontainers-junit-jupiter:{{latest_version}}"
     ```
 === "Maven"
     ```xml
@@ -43,7 +43,7 @@ First, add Testcontainers as a dependency as follows:
     </dependency>
     <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>junit-jupiter</artifactId>
+        <artifactId>testcontainers-junit-jupiter</artifactId>
         <version>{{latest_version}}</version>
         <scope>test</scope>
     </dependency>

--- a/docs/quickstart/spock_quickstart.md
+++ b/docs/quickstart/spock_quickstart.md
@@ -23,13 +23,13 @@ First, add Testcontainers as a dependency as follows:
 
 === "Gradle"
     ```groovy
-    testImplementation "org.testcontainers:spock:{{latest_version}}"
+    testImplementation "org.testcontainers:testcontainers-spock:{{latest_version}}"
     ```
 === "Maven"
     ```xml
     <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>spock</artifactId>
+        <artifactId>testcontainers-spock</artifactId>
         <version>{{latest_version}}</version>
         <scope>test</scope>
     </dependency>

--- a/docs/test_framework_integration/spock.md
+++ b/docs/test_framework_integration/spock.md
@@ -19,13 +19,13 @@ Add the following dependency to your `pom.xml`/`build.gradle` file:
 
 === "Gradle"
     ```groovy
-    testImplementation "org.testcontainers:spock:{{latest_version}}"
+    testImplementation "org.testcontainers:testcontainers-spock:{{latest_version}}"
     ```
 === "Maven"
     ```xml
     <dependency>
         <groupId>org.testcontainers</groupId>
-        <artifactId>spock</artifactId>
+        <artifactId>testcontainers-spock</artifactId>
         <version>{{latest_version}}</version>
         <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Release 2.0.0 standardised the Maven coordinates for all Testcontainers artefacts. This change aligns the "Get started" doc with the new coordinates.

Fixes https://github.com/testcontainers/testcontainers-java/issues/11112