### PR TITLE
Feat/mysql oracle image compatibility

### DIFF
--- a/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/containers/MySQLContainer.java
@@ -22,6 +22,9 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mysql");
 
+    private static final DockerImageName ORACLE_IMAGE_NAME =
+        DockerImageName.parse("container-registry.oracle.com/mysql/community-server");
+
     @Deprecated
     public static final String DEFAULT_TAG = "5.7.34";
 
@@ -58,7 +61,7 @@ public class MySQLContainer<SELF extends MySQLContainer<SELF>> extends JdbcDatab
 
     public MySQLContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, ORACLE_IMAGE_NAME);
 
         addExposedPort(MYSQL_PORT);
     }

--- a/modules/mysql/src/main/java/org/testcontainers/mysql/MySQLContainer.java
+++ b/modules/mysql/src/main/java/org/testcontainers/mysql/MySQLContainer.java
@@ -20,6 +20,8 @@ public class MySQLContainer extends JdbcDatabaseContainer<MySQLContainer> {
     public static final String NAME = "mysql";
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mysql");
+    private static final DockerImageName ORACLE_IMAGE_NAME =
+        DockerImageName.parse("container-registry.oracle.com/mysql/community-server");
 
     static final String DEFAULT_USER = "test";
 
@@ -43,7 +45,7 @@ public class MySQLContainer extends JdbcDatabaseContainer<MySQLContainer> {
 
     public MySQLContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
-        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, ORACLE_IMAGE_NAME);
 
         addExposedPort(MYSQL_PORT);
     }

--- a/modules/mysql/src/test/java/org/testcontainers/mysql/MySQLContainerTest.java
+++ b/modules/mysql/src/test/java/org/testcontainers/mysql/MySQLContainerTest.java
@@ -7,6 +7,7 @@ import org.testcontainers.MySQLTestImages;
 import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.net.URL;
@@ -28,6 +29,8 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
 
 class MySQLContainerTest extends AbstractContainerDatabaseTest {
 
@@ -268,6 +271,15 @@ class MySQLContainerTest extends AbstractContainerDatabaseTest {
             int resultSetInt = resultSet.getInt(1);
             assertThat(resultSetInt).as("A basic SELECT query succeeds").isEqualTo(1);
         }
+    }
+
+    @Test
+    void shouldAcceptOracleImageName() {
+        DockerImageName oracleImage = DockerImageName
+            .parse("container-registry.oracle.com/mysql/community-server:8.0");
+
+        assertThatNoException()
+            .isThrownBy(() -> new MySQLContainer(oracleImage));
     }
 
     private void assertHasCorrectExposedAndLivenessCheckPorts(MySQLContainer mysql) {


### PR DESCRIPTION
## What

Adds `container-registry.oracle.com/mysql/community-server` as a natively 
compatible image name in `MySQLContainer`.

## Why

Per [MySQL's official documentation](https://dev.mysql.com/doc/refman/9.1/en/docker-mysql-getting-started.html),
`container-registry.oracle.com/mysql/community-server` is the official
Docker image of MySQL. The `docker.io/mysql` image is not officially maintained by Oracle.

Previously, users who wanted to use the official image had to use a workaround:

```java
DockerImageName.parse("container-registry.oracle.com/mysql/community-server:8.0")
    .asCompatibleSubstituteFor("mysql")
```

This change makes that unnecessary:

```java
new MySQLContainer(DockerImageName.parse(
    "container-registry.oracle.com/mysql/community-server:8.0"))
```

## Changes

- Added `ORACLE_IMAGE_NAME` constant to `org.testcontainers.mysql.MySQLContainer`
- Added `ORACLE_IMAGE_NAME` constant to deprecated `org.testcontainers.containers.MySQLContainer`  
- Updated `assertCompatibleWith` in both classes to accept the Oracle image
- Added test verifying Oracle image name is accepted without throwing

Closes #9452