### PR TITLE
Fix: Shade jackson-annotations and jackson-core to avoid classpath conflicts

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,6 +56,8 @@ tasks.japicmp {
 
 configurations.all {
     resolutionStrategy {
+        force 'com.fasterxml.jackson.core:jackson-annotations:2.18.4'
+        force 'com.fasterxml.jackson.core:jackson-core:2.18.4'
         force 'com.fasterxml.jackson.core:jackson-databind:2.18.4'
         force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.4'
     }
@@ -83,11 +85,16 @@ dependencies {
     api platform('com.github.docker-java:docker-java-bom:3.7.0')
     shaded platform('com.github.docker-java:docker-java-bom:3.7.0')
 
-    api "com.github.docker-java:docker-java-api"
+    api("com.github.docker-java:docker-java-api") {
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+    }
 
     shaded('com.github.docker-java:docker-java-core') {
         exclude group: 'com.google.guava', module: 'guava'
     }
+
+    shaded 'com.fasterxml.jackson.core:jackson-annotations:2.18.4'
+    shaded 'com.fasterxml.jackson.core:jackson-core:2.18.4'
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 

--- a/core/src/jarFileTest/java/org/testcontainers/JarFileShadingTest.java
+++ b/core/src/jarFileTest/java/org/testcontainers/JarFileShadingTest.java
@@ -38,6 +38,20 @@ class JarFileShadingTest extends AbstractJarFileTest {
             .allMatch(it -> it.startsWith("org.testcontainers."));
     }
 
+    @Test
+    void testJacksonAnnotationsAreShaded() throws Exception {
+        Path jacksonAnnotations = root.resolve("org/testcontainers/shaded/com/fasterxml/jackson/annotation");
+        assertThat(Files.exists(jacksonAnnotations))
+            .as("Jackson annotations should be shaded to avoid classpath conflicts")
+            .isTrue();
+    }
+
+    @Test
+    void testJacksonCoreIsShaded() throws Exception {
+        Path jacksonCore = root.resolve("org/testcontainers/shaded/com/fasterxml/jackson/core");
+        assertThat(Files.exists(jacksonCore)).as("Jackson core should be shaded to avoid classpath conflicts").isTrue();
+    }
+
     private ListAssert<String> assertThatFileList(Path path) throws IOException {
         return (ListAssert) assertThat(Files.list(path))
             .extracting(Path::getFileName)


### PR DESCRIPTION
Description:

Fixes #11236

## Problem
Users with older Jackson versions (e.g., 2.12.7) encounter `NoSuchFieldError: READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE` because `jackson-annotations` was not being shaded alongside `jackson-databind`.

## Root Cause
- `docker-java-api` (an `api` dependency) brings in `jackson-annotations` as transitive
- The shading logic excludes all `api` transitives from being shaded
- So `jackson-annotations` remained unshaded while `jackson-databind` was relocated

## Fix
- Exclude `jackson-annotations` from `docker-java-api`
- Add explicit `shaded` dependencies for `jackson-annotations` and `jackson-core`
- Added tests to verify both are properly shaded
