### PR TITLE
Add property ryuk.disabled

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/ResourceReaper.java
@@ -74,7 +74,7 @@ public class ResourceReaper {
 
     public static synchronized ResourceReaper instance() {
         if (instance == null) {
-            boolean useRyuk = !Boolean.parseBoolean(System.getenv("TESTCONTAINERS_RYUK_DISABLED"));
+            boolean useRyuk = !TestcontainersConfiguration.getInstance().isRyukDisabled();
             if (useRyuk) {
                 //noinspection deprecation
                 instance = new RyukResourceReaper();

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -137,6 +137,10 @@ public class TestcontainersConfiguration {
         return getImage(ALPINE_IMAGE).asCanonicalNameString();
     }
 
+    public boolean isRyukDisabled() {
+        return Boolean.parseBoolean(getEnvVarOrProperty("ryuk.disabled", "false"));
+    }
+
     public boolean isRyukPrivileged() {
         return Boolean.parseBoolean(getEnvVarOrProperty("ryuk.container.privileged", "true"));
     }

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -80,10 +80,10 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > In some environments ryuk must be started in privileged mode to work properly (--privileged flag)
 
 ### Disabling Ryuk
-Ryuk must be started as a privileged container.  
+Ryuk must be started as a privileged container.
 If your environment already implements automatic cleanup of containers after the execution,
 but does not allow starting privileged containers, you can turn off the Ryuk container by setting
-`TESTCONTAINERS_RYUK_DISABLED` **environment variable** to `true`.
+`ryuk.disabled` to `true`.
 
 !!!tip
     Note that Testcontainers will continue doing the cleanup at JVM's shutdown, unless you `kill -9` your JVM process.

--- a/docs/supported_docker_environment/index.md
+++ b/docs/supported_docker_environment/index.md
@@ -49,11 +49,7 @@ Linux:
 export DOCKER_HOST=unix://${XDG_RUNTIME_DIR}/podman/podman.sock
 ```
 
-If you're running Podman in rootless mode, ensure to include the following line to disable Ryuk:
-
-```bash
-export TESTCONTAINERS_RYUK_DISABLED=true
-```
+If you're running Podman in rootless mode, make sure to [disable Ryuk](/docs/features/configuration/#disabling-ryuk).
 
 !!! note
     Previous to version 1.19.0, `export TESTCONTAINERS_RYUK_PRIVILEGED=true`


### PR DESCRIPTION
This allows disabling the Ryuk container via a property, while being backwards compatible with the existing environment variable.

Solves https://github.com/testcontainers/testcontainers-java/issues/11413.