### PR TITLE
fix(azure): correct EventHubs emulator test client builder usage

### DIFF
--- a/modules/azure/src/test/java/org/testcontainers/azure/EventHubsEmulatorContainerTest.java
+++ b/modules/azure/src/test/java/org/testcontainers/azure/EventHubsEmulatorContainerTest.java
@@ -43,14 +43,10 @@ class EventHubsEmulatorContainerTest {
             emulator.start();
             // createProducerAndConsumer {
             EventHubProducerClient producer = new EventHubClientBuilder()
-                .connectionString(emulator.getConnectionString())
-                .fullyQualifiedNamespace("emulatorNs1")
-                .eventHubName("eh1")
+                .connectionString(emulator.getConnectionString(), "eh1")
                 .buildProducerClient();
             EventHubConsumerClient consumer = new EventHubClientBuilder()
-                .connectionString(emulator.getConnectionString())
-                .fullyQualifiedNamespace("emulatorNs1")
-                .eventHubName("eh1")
+                .connectionString(emulator.getConnectionString(), "eh1")
                 .consumerGroup("cg1")
                 .buildConsumerClient();
             // }


### PR DESCRIPTION
## Problem
`EventHubsEmulatorContainerTest.testWithEventHubsClient()` was failing with:

```
AmqpException: The messaging entity 'sb://emulatorns1.eventhubs.emulator.net/eh1' could not be found.
```

The test called both `.connectionString(emulator.getConnectionString())` and `.fullyQualifiedNamespace("emulatorNs1")` on `EventHubClientBuilder`. In the Azure SDK these two methods are mutually exclusive — `.fullyQualifiedNamespace()` overrides the endpoint from the connection string, causing the SDK to resolve `emulatorNs1.eventhubs.emulator.net` instead of the mapped localhost port.

## Fix
Replace the broken chained calls with the two-arg `connectionString(connectionString, eventHubName)` overload, which correctly sets both the endpoint and entity name:

```java
// Before (broken)
new EventHubClientBuilder()
    .connectionString(emulator.getConnectionString())
    .fullyQualifiedNamespace("emulatorNs1")  // overrides localhost endpoint!
    .eventHubName("eh1")
    .buildProducerClient();

// After (fixed)
new EventHubClientBuilder()
    .connectionString(emulator.getConnectionString(), "eh1")
    .buildProducerClient();
```

The emulator container implementation and config file (`eventhubs_config.json`) are correct and unchanged.