### PR TITLE
Fix K3sContainer not working under WSL2

### DIFF
--- a/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
+++ b/modules/k3s/src/main/java/org/testcontainers/k3s/K3sContainer.java
@@ -36,10 +36,6 @@ public class K3sContainer extends GenericContainer<K3sContainer> {
 
         addExposedPorts(KUBE_SECURE_PORT, RANCHER_WEBHOOK_PORT);
         setPrivilegedMode(true);
-        withCreateContainerCmdModifier(it -> {
-            it.getHostConfig().withCgroupnsMode("host");
-        });
-        addFileSystemBind("/sys/fs/cgroup", "/sys/fs/cgroup", BindMode.READ_WRITE);
 
         Map<String, String> tmpFsMapping = new HashMap<>();
         tmpFsMapping.put("/run", "");


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

- Fixes #9605 .
- Fixes #10375 .
- Fix K3sContainer not working under WSL2.
- The Github Actions configuration file for testcontainers-java does not appear to install Rancher Desktop on the Windows Server 2025 runner like downstream projects, thus preventing the addition of unit tests for WSL2. I'm referring to operations like the following. The content of `wait-for-rancher-desktop-backend.ps1` can be found in the file I wrote at https://github.com/apache/shardingsphere/blob/master/test/native/src/test/resources/test-native/ps1/wait-for-rancher-desktop-backend.ps1 .
```powershell
iex "& { $(irm https://raw.githubusercontent.com/microsoft/Windows-Containers/refs/heads/Main/helpful_tools/Install-DockerCE/uninstall-docker-ce.ps1) } -Force"
irm https://raw.githubusercontent.com/jazzdelightsme/WingetPathUpdater/v1.2/WingetPathUpdaterInstall.ps1 | iex
winget install --id SUSE.RancherDesktop --source winget --skip-dependencies
rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
./wait-for-rancher-desktop-backend.ps1

@'
{
  "features": {
    "containerd-snapshotter": true
  },
  "log-driver": "local"
}
'@ | rdctl shell sudo tee /etc/docker/daemon.json

rdctl shutdown
rdctl start --application.start-in-background --container-engine.name=moby --kubernetes.enabled=false
./wait-for-rancher-desktop-backend.ps1
"PATH=$env:PATH" >> $env:GITHUB_ENV
```
