### PR TITLE
Add helper to ignore check version on azurite container

### DIFF
--- a/docs/modules/azure.md
+++ b/docs/modules/azure.md
@@ -27,6 +27,18 @@ Start Azurite Emulator during a test:
 !!! note
     SSL configuration is possible using the `withSsl(MountableFile, String)` and  `withSsl(MountableFile, MountableFile)` methods.
 
+!!! note
+    The Azure SDK evolves faster than the Azurite image in some cases. If your client fails to connect with an error such as
+    `The API version {{version}} is not supported by Azurite. Please upgrade Azurite to latest version and retry.`,
+    you can disable the version check with `withSkipApiVersionCheck()`.
+
+Example:
+
+```java
+AzuriteContainer azurite = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:latest")
+    .withSkipApiVersionCheck();
+```
+
 If the tested application needs to use more than one set of credentials, the container can be configured to use custom credentials.
 Please see some examples below.
 

--- a/modules/azure/src/main/java/org/testcontainers/azure/AzuriteContainer.java
+++ b/modules/azure/src/main/java/org/testcontainers/azure/AzuriteContainer.java
@@ -51,6 +51,7 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
     private MountableFile key = null;
 
     private String pwd = null;
+    private boolean skipApiVersionCheck = false;
 
     /**
      * @param dockerImageName specified docker image name to run
@@ -93,6 +94,17 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
         this.cert = pemCert;
         this.key = pemKey;
         this.certExtension = ".pem";
+        return this;
+    }
+
+    /**
+     * Configure the container to skip version checks.
+     * This is useful as Azure SDK update are more frequent than Azurite releases.
+     *
+     * @return this
+     */
+    public AzuriteContainer withSkipApiVersionCheck() {
+        this.skipApiVersionCheck = true;
         return this;
     }
 
@@ -152,6 +164,9 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
         args.append(" --blobHost ").append(ALLOW_ALL_CONNECTIONS);
         args.append(" --queueHost ").append(ALLOW_ALL_CONNECTIONS);
         args.append(" --tableHost ").append(ALLOW_ALL_CONNECTIONS);
+        if (this.skipApiVersionCheck) {
+            args.append(" --skipApiVersionCheck");
+        }
         if (this.cert != null) {
             args.append(" --cert ").append("/cert").append(this.certExtension);
             if (this.pwd != null) {

--- a/modules/azure/src/test/java/org/testcontainers/azure/AzuriteContainerTest.java
+++ b/modules/azure/src/test/java/org/testcontainers/azure/AzuriteContainerTest.java
@@ -155,6 +155,35 @@ class AzuriteContainerTest {
     }
 
     @Test
+    void testWithIgnoreApiVersionCheckAlone() {
+        AzuriteContainer withoutSsl = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:3.33.0")
+            .withSkipApiVersionCheck();
+
+        assertThat(withoutSsl.getCommandLine())
+            .contains("--skipApiVersionCheck")
+            .doesNotContain("--cert")
+            .doesNotContain("--key");
+    }
+
+    @Test
+    void testWithIgnoreApiVersionCheckWithSsl() {
+        AzuriteContainer withSsl = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:3.33.0")
+            .withSkipApiVersionCheck()
+            .withSsl(MountableFile.forClasspathResource("/keystore.pfx"), PASSWORD);
+
+        assertThat(withSsl.getCommandLine())
+            .contains("--skipApiVersionCheck")
+            .contains("--cert /cert.pfx")
+            .contains("--pwd " + PASSWORD);
+    }
+
+    @Test
+    void testDefaultCommandLineDoesNotContainSkipApiVersionCheck() {
+        AzuriteContainer container = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:3.33.0");
+        assertThat(container.getCommandLine()).doesNotContain("--skipApiVersionCheck");
+    }
+
+    @Test
     void testTwoAccountKeysWithBlobServiceClient() {
         try (
             // withTwoAccountKeys {


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Before submitting a pull request, please
review our contributing guidelines at https://java.testcontainers.org/contributing/

Please also review the following notes before submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
Hello,
As my team and I have trouble with the fact Azurite images and sdk version are not synchronized, we always have to find a way to put the `--skipApiVersionCheck` flag.

For now that means using `GenericContainer` instead of `AzuriteContainer` as the `getCommandLine` version would overwrite any change done with the `withCommand` helper we inherit.

To fit with current state of `AzuriteContainer` design, I added the `withIgnoreApiVersionCheck` helper and updated the `getCommandLine` method.