### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testImplementation 'com.azure:azure-data-tables'
     testImplementation 'com.azure:azure-messaging-eventhubs'
     testImplementation 'com.azure:azure-messaging-servicebus'
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.3.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11'
 }
 
 tasks.japicmp {

--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -5,12 +5,12 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     compileOnly project(':testcontainers-r2dbc')
-    compileOnly(group: 'com.clickhouse', name: 'clickhouse-r2dbc', version: '0.9.4', classifier: 'http')
+    compileOnly(group: 'com.clickhouse', name: 'clickhouse-r2dbc', version: '0.9.8', classifier: 'http')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-jdbc', version: '0.9.4', classifier: 'all')
+    testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-jdbc', version: '0.9.8', classifier: 'all')
 
-    testImplementation 'com.clickhouse:client-v2:0.9.4'
+    testImplementation 'com.clickhouse:client-v2:0.9.8'
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
-    testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-r2dbc', version: '0.9.4', classifier: 'http')
+    testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-r2dbc', version: '0.9.8', classifier: 'http')
 }

--- a/modules/databend/build.gradle
+++ b/modules/databend/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'com.databend:databend-jdbc:0.4.5'
+    testRuntimeOnly 'com.databend:databend-jdbc:0.4.6'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     api 'org.assertj:assertj-core:3.27.7'
 
-    api 'org.apache.tomcat:tomcat-jdbc:11.0.14'
+    api 'org.apache.tomcat:tomcat-jdbc:11.0.21'
     api 'org.vibur:vibur-dbcp:26.0'
     api 'com.mysql:mysql-connector-j:9.6.0'
     api 'org.junit.jupiter:junit-jupiter:5.14.3'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:26.0.2-1'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:26.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.14'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.21'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: JDBC"
 dependencies {
     api project(':testcontainers-database-commons')
 
-    compileOnly 'org.jetbrains:annotations:26.0.2-1'
+    compileOnly 'org.jetbrains:annotations:26.1.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:26.0'
     testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.14'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.6'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.8'
 
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-mssql:1.0.3.RELEASE'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.3.0.jre8-preview'
+    testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11'
 
     testImplementation project(':testcontainers-r2dbc')
     testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.3.RELEASE'

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.0.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.1.0.0'
 
     compileOnly 'org.jetbrains:annotations:26.0.2-1'
 

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.0.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.1.0.0'
 
     compileOnly 'org.jetbrains:annotations:26.0.2-1'
 

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:478'
+    testRuntimeOnly 'io.trino:trino-jdbc:480'
     compileOnly 'org.jetbrains:annotations:26.0.2-1'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.apache.tomcat:tomcat-jdbc from 11.0.14 to 11.0.21 in /modules/jdbc (#11638) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 11.0.14 to 11.0.21 in /modules/jdbc-test (#11643) @app/dependabot
* Bump io.trino:trino-jdbc from 478 to 480 in /modules/trino (#11607) @app/dependabot
* Bump com.databend:databend-jdbc from 0.4.5 to 0.4.6 in /modules/databend (#11675) @app/dependabot
* Bump com.clickhouse:clickhouse-jdbc from 0.9.4 to 0.9.8 in /modules/clickhouse (#11602) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.5.6 to 3.5.8 in /modules/mariadb (#11598) @app/dependabot
* Bump org.jetbrains:annotations from 26.0.2-1 to 26.1.0 in /modules/jdbc (#11505) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 13.3.0.jre8-preview to 13.4.0.jre11 in /modules/azure (#11606) @app/dependabot
* Bump com.microsoft.sqlserver:mssql-jdbc from 13.3.0.jre8-preview to 13.4.0.jre11 in /modules/mssqlserver (#11603) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.26.0.0.0 to 23.26.1.0.0 in /modules/oracle-free (#11542) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.26.0.0.0 to 23.26.1.0.0 in /modules/oracle-xe (#11502) @app/dependabot
