### PR TITLE
Combined dependencies PR

### DIFF
--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.72.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.79.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     compileOnly 'org.influxdb:influxdb-java:2.25'
 
     testImplementation 'org.influxdb:influxdb-java:2.25'
-    testImplementation "com.influxdb:influxdb-client-java:7.4.0"
+    testImplementation "com.influxdb:influxdb-client-java:7.5.0"
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -4,13 +4,13 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     compileOnly project(':testcontainers-r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.3.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.4.RELEASE'
 
     testImplementation project(':testcontainers-jdbc-test')
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11'
 
     testImplementation project(':testcontainers-r2dbc')
-    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.3.RELEASE'
+    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.4.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':testcontainers-r2dbc'))

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     api "com.orientechnologies:orientdb-client:3.2.46"
 
-    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.8.0'
+    testImplementation 'org.apache.tinkerpop:gremlin-driver:3.8.1'
     testImplementation "com.orientechnologies:orientdb-gremlin:3.2.46"
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
 
-    testImplementation 'com.rabbitmq:amqp-client:5.28.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.29.0'
     compileOnly 'org.jetbrains:annotations:26.1.0'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.3.0'
 
-    testImplementation 'com.solacesystems:sol-jcsmp:10.29.0'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.29.1'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump org.apache.tinkerpop:gremlin-driver from 3.8.0 to 3.8.1 in /modules/orientdb (#11646) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.72.0 to 26.79.0 in /modules/gcloud (#11605) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.28.0 to 5.29.0 in /modules/rabbitmq (#11527) @app/dependabot
* Bump com.influxdb:influxdb-client-java from 7.4.0 to 7.5.0 in /modules/influxdb (#11494) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.29.0 to 10.29.1 in /modules/solace (#11471) @app/dependabot
* Bump io.r2dbc:r2dbc-mssql from 1.0.3.RELEASE to 1.0.4.RELEASE in /modules/mssqlserver (#11441) @app/dependabot
