### PR TITLE
docs(bounty): specify the bounty label name and link to bounty issues

### DIFF
--- a/docs/bounty.md
+++ b/docs/bounty.md
@@ -20,7 +20,7 @@ As a sponsor, the process for creating a bounty is as follows:
 
 * Raise an issue, or find an existing issue that describes the bug or feature.
 * Start a discussion with the [Testcontainers org core maintainers](#organisation-core-maintainers) to agree that the issue is suitable for a bounty, and how much the reward amount should be.
-* Once agreed, we will assign a label to the issue so that interested developers can find it.
+- Once agreed, we will assign the `bounty` label to the issue so that interested developers can find it. You can view all open bounty issues at: https://github.com/testcontainers/testcontainers-java/labels/bounty
 
 Sponsors can create up to 1 or 3 bounties (according to tier) _per calendar month_ - i.e. the counter resets on the 1st of each month. 
 If a sponsor does not use their full quota of bounty credits in a calendar month, they cannot be rolled over to the next month.


### PR DESCRIPTION
## Summary
Fixes #6835.

The bounty documentation mentioned that a label would be assigned to bounty issues but did not specify the label name. This PR:

- Declares that bounty issues are tagged with the `bounty` label
- Adds a direct link to the bounty label filter for discoverability

## Changes
- Updated `docs/bounty.md` to specify the `bounty` label name and provide a link to all open bounty issues.