### PR TITLE
Update kotest-extensions-testcontainers link

### DIFF
--- a/docs/test_framework_integration/external.md
+++ b/docs/test_framework_integration/external.md
@@ -5,6 +5,6 @@ The following Open Source frameworks add direct integration to Testcontainers
 | Framework | Source Code | Documentation |
 | --- | --- | --- |
 | jqwik | [jqwik-testcontainers](https://github.com/jqwik-team/jqwik-testcontainers) | [README](https://github.com/jqwik-team/jqwik-testcontainers) |
-| Kotest | [Kotest Extensions Testcontainers](https://github.com/kotest/kotest-extensions-testcontainers) | [kotest.io](https://kotest.io/docs/extensions/test_containers.html) |
+| Kotest | [Kotest Extensions Testcontainers](https://github.com/kotest/kotest/tree/master/kotest-extensions/kotest-extensions-testcontainers) | [kotest.io](https://kotest.io/docs/extensions/test_containers.html) |
 | Synthesized | [Synthesized TDK-Testcontainers integration](https://github.com/synthesized-io/tdk-tc) | [synthesized.io](https://docs.synthesized.io/tdk/latest/user_guide/integrations/testcontainers) |
 | TCI | [Testcontainers Infrastructure (TCI) Framework](https://github.com/xdev-software/tci-base) | [README](https://github.com/xdev-software/tci-base) |


### PR DESCRIPTION
kotest-extensions-testcontainers repository has been archived.
This PR updates the link to the kotest main repository.