### PR TITLE
Replace deprecated MSSQLServerContainer in ServiceBusEmulatorContainer

### DIFF
--- a/modules/azure/src/main/java/org/testcontainers/azure/ServiceBusEmulatorContainer.java
+++ b/modules/azure/src/main/java/org/testcontainers/azure/ServiceBusEmulatorContainer.java
@@ -1,9 +1,9 @@
 package org.testcontainers.azure;
 
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.LicenseAcceptance;
 
@@ -25,7 +25,7 @@ public class ServiceBusEmulatorContainer extends GenericContainer<ServiceBusEmul
         "mcr.microsoft.com/azure-messaging/servicebus-emulator"
     );
 
-    private MSSQLServerContainer<?> msSqlServerContainer;
+    private MSSQLServerContainer msSqlServerContainer;
 
     /**
      * @param dockerImageName The specified docker image name to run
@@ -51,7 +51,7 @@ public class ServiceBusEmulatorContainer extends GenericContainer<ServiceBusEmul
      * @param msSqlServerContainer The MS SQL Server container used by Service Bus as a dependency
      * @return this
      */
-    public ServiceBusEmulatorContainer withMsSqlServerContainer(final MSSQLServerContainer<?> msSqlServerContainer) {
+    public ServiceBusEmulatorContainer withMsSqlServerContainer(final MSSQLServerContainer msSqlServerContainer) {
         dependsOn(msSqlServerContainer);
         this.msSqlServerContainer = msSqlServerContainer;
         return this;

--- a/modules/azure/src/test/java/org/testcontainers/azure/ServiceBusEmulatorContainerTest.java
+++ b/modules/azure/src/test/java/org/testcontainers/azure/ServiceBusEmulatorContainerTest.java
@@ -10,8 +10,8 @@ import com.azure.messaging.servicebus.ServiceBusSenderClient;
 import com.github.dockerjava.api.model.Capability;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.mssqlserver.MSSQLServerContainer;
 import org.testcontainers.utility.MountableFile;
 
 import java.util.List;
@@ -31,7 +31,7 @@ class ServiceBusEmulatorContainerTest {
             Network network = Network.newNetwork();
             // }
             // sqlContainer {
-            MSSQLServerContainer<?> mssqlServerContainer = new MSSQLServerContainer<>(
+            MSSQLServerContainer mssqlServerContainer = new MSSQLServerContainer(
                 "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04"
             )
                 .acceptLicense()


### PR DESCRIPTION
 ## Description

  Replace deprecated `org.testcontainers.containers.MSSQLServerContainer` with
  `org.testcontainers.mssqlserver.MSSQLServerContainer` in `ServiceBusEmulatorContainer`.

  ## Changes

  - Updated import to use the new non-deprecated package
  - Removed generic type parameters (`<?>`) as the new class doesn't use them

  ## Related Issue

  Fixes #11373

  ## Breaking Change

  This changes the method signature of `withMsSqlServerContainer()`.
  Users passing the deprecated `MSSQLServerContainer` will need to migrate
  to the new class. Since the old class is already deprecated, this aligns
  with the intended migration path.