### PR TITLE
Merge caller JDBC Properties in createConnection

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -263,7 +263,10 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
      */
     public Connection createConnection(String queryString, Properties info)
         throws SQLException, NoDriverFoundException {
-        Properties properties = new Properties(info);
+        Properties properties = new Properties();
+        if (info != null) {
+            properties.putAll(info);
+        }
         properties.put("user", this.getUsername());
         properties.put("password", this.getPassword());
         final String url = constructUrlForConnection(queryString);

--- a/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerCreateConnectionTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerCreateConnectionTest.java
@@ -1,0 +1,98 @@
+package org.testcontainers.containers;
+
+import lombok.NonNull;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.testcontainers.utility.DockerImageName;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class JdbcDatabaseContainerCreateConnectionTest {
+
+    @Test
+    void createConnectionMergesCallerInfoIntoDriverProperties() throws Exception {
+        Driver driver = mock(Driver.class);
+        Connection connection = mock(Connection.class);
+        when(driver.connect(anyString(), any(Properties.class))).thenAnswer(invocation -> {
+            Properties p = invocation.getArgument(1);
+            assertThat(
+                p.entrySet()
+                    .stream()
+                    .map(e -> (String) e.getKey())
+                    .collect(Collectors.toSet())
+            ).contains("rewriteBatchedStatements");
+            assertThat(p.getProperty("rewriteBatchedStatements")).isEqualTo("true");
+            assertThat(p.getProperty("user")).isEqualTo("u");
+            assertThat(p.getProperty("password")).isEqualTo("secret");
+            return connection;
+        });
+
+        TestContainer container = new TestContainer(driver);
+        Properties info = new Properties();
+        info.setProperty("rewriteBatchedStatements", "true");
+
+        assertThat(container.createConnection("", info)).isSameAs(connection);
+    }
+
+    static class TestContainer extends JdbcDatabaseContainer<TestContainer> {
+
+        private final Driver testDriver;
+
+        TestContainer(Driver testDriver) {
+            super(DockerImageName.parse("mysql:5.7"));
+            this.testDriver = testDriver;
+        }
+
+        @Override
+        public String getDriverClassName() {
+            return "ignored";
+        }
+
+        @Override
+        public String getJdbcUrl() {
+            return "jdbc:mock://localhost/db";
+        }
+
+        @Override
+        public String getUsername() {
+            return "u";
+        }
+
+        @Override
+        public String getPassword() {
+            return "secret";
+        }
+
+        @Override
+        protected String getTestQueryString() {
+            return "SELECT 1";
+        }
+
+        @Override
+        public Driver getJdbcDriverInstance() {
+            return testDriver;
+        }
+
+        @Override
+        public boolean isRunning() {
+            return true;
+        }
+
+        @Override
+        protected Logger logger() {
+            return mock(Logger.class);
+        }
+
+        @Override
+        public void setDockerImageName(@NonNull String dockerImageName) {}
+    }
+}


### PR DESCRIPTION
## What is the purpose of your change?

Hikari and other pools pass URL-level options through the \info\ map on \Driver.connect\. Those entries must show up on the same \Properties\ instance we hand to the delegate driver, together with the container username and password.

Using \
ew Properties(info)\ keeps caller keys on the defaults list. Drivers that only inspect the primary map (or build cache keys from \stringPropertyNames()\ without merging defaults the way you expect) effectively drop those options.

## How does it work?

Start from an empty \Properties\, \putAll\ the caller map when \info\ is non-null, then put \user\ and \password\ as today. Added a unit test with a mock \Driver\ that asserts a sample caller key is present in \stringPropertyNames()\ after the merge.

Fixes #1537.

Note: I could not run \./gradlew spotlessApply\ locally (no JDK in this environment). Please rely on CI for Spotless and the jdbc test task.
