### PR TITLE
Avoid 'Text file busy' race when starting KafkaContainer

### DIFF
--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaContainer.java
@@ -72,6 +72,12 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
         command += "/etc/kafka/docker/run \n";
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+        // Marker file: created after the starter script copy has fully released its
+        // writer, so the wait loop in KafkaHelper.COMMAND only proceeds when the
+        // script is safe to execve. Without this, on busy hosts the loop can see the
+        // starter script entry before docker-cp has closed it and fail with
+        // "Text file busy" (exit 126).
+        copyFileToContainer(Transferable.of(""), KafkaHelper.STARTER_SCRIPT_READY_FLAG);
     }
 
     /**

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
@@ -25,10 +25,12 @@ class KafkaHelper {
 
     static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
 
+    static final String STARTER_SCRIPT_READY_FLAG = "/tmp/testcontainers_start.ready";
+
     static final String[] COMMAND = {
         "sh",
         "-c",
-        "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
+        "while [ ! -f " + STARTER_SCRIPT_READY_FLAG + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
     };
 
     static final WaitStrategy WAIT_STRATEGY = Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1);


### PR DESCRIPTION
The container's startup command waits for `/tmp/testcontainers_start.sh` to appear, then `exec`s it. `containerIsStarting` writes the script via `copyFileToContainer`, which is a single Container Archive PUT. On busy hosts the directory entry can become visible before the docker engine has closed the writer, and the immediate `exec` then fails with ETXTBSY (exit code 126), which is what #11682 reports.

This PR switches to a two-file handshake: write the starter script first, then a separate `/tmp/testcontainers_start.ready` marker. The wait loop in `KafkaHelper.COMMAND` now polls the marker instead of the script. The marker copy only completes after the script copy has fully closed, so by the time the wait loop unblocks the subsequent `exec` against the script is safe. The marker itself is never executed, so its own copy can race with the directory listing harmlessly.

Fixes #11682.
