### PR TITLE
Combine Dependabot PRs

### DIFF
--- a/.github/workflows/moby-latest.yml
+++ b/.github/workflows/moby-latest.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Notify to Slack on failures
         if: failure()
         id: slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.2
         with:
           payload: |
             {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     dependencies {
         // https://github.com/melix/japicmp-gradle-plugin/issues/36
-        classpath 'com.google.guava:guava:33.3.1-jre'
+        classpath 'com.google.guava:guava:33.5.0-jre'
         classpath 'com.github.tjni.captainhook:captain-hook:0.1.5'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -135,7 +135,7 @@ subprojects {
 
     dependencies {
         testImplementation 'ch.qos.logback:logback-classic:1.3.15'
-        testImplementation 'org.assertj:assertj-core:3.27.4'
+        testImplementation 'org.assertj:assertj-core:3.27.7'
         testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
 
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ subprojects {
     dependencies {
         testImplementation 'ch.qos.logback:logback-classic:1.3.15'
         testImplementation 'org.assertj:assertj-core:3.27.4'
-        testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
 
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,8 @@ subprojects {
     }
 
     dependencies {
+        compileOnly 'com.google.code.findbugs:jsr305:3.0.2'
+
         testImplementation 'ch.qos.logback:logback-classic:1.3.15'
         testImplementation 'org.assertj:assertj-core:3.27.7'
         testImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.gradleup.shadow' version '8.3.9'
+    id 'com.gradleup.shadow' version '8.3.10'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.22.0' apply false
     id 'org.jreleaser' version '1.20.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'com.gradleup.shadow' version '8.3.9'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.22.0' apply false
-    id 'org.jreleaser' version '1.20.0' apply false
+    id 'org.jreleaser' version '1.23.0' apply false
 }
 
 apply from: "$rootDir/gradle/ci-support.gradle"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'redis.clients:jedis:7.4.1'
-    testImplementation 'com.rabbitmq:amqp-client:5.26.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.30.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,7 +100,7 @@ dependencies {
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.3'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
     testImplementation('com.google.cloud.tools:jib-core:0.28.1')  {
         exclude group: 'com.google.guava', module: 'guava'
     }
@@ -121,7 +121,7 @@ dependencies {
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
     jarFileTestRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.3'
-    jarFileTestImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    jarFileTestImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
     jarFileTestImplementation 'org.assertj:assertj-core:3.27.7'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,7 @@ dependencies {
 
     api 'com.github.docker-java:docker-java-transport-zerodep'
 
-    shaded 'com.google.guava:guava:33.3.1-jre'
+    shaded 'com.google.guava:guava:33.6.0-jre'
     shaded "org.yaml:snakeyaml:2.6"
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testImplementation project(":testcontainers")
     testImplementation project(":testcontainers-junit-jupiter")
-    testImplementation 'org.assertj:assertj-core:3.27.4'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
 }
 
 test {

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.8.0.RELEASE"
+    api "io.lettuce:lettuce-core:7.5.1.RELEASE"
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.8.0.RELEASE"
 
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.14.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testImplementation project(":testcontainers")
     testImplementation project(":testcontainers-junit-jupiter")

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.8.0.RELEASE"
+    api "io.lettuce:lettuce-core:7.5.1.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":testcontainers-spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.13.4')
     testImplementation 'org.junit.platform:junit-platform-suite'
-    testImplementation platform('io.cucumber:cucumber-bom:7.30.0')
+    testImplementation platform('io.cucumber:cucumber-bom:7.34.3')
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit-platform-engine'
     testImplementation 'org.testcontainers:testcontainers-selenium'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.38"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.38"
+    testCompileOnly "org.projectlombok:lombok:1.18.44"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.44"
     testImplementation 'org.testcontainers:testcontainers-kafka'
     testImplementation 'org.apache.kafka:kafka-clients:4.1.0'
     testImplementation 'org.assertj:assertj-core:3.27.4'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:6.2.0'
+    implementation 'redis.clients:jedis:7.4.1'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:6.2.0'
+    implementation 'redis.clients:jedis:7.4.1'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'com.github.mwiede:jsch:2.27.2'
+    testImplementation 'com.github.mwiede:jsch:2.28.0'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:6.2.0'
+    implementation 'redis.clients:jedis:7.4.1'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.38"
-    annotationProcessor "org.projectlombok:lombok:1.18.38"
+    compileOnly "org.projectlombok:lombok:1.18.44"
+    annotationProcessor "org.projectlombok:lombok:1.18.44"
 
     implementation 'org.apache.solr:solr-solrj:8.11.4'
 

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -8,7 +8,7 @@ configurations.all {
 
 dependencies {
     api project(":testcontainers-database-commons")
-    api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
+    api "com.datastax.cassandra:cassandra-driver-core:4.0.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
 }

--- a/modules/cassandra/build.gradle
+++ b/modules/cassandra/build.gradle
@@ -8,7 +8,7 @@ configurations.all {
 
 dependencies {
     api project(":testcontainers-database-commons")
-    api "com.datastax.cassandra:cassandra-driver-core:4.0.0"
+    api "com.datastax.cassandra:cassandra-driver-core:3.10.0"
 
     testImplementation 'com.datastax.oss:java-driver-core:4.17.0'
 }

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'org.questdb:questdb:9.2.2'
+    testImplementation 'org.questdb:questdb:9.3.4'
     testImplementation 'org.awaitility:awaitility:4.3.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -6,7 +6,7 @@ description = "Testcontainers :: Spock-Extension"
 
 dependencies {
     api project(':testcontainers')
-    implementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    implementation 'org.spockframework:spock-core:2.4-groovy-4.0'
 
     testImplementation project(':testcontainers-selenium')
     testImplementation project(':testcontainers-mysql')

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.19.2"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.5.0"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.6.0"
         classpath "org.gradle.toolchains:foojay-resolver:0.8.0"
     }
 }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.assertj:assertj-core:3.27.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.3'

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
-    testImplementation 'org.assertj:assertj-core:3.27.4'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.3'
 }
 

--- a/test-support/build.gradle
+++ b/test-support/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'org.slf4j:slf4j-api:2.0.17'
-    testImplementation 'org.assertj:assertj-core:3.27.4'
+    testImplementation 'org.assertj:assertj-core:3.27.7'
 }


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump slackapi/slack-github-action from 3.0.1 to 3.0.2 in /.github/workflows (#11722) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.26.0 to 5.30.0 in /core (#11715) @app/dependabot
* Bump com.google.guava:guava from 33.3.1-jre to 33.6.0-jre in /core (#11714) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.13.4 to 5.14.3 in /core (#11687) @app/dependabot
* Bump com.gradle:common-custom-user-data-gradle-plugin from 2.5.0 to 2.6.0 (#11680) @app/dependabot
* Bump com.github.mwiede:jsch from 2.27.2 to 2.28.0 in /examples (#11669) @app/dependabot
* Bump redis.clients:jedis from 6.2.0 to 7.4.1 in /examples (#11667) @app/dependabot
* Bump org.jreleaser from 1.20.0 to 1.23.0 in /smoke-test (#11666) @app/dependabot
* Bump org.junit.jupiter:junit-jupiter from 5.13.4 to 5.14.3 in /smoke-test (#11660) @app/dependabot
* Bump io.lettuce:lettuce-core from 6.8.0.RELEASE to 7.5.1.RELEASE in /smoke-test (#11659) @app/dependabot
* Bump org.projectlombok:lombok from 1.18.38 to 1.18.44 in /examples (#11658) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.4 to 3.27.7 in /smoke-test (#11657) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.3 to 1.14.3 in /smoke-test (#11654) @app/dependabot
* Bump org.questdb:questdb from 9.2.2 to 9.3.4 in /modules/questdb (#11617) @app/dependabot
* Bump com.datastax.cassandra:cassandra-driver-core from 3.10.0 to 4.0.0 in /modules/cassandra (#11596) @app/dependabot
* Bump com.gradleup.shadow from 8.3.9 to 8.3.10 (#11557) @app/dependabot
* Bump org.spockframework:spock-core from 2.3-groovy-4.0 to 2.4-groovy-4.0 in /modules/spock (#11458) @app/dependabot
* Bump org.junit.platform:junit-platform-launcher from 1.10.3 to 1.14.3 in /smoke-test (#11321) @app/dependabot
* Bump com.github.mwiede:jsch from 2.27.2 to 2.28.0 in /examples (#11312) @app/dependabot
* Bump io.cucumber:cucumber-bom from 7.30.0 to 7.34.3 in /examples (#11310) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.3.15 to 1.3.16 in /smoke-test (#11307) @app/dependabot
* Bump org.projectlombok:lombok from 1.18.38 to 1.18.44 in /examples (#11163) @app/dependabot
* Bump com.google.guava:guava from 33.3.1-jre to 33.5.0-jre in /smoke-test (#11042) @app/dependabot
* Bump org.assertj:assertj-core from 3.27.4 to 3.27.7 in /smoke-test (#11038) @app/dependabot

## Skipped PRs

The following PRs were skipped due to failing checks (CI re-runs triggered where possible):
* #11696 - release-drafter workflow failure (non-CI)
* #11677 - testcontainers-mongodb check failure (CI re-run triggered)
* #11656 - spring-boot example check failure (CI re-run triggered)
* #11640 - testcontainers-azure check failure (CI re-run triggered)
* #11508 - kafka + azure check failures (dependabot rebase triggered)
* #11458 - spock-redis docs example failure (dependabot rebase triggered)
* #11319 - spring-boot example check failure (CI re-run triggered)
* #11311 - pinecone check failure (CI re-run triggered)

The following PRs were skipped due to merge conflicts:
* #11655 - io.lettuce:lettuce-core in /examples (conflicts)
* #11653 - io.cucumber:cucumber-bom in /examples (conflicts)
* #11320 - org.jreleaser in /smoke-test (conflicts)
* #11172 - logback-classic in /examples (conflicts)