### PR TITLE
fix: return mapped port from MariaDBContainer.getLivenessCheckPortNumbers

### DIFF
--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -3,8 +3,6 @@ package org.testcontainers.containers;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Set;
-
 /**
  * Testcontainers implementation for MariaDB.
  * <p>
@@ -52,11 +50,6 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
         addExposedPort(MARIADB_PORT);
-    }
-
-    @Override
-    public Set<Integer> getLivenessCheckPortNumbers() {
-        return super.getLivenessCheckPortNumbers();
     }
 
     @Override

--- a/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/containers/MariaDBContainer.java
@@ -1,6 +1,5 @@
 package org.testcontainers.containers;
 
-import com.google.common.collect.Sets;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
@@ -57,7 +56,7 @@ public class MariaDBContainer<SELF extends MariaDBContainer<SELF>> extends JdbcD
 
     @Override
     public Set<Integer> getLivenessCheckPortNumbers() {
-        return Sets.newHashSet(MARIADB_PORT);
+        return super.getLivenessCheckPortNumbers();
     }
 
     @Override

--- a/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBContainer.java
@@ -1,6 +1,5 @@
 package org.testcontainers.mariadb;
 
-import com.google.common.collect.Sets;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.images.builder.Transferable;
@@ -50,7 +49,7 @@ public class MariaDBContainer extends JdbcDatabaseContainer<MariaDBContainer> {
 
     @Override
     public Set<Integer> getLivenessCheckPortNumbers() {
-        return Sets.newHashSet(MARIADB_PORT);
+        return super.getLivenessCheckPortNumbers();
     }
 
     @Override

--- a/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBContainer.java
@@ -5,8 +5,6 @@ import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
-import java.util.Set;
-
 /**
  * Testcontainers implementation for MariaDB.
  * <p>
@@ -45,11 +43,6 @@ public class MariaDBContainer extends JdbcDatabaseContainer<MariaDBContainer> {
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
         addExposedPort(MARIADB_PORT);
-    }
-
-    @Override
-    public Set<Integer> getLivenessCheckPortNumbers() {
-        return super.getLivenessCheckPortNumbers();
     }
 
     @Override

--- a/modules/mariadb/src/test/java/org/testcontainers/mariadb/MariaDBContainerTest.java
+++ b/modules/mariadb/src/test/java/org/testcontainers/mariadb/MariaDBContainerTest.java
@@ -33,6 +33,7 @@ class MariaDBContainerTest extends AbstractContainerDatabaseTest {
             int resultSetInt = resultSet.getInt(1);
 
             assertThat(resultSetInt).as("A basic SELECT query succeeds").isEqualTo(1);
+            assertHasCorrectExposedAndLivenessCheckPorts(mariadb);
         }
     }
 
@@ -143,6 +144,12 @@ class MariaDBContainerTest extends AbstractContainerDatabaseTest {
 
             assertThat(resultSetInt).isEqualTo(1);
         }
+    }
+
+    private void assertHasCorrectExposedAndLivenessCheckPorts(MariaDBContainer mariadb) {
+        assertThat(mariadb.getExposedPorts()).containsExactly(MariaDBContainer.MARIADB_PORT);
+        assertThat(mariadb.getLivenessCheckPortNumbers())
+            .containsExactly(mariadb.getMappedPort(MariaDBContainer.MARIADB_PORT));
     }
 
     private void assertThatCustomIniFileWasUsed(MariaDBContainer mariadb) throws SQLException {


### PR DESCRIPTION
## Summary
Fix `MariaDBContainer.getLivenessCheckPortNumbers()` to return the mapped external port instead of the hardcoded internal port.

## Problem
`getLivenessCheckPortNumbers()` returns `Sets.newHashSet(3306)` (the internal container port) instead of the mapped external port. This causes `HostPortWaitStrategy` and other liveness checks to potentially inspect the wrong port for readiness.

## Root Cause
This bug was originally fixed for other containers in PR #5734 but MariaDB was missed. The new `MariaDBContainer` class (PR #11083) then copied the same buggy implementation.

## Fix
Delegate to `super.getLivenessCheckPortNumbers()` which correctly maps internal ports to external mapped ports via `getMappedPort()`.

Applied to both:
- `org.testcontainers.mariadb.MariaDBContainer` (current)
- `org.testcontainers.containers.MariaDBContainer` (deprecated)

## Test
Added test verifying `getLivenessCheckPortNumbers()` returns the mapped port, following the same pattern used in `MySQLContainerTest`, `PostgreSQLContainerTest`, and `MSSQLServerContainerTest`.

Fixes #10359