### PR TITLE
Make GenericContainer.start() and stop() thread-safe

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -28,6 +28,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.SneakyThrows;
+import lombok.Synchronized;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
@@ -169,7 +170,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      */
     @Setter(AccessLevel.NONE)
     @VisibleForTesting
-    String containerId;
+    volatile String containerId;
 
     @Setter(AccessLevel.NONE)
     private InspectContainerResponse containerInfo;
@@ -306,6 +307,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * Starts the container using docker, pulling an image if necessary.
      */
     @Override
+    @Synchronized
     @SneakyThrows({ InterruptedException.class, ExecutionException.class })
     public void start() {
         if (containerId != null) {
@@ -634,6 +636,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * Kill and remove the container.
      */
     @Override
+    @Synchronized
     public void stop() {
         if (containerId == null) {
             return;

--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -28,7 +28,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.SneakyThrows;
-import lombok.Synchronized;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
@@ -307,9 +306,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * Starts the container using docker, pulling an image if necessary.
      */
     @Override
-    @Synchronized
     @SneakyThrows({ InterruptedException.class, ExecutionException.class })
-    public void start() {
+    public synchronized void start() {
         if (containerId != null) {
             return;
         }
@@ -636,8 +634,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      * Kill and remove the container.
      */
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         if (containerId == null) {
             return;
         }

--- a/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseR2DBCDatabaseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseR2DBCDatabaseContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.clickhouse;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import lombok.Synchronized;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
 /**
@@ -24,11 +25,13 @@ public class ClickHouseR2DBCDatabaseContainer implements R2DBCDatabaseContainer 
     }
 
     @Override
+    @Synchronized
     public void start() {
         this.container.start();
     }
 
     @Override
+    @Synchronized
     public void stop() {
         this.container.stop();
     }

--- a/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseR2DBCDatabaseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseR2DBCDatabaseContainer.java
@@ -1,7 +1,6 @@
 package org.testcontainers.clickhouse;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.Synchronized;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
 /**
@@ -25,14 +24,12 @@ public class ClickHouseR2DBCDatabaseContainer implements R2DBCDatabaseContainer 
     }
 
     @Override
-    @Synchronized
-    public void start() {
+    public synchronized void start() {
         this.container.start();
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         this.container.stop();
     }
 

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelDependsOnTest.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ParallelDependsOnTest.java
@@ -1,0 +1,66 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that concurrent {@link GenericContainer#start()} calls on the same
+ * container do not result in {@link GenericContainer#doStart()} being
+ * called more than once.
+ *
+ * <p>A background thread calls {@code container.start()} during class initialization,
+ * racing with the extension's {@link Startables#deepStart(Stream)} which also starts
+ * the container as part of the {@code @Container} lifecycle.</p>
+ */
+@Testcontainers(parallel = true)
+class ParallelDependsOnTest {
+    static {
+        // Pre-initialize the Docker client to increase the chance of a race
+        // and to emulate a test suite where an earlier test class already
+        // triggered the initialization.
+        DockerClientFactory.instance().client();
+    }
+
+    private static final AtomicInteger doStartCount = new AtomicInteger();
+
+    @Container
+    private static final StartCountingContainer container = new StartCountingContainer(
+        JUnitJupiterTestImages.HTTPD_IMAGE,
+        doStartCount
+    );
+
+    static {
+        // Race with the extension's Startables.deepStart.
+        new Thread(() -> container.start()).start();
+    }
+
+    @Test
+    void containerShouldBeStartedOnlyOnce() {
+        assertThat(container.isRunning()).isTrue();
+        assertThat(doStartCount).as("doStart() invocations").hasValue(1);
+    }
+
+    private static class StartCountingContainer extends GenericContainer<StartCountingContainer> {
+
+        private final AtomicInteger doStartCount;
+
+        StartCountingContainer(DockerImageName image, AtomicInteger doStartCount) {
+            super(image);
+            this.doStartCount = doStartCount;
+        }
+
+        @Override
+        protected void doStart() {
+            doStartCount.incrementAndGet();
+            super.doStart();
+        }
+    }
+}

--- a/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBR2DBCDatabaseContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBR2DBCDatabaseContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.mariadb;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import lombok.Synchronized;
 import org.mariadb.r2dbc.MariadbConnectionFactoryProvider;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
@@ -42,11 +43,13 @@ public class MariaDBR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
+    @Synchronized
     public void start() {
         this.container.start();
     }
 
     @Override
+    @Synchronized
     public void stop() {
         this.container.stop();
     }

--- a/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBR2DBCDatabaseContainer.java
+++ b/modules/mariadb/src/main/java/org/testcontainers/mariadb/MariaDBR2DBCDatabaseContainer.java
@@ -1,7 +1,6 @@
 package org.testcontainers.mariadb;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.Synchronized;
 import org.mariadb.r2dbc.MariadbConnectionFactoryProvider;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
@@ -43,14 +42,12 @@ public class MariaDBR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
-    @Synchronized
-    public void start() {
+    public synchronized void start() {
         this.container.start();
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         this.container.stop();
     }
 

--- a/modules/mssqlserver/src/main/java/org/testcontainers/mssqlserver/MSSQLR2DBCDatabaseContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/mssqlserver/MSSQLR2DBCDatabaseContainer.java
@@ -2,6 +2,7 @@ package org.testcontainers.mssqlserver;
 
 import io.r2dbc.mssql.MssqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -43,11 +44,13 @@ public class MSSQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
+    @Synchronized
     public void start() {
         this.container.start();
     }
 
     @Override
+    @Synchronized
     public void stop() {
         this.container.stop();
     }

--- a/modules/mssqlserver/src/main/java/org/testcontainers/mssqlserver/MSSQLR2DBCDatabaseContainer.java
+++ b/modules/mssqlserver/src/main/java/org/testcontainers/mssqlserver/MSSQLR2DBCDatabaseContainer.java
@@ -2,7 +2,6 @@ package org.testcontainers.mssqlserver;
 
 import io.r2dbc.mssql.MssqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -44,14 +43,12 @@ public class MSSQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
-    @Synchronized
-    public void start() {
+    public synchronized void start() {
         this.container.start();
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         this.container.stop();
     }
 

--- a/modules/mysql/src/main/java/org/testcontainers/mysql/MySQLR2DBCDatabaseContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/mysql/MySQLR2DBCDatabaseContainer.java
@@ -2,6 +2,7 @@ package org.testcontainers.mysql;
 
 import io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -42,11 +43,13 @@ public class MySQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
+    @Synchronized
     public void start() {
         this.container.start();
     }
 
     @Override
+    @Synchronized
     public void stop() {
         this.container.stop();
     }

--- a/modules/mysql/src/main/java/org/testcontainers/mysql/MySQLR2DBCDatabaseContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/mysql/MySQLR2DBCDatabaseContainer.java
@@ -2,7 +2,6 @@ package org.testcontainers.mysql;
 
 import io.asyncer.r2dbc.mysql.MySqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -43,14 +42,12 @@ public class MySQLR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
-    @Synchronized
-    public void start() {
+    public synchronized void start() {
         this.container.start();
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         this.container.stop();
     }
 

--- a/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleR2DBCDatabaseContainer.java
+++ b/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleR2DBCDatabaseContainer.java
@@ -1,6 +1,7 @@
 package org.testcontainers.oracle;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -41,11 +42,13 @@ public class OracleR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
+    @Synchronized
     public void start() {
         this.container.start();
     }
 
     @Override
+    @Synchronized
     public void stop() {
         this.container.stop();
     }

--- a/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleR2DBCDatabaseContainer.java
+++ b/modules/oracle-free/src/main/java/org/testcontainers/oracle/OracleR2DBCDatabaseContainer.java
@@ -1,7 +1,6 @@
 package org.testcontainers.oracle;
 
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -42,14 +41,12 @@ public class OracleR2DBCDatabaseContainer implements R2DBCDatabaseContainer {
     }
 
     @Override
-    @Synchronized
-    public void start() {
+    public synchronized void start() {
         this.container.start();
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         this.container.stop();
     }
 

--- a/modules/postgresql/src/main/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainer.java
@@ -2,6 +2,7 @@ package org.testcontainers.postgresql;
 
 import io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
+import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -42,11 +43,13 @@ public final class PostgreSQLR2DBCDatabaseContainer implements R2DBCDatabaseCont
     }
 
     @Override
+    @Synchronized
     public void start() {
         this.container.start();
     }
 
     @Override
+    @Synchronized
     public void stop() {
         this.container.stop();
     }

--- a/modules/postgresql/src/main/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainer.java
+++ b/modules/postgresql/src/main/java/org/testcontainers/postgresql/PostgreSQLR2DBCDatabaseContainer.java
@@ -2,7 +2,6 @@ package org.testcontainers.postgresql;
 
 import io.r2dbc.postgresql.PostgresqlConnectionFactoryProvider;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import lombok.Synchronized;
 import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.r2dbc.R2DBCDatabaseContainer;
 
@@ -43,14 +42,12 @@ public final class PostgreSQLR2DBCDatabaseContainer implements R2DBCDatabaseCont
     }
 
     @Override
-    @Synchronized
-    public void start() {
+    public synchronized void start() {
         this.container.start();
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         this.container.stop();
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -5,6 +5,7 @@ import com.github.dockerjava.api.model.AccessMode;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import com.google.common.collect.ImmutableSet;
+import lombok.Synchronized;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
@@ -351,6 +352,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     }
 
     @Override
+    @Synchronized
     public void stop() {
         if (driver != null) {
             try {

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.model.AccessMode;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import com.google.common.collect.ImmutableSet;
-import lombok.Synchronized;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
@@ -352,8 +351,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         if (driver != null) {
             try {
                 driver.quit();

--- a/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
@@ -5,6 +5,7 @@ import com.github.dockerjava.api.model.AccessMode;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import com.google.common.collect.ImmutableSet;
+import lombok.Synchronized;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
@@ -202,6 +203,7 @@ public class BrowserWebDriverContainer
     }
 
     @Override
+    @Synchronized
     public void stop() {
         if (vncRecordingContainer != null) {
             try {

--- a/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
@@ -5,7 +5,6 @@ import com.github.dockerjava.api.model.AccessMode;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.Volume;
 import com.google.common.collect.ImmutableSet;
-import lombok.Synchronized;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
@@ -203,8 +202,7 @@ public class BrowserWebDriverContainer
     }
 
     @Override
-    @Synchronized
-    public void stop() {
+    public synchronized void stop() {
         if (vncRecordingContainer != null) {
             try {
                 vncRecordingContainer.stop();


### PR DESCRIPTION
## Summary

`GenericContainer.start()` guards against double-start with `if (containerId != null) return`, but `start()` is not synchronized. When two threads call `start()` on the same container concurrently, both can pass the guard before either sets `containerId`, creating two Docker containers for one logical dependency.

This can happen when `@Testcontainers` is used and the container is also started from another context. In our case, we have custom test infrastructure that handles `@Container` annotations and starts containers. It does not cover all use-cases, so some test classes still need to use `@Testcontainers`. When both the custom infrastructure and the extension call `start()` on the same container, they race.

The workaround is to not annotate dependencies with `@Container`, but this is not obvious to developers and error-prone.

The fix adds `@Synchronized` to `start()` and `stop()` in `GenericContainer` and all other `Startable` implementations that override these methods. `containerId` is also made `volatile` for cross-thread visibility.

Fixes #11719