### PR TITLE
Honor checks.disable in Docker detection test

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -154,6 +154,12 @@ public abstract class DockerClientProviderStrategy {
      */
     @UnstableAPI
     protected boolean test() {
+        // Skip connectivity test if checks are disabled (useful for Windows/WSL2)
+        if (TestcontainersConfiguration.getInstance().isDisableChecks()) {
+            log.debug("Checks are disabled, skipping Docker connectivity test");
+            return true;
+        }
+
         TransportConfig transportConfig = getTransportConfig();
         URI dockerHost = transportConfig.getDockerHost();
 


### PR DESCRIPTION
## Problem

TestContainers cannot detect Docker on Windows/WSL2 despite Docker being accessible via CLI and TCP. This is a known issue (#4958, open 3+ years).

The socket connectivity test in \DockerClientProviderStrategy.test()\ fails on Windows/WSL2 even when:
- Docker is accessible via CLI (\docker ps\ works)
- Docker is accessible via curl (\curl http://localhost:2375/version\ works)
- \docker.host\ is explicitly configured in testcontainers.properties

## Root Cause

The \	est()\ method creates a Java \Socket\ and attempts to connect to the Docker host. On Windows/WSL2, this socket connection times out or fails despite curl working, likely due to differences in how Java's socket implementation handles localhost resolution vs curl.

## Solution

Honor the existing \checks.disable\ configuration in the \	est()\ method. When \checks.disable=true\, skip the socket connectivity test and return \	rue\ immediately.

This allows users who have manually verified Docker is working to bypass the failing socket test while still enabling Docker detection.

## Changes

- Added check at the beginning of \DockerClientProviderStrategy.test()\ to skip connectivity test when \checks.disable\ is set
- Only 4 lines of code added
- Uses existing configuration option (no new configuration needed)
- Opt-in: users must explicitly set \checks.disable=true\

## Testing

Tested on Windows/WSL2 with:
- Docker running in Debian WSL2
- TCP access enabled on port 2375
- \~/.testcontainers.properties\ configured with:
  \\\
  checks.disable=true
  docker.host=tcp://localhost:2375
  docker.client.strategy=org.testcontainers.dockerclient.EnvironmentAndSystemPropertyClientProviderStrategy
  \\\

Integration tests now pass successfully with MySQL container starting in ~52 seconds.

## Backwards Compatibility

- No breaking changes
- Only affects users who explicitly set \checks.disable=true\
- Users who don't set this option see no change in behavior
- The \checks.disable\ configuration already existed but wasn't being used in the \	est()\ method

## Notes

This fix was discovered and implemented by the SWE-1.6 AI model during pair programming. After extensive investigation of the TestContainers source code to understand why Docker detection was failing on Windows/WSL2 despite Docker being accessible, the solution was found by leveraging the existing \checks.disable\ configuration option to provide an escape hatch for environments where the socket connectivity test doesn't work despite Docker being functional.

## Fixes

Fixes #4958