### PR TITLE
Combined dependencies PR

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -116,7 +116,7 @@ dependencies {
     testImplementation files('testlib/repo/fakejar/fakejar/0/fakejar-0.jar')
 
     testImplementation 'org.assertj:assertj-core:3.27.7'
-    testImplementation 'io.rest-assured:rest-assured:5.5.6'
+    testImplementation 'io.rest-assured:rest-assured:5.5.7'
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ActiveMQ"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation "org.apache.activemq:activemq-client:6.2.0"
+    testImplementation "org.apache.activemq:activemq-client:6.2.4"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.44.0"
 }

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'com.ibm.db2:jcc:12.1.3.0'
+    testRuntimeOnly 'com.ibm.db2:jcc:12.1.4.0'
 }

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'io.rest-assured:rest-assured:5.5.7'
-    testImplementation 'io.micrometer:micrometer-registry-otlp:1.16.1'
+    testImplementation 'io.micrometer:micrometer-registry-otlp:1.16.5'
     testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.8'
 
     testImplementation platform('io.opentelemetry:opentelemetry-bom:1.57.0')

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.16.1'
     testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.8'
 
-    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.57.0')
+    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.61.0')
     testImplementation 'io.opentelemetry:opentelemetry-api'
     testImplementation 'io.opentelemetry:opentelemetry-sdk'
     testImplementation 'io.opentelemetry:opentelemetry-exporter-otlp'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     shaded("net.lingala.zip4j:zip4j:2.11.6")
 
     testImplementation(project(":testcontainers-junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.47.1")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.50.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.13")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.22")

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.46"
+    api "com.orientechnologies:orientdb-client:3.2.51"
 
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.8.1'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.46"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.51"
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ScyllaDB"
 dependencies {
     api project(":testcontainers")
 
-    testImplementation 'com.scylladb:java-driver-core:4.19.0.4'
+    testImplementation 'com.scylladb:java-driver-core:4.19.0.8'
     testImplementation 'software.amazon.awssdk:dynamodb:2.40.4'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump io.opentelemetry:opentelemetry-bom from 1.57.0 to 1.61.0 in /modules/grafana (#11689) @app/dependabot
* Bump com.orientechnologies:orientdb-client from 3.2.46 to 3.2.51 in /modules/orientdb (#11614) @app/dependabot
* Bump org.apache.activemq:activemq-client from 6.2.0 to 6.2.4 in /modules/activemq (#11674) @app/dependabot
* Bump io.micrometer:micrometer-registry-otlp from 1.16.1 to 1.16.4 in /modules/grafana (#11624) @app/dependabot
* Bump com.hivemq:hivemq-extension-sdk from 4.47.1 to 4.50.0 in /modules/hivemq (#11615) @app/dependabot
* Bump com.ibm.db2:jcc from 12.1.3.0 to 12.1.4.0 in /modules/db2 (#11612) @app/dependabot
* Bump com.scylladb:java-driver-core from 4.19.0.4 to 4.19.0.8 in /modules/scylladb (#11628) @app/dependabot
* Bump io.rest-assured:rest-assured from 5.5.6 to 5.5.7 in /core (#11673) @app/dependabot
