### PR TITLE
Skip execInContainer(...) null or empty command parts.

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
+++ b/core/src/main/java/org/testcontainers/containers/ExecInContainerPattern.java
@@ -16,8 +16,10 @@ import org.testcontainers.utility.TestEnvironment;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -199,7 +201,11 @@ public class ExecInContainerPattern {
         String containerId = containerInfo.getId();
         String containerName = containerInfo.getName();
 
-        String[] command = execConfig.getCommand();
+        String[] command = Arrays
+            .stream(execConfig.getCommand())
+            .filter(Objects::nonNull)
+            .filter(str -> !str.trim().isEmpty())
+            .toArray(String[]::new);
         log.debug("{}: Running \"exec\" command: {}", containerName, String.join(" ", command));
         final ExecCreateCmd execCreateCmd = dockerClient
             .execCreateCmd(containerId)

--- a/core/src/test/java/org/testcontainers/junit/ExecInContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ExecInContainerTest.java
@@ -3,6 +3,9 @@ package org.testcontainers.junit;
 import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.TestImages;
 import org.testcontainers.containers.ExecConfig;
 import org.testcontainers.containers.GenericContainer;
@@ -34,6 +37,19 @@ class ExecInContainerTest {
             .startsWith("master");
         assertThat(result.getStderr()).as("Stderr for \"redis-cli role\" command should be empty").isEmpty();
         // We expect to reach this point for modern Docker versions.
+    }
+
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = { "", " ", "  " })
+    void shouldExecuteCommandAndSkipCommand(String commandParam) throws Exception {
+        Assumptions.assumeThat(TestEnvironment.dockerExecutionDriverSupportsExec()).isTrue();
+
+        final GenericContainer.ExecResult result = redis.execInContainer("redis-cli", commandParam, "role");
+        assertThat(result.getStdout())
+            .as("Output for \"redis-cli role\" command should start with \"master\"")
+            .startsWith("master");
+        assertThat(result.getStderr()).as("Stderr for \"redis-cli role\" command should be empty").isEmpty();
     }
 
     @Test


### PR DESCRIPTION
Hi,
I have added this small tweak to help with `null` or empty values in command array when calling `execInContainer(...)` method.
This will help me (and others), to write more concise code like this:

```kotlin
minioContainer.execInContainer(
            "mc", debug(),
            "mb", "--region=eu-central-1",
            "$alias/mynewbucket"
        ).requireSuccess()
            .also { println(it) }

        private fun debug() = if (false) {
            "--debug"
        } else {
            null
        }
```

Instead of creating another array to be able to IF values:
```java
        String[] command1 = new String[5];
        command1[0] = "mc";
        command1[1] = debug();
        command1[2] = "mb";
        command1[3] = "--region=eu-central-1";
        command1[4] = "$alias/mynewbucket";

        String[] command2 = new String[]{"mc", debug(), "mb", "--region=eu-central-1", "$alias/mynewbucket"};
        minioContainer.execInContainer(command1);
```


What do you think?

Thx 

Ivos