### PR TITLE
Add getBaseUrl() to NginxContainer using NGINX_DEFAULT_PORT

### DIFF
--- a/modules/nginx/src/main/java/org/testcontainers/nginx/NginxContainer.java
+++ b/modules/nginx/src/main/java/org/testcontainers/nginx/NginxContainer.java
@@ -27,4 +27,8 @@ public class NginxContainer extends GenericContainer<NginxContainer> {
     public URL getBaseUrl(String scheme, int port) throws MalformedURLException {
         return new URL(scheme + "://" + getHost() + ":" + getMappedPort(port));
     }
+
+    public URL getBaseUrl(String scheme) throws MalformedURLException {
+        return getBaseUrl(scheme, NGINX_DEFAULT_PORT);
+    }
 }


### PR DESCRIPTION
The default exposed port of Nginx image is NGINX_DEFAULT_PORT.
