### PR TITLE
Deprecate bundled MockServer module in favour of the MockServer-maintained module

### DIFF
--- a/docs/modules/mockserver.md
+++ b/docs/modules/mockserver.md
@@ -1,5 +1,14 @@
 # Mockserver Module
 
+!!! note "Deprecated — use the MockServer-maintained module for new projects"
+    This bundled module is deprecated. For new projects, prefer the MockServer-maintained
+    module [`org.mock-server:mockserver-testcontainers`](https://www.mock-server.com/mock_server/mockserver_testcontainers.html)
+    (class `org.mockserver.testcontainers.MockServerContainer`). It tracks current MockServer
+    releases, derives its image tag from the client library so the container and client stay in
+    lockstep, and adds configuration helpers (DNS, transparent proxy, HTTP/3, initialization JSON,
+    log level, arbitrary properties) plus direct `MockServerClient` wiring. This page documents the
+    legacy bundled module.
+
 Mock Server can be used to mock HTTP services by matching requests against user-defined expectations.
 
 ## Usage example

--- a/modules/mockserver/build.gradle
+++ b/modules/mockserver/build.gradle
@@ -3,6 +3,8 @@ description = "Testcontainers :: MockServer"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.mock-server:mockserver-client-java:5.15.0'
+    // Single source of truth for the MockServer version: the test derives its container image
+    // tag from this client jar's implementation version, so bumping here updates both in lockstep.
+    testImplementation 'org.mock-server:mockserver-client-java:7.1.0'
     testImplementation 'io.rest-assured:rest-assured:5.5.7'
 }

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -10,13 +10,17 @@ import org.testcontainers.utility.DockerImageName;
  * (class {@code org.mockserver.testcontainers.MockServerContainer}). It tracks current MockServer
  * releases, derives its image tag from the client library so the two stay in lockstep, and adds
  * configuration helpers (DNS, transparent proxy, HTTP/3, initialization JSON, log level, arbitrary
- * properties) plus direct {@code MockServerClient} wiring. See
- * https://www.mock-server.com/mock_server/mockserver_testcontainers.html
+ * properties) plus direct {@code MockServerClient} wiring.
+ *
+ * @see <a href="https://www.mock-server.com/mock_server/mockserver_testcontainers.html">MockServer Testcontainers module</a>
  */
 @Slf4j
 @Deprecated
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
+    // Intentionally frozen at this legacy image/tag: this superseded redirect stub keeps its original
+    // jamesdbloom/mockserver default for backwards compatibility. New code should use the
+    // MockServer-maintained module referenced in the deprecation notice above.
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("jamesdbloom/mockserver");
 
     private static final String DEFAULT_TAG = "mockserver-5.5.4";

--- a/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/containers/MockServerContainer.java
@@ -5,7 +5,13 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 /**
- * @deprecated use {@link org.testcontainers.mockserver.MockServerContainer} instead.
+ * @deprecated Use the MockServer-maintained module instead:
+ * {@code org.mock-server:mockserver-testcontainers}
+ * (class {@code org.mockserver.testcontainers.MockServerContainer}). It tracks current MockServer
+ * releases, derives its image tag from the client library so the two stay in lockstep, and adds
+ * configuration helpers (DNS, transparent proxy, HTTP/3, initialization JSON, log level, arbitrary
+ * properties) plus direct {@code MockServerClient} wiring. See
+ * https://www.mock-server.com/mock_server/mockserver_testcontainers.html
  */
 @Slf4j
 @Deprecated

--- a/modules/mockserver/src/main/java/org/testcontainers/mockserver/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/mockserver/MockServerContainer.java
@@ -18,9 +18,9 @@ import org.testcontainers.utility.DockerImageName;
 @Deprecated
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("jamesdbloom/mockserver");
+    private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mockserver/mockserver");
 
-    private static final String DEFAULT_TAG = "mockserver-5.5.4";
+    private static final String DEFAULT_TAG = "mockserver-7.0.0";
 
     @Deprecated
     public static final String VERSION = DEFAULT_TAG;

--- a/modules/mockserver/src/main/java/org/testcontainers/mockserver/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/mockserver/MockServerContainer.java
@@ -5,7 +5,17 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+/**
+ * @deprecated Use the MockServer-maintained module instead:
+ * {@code org.mock-server:mockserver-testcontainers}
+ * (class {@code org.mockserver.testcontainers.MockServerContainer}). It tracks current MockServer
+ * releases, derives its image tag from the client library so the two stay in lockstep, and adds
+ * configuration helpers (DNS, transparent proxy, HTTP/3, initialization JSON, log level, arbitrary
+ * properties) plus direct {@code MockServerClient} wiring. See
+ * https://www.mock-server.com/mock_server/mockserver_testcontainers.html
+ */
 @Slf4j
+@Deprecated
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("jamesdbloom/mockserver");

--- a/modules/mockserver/src/main/java/org/testcontainers/mockserver/MockServerContainer.java
+++ b/modules/mockserver/src/main/java/org/testcontainers/mockserver/MockServerContainer.java
@@ -11,8 +11,9 @@ import org.testcontainers.utility.DockerImageName;
  * (class {@code org.mockserver.testcontainers.MockServerContainer}). It tracks current MockServer
  * releases, derives its image tag from the client library so the two stay in lockstep, and adds
  * configuration helpers (DNS, transparent proxy, HTTP/3, initialization JSON, log level, arbitrary
- * properties) plus direct {@code MockServerClient} wiring. See
- * https://www.mock-server.com/mock_server/mockserver_testcontainers.html
+ * properties) plus direct {@code MockServerClient} wiring.
+ *
+ * @see <a href="https://www.mock-server.com/mock_server/mockserver_testcontainers.html">MockServer Testcontainers module</a>
  */
 @Slf4j
 @Deprecated
@@ -20,7 +21,9 @@ public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("mockserver/mockserver");
 
-    private static final String DEFAULT_TAG = "mockserver-7.0.0";
+    // Keep this tag aligned with the mockserver-client-java version in build.gradle: the tests derive
+    // their image tag from that client jar, so the default here must track the same MockServer release.
+    private static final String DEFAULT_TAG = "mockserver-7.1.0";
 
     @Deprecated
     public static final String VERSION = DEFAULT_TAG;

--- a/modules/mockserver/src/test/java/org/testcontainers/mockserver/MockServerContainerTest.java
+++ b/modules/mockserver/src/test/java/org/testcontainers/mockserver/MockServerContainerTest.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 
+@SuppressWarnings("deprecation") // testing the deprecated bundled module
 class MockServerContainerTest {
 
     public static final DockerImageName MOCKSERVER_IMAGE = DockerImageName
@@ -34,7 +35,9 @@ class MockServerContainerTest {
             try (MockServerClient client = new MockServerClient(mockServer.getHost(), mockServer.getServerPort())) {
                 assertThat(client.hasStarted()).as("Mockserver running").isTrue();
 
+                // testSimpleExpectation {
                 client.when(request().withPath("/hello")).respond(response().withBody(expectedBody));
+                // }
 
                 assertThat(given().when().get(mockServer.getEndpoint() + "/hello").then().extract().body().asString())
                     .as("MockServer returns correct result")


### PR DESCRIPTION
The bundled `org.testcontainers.mockserver.MockServerContainer` ships a single TCP port,
defaults to the retired `jamesdbloom/mockserver:mockserver-5.5.4` image, and has no
configuration helpers.

MockServer now publishes and maintains its own Testcontainers module,
`org.mock-server:mockserver-testcontainers` (`org.mockserver.testcontainers.MockServerContainer`),
which derives the image tag from the client library so container and client stay in version
lockstep, exposes DNS, transparent-proxy (NET_ADMIN), HTTP/3, initialization-JSON, log-level and
arbitrary-property helpers, and provides direct `MockServerClient` wiring via `getClient()`.

This PR deprecates the bundled class with a Javadoc pointer to the MockServer-maintained module so
existing users are guided to the supported option, and (separate commit) refreshes the stale default
image. Maintained by the MockServer project (github.com/mock-server).
