### PR TITLE
Fix host UID/GID leakage in copyFileToContainer TAR entries

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -356,6 +356,10 @@ public class MountableFile implements Transferable {
 
             // TarArchiveEntry automatically sets the mode for file/directory, but we can update to ensure that the mode is set exactly (inc executable bits)
             tarEntry.setMode(getUnixFileMode(itemPath));
+            // Avoid propagating host UID/GID into containers. This is important for rootless Docker setups
+            // where host IDs may be unmapped and cause permission issues after copyArchiveToContainer.
+            tarEntry.setUserId(0);
+            tarEntry.setGroupId(0);
             tarArchive.putArchiveEntry(tarEntry);
 
             if (sourceFile.isFile()) {


### PR DESCRIPTION
Fixes #11487

## Problem
When `copyFileToContainer` copies a `MountableFile`, TAR entries are created from host files. The TAR metadata may carry host UID/GID values into the container.

On rootless Docker setups, those IDs may be unmapped, causing permission/ownership issues (e.g. Keycloak dev service failing to read copied config).

## Solution
Normalize TAR entry ownership for `MountableFile` copies:
- set TAR entry `uid=0`
- set TAR entry `gid=0`

This avoids leaking host identity into the container filesystem metadata.

## Tests
Added `MountableFileTest#tarEntriesShouldUseRootOwnership` to verify generated TAR entries use UID/GID 0.

## Related
- testcontainers-java issue #11487
- quarkusio/quarkus#45940