### PR TITLE
Retry failed container removals (JVMHookResourceReaper)

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/JVMHookResourceReaper.java
+++ b/core/src/main/java/org/testcontainers/utility/JVMHookResourceReaper.java
@@ -1,9 +1,14 @@
 package org.testcontainers.utility;
 
+import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Container;
 import com.github.dockerjava.api.model.PruneType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -13,19 +18,34 @@ import java.util.Map;
  */
 class JVMHookResourceReaper extends ResourceReaper {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(JVMHookResourceReaper.class);
+
     @Override
     public void init() {
         setHook();
     }
 
+    /**
+     * Perform a cleanup.
+     * @deprecated no longer supported API, use {@link DockerClient} directly
+     */
     @Override
+    @Deprecated
     public synchronized void performCleanup() {
         super.performCleanup();
         synchronized (DEATH_NOTE) {
-            DEATH_NOTE.forEach(filters -> prune(PruneType.CONTAINERS, filters));
-            DEATH_NOTE.forEach(filters -> prune(PruneType.NETWORKS, filters));
-            DEATH_NOTE.forEach(filters -> prune(PruneType.VOLUMES, filters));
-            DEATH_NOTE.forEach(filters -> prune(PruneType.IMAGES, filters));
+            tryPrune(PruneType.CONTAINERS);
+            tryPrune(PruneType.NETWORKS);
+            tryPrune(PruneType.VOLUMES);
+            tryPrune(PruneType.IMAGES);
+        }
+    }
+
+    private void tryPrune(PruneType pruneType) {
+        try {
+            DEATH_NOTE.forEach(filters -> prune(pruneType, filters));
+        } catch (Exception e) {
+            LOGGER.warn("Exception pruning {} resources: {}", pruneType, e.getMessage(), e);
         }
     }
 
@@ -35,28 +55,45 @@ class JVMHookResourceReaper extends ResourceReaper {
             .filter(it -> "label".equals(it.getKey()))
             .map(Map.Entry::getValue)
             .toArray(String[]::new);
-        switch (pruneType) {
-            // Docker only prunes stopped containers, so we have to do it manually
-            case CONTAINERS:
-                List<Container> containers = dockerClient
-                    .listContainersCmd()
-                    .withFilter("label", Arrays.asList(labels))
-                    .withShowAll(true)
-                    .exec();
 
-                containers
-                    .parallelStream()
-                    .forEach(container -> {
-                        dockerClient
-                            .removeContainerCmd(container.getId())
-                            .withForce(true)
-                            .withRemoveVolumes(true)
-                            .exec();
-                    });
-                break;
-            default:
-                dockerClient.pruneCmd(pruneType).withLabelFilter(labels).exec();
-                break;
+        if (pruneType == PruneType.CONTAINERS) {
+            // Docker only prunes stopped containers, so we have to do it manually
+            removeContainers(labels);
+        } else {
+            dockerClient.pruneCmd(pruneType).withLabelFilter(labels).exec();
+        }
+    }
+
+    private void removeContainers(String[] labels) {
+        List<Container> containers = listContainers(labels);
+        int retries = 5;
+
+        while (!containers.isEmpty() && retries-- > 0) {
+            List<Throwable> errors = new ArrayList<>();
+
+            containers.parallelStream().forEach(container -> removeContainer(container, errors));
+
+            if (errors.isEmpty()) {
+                containers = Collections.emptyList();
+            } else if (retries < 1) {
+                RuntimeException removeError = new RuntimeException("Error removing one or more containers");
+                errors.forEach(removeError::addSuppressed);
+                throw removeError;
+            } else {
+                containers = listContainers(labels);
+            }
+        }
+    }
+
+    private List<Container> listContainers(String[] labels) {
+        return dockerClient.listContainersCmd().withFilter("label", Arrays.asList(labels)).withShowAll(true).exec();
+    }
+
+    private void removeContainer(Container container, List<Throwable> errors) {
+        try {
+            dockerClient.removeContainerCmd(container.getId()).withForce(true).withRemoveVolumes(true).exec();
+        } catch (Exception e) {
+            errors.add(e);
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Please review the following notes before
submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->

This change tightens up the processing in the `JVMHookResourceReaper` with error handling and up to 5 tries when removing container images. This fixes a problem in podman where containers may have dependencies and one or more may fail to be removed initially. A subsequent pass over existing containers will remove those that failed initially, provided the dependent container was removed.