### PR TITLE
Fix Docker API version incompatibility by removing forced default version

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.api.model.Network;
 import com.github.dockerjava.core.DefaultDockerClientConfig;
 import com.github.dockerjava.core.DockerClientImpl;
-import com.github.dockerjava.core.RemoteApiVersion;
 import com.github.dockerjava.transport.DockerHttpClient;
 import com.github.dockerjava.transport.NamedPipeSocket;
 import com.github.dockerjava.transport.SSLConfig;
@@ -403,9 +402,6 @@ public abstract class DockerClientProviderStrategy {
 
         DefaultDockerClientConfig.Builder configBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder();
 
-        if (configBuilder.build().getApiVersion() == RemoteApiVersion.UNKNOWN_VERSION) {
-            configBuilder.withApiVersion(RemoteApiVersion.VERSION_1_44);
-        }
         Map<String, String> headers = new HashMap<>();
         headers.put("x-tc-sid", DockerClientFactory.SESSION_ID);
         headers.put("User-Agent", String.format("tc-java/%s", DockerClientFactory.TESTCONTAINERS_VERSION));


### PR DESCRIPTION
# Motivation
Fixes #11232

In #11216, a default fallback to VERSION_1_44 was introduced in DockerClientProviderStrategy. However, this change broke compatibility for users running older Docker versions (e.g., Docker v24 supports up to API 1.43) because the client forces a newer API version than the server supports.

Since docker-java supports auto-negotiation when the version is null (UNKNOWN), strictly pinning it to 1.44 is unnecessary and causes regressions for legacy environments.

# Changes
Removed the block that forces VERSION_1_44 when the API version is unknown.

This restores the behavior of relying on docker-java's auto-negotiation (or safe defaults).

# Verification
I have verified this fix locally on the following environments:

Docker v29.1.2 (API 1.52, Min 1.44): Passed. (Auto-negotiated correctly)

Docker v24.0 (dind, API 1.43): Passed. (Auto-negotiated correctly)