### PR TITLE
feat(core and module/postgresql): add getR2dbcUrl() method for R2DBC support to PostgreSQLContainerProvider and JdbcDatabaseContainer

### DIFF
--- a/modules/postgresql/src/main/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainer.java
@@ -24,6 +24,24 @@ public final class PostgreSQLR2DBCDatabaseContainer implements R2DBCDatabaseCont
         return new PostgreSQLR2DBCDatabaseContainer(container).configure(options);
     }
 
+    /**
+     * Returns the R2DBC URL for connecting to the PostgreSQL database.
+     *
+     * @param container the PostgreSQL container instance
+     * @return the R2DBC URL in the format: r2dbc:postgresql://username:password@host:port/database
+     */
+    public static String getR2dbcUrl(PostgreSQLContainer container) {
+        return String.format(
+            "r2dbc:%s://%s:%s@%s:%d/%s",
+            PostgresqlConnectionFactoryProvider.POSTGRESQL_DRIVER,
+            container.getUsername(),
+            container.getPassword(),
+            container.getHost(),
+            container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+            container.getDatabaseName()
+        );
+    }
+
     @Override
     public ConnectionFactoryOptions configure(ConnectionFactoryOptions options) {
         return options
@@ -54,5 +72,10 @@ public final class PostgreSQLR2DBCDatabaseContainer implements R2DBCDatabaseCont
     @Override
     public void close() {
         this.container.close();
+    }
+
+    @Override
+    public String getR2dbcUrl() {
+        return getR2dbcUrl(this.container);
     }
 }

--- a/modules/postgresql/src/test/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainerTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainerTest.java
@@ -27,4 +27,39 @@ public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseC
     protected String createR2DBCUrl() {
         return "r2dbc:tc:postgresql:///db?TC_IMAGE_TAG=10-alpine";
     }
+
+    @org.junit.jupiter.api.Test
+    void testGetR2dbcUrl() {
+        try (PostgreSQLContainer container = createContainer()) {
+            container.start();
+
+            // Test static method
+            String r2dbcUrlStatic = PostgreSQLR2DBCDatabaseContainer.getR2dbcUrl(container);
+
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).isNotNull();
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).startsWith("r2dbc:postgresql://");
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getHost());
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(String.valueOf(container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)));
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getDatabaseName());
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getUsername());
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getPassword());
+
+            // Verify the format: r2dbc:postgresql://username:password@host:port/database
+            String expectedUrl = String.format(
+                "r2dbc:postgresql://%s:%s@%s:%d/%s",
+                container.getUsername(),
+                container.getPassword(),
+                container.getHost(),
+                container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
+                container.getDatabaseName()
+            );
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).isEqualTo(expectedUrl);
+
+            // Test instance method
+            PostgreSQLR2DBCDatabaseContainer r2dbcContainer = new PostgreSQLR2DBCDatabaseContainer(container);
+            String r2dbcUrlInstance = r2dbcContainer.getR2dbcUrl();
+
+            org.assertj.core.api.Assertions.assertThat(r2dbcUrlInstance).isEqualTo(r2dbcUrlStatic);
+        }
+    }
 }

--- a/modules/postgresql/src/test/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainerTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainerTest.java
@@ -7,7 +7,7 @@ import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<PostgreSQLContainer> {
+class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<PostgreSQLContainer> {
 
     @Override
     protected PostgreSQLContainer createContainer() {
@@ -59,10 +59,11 @@ public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseC
             assertThat(r2dbcUrlStatic).isEqualTo(expectedUrl);
 
             // Test instance method
-            PostgreSQLR2DBCDatabaseContainer r2dbcContainer = new PostgreSQLR2DBCDatabaseContainer(container);
+            try(PostgreSQLR2DBCDatabaseContainer r2dbcContainer = new PostgreSQLR2DBCDatabaseContainer(container)) {
             String r2dbcUrlInstance = r2dbcContainer.getR2dbcUrl();
 
             assertThat(r2dbcUrlInstance).isEqualTo(r2dbcUrlStatic);
+            } 
         }
     }
 }

--- a/modules/postgresql/src/test/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainerTest.java
+++ b/modules/postgresql/src/test/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainerTest.java
@@ -1,8 +1,11 @@
 package org.testcontainers.postgresql;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.PostgreSQLTestImages;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<PostgreSQLContainer> {
 
@@ -28,7 +31,7 @@ public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseC
         return "r2dbc:tc:postgresql:///db?TC_IMAGE_TAG=10-alpine";
     }
 
-    @org.junit.jupiter.api.Test
+    @Test
     void testGetR2dbcUrl() {
         try (PostgreSQLContainer container = createContainer()) {
             container.start();
@@ -36,13 +39,13 @@ public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseC
             // Test static method
             String r2dbcUrlStatic = PostgreSQLR2DBCDatabaseContainer.getR2dbcUrl(container);
 
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).isNotNull();
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).startsWith("r2dbc:postgresql://");
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getHost());
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(String.valueOf(container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)));
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getDatabaseName());
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getUsername());
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).contains(container.getPassword());
+            assertThat(r2dbcUrlStatic).isNotNull();
+            assertThat(r2dbcUrlStatic).startsWith("r2dbc:postgresql://");
+            assertThat(r2dbcUrlStatic).contains(container.getHost());
+            assertThat(r2dbcUrlStatic).contains(String.valueOf(container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT)));
+            assertThat(r2dbcUrlStatic).contains(container.getDatabaseName());
+            assertThat(r2dbcUrlStatic).contains(container.getUsername());
+            assertThat(r2dbcUrlStatic).contains(container.getPassword());
 
             // Verify the format: r2dbc:postgresql://username:password@host:port/database
             String expectedUrl = String.format(
@@ -53,13 +56,13 @@ public class PostgreSQLR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseC
                 container.getMappedPort(PostgreSQLContainer.POSTGRESQL_PORT),
                 container.getDatabaseName()
             );
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlStatic).isEqualTo(expectedUrl);
+            assertThat(r2dbcUrlStatic).isEqualTo(expectedUrl);
 
             // Test instance method
             PostgreSQLR2DBCDatabaseContainer r2dbcContainer = new PostgreSQLR2DBCDatabaseContainer(container);
             String r2dbcUrlInstance = r2dbcContainer.getR2dbcUrl();
 
-            org.assertj.core.api.Assertions.assertThat(r2dbcUrlInstance).isEqualTo(r2dbcUrlStatic);
+            assertThat(r2dbcUrlInstance).isEqualTo(r2dbcUrlStatic);
         }
     }
 }

--- a/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/R2DBCDatabaseContainer.java
+++ b/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/R2DBCDatabaseContainer.java
@@ -5,4 +5,17 @@ import org.testcontainers.lifecycle.Startable;
 
 public interface R2DBCDatabaseContainer extends Startable {
     ConnectionFactoryOptions configure(ConnectionFactoryOptions options);
+
+    /**
+     * Returns the R2DBC URL for connecting to the database.
+     * <p>
+     * The default implementation throws {@link UnsupportedOperationException}.
+     * Implementations should override this method to provide the actual R2DBC URL.
+     *
+     * @return the R2DBC URL in the format: r2dbc:driver://username:password@host:port/database
+     * @throws UnsupportedOperationException if the implementation does not support R2DBC URLs
+     */
+    default String getR2dbcUrl() {
+        throw new UnsupportedOperationException("R2DBC URL is not supported by this container");
+    }
 }


### PR DESCRIPTION
This PR adds a new method getR2dbcUrl() to JdbcDatabaseContainer and its PostgreSQL implementation. It allows developers to easily obtain an R2DBC-compliant connection URL, improving compatibility with R2DBC-based applications.
Changes

- Added getR2dbcUrl() to JdbcDatabaseContainer.
- Overridden the method in PostgreSQLContainerProvider.
- Added getR2dbcDriverName() for PostgreSQL.
- Wrote a test in PostgreSQLR2DBCDatabaseContainerTest to verify the R2DBC URL.

I believe this should fix ##8797

Is that what you had in mind @eddumelendez with this [comment](https://github.com/testcontainers/testcontainers-java/issues/8797#issuecomment-2420198240) ?
    
    
