### PR TITLE
Ignore container_name in docker-compose files instead of throwing exception

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
+++ b/core/src/main/java/org/testcontainers/containers/ParsedDockerComposeFile.java
@@ -131,12 +131,11 @@ class ParsedDockerComposeFile {
 
     private void validateNoContainerNameSpecified(String serviceName, Map<String, ?> serviceDefinitionMap) {
         if (serviceDefinitionMap.containsKey("container_name")) {
-            throw new IllegalStateException(
-                String.format(
-                    "Compose file %s has 'container_name' property set for service '%s' but this property is not supported by Testcontainers, consider removing it",
-                    composeFileName,
-                    serviceName
-                )
+            log.warn(
+                "Compose file {} has 'container_name' property set for service '{}'. " +
+                "This property is not supported by Testcontainers and will be ignored.",
+                composeFileName,
+                serviceName
             );
         }
     }

--- a/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
@@ -22,26 +22,26 @@ class ParsedDockerComposeFileValidationTest {
     public Path temporaryFolder;
 
     @Test
-    void shouldValidate() {
+    void shouldIgnoreContainerNameV1() {
         File file = new File("src/test/resources/docker-compose-container-name-v1.yml");
-        assertThatThrownBy(() -> {
-                new ParsedDockerComposeFile(file);
-            })
-            .hasMessageContaining(file.getAbsolutePath())
-            .hasMessageContaining("'container_name' property set for service 'redis'");
+        // container_name should be ignored (with a warning log) instead of throwing an exception
+        assertThatNoException().isThrownBy(() -> new ParsedDockerComposeFile(file));
     }
 
     @Test
-    void shouldRejectContainerNameV1() {
-        assertThatThrownBy(() -> {
-                new ParsedDockerComposeFile(ImmutableMap.of("redis", ImmutableMap.of("container_name", "redis")));
-            })
-            .hasMessageContaining("'container_name' property set for service 'redis'");
+    void shouldIgnoreContainerNameInMapV1() {
+        // container_name should be ignored (with a warning log) instead of throwing an exception
+        assertThatNoException()
+            .isThrownBy(() ->
+                new ParsedDockerComposeFile(ImmutableMap.of("redis", ImmutableMap.of("container_name", "redis")))
+            );
     }
 
     @Test
-    void shouldRejectContainerNameV2() {
-        assertThatThrownBy(() -> {
+    void shouldIgnoreContainerNameV2() {
+        // container_name should be ignored (with a warning log) instead of throwing an exception
+        assertThatNoException()
+            .isThrownBy(() ->
                 new ParsedDockerComposeFile(
                     ImmutableMap.of(
                         "version",
@@ -49,9 +49,8 @@ class ParsedDockerComposeFileValidationTest {
                         "services",
                         ImmutableMap.of("redis", ImmutableMap.of("container_name", "redis"))
                     )
-                );
-            })
-            .hasMessageContaining("'container_name' property set for service 'redis'");
+                )
+            );
     }
 
     @Test


### PR DESCRIPTION
## Summary
Fixes #2472

## Changes
Previously, Testcontainers would throw an `IllegalStateException` when parsing a docker-compose file that contained the `container_name` property. This prevented users from reusing their production docker-compose files without modification.

This change modifies the behavior to log a warning instead of throwing an exception, allowing users to use docker-compose files with `container_name` properties. The `container_name` is simply ignored since Testcontainers manages container naming internally.

## Implementation Details
- **ParsedDockerComposeFile.java**: Changed `validateNoContainerNameSpecified()` to log a warning instead of throwing `IllegalStateException`
- **ParsedDockerComposeFileValidationTest.java**: Updated tests to verify that `container_name` is now ignored rather than rejected

## Testing
All existing tests pass, and the updated tests verify the new behavior:
- `shouldIgnoreContainerNameV1()` - Tests file-based compose with container_name
- `shouldIgnoreContainerNameInMapV1()` - Tests v1 format map with container_name  
- `shouldIgnoreContainerNameV2()` - Tests v2 format with container_name

## Motivation
As discussed in #2472, many users want to reuse their production docker-compose files for testing. The `container_name` property is valid Docker Compose syntax and should not cause Testcontainers to fail. Instead, it should be gracefully ignored with a warning.
