### PR TITLE
Disable Awaitility uncaught-exception catching (fixes #11483)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -447,6 +447,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             // Wait until inspect container returns the mapped ports
             containerInfo =
                 await()
+                    .dontCatchUncaughtExceptions()
                     .atMost(5, TimeUnit.SECONDS)
                     .pollInterval(DynamicPollInterval.ofMillis(50))
                     .pollInSameThread()

--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
@@ -82,6 +82,7 @@ public class HostPortWaitStrategy extends AbstractWaitStrategy {
                         Instant now = Instant.now();
                         Awaitility
                             .await()
+                            .dontCatchUncaughtExceptions()
                             .pollInSameThread()
                             .pollInterval(Duration.ofMillis(100))
                             .pollDelay(Duration.ZERO)

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -208,6 +208,7 @@ public abstract class DockerClientProviderStrategy {
         try (Socket socket = socketProvider.call()) {
             Awaitility
                 .await()
+                .dontCatchUncaughtExceptions()
                 .atMost(TestcontainersConfiguration.getInstance().getClientPingTimeout(), TimeUnit.SECONDS) // timeout after configured duration
                 .pollInterval(Duration.ofMillis(200)) // check state every 200ms
                 .pollDelay(Duration.ofSeconds(0)) // start checking immediately

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -102,6 +102,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
 
             Awaitility
                 .await()
+                .dontCatchUncaughtExceptions()
                 .pollInSameThread()
                 .pollDelay(Duration.ZERO) // start checking immediately
                 .atMost(PULL_RETRY_TIME_LIMIT)

--- a/core/src/test/java/org/testcontainers/utility/DockerClientProviderStrategyUncaughtExceptionHandlerTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DockerClientProviderStrategyUncaughtExceptionHandlerTest.java
@@ -1,0 +1,94 @@
+package org.testcontainers.utility;
+
+import org.junit.jupiter.api.Test;
+import org.awaitility.Awaitility;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DockerClientProviderStrategyUncaughtExceptionHandlerTest {
+
+    @Test
+    void dockerClientProviderStrategyTestShouldUseDontCatchUncaughtExceptions() throws Exception {
+        byte[] bytes;
+        try (InputStream is = getClass()
+            .getClassLoader()
+            .getResourceAsStream("org/testcontainers/dockerclient/DockerClientProviderStrategy.class")) {
+            assertThat(is).isNotNull();
+            bytes = is.readAllBytes();
+        }
+
+        // Use ISO_8859_1 to preserve a stable 1:1 mapping of bytes to chars for a lightweight constant-pool substring check.
+        String content = new String(bytes, StandardCharsets.ISO_8859_1);
+        assertThat(content).contains("dontCatchUncaughtExceptions");
+    }
+
+    @Test
+    void shouldNotInterceptUncaughtExceptionsFromOtherThreads() throws Exception {
+        Thread.UncaughtExceptionHandler originalHandler = Thread.getDefaultUncaughtExceptionHandler();
+        AtomicReference<Throwable> observedException = new AtomicReference<>();
+        CountDownLatch observedExceptionLatch = new CountDownLatch(1);
+        Thread.UncaughtExceptionHandler expectedHandler = (t, e) -> {
+            if (observedException.compareAndSet(null, e)) {
+                observedExceptionLatch.countDown();
+            }
+        };
+
+        Thread.setDefaultUncaughtExceptionHandler(expectedHandler);
+        try {
+            AtomicReference<Thread.UncaughtExceptionHandler> changedHandler = new AtomicReference<>();
+            AtomicBoolean monitorStop = new AtomicBoolean(false);
+            Thread monitor = new Thread(() -> {
+                while (!monitorStop.get()) {
+                    Thread.UncaughtExceptionHandler current = Thread.getDefaultUncaughtExceptionHandler();
+                    if (current != expectedHandler) {
+                        changedHandler.compareAndSet(null, current);
+                        break;
+                    }
+                    LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(1));
+                }
+            }, "docker-strategy-uncaught-handler-monitor");
+
+            Thread thrower = new Thread(() -> {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException ignored) {
+                    return;
+                }
+                throw new RuntimeException("boom");
+            }, "docker-strategy-uncaught-handler-thrower");
+
+            monitor.start();
+            thrower.start();
+
+            Awaitility
+                .await()
+                .dontCatchUncaughtExceptions()
+                .pollDelay(Duration.ZERO)
+                .pollInterval(Duration.ofMillis(25))
+                .atMost(Duration.ofSeconds(2))
+                .until(() -> {
+                    Thread.sleep(300);
+                    return true;
+                });
+
+            monitorStop.set(true);
+            monitor.join(TimeUnit.SECONDS.toMillis(5));
+            thrower.join(TimeUnit.SECONDS.toMillis(5));
+
+            assertThat(changedHandler.get()).isNull();
+            assertThat(observedExceptionLatch.await(5, TimeUnit.SECONDS)).isTrue();
+            assertThat(observedException.get()).isInstanceOf(RuntimeException.class).hasMessage("boom");
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(originalHandler);
+        }
+    }
+}

--- a/modules/solace/src/main/java/org/testcontainers/solace/SolaceContainer.java
+++ b/modules/solace/src/main/java/org/testcontainers/solace/SolaceContainer.java
@@ -222,6 +222,7 @@ public class SolaceContainer extends GenericContainer<SolaceContainer> {
     private void waitOnCommandResult(String waitingFor, String... command) {
         Awaitility
             .await()
+            .dontCatchUncaughtExceptions()
             .pollInterval(Duration.ofMillis(500))
             .timeout(Duration.ofSeconds(30))
             .until(() -> {


### PR DESCRIPTION
Fixes #11483

Testcontainers uses Awaitility in a few internal wait loops (e.g. during Docker client strategy probing, image pull retry, container start/port checks). Awaitility’s default behavior can temporarily install a global default uncaught exception handler, which may intercept uncaught exceptions from unrelated threads and can lead to surprising/flaky test behavior.

This change explicitly disables that behavior by adding `.dontCatchUncaughtExceptions()` to all internal Awaitility usages.

Tests:
- Added a regression test to ensure the strategy probing code path includes `dontCatchUncaughtExceptions`, and to validate Awaitility does not intercept uncaught exceptions from other threads when configured accordingly.
