### PR TITLE
Fix dependency conflict after upgrading to Testcontainers 2.0.5

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -5,3 +5,7 @@ plugins {
 repositories {
     mavenCentral()
 }
+
+dependencies {
+    implementation 'org.apache.maven:maven-artifact:3.9.9'
+}

--- a/buildSrc/src/main/groovy/org/testcontainers/build/ComparePOMWithLatestReleasedTask.groovy
+++ b/buildSrc/src/main/groovy/org/testcontainers/build/ComparePOMWithLatestReleasedTask.groovy
@@ -1,6 +1,7 @@
 package org.testcontainers.build
 
 import groovy.xml.XmlSlurper
+import org.apache.maven.artifact.versioning.ComparableVersion
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
@@ -9,6 +10,9 @@ class ComparePOMWithLatestReleasedTask extends DefaultTask {
 
     @Input
     Set<String> ignore = []
+
+    @Input
+    Map<String, String> minimumVersions = [:]
 
     @TaskAction
     def doCompare() {
@@ -23,13 +27,27 @@ class ComparePOMWithLatestReleasedTask extends DefaultTask {
         def releasedRootNode = new XmlSlurper()
             .parse("https://repo1.maven.org/maven2/org/testcontainers/${artifactId}/${latestRelease}/${artifactId}-${latestRelease}.pom")
 
-        Set<String> dependencies = releasedRootNode.dependencies.children()
+        Set<String> releasedDependencies = releasedRootNode.dependencies.children()
             .collect { "${it.groupId.text()}:${it.artifactId.text()}".toString() }
 
+        Map<String, String> currentVersions = [:]
         for (dependency in rootNode.dependencies.children()) {
             def coordinates = "${dependency.groupId.text()}:${dependency.artifactId.text()}".toString()
-            if (!dependencies.contains(coordinates) && !ignore.contains(coordinates)) {
+            currentVersions[coordinates] = dependency.version.text()
+            if (!releasedDependencies.contains(coordinates) && !ignore.contains(coordinates)) {
                 throw new IllegalStateException("A new dependency '${coordinates}' has been added to 'org.testcontainers:${artifactId}' - if this was intentional please add it to the ignore list in ${project.buildFile}")
+            }
+        }
+
+        for (entry in minimumVersions) {
+            def coords = entry.key
+            def minVersion = entry.value
+            def currentVersion = currentVersions[coords]
+            if (currentVersion == null || currentVersion.isEmpty()) {
+                throw new IllegalStateException("Dependency '${coords}' has a minimum version '${minVersion}' declared in ${project.buildFile} but is missing from the generated POM of 'org.testcontainers:${artifactId}'")
+            }
+            if (new ComparableVersion(currentVersion) < new ComparableVersion(minVersion)) {
+                throw new IllegalStateException("Dependency '${coords}' resolved to '${currentVersion}' in the POM of 'org.testcontainers:${artifactId}', which is below the required minimum '${minVersion}' declared in ${project.buildFile}")
             }
         }
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -66,6 +66,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:26.1.0'
     testCompileOnly 'org.jetbrains:annotations:26.1.0'
     api 'org.apache.commons:commons-compress:1.28.0'
+    api 'org.apache.commons:commons-lang3:3.20.0'
     api ('org.rnorth.duct-tape:duct-tape:1.0.8') {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
@@ -129,6 +130,10 @@ dependencies {
 tasks.generatePomFileForMavenJavaPublication.finalizedBy(
     tasks.register('checkPOMdependencies', org.testcontainers.build.ComparePOMWithLatestReleasedTask) {
         ignore = [
+            'org.apache.commons:commons-lang3',
+        ]
+        minimumVersions = [
+            'org.apache.commons:commons-lang3': '3.18.0',
         ]
     }
 )


### PR DESCRIPTION
The PR addresses the issue https://github.com/testcontainers/testcontainers-java/issues/11771

### Issue
                                                                                                                                                              
commons-compress:1.28.0 (declared api in core/build.gradle) calls org.apache.commons.lang3.ArrayFill, which only exists in commons-lang3 >= 3.18.0.         
Testcontainers does not declare commons-lang3 directly, so it arrives only at depth 2 via commons-compress. In consumer projects that already have an older commons-lang3 at depth 1 via another library, Maven's "nearest definition wins" rule selects the older version and GenericContainer.start() fails at runtime with NoClassDefFoundError: org/apache/commons/lang3/ArrayFill.                                                                                           

###  Fix                                                                                                                                                         
  
Declare commons-lang3 as a direct api dependency in core/build.gradle:                                                                                      
                                                                                                                                                            
`api 'org.apache.commons:commons-compress:1.28.0'`
`api 'org.apache.commons:commons-lang3:3.20.0'`
  
This places commons-lang3 at depth 1 in our published POM so Maven's nearest-wins rule selects it over older depth-2+ transitives. 3.20.0 matches the version already used by modules/jdbc-test and modules/hivemq and is comfortably above the 3.18.0 floor required by commons-compress:1.28.0. No public API change; commons-lang3 is already used internally by 18 files in core.                                                                                       
                                                                                                                                                            
###  Supporting test
Extended `ComparePOMWithLatestReleasedTask` (buildSrc/) with a minimumVersions field that uses Maven's ComparableVersion for correct version comparison.  
core/build.gradle pins the floor at 3.18.0 — the true commons-compress requirement, decoupled from our chosen 3.20.0.
The build fails if anyone removes the declaration (missing from the generated POM) or downgrades below the floor (below the required minimum). Both failure paths verified by temporarily reverting the fix.        