### PR TITLE
Fix DockerDesktopClientProviderStrategy always being applicable

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerDesktopClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerDesktopClientProviderStrategy.java
@@ -66,7 +66,7 @@ public class DockerDesktopClientProviderStrategy extends DockerClientProviderStr
 
     @Override
     protected boolean isApplicable() {
-        return (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) && this.socketPath != null;
+        return (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) && getSocketPath() != null;
     }
 
     private Optional<Path> tryFolder(Path path) {

--- a/core/src/test/java/org/testcontainers/dockerclient/DockerDesktopClientProviderStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/DockerDesktopClientProviderStrategyTest.java
@@ -1,0 +1,48 @@
+package org.testcontainers.dockerclient;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("deprecation")
+class DockerDesktopClientProviderStrategyTest {
+
+    private final String originalUserHome = System.getProperty("user.home");
+
+    @AfterEach
+    void restoreUserHome() {
+        System.setProperty("user.home", originalUserHome);
+    }
+
+    @Test
+    @EnabledOnOs({ OS.LINUX, OS.MAC })
+    void notApplicableWhenDockerDesktopSocketIsMissing(@TempDir Path userHome) {
+        // user.home without a Docker Desktop socket under .docker/desktop or .docker/run
+        System.setProperty("user.home", userHome.toString());
+
+        DockerDesktopClientProviderStrategy strategy = new DockerDesktopClientProviderStrategy();
+
+        assertThat(strategy.isApplicable()).isFalse();
+    }
+
+    @Test
+    @EnabledOnOs({ OS.LINUX, OS.MAC })
+    void applicableWhenDockerDesktopSocketExists(@TempDir Path userHome) throws IOException {
+        Path socketPath = userHome.resolve(".docker").resolve("desktop").resolve("docker.sock");
+        Files.createDirectories(socketPath.getParent());
+        Files.createFile(socketPath);
+        System.setProperty("user.home", userHome.toString());
+
+        DockerDesktopClientProviderStrategy strategy = new DockerDesktopClientProviderStrategy();
+
+        assertThat(strategy.isApplicable()).isTrue();
+    }
+}


### PR DESCRIPTION
Fixes #11829

### Problem

`DockerDesktopClientProviderStrategy.isApplicable()` returns `true` on Linux/macOS even when Docker Desktop is not installed, after which `getTransportConfig()` throws a `NullPointerException`.

The cause is a Lombok pitfall. The `socketPath` field is declared with `@Getter(lazy = true)`:

```java
@Getter(lazy = true)
@Nullable
private final Path socketPath = resolveSocketPath();
```

Lombok rewrites a `lazy` field into an `AtomicReference` that holds the memoized value, so the field itself is **never** `null`. `isApplicable()` checked the raw field rather than the generated accessor:

```java
return (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) && this.socketPath != null; // AtomicReference is never null
```

As a result the strategy is always considered applicable, and `getTransportConfig()` then dereferences `getSocketPath()` (which resolves to `null` when no `~/.docker/desktop/docker.sock` or `~/.docker/run/docker.sock` exists), producing the NPE reported in #11829.

### Fix

Use the Lombok-generated `getSocketPath()` accessor — which resolves the lazy value to the actual `Path` (or `null`) — instead of reading the backing field directly. `getDescription()` and `getTransportConfig()` already use the accessor; this aligns `isApplicable()` with them.

```java
return (SystemUtils.IS_OS_LINUX || SystemUtils.IS_OS_MAC) && getSocketPath() != null;
```

### Tests

Added `DockerDesktopClientProviderStrategyTest` (no Docker required) covering both directions by pointing `user.home` at a temp directory:

- `notApplicableWhenDockerDesktopSocketIsMissing` — no Docker Desktop socket present ⇒ `isApplicable()` is `false`. This **fails on the current code** (returns `true`) and passes with the fix.
- `applicableWhenDockerDesktopSocketExists` — a `.docker/desktop/docker.sock` present ⇒ `isApplicable()` is `true`.

Verification done: ran `./gradlew :testcontainers:test --tests "org.testcontainers.dockerclient.DockerDesktopClientProviderStrategyTest"` — both tests pass with the fix; reverting the one-line change makes `notApplicableWhenDockerDesktopSocketIsMissing` fail, confirming the test reproduces the bug. `./gradlew spotlessApply` reports no formatting changes.