### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:5.3.2'
 
-    testImplementation 'com.couchbase.client:java-client:3.10.0'
+    testImplementation 'com.couchbase.client:java-client:3.11.2'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.2.2"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.3.3"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':testcontainers-mysql')
     testImplementation project(':testcontainers-postgresql')
     testImplementation 'com.zaxxer:HikariCP:7.0.2'
-    testImplementation 'redis.clients:jedis:7.1.0'
+    testImplementation 'redis.clients:jedis:7.4.1'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     // Synchronize with the jackson version, must match major and minor version
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.4'
 
-    testImplementation 'io.fabric8:kubernetes-client:7.4.0'
+    testImplementation 'io.fabric8:kubernetes-client:7.6.1'
     testImplementation 'io.kubernetes:client-java:25.0.0-legacy'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("software.amazon.awssdk:bom:2.40.4")
+    testImplementation platform("software.amazon.awssdk:bom:2.42.33")
     testImplementation 'software.amazon.awssdk:s3'
     testImplementation 'software.amazon.awssdk:sqs'
     testImplementation 'software.amazon.awssdk:cloudwatchlogs'

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:8.6.0")
+    testImplementation("io.minio:minio:9.0.0")
 }

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,5 +33,5 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.21'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.22'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: OpenFGA"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'dev.openfga:openfga-sdk:0.9.4'
+    testImplementation 'dev.openfga:openfga-sdk:0.9.7'
 }
 
 test {

--- a/modules/pulsar/build.gradle
+++ b/modules/pulsar/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Pulsar"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("org.apache.pulsar:pulsar-bom:4.1.1")
+    testImplementation platform("org.apache.pulsar:pulsar-bom:4.2.0")
     testImplementation 'org.apache.pulsar:pulsar-client'
     testImplementation 'org.apache.pulsar:pulsar-client-admin'
 }

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'io.qdrant:client:1.17.0'
-    testImplementation platform('io.grpc:grpc-bom:1.75.0')
+    testImplementation platform('io.grpc:grpc-bom:1.80.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'
     testImplementation 'io.grpc:grpc-netty-shaded'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':testcontainers-postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.8.1'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.8.4'
     testFixturesImplementation 'org.assertj:assertj-core:3.27.7'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.34'
 
-    testImplementation 'org.apache.kafka:kafka-clients:4.1.1'
+    testImplementation 'org.apache.kafka:kafka-clients:4.2.0'
     testImplementation 'io.rest-assured:rest-assured:5.5.7'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.11'
 
-    testImplementation 'redis.clients:jedis:7.1.0'
+    testImplementation 'redis.clients:jedis:7.4.1'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump software.amazon.awssdk:bom from 2.40.4 to 2.42.33 in /modules/localstack (#11690) @app/dependabot
* Bump redis.clients:jedis from 7.1.0 to 7.4.1 in /modules/toxiproxy (#11650) @app/dependabot
* Bump redis.clients:jedis from 7.1.0 to 7.4.1 in /modules/junit-jupiter (#11647) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 9.2.2 to 9.3.3 in /modules/elasticsearch (#11642) @app/dependabot
* Bump io.grpc:grpc-bom from 1.75.0 to 1.80.0 in /modules/qdrant (#11623) @app/dependabot
* Bump dev.openfga:openfga-sdk from 0.9.4 to 0.9.7 in /modules/openfga (#11622) @app/dependabot
* Bump io.minio:minio from 8.6.0 to 9.0.0 in /modules/minio (#11618) @app/dependabot
* Bump io.fabric8:kubernetes-client from 7.4.0 to 7.6.1 in /modules/k3s (#11610) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.8.1 to 3.8.4 in /modules/r2dbc (#11608) @app/dependabot
* Bump org.neo4j.driver:neo4j-java-driver from 4.4.21 to 4.4.22 in /modules/neo4j (#11595) @app/dependabot
* Bump org.apache.pulsar:pulsar-bom from 4.1.1 to 4.2.0 in /modules/pulsar (#11593) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 4.1.1 to 4.2.0 in /modules/redpanda (#11535) @app/dependabot
* Bump com.couchbase.client:java-client from 3.10.0 to 3.11.1 in /modules/couchbase (#11506) @app/dependabot
