### PR TITLE
Fix GitHub-Action Generate PR descriptions

### DIFF
--- a/.github/workflows/update-docs-version.yml
+++ b/.github/workflows/update-docs-version.yml
@@ -20,14 +20,14 @@ jobs:
           ref: main
       - name: Update latest_version property in mkdocs.yml
         run: |
-          sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF##*/}/g" mkdocs.yml
+          sed -i "s/latest_version: .*/latest_version: ${GITHUB_REF_NAME}/g" mkdocs.yml
           git diff
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v3.10.1
         with:
-          title: Update docs version to ${GITHUB_REF##*/}
+          title: Update docs version to ${{ github.ref_name }}
           body: |
-            Update docs version to ${GITHUB_REF##*/}
+            Update docs version to ${{ github.ref_name }}
             skip-checks: true
           branch: update-docs-version
           delete-branch: true

--- a/.github/workflows/update-testcontainers-version.yml
+++ b/.github/workflows/update-testcontainers-version.yml
@@ -20,13 +20,13 @@ jobs:
           ref: main
       - name: Update testcontainers.version property in gradle.properties
         run: |
-          sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF##*/}/g" gradle.properties
+          sed -i "s/^testcontainers\.version=.*/testcontainers\.version=${GITHUB_REF_NAME}/g" gradle.properties
           git diff
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v3.10.1
         with:
-          title: Update testcontainers version to ${GITHUB_REF##*/}
+          title: Update testcontainers version to ${{ github.ref_name }}
           body: |
-            Update testcontainers version to ${GITHUB_REF##*/}
+            Update testcontainers version to ${{ github.ref_name }}
           branch: update-tc-version
           delete-branch: true


### PR DESCRIPTION
When `update-docs-version` ran, it created this PR - https://github.com/testcontainers/testcontainers-java/pull/11110:
> Update docs version to ${GITHUB_REF##*/}

The branch name was not expanded in the PR description, it uses Bash syntax not applicable outside of a `run` block.

Fixed by replacing Bash expansion to derive the branch name with the _actual_ branch name.

Tested in my fork:
- [release created](https://github.com/JackPGreen/testcontainers-java/releases/tag/v2.0.9)
- [action triggered](https://github.com/JackPGreen/testcontainers-java/actions/runs/18590188222/job/53003208738)
- [PR created](https://github.com/JackPGreen/testcontainers-java/pull/2)