### PR TITLE
Fix JUnit 4 quickstart full-class codeinclude

### DIFF
--- a/docs/examples/junit4/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java
+++ b/docs/examples/junit4/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java
@@ -8,6 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// class {
 public class RedisBackedCacheIntTest {
 
     private RedisBackedCache underTest;
@@ -36,3 +37,4 @@ public class RedisBackedCacheIntTest {
         assertThat(retrieved).isEqualTo("example");
     }
 }
+// }

--- a/docs/quickstart/junit_4_quickstart.md
+++ b/docs/quickstart/junit_4_quickstart.md
@@ -78,6 +78,6 @@ That's it!
 Let's look at our complete test class to see how little we had to add to get up and running with Testcontainers:
 
 <!--codeinclude-->
-[RedisBackedCacheIntTest](../examples/junit4/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java) block:RedisBackedCacheIntTest
+[RedisBackedCacheIntTest](../examples/junit4/redis/src/test/java/quickstart/RedisBackedCacheIntTest.java) inside_block:class
 <!--/codeinclude-->
 


### PR DESCRIPTION
Fixes #1415.

**What is the purpose of your change**

Section 4 on the JUnit 4 quickstart page showed broken codeinclude output (readers saw macro-related text instead of the full example class).

**How does it work**

The full-class snippet now matches the JUnit 5 quickstart: inside_block:class plus // class { … // } markers around the sample in RedisBackedCacheIntTest.java, which is the pattern already documented in docs/contributing_docs.md for grabbing a whole class without relying on fragile lock: matching.
