### PR TITLE
test: verify both wait strategies in WaitAllStrategyTest

### DIFF
--- a/core/src/test/java/org/testcontainers/containers/wait/strategy/WaitAllStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/containers/wait/strategy/WaitAllStrategyTest.java
@@ -151,7 +151,7 @@ class WaitAllStrategyTest {
             .withStrategy(strategy2);
 
         verify(strategy1, never()).withStartupTimeout(any());
-        verify(strategy1, never()).withStartupTimeout(any());
+        verify(strategy2, never()).withStartupTimeout(any());
     }
 
     @Test
@@ -160,7 +160,7 @@ class WaitAllStrategyTest {
         new WaitAllStrategy().withStartupTimeout(someSeconds).withStrategy(strategy1).withStrategy(strategy2);
 
         verify(strategy1).withStartupTimeout(someSeconds);
-        verify(strategy1).withStartupTimeout(someSeconds);
+        verify(strategy2).withStartupTimeout(someSeconds);
     }
 
     static class DummyStrategy extends AbstractWaitStrategy {


### PR DESCRIPTION
## Summary

Fix a copy-paste issue in `WaitAllStrategyTest`.

Two tests were verifying `strategy1` twice and never verifying `strategy2`. As a result, the tests did not fully assert behavior for both configured wait strategies.

## Changes

* Update `shouldNotMessWithIndividualTimeouts` to verify that `strategy2` does not receive an individual startup timeout.
* Update `shouldOverwriteIndividualTimeouts` to verify that `strategy2` receives the configured startup timeout.
* No production code changes.

## Testing

Ran the focused test:

```bash
./gradlew :testcontainers:test --tests org.testcontainers.containers.wait.strategy.WaitAllStrategyTest
```

Also ran formatting/check commands as requested:

```bash
./gradlew checkstyleMain checkstyleTest spotlessApply
```
