### PR TITLE
docs: add auth token guidance for LocalStack module

### DIFF
--- a/docs/modules/localstack.md
+++ b/docs/modules/localstack.md
@@ -2,6 +2,13 @@
 
 Testcontainers module for [LocalStack](http://localstack.cloud/), 'a fully functional local AWS cloud stack', to develop and test your cloud and serverless apps without actually using the cloud.
 
+!!! warning "Auth Token Required for `localstack/localstack:latest`"
+    Starting March 23, 2026, `localstack/localstack:latest` requires a
+    `LOCALSTACK_AUTH_TOKEN` environment variable. To continue without an
+    auth token, pin to a pre-change version such as `4.14.0`.
+    See the [LocalStack Auth Token documentation](https://docs.localstack.cloud/getting-started/auth-token/)
+    for details.
+
 ## Usage example
 
 You can start a LocalStack container instance from any Java application by using:
@@ -9,6 +16,26 @@ You can start a LocalStack container instance from any Java application by using
 <!--codeinclude-->
 [Container creation](../../modules/localstack/src/test/java/org/testcontainers/localstack/LocalStackContainerTest.java) inside_block:container
 <!--/codeinclude-->
+
+### Using an Auth Token
+
+For LocalStack versions that require authentication, set your auth token:
+
+```java
+LocalStackContainer localstack = new LocalStackContainer(
+    DockerImageName.parse("localstack/localstack:latest")
+).withEnv("LOCALSTACK_AUTH_TOKEN", System.getenv("LOCALSTACK_AUTH_TOKEN"));
+```
+
+### Pinning to a Pre-Change Version
+
+To continue without an auth token, pin to a pre-change version such as `4.14.0`:
+
+```java
+LocalStackContainer localstack = new LocalStackContainer(
+    DockerImageName.parse("localstack/localstack:4.14.0")
+);
+```
 
 ## Creating a client using AWS SDK
 


### PR DESCRIPTION
## Summary
- Add warning about LocalStack auth token requirement starting March 23, 2026
- Show how to set `LOCALSTACK_AUTH_TOKEN` via `.withEnv()`
- Document version pinning as an alternative

Closes #11568

## Test plan
- [ ] Verify docs render correctly via Netlify deploy preview
- [ ] Codeinclude blocks unchanged; verify rendered page in deploy preview
- [ ] No Java code changes, existing tests unaffected