### PR TITLE
Handle sub second pulls in LoggedPullImageResultCallback

### DIFF
--- a/core/src/main/java/org/testcontainers/images/LoggedPullImageResultCallback.java
+++ b/core/src/main/java/org/testcontainers/images/LoggedPullImageResultCallback.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import java.io.Closeable;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -110,7 +111,7 @@ class LoggedPullImageResultCallback extends PullImageResultCallback {
         super.onComplete();
 
         final long downloadedLayerSize = downloadedLayerSize();
-        final long duration = Duration.between(start, Instant.now()).getSeconds();
+        final double duration = Duration.between(start, Instant.now()).get(ChronoUnit.MILLIS) / 1000.0;
 
         if (completed) {
             logger.info(


### PR DESCRIPTION
Mitigates the issues described in [[Bug]: LoggedPullImageResultCallback throws java.lang.ArithmeticException: / by zero](https://github.com/testcontainers/testcontainers-java/issues/11416).

From the issue:
When running tests in GitHub actions, it fails due to [line 121 in LoggedPullImageResultCallback throws an java.lang.ArithmeticException: / by zero](https://github.com/testcontainers/testcontainers-java/blob/43c6a97ea911f05eaf6178179286f6c8955c1fba/core/src/main/java/org/testcontainers/images/LoggedPullImageResultCallback.java#L121). Out of 10 times running our tests, it has failed 8 times and succeeded2. I have not been able to reproduce this in a reliable way but it seems like this would happen if a pull takes less than one full second since [duration will become 0](https://github.com/testcontainers/testcontainers-java/blob/43c6a97ea911f05eaf6178179286f6c8955c1fba/core/src/main/java/org/testcontainers/images/LoggedPullImageResultCallback.java#L113).