### PR TITLE
Fix typo in GenericContainer namespace validation error message

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1115,7 +1115,7 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     @Override
     public SELF withLabel(String key, String value) {
         if (key.startsWith("org.testcontainers")) {
-            throw new IllegalArgumentException("The org.testcontainers namespace is reserved for interal use");
+            throw new IllegalArgumentException("The org.testcontainers namespace is reserved for internal use");
         }
         this.containerDef.addLabel(key, value);
         return self();


### PR DESCRIPTION
Fix a small typo in the error message thrown when a reserved namespace is used.

"interal" → "internal"

File: core/src/main/java/org/testcontainers/containers/GenericContainer.java

Thanks :)

<!--
Thanks for contributing to Testcontainers. Before submitting a pull request, please
review our contributing guidelines at https://java.testcontainers.org/contributing/

Please also review the following notes before submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
