### PR TITLE
Print containerAlias into logs to distinguish between same image containers

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/Container.java
+++ b/core/src/main/java/org/testcontainers/containers/Container.java
@@ -376,6 +376,13 @@ public interface Container<SELF extends Container<SELF>> extends LinkableContain
     SELF withWorkingDirectory(String workDir);
 
     /**
+     * Set the container alias to distinguish between multiple containers.
+     *
+     * @param alias name
+     */
+    SELF withContainerAlias(String alias);
+
+    /**
      * <b>Resolve</b> Docker image and set it.
      *
      * @param dockerImageName image name

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -138,6 +138,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Nullable
     private String workingDirectory = null;
 
+    @Nullable
+    private String containerAlias = null;
+
     /**
      * The shared memory size to use when starting the container.
      * This value is in bytes.
@@ -343,7 +346,14 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 }
             );
         } catch (Exception e) {
-            throw new ContainerLaunchException("Container startup failed for image " + getDockerImageName(), e);
+            String containerAliasStr = "";
+            if (StringUtils.isNotBlank(containerAlias)) {
+                containerAliasStr = " (containerAlias='" + containerAlias.trim() + "')";
+            }
+            throw new ContainerLaunchException(
+                "Container startup failed for image " + getDockerImageName() + containerAliasStr,
+                e
+            );
         }
     }
 
@@ -663,7 +673,11 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * @return a logger that references the docker image name
      */
     protected Logger logger() {
-        return DockerLoggerFactory.getLogger(this.getDockerImageName());
+        String loggerName = this.getDockerImageName();
+        if (StringUtils.isNotBlank(containerAlias)) {
+            loggerName = loggerName + "--" + containerAlias.trim();
+        }
+        return DockerLoggerFactory.getLogger(loggerName);
     }
 
     /**
@@ -1253,6 +1267,12 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withWorkingDirectory(String workDir) {
         this.setWorkingDirectory(workDir);
+        return self();
+    }
+
+    @Override
+    public SELF withContainerAlias(String alias) {
+        this.setContainerAlias(alias);
         return self();
     }
 

--- a/core/src/test/java/org/testcontainers/junit/ContainerAliasTest.java
+++ b/core/src/test/java/org/testcontainers/junit/ContainerAliasTest.java
@@ -1,0 +1,102 @@
+package org.testcontainers.junit;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.TestImages;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.startupcheck.OneShotStartupCheckStrategy;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ContainerAliasTest {
+
+    private final TestLogger testLogger = new TestLogger();
+
+    public GenericContainer container1 = new GenericContainer(TestImages.ALPINE_IMAGE)
+        .withContainerAlias("potato")
+        .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+        .withCommand("ls", "-al");
+
+    public GenericContainer container2 = new GenericContainer(TestImages.ALPINE_IMAGE)
+        .withContainerAlias("monkey")
+        .withStartupCheckStrategy(new OneShotStartupCheckStrategy())
+        .withCommand("non-existing-command");
+
+    @BeforeEach
+    void setUp() {
+        testLogger.startCapturing();
+    }
+
+    @AfterEach
+    void tearDown() {
+        testLogger.stopCapturing();
+    }
+
+    @Test
+    void checkOutput() {
+        assertThatNoException()
+            .isThrownBy(() -> {
+                container1.start();
+            });
+
+        assertThatThrownBy(() -> {
+                container2.start();
+            })
+            .isInstanceOf(ContainerLaunchException.class)
+            .hasMessage("Container startup failed for image alpine:3.17 (containerAlias='monkey')");
+
+        List<String> container1PotatoLogs = testLogger
+            .getLogs()
+            .stream()
+            .filter(it -> "tc.alpine:3.17--potato".equals(it.getLoggerName()))
+            .map(ILoggingEvent::getFormattedMessage)
+            .toList();
+        assertThat(container1PotatoLogs)
+            .anyMatch(it -> it.equals("Creating container for image: alpine:3.17"))
+            .anyMatch(it -> it.startsWith("Container alpine:3.17 is starting: "))
+            .anyMatch(it -> it.startsWith("Container alpine:3.17 started in P"));
+
+        List<String> container2MonkeyLogs = testLogger
+            .getLogs()
+            .stream()
+            .filter(it -> "tc.alpine:3.17--monkey".equals(it.getLoggerName()))
+            .map(ILoggingEvent::getFormattedMessage)
+            .toList();
+        assertThat(container2MonkeyLogs)
+            .anyMatch(it -> it.equals("Creating container for image: alpine:3.17"))
+            .anyMatch(it -> it.startsWith("Container alpine:3.17 is starting: "))
+            .anyMatch(it -> it.equals("Could not start container"))
+            .anyMatch(it -> it.equals("There are no stdout/stderr logs available for the failed container"));
+    }
+}
+
+class TestLogger {
+
+    private final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+
+    public void startCapturing() {
+        Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        listAppender.start();
+        rootLogger.addAppender(listAppender);
+    }
+
+    public void stopCapturing() {
+        Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        rootLogger.detachAppender(listAppender);
+        listAppender.stop();
+    }
+
+    public List<ILoggingEvent> getLogs() {
+        return listAppender.list;
+    }
+}


### PR DESCRIPTION
Hi,
this PR fixes https://github.com/testcontainers/testcontainers-java/issues/2246 feature request to display container aliases in the logs to distinguish between them when reading logs.
Please take a look, what do you think?
Thx
Ivos

Sample of the logs after change:
```
15:44:46.231 INFO  tc.alpine:3.17--potato - Creating container for image: alpine:3.17
15:44:46.310 INFO  tc.alpine:3.17--potato - Container alpine:3.17 is starting: 54fe7af01a03c02c30a1e7614764a0b4be2cdaf6f45f5745a1752326e1df59b6
15:44:46.840 INFO  tc.alpine:3.17--potato - Container alpine:3.17 started in PT0.608617S
15:44:46.848 INFO  tc.alpine:3.17--monkey - Creating container for image: alpine:3.17
15:44:46.912 INFO  tc.alpine:3.17--monkey - Container alpine:3.17 is starting: 09fa4875896e95e934c8bee677726cbd7e8b06fc5c6d678b2d166cd4f3d3af46
15:44:47.020 ERROR tc.alpine:3.17--monkey - Could not start container
```