### PR TITLE
fix(build): declare explicit task dependencies for Gradle 8 strict validation

### DIFF
--- a/gradle/shading.gradle
+++ b/gradle/shading.gradle
@@ -57,10 +57,34 @@ project.afterEvaluate {
     }
 
     // Add shaded JARs first
-    tasks.test.classpath = findShadedProjects(project)
-        .plus(project)
+    def shadedProjects = findShadedProjects(project).plus(project)
+    tasks.test.classpath = shadedProjects
         .sum { it.tasks.findByName("shadowJar").outputs.files }
         .plus(sourceSets.test.runtimeClasspath)
+
+    // Gradle 8: declare explicit task dependencies for all jar/shadowJar tasks whose outputs
+    // are added to the test classpath, to satisfy strict implicit dependency validation.
+    // Both jar and shadowJar must be declared because non-published modules (e.g. test-support,
+    // docs examples) do not set jar.archiveClassifier, so both tasks write the same filename.
+    shadedProjects.each { p ->
+        def shadowJarTask = p.tasks.findByName("shadowJar")
+        if (shadowJarTask != null) {
+            tasks.test.dependsOn(shadowJarTask)
+        }
+        def jarTask = p.tasks.findByName("jar")
+        if (jarTask != null) {
+            tasks.test.dependsOn(jarTask)
+        }
+    }
+
+    // Also declare explicit dependency on shadowJar tasks from testImplementation project
+    // dependencies, since their shadowJar output (classifier=null) is the resolved artifact.
+    configurations.testImplementation.dependencies.withType(ProjectDependency).each { dep ->
+        def shadowJarTask = dep.dependencyProject.tasks.findByName("shadowJar")
+        if (shadowJarTask != null) {
+            tasks.test.dependsOn(shadowJarTask)
+        }
+    }
 }
 
 static Set<Project> findShadedProjects(Project project) {


### PR DESCRIPTION
## Problem
`./gradlew build` fails with 16 tasks reporting implicit dependency errors under Gradle 8's stricter task dependency validation:

```
Task uses output of another task without declaring an explicit or implicit dependency
```

Three groups of modules are affected:
- **`test-support`** — own `shadowJar`/`jar` output placed on test classpath without `test.dependsOn`
- **13 JDBC modules** (mariadb, mssqlserver, mysql, oceanbase, oracle-free, oracle-xe, postgresql, presto, questdb, tidb, timeplus, trino, yugabytedb) — `testImplementation project(':testcontainers-jdbc-test')` resolves to the `shadowJar` output but no dependency was declared from the consuming module's `test` task
- **`docs/examples` redis tests** (junit5 + spock) — same issue as test-support

All root cause is in `gradle/shading.gradle`, which is applied to all subprojects via root `build.gradle`. Its `afterEvaluate` block manually builds `tasks.test.classpath` with shadow JAR outputs but never declares those tasks as dependencies of `test`.

Note: 5 additional JDBC modules (clickhouse, cockroachdb, cratedb, databend, db2) have the same underlying issue but their tests were served from cache — they are also fixed by this change.

## Fix

Two new blocks added to `gradle/shading.gradle` (26 lines):

1. **`shadedProjects.each`** — declares `test.dependsOn(shadowJar)` and `test.dependsOn(jar)` for every project in the shaded chain, including the project itself. Both are required because non-published modules write both tasks to the same output filename.

2. **`configurations.testImplementation.dependencies.withType(ProjectDependency).each`** — declares `test.dependsOn(shadowJar)` for each `testImplementation` project dependency whose primary artifact is the shadow JAR. This covers all 13 JDBC modules and any future modules added with the same pattern.

## Validation
- `./gradlew --dry-run` for all 16 previously failing tasks shows no implicit dependency errors
- `jar`, `shadowJar`, and `:testcontainers-jdbc-test:shadowJar` all appear before their respective `test` tasks in the execution graph