### PR TITLE
Add getR2dbcUrl() to MariaDBR2DBCDatabaseContainer

### DIFF
--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainer.java
@@ -32,4 +32,15 @@ public class MariaDBR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
             .option(ConnectionFactoryOptions.PASSWORD, container.getPassword())
             .build();
     }
+
+    public static String getR2dbcUrl(MariaDBContainer<?> container) {
+        return String.format(
+            "r2dbc:mariadb://%s:%s@%s:%d/%s",
+            container.getUsername(),
+            container.getPassword(),
+            container.getHost(),
+            container.getMappedPort(MariaDBContainer.MARIADB_PORT),
+            container.getDatabaseName()
+        );
+    }
 }

--- a/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/containers/MariaDBR2DBCDatabaseContainerTest.java
@@ -1,8 +1,12 @@
 package org.testcontainers.containers;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.MariaDBTestImages;
 import org.testcontainers.r2dbc.AbstractR2DBCDatabaseContainerTest;
 import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MariaDBR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseContainerTest<MariaDBContainer<?>> {
 
@@ -19,5 +23,26 @@ public class MariaDBR2DBCDatabaseContainerTest extends AbstractR2DBCDatabaseCont
     @Override
     protected MariaDBContainer<?> createContainer() {
         return new MariaDBContainer<>(DockerImageName.parse("mariadb:10.3.39"));
+    }
+
+    @Test
+    public void testGetR2dbcUrl() {
+        try (MariaDBContainer<?> container = new MariaDBContainer<>(MariaDBTestImages.MARIADB_IMAGE)) {
+            container.start();
+
+            String r2dbcUrl = MariaDBR2DBCDatabaseContainer.getR2dbcUrl(container);
+
+            String user = container.getUsername();
+            String password = container.getPassword();
+            String host = container.getHost();
+            Integer port = container.getMappedPort(MariaDBContainer.MARIADB_PORT);
+            String db = container.getDatabaseName();
+
+            String expectedPattern = String.format("^r2dbc:mariadb://%s:%s@%s:%d/%s$", user, password, host, port, db);
+
+            assertThat(r2dbcUrl)
+                .as("URL must strictly match format 'r2dbc:mariadb://user:pass@host:port/db'")
+                .matches(expectedPattern);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
This PR implements the static `getR2dbcUrl()` helper method for the MariaDB module, as discussed in #8797.

**This implementation follows the static method approach suggested by @eddumelendez in the issue comments (instead of adding it to the interface), ensuring discoverability without breaking changes.**

Currently, users have to manually construct connection strings. This helper provides a standardized way to obtain a valid R2DBC URL.

### Changes
* Added `public static String getR2dbcUrl(MariaDBContainer<?> container)` to `MariaDBR2DBCDatabaseContainer`.
* Added test case to verify the URL format and parameters.

### Verification
* Ran `./gradlew :testcontainers-mariadb:test` and verified that tests pass.
* Verified code style with Spotless.

Relates to #8797