### PR TITLE
Combined dependencies PR

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v5.19.0
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
-    id 'com.gradleup.shadow' version '8.3.9'
+    id 'com.gradleup.shadow' version '8.3.11'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.22.0' apply false
     id 'org.jreleaser' version '1.20.0' apply false

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'com.gradleup.shadow' version '8.3.9'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
     id 'com.diffplug.spotless' version '6.22.0' apply false
-    id 'org.jreleaser' version '1.20.0' apply false
+    id 'org.jreleaser' version '1.24.0' apply false
 }
 
 apply from: "$rootDir/gradle/ci-support.gradle"

--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ subprojects {
     dependencies {
         testImplementation 'ch.qos.logback:logback-classic:1.3.15'
         testImplementation 'org.assertj:assertj-core:3.27.4'
-        testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+        testImplementation 'org.junit.jupiter:junit-jupiter:5.14.4'
 
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.11.0'
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -98,7 +98,7 @@ dependencies {
 
     shaded 'org.zeroturnaround:zt-exec:1.12'
 
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.3'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.4'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation('com.google.cloud.tools:jib-core:0.28.1')  {
@@ -120,7 +120,7 @@ dependencies {
 
     jarFileTestCompileOnly "org.projectlombok:lombok:${lombok.version}"
     jarFileTestAnnotationProcessor "org.projectlombok:lombok:${lombok.version}"
-    jarFileTestRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.3'
+    jarFileTestRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.4'
     jarFileTestImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     jarFileTestImplementation 'org.assertj:assertj-core:3.27.7'
     jarFileTestImplementation 'org.ow2.asm:asm-debug-all:5.2'

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -1,7 +1,7 @@
 description = "Examples for docs"
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.8.0.RELEASE"
+    api "io.lettuce:lettuce-core:7.5.1.RELEASE"
 
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.13.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'

--- a/docs/examples/junit5/redis/build.gradle
+++ b/docs/examples/junit5/redis/build.gradle
@@ -3,7 +3,7 @@ description = "Examples for docs"
 dependencies {
     api "io.lettuce:lettuce-core:6.8.0.RELEASE"
 
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter:5.14.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.3'
     testImplementation project(":testcontainers")
     testImplementation project(":testcontainers-junit-jupiter")

--- a/docs/examples/spock/redis/build.gradle
+++ b/docs/examples/spock/redis/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    api "io.lettuce:lettuce-core:6.8.0.RELEASE"
+    api "io.lettuce:lettuce-core:7.5.1.RELEASE"
     testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
     testImplementation project(":testcontainers-spock")
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/examples/cucumber/build.gradle
+++ b/examples/cucumber/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.13.4')
     testImplementation 'org.junit.platform:junit-platform-suite'
-    testImplementation platform('io.cucumber:cucumber-bom:7.30.0')
+    testImplementation platform('io.cucumber:cucumber-bom:7.34.3')
     testImplementation 'io.cucumber:cucumber-java'
     testImplementation 'io.cucumber:cucumber-junit-platform-engine'
     testImplementation 'org.testcontainers:testcontainers-selenium'

--- a/examples/kafka-cluster/build.gradle
+++ b/examples/kafka-cluster/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    testCompileOnly "org.projectlombok:lombok:1.18.38"
-    testAnnotationProcessor "org.projectlombok:lombok:1.18.38"
+    testCompileOnly "org.projectlombok:lombok:1.18.46"
+    testAnnotationProcessor "org.projectlombok:lombok:1.18.46"
     testImplementation 'org.testcontainers:testcontainers-kafka'
     testImplementation 'org.apache.kafka:kafka-clients:4.1.0'
     testImplementation 'org.assertj:assertj-core:3.27.4'

--- a/examples/redis-backed-cache-testng/build.gradle
+++ b/examples/redis-backed-cache-testng/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:6.2.0'
+    implementation 'redis.clients:jedis:7.5.0'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/redis-backed-cache/build.gradle
+++ b/examples/redis-backed-cache/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
     compileOnly 'org.slf4j:slf4j-api:1.7.36'
-    implementation 'redis.clients:jedis:6.2.0'
+    implementation 'redis.clients:jedis:7.5.0'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.google.guava:guava:23.0'
     testImplementation 'org.testcontainers:testcontainers'

--- a/examples/sftp/build.gradle
+++ b/examples/sftp/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'com.github.mwiede:jsch:2.27.2'
+    testImplementation 'com.github.mwiede:jsch:2.28.2'
     testImplementation 'org.testcontainers:testcontainers'
     testImplementation 'org.assertj:assertj-core:3.27.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'

--- a/examples/singleton-container/build.gradle
+++ b/examples/singleton-container/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 dependencies {
 
-    implementation 'redis.clients:jedis:6.2.0'
+    implementation 'redis.clients:jedis:7.5.0'
     implementation 'com.google.code.gson:gson:2.13.2'
     implementation 'com.google.guava:guava:23.0'
     compileOnly 'org.slf4j:slf4j-api:1.7.36'

--- a/examples/solr-container/build.gradle
+++ b/examples/solr-container/build.gradle
@@ -7,8 +7,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly "org.projectlombok:lombok:1.18.38"
-    annotationProcessor "org.projectlombok:lombok:1.18.38"
+    compileOnly "org.projectlombok:lombok:1.18.46"
+    annotationProcessor "org.projectlombok:lombok:1.18.46"
 
     implementation 'org.apache.solr:solr-solrj:8.11.4'
 

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: ActiveMQ"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation "org.apache.activemq:activemq-client:6.2.4"
+    testImplementation "org.apache.activemq:activemq-client:6.2.6"
     testImplementation "org.apache.activemq:artemis-jakarta-client:2.53.0"
 }

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     // TODO use JDK's HTTP client and/or Apache HttpClient5
     shaded 'com.squareup.okhttp3:okhttp:5.3.2'
 
-    testImplementation 'com.couchbase.client:java-client:3.11.2'
+    testImplementation 'com.couchbase.client:java-client:3.12.0'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.3.3"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.4.2"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.79.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.83.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.50.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.13")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.5.32")
+    testImplementation("ch.qos.logback:logback-classic:1.5.34")
 }
 
 test {

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     shaded("net.lingala.zip4j:zip4j:2.11.6")
 
     testImplementation(project(":testcontainers-junit-jupiter"))
-    testImplementation("com.hivemq:hivemq-extension-sdk:4.50.0")
+    testImplementation("com.hivemq:hivemq-extension-sdk:4.52.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.13")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.32")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     shaded("org.apache.commons:commons-lang3:3.20.0")
     shaded("commons-io:commons-io:2.21.0")
-    shaded("org.javassist:javassist:3.30.2-GA")
+    shaded("org.javassist:javassist:3.31.0-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.6")

--- a/modules/influxdb/build.gradle
+++ b/modules/influxdb/build.gradle
@@ -6,5 +6,5 @@ dependencies {
     compileOnly 'org.influxdb:influxdb-java:2.25'
 
     testImplementation 'org.influxdb:influxdb-java:2.25'
-    testImplementation "com.influxdb:influxdb-client-java:7.5.0"
+    testImplementation "com.influxdb:influxdb-client-java:8.0.0"
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     api 'org.apache.tomcat:tomcat-jdbc:11.0.21'
     api 'org.vibur:vibur-dbcp:26.0'
     api 'com.mysql:mysql-connector-j:9.6.0'
-    api 'org.junit.jupiter:junit-jupiter:5.14.3'
+    api 'org.junit.jupiter:junit-jupiter:5.14.4'
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':testcontainers-jdbc')
 
-    api 'com.google.guava:guava:33.5.0-jre'
+    api 'com.google.guava:guava:33.6.0-jre'
     api 'org.apache.commons:commons-lang3:3.20.0'
     api 'com.zaxxer:HikariCP-java6:2.3.13'
     api 'commons-dbutils:commons-dbutils:1.8.1'

--- a/modules/jdbc/build.gradle
+++ b/modules/jdbc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:26.1.0'
     testImplementation 'commons-dbutils:commons-dbutils:1.8.1'
     testImplementation 'org.vibur:vibur-dbcp:26.0'
-    testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.21'
+    testImplementation 'org.apache.tomcat:tomcat-jdbc:11.0.22'
     testImplementation 'com.zaxxer:HikariCP-java6:2.3.13'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     }
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
-    testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
+    testRuntimeOnly 'com.mysql:mysql-connector-j:9.7.0'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -2,7 +2,7 @@ description = "Testcontainers :: JUnit Jupiter Extension"
 
 dependencies {
     api project(':testcontainers')
-    implementation platform('org.junit:junit-bom:5.14.3')
+    implementation platform('org.junit:junit-bom:5.14.4')
     implementation 'org.junit.jupiter:junit-jupiter-api'
 
     testImplementation project(':testcontainers-mysql')

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':testcontainers-mysql')
     testImplementation project(':testcontainers-postgresql')
     testImplementation 'com.zaxxer:HikariCP:7.0.2'
-    testImplementation 'redis.clients:jedis:7.4.1'
+    testImplementation 'redis.clients:jedis:7.5.2'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     // Synchronize with the jackson version, must match major and minor version
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.4'
 
-    testImplementation 'io.fabric8:kubernetes-client:7.6.1'
+    testImplementation 'io.fabric8:kubernetes-client:7.7.0'
     testImplementation 'io.kubernetes:client-java:25.0.0-legacy'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
+    testImplementation 'org.apache.kafka:kafka-clients:4.3.0'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("software.amazon.awssdk:bom:2.42.33")
+    testImplementation platform("software.amazon.awssdk:bom:2.46.2")
     testImplementation 'software.amazon.awssdk:s3'
     testImplementation 'software.amazon.awssdk:sqs'
     testImplementation 'software.amazon.awssdk:cloudwatchlogs'

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Milvus"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.milvus:milvus-sdk-java:2.6.17'
+    testImplementation 'io.milvus:milvus-sdk-java:3.0.1'
 }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:9.0.0")
+    testImplementation("io.minio:minio:9.0.1")
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -4,13 +4,13 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     compileOnly project(':testcontainers-r2dbc')
-    compileOnly 'io.asyncer:r2dbc-mysql:1.4.1'
+    compileOnly 'io.asyncer:r2dbc-mysql:1.4.2'
 
     testImplementation project(':testcontainers-jdbc-test')
     testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
 
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
-    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.4.1'
+    testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.4.2'
 
     compileOnly 'org.jetbrains:annotations:26.1.0'
 }

--- a/modules/mysql/build.gradle
+++ b/modules/mysql/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'io.asyncer:r2dbc-mysql:1.4.1'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
+    testRuntimeOnly 'com.mysql:mysql-connector-j:9.7.0'
 
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
     testRuntimeOnly 'io.asyncer:r2dbc-mysql:1.4.1'

--- a/modules/neo4j/build.gradle
+++ b/modules/neo4j/build.gradle
@@ -33,5 +33,5 @@ dependencies {
 
     api project(":testcontainers")
 
-    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.22'
+    testImplementation 'org.neo4j.driver:neo4j-java-driver:4.4.24'
 }

--- a/modules/oceanbase/build.gradle
+++ b/modules/oceanbase/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
+    testRuntimeOnly 'com.mysql:mysql-connector-j:9.7.0'
 }

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: OpenFGA"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'dev.openfga:openfga-sdk:0.9.7'
+    testImplementation 'dev.openfga:openfga-sdk:0.9.9'
 }
 
 test {

--- a/modules/oracle-xe/build.gradle
+++ b/modules/oracle-xe/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.1.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.2.0.0'
 
     compileOnly 'org.jetbrains:annotations:26.1.0'
 

--- a/modules/orientdb/build.gradle
+++ b/modules/orientdb/build.gradle
@@ -3,8 +3,8 @@ description = "Testcontainers :: Orientdb"
 dependencies {
     api project(":testcontainers")
 
-    api "com.orientechnologies:orientdb-client:3.2.51"
+    api "com.orientechnologies:orientdb-client:3.2.53"
 
     testImplementation 'org.apache.tinkerpop:gremlin-driver:3.8.1'
-    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.51"
+    testImplementation "com.orientechnologies:orientdb-gremlin:3.2.53"
 }

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Qdrant"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.qdrant:client:1.17.0'
+    testImplementation 'io.qdrant:client:1.18.1'
     testImplementation platform('io.grpc:grpc-bom:1.80.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':testcontainers-jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.11'
 
     testImplementation project(':testcontainers-jdbc-test')
     testImplementation 'org.questdb:questdb:9.2.2'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':testcontainers-postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.8.4'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.8.5'
     testFixturesImplementation 'org.assertj:assertj-core:3.27.7'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.34'
 
-    testImplementation 'org.apache.kafka:kafka-clients:4.2.0'
+    testImplementation 'org.apache.kafka:kafka-clients:4.3.0'
     testImplementation 'io.rest-assured:rest-assured:5.5.7'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'com.scylladb:java-driver-core:4.19.0.8'
-    testImplementation 'software.amazon.awssdk:dynamodb:2.42.34'
+    testImplementation 'software.amazon.awssdk:dynamodb:2.46.2'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.3.0'
 
-    testImplementation 'com.solacesystems:sol-jcsmp:10.29.1'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.30.1'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
     testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
-    testRuntimeOnly platform('org.junit:junit-bom:5.14.3')
+    testRuntimeOnly platform('org.junit:junit-bom:5.14.4')
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'org.junit.platform:junit-platform-testkit'
 

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:7.0.2'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.11'
     testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
     testRuntimeOnly platform('org.junit:junit-bom:5.14.3')
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/modules/tidb/build.gradle
+++ b/modules/tidb/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
+    testRuntimeOnly 'com.mysql:mysql-connector-j:9.7.0'
     compileOnly 'org.jetbrains:annotations:26.1.0'
 }

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.11'
 
-    testImplementation 'redis.clients:jedis:7.4.1'
+    testImplementation 'redis.clients:jedis:7.5.2'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:480'
+    testRuntimeOnly 'io.trino:trino-jdbc:481'
     compileOnly 'org.jetbrains:annotations:26.1.0'
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Weaviate"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.weaviate:client6:6.1.0'
+    testImplementation 'io.weaviate:client6:6.2.1'
 }
 
 test {

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.19.2"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.5.0"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.6.0"
         classpath "org.gradle.toolchains:foojay-resolver:0.8.0"
     }
 }

--- a/smoke-test/turbo-mode/build.gradle
+++ b/smoke-test/turbo-mode/build.gradle
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     testImplementation 'org.testcontainers:testcontainers'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.14.4'
     testImplementation 'ch.qos.logback:logback-classic:1.3.15'
     testImplementation 'org.assertj:assertj-core:3.27.4'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.13.3'


### PR DESCRIPTION
Combines 51 passing Dependabot PRs into a single PR, per the [documented process](https://github.com/testcontainers/testcontainers-java/blob/main/docs/contributing.md#combining-dependabot-prs).

### Combined PRs

- #11310 Bump io.cucumber:cucumber-bom from 7.30.0 to 7.34.3 in /examples
- #11653 Bump io.cucumber:cucumber-bom from 7.30.0 to 7.34.3 in /examples
- #11658 Bump org.projectlombok:lombok from 1.18.38 to 1.18.46 in /examples
- #11659 Bump io.lettuce:lettuce-core from 6.8.0.RELEASE to 7.5.1.RELEASE in /smoke-test
- #11660 Bump org.junit.jupiter:junit-jupiter from 5.13.4 to 5.14.4 in /smoke-test
- #11666 Bump org.jreleaser from 1.20.0 to 1.24.0 in /smoke-test
- #11667 Bump redis.clients:jedis from 6.2.0 to 7.5.0 in /examples
- #11669 Bump com.github.mwiede:jsch from 2.27.2 to 2.28.2 in /examples
- #11680 Bump com.gradle:common-custom-user-data-gradle-plugin from 2.5.0 to 2.6.0
- #11727 Bump org.junit.platform:junit-platform-launcher from 1.14.3 to 1.14.4 in /core
- #11731 Bump org.junit:junit-bom from 5.14.3 to 5.14.4 in /modules/spock
- #11733 Bump com.influxdb:influxdb-client-java from 7.5.0 to 8.0.0 in /modules/influxdb
- #11737 Bump io.asyncer:r2dbc-mysql from 1.4.1 to 1.4.2 in /modules/mysql
- #11739 Bump org.postgresql:postgresql from 42.7.10 to 42.7.11 in /modules/spock
- #11740 Bump com.mysql:mysql-connector-j from 9.6.0 to 9.7.0 in /modules/mysql
- #11741 Bump org.junit.jupiter:junit-jupiter from 5.14.3 to 5.14.4 in /modules/jdbc-test
- #11743 Bump com.google.guava:guava from 33.5.0-jre to 33.6.0-jre in /modules/jdbc-test
- #11744 Bump com.mysql:mysql-connector-j from 9.6.0 to 9.7.0 in /modules/junit-jupiter
- #11745 Bump org.junit:junit-bom from 5.14.3 to 5.14.4 in /modules/junit-jupiter
- #11749 Bump io.projectreactor:reactor-core from 3.8.4 to 3.8.5 in /modules/r2dbc
- #11755 Bump com.mysql:mysql-connector-j from 9.6.0 to 9.7.0 in /modules/tidb
- #11756 Bump org.javassist:javassist from 3.30.2-GA to 3.31.0-GA in /modules/hivemq
- #11758 Bump org.postgresql:postgresql from 42.7.10 to 42.7.11 in /modules/questdb
- #11765 Bump com.mysql:mysql-connector-j from 9.6.0 to 9.7.0 in /modules/oceanbase
- #11785 Bump com.gradleup.shadow from 8.3.9 to 8.3.11
- #11786 Bump release-drafter/release-drafter from 6.1.0 to 7.3.1 in /.github/workflows
- #11790 Bump org.apache.tomcat:tomcat-jdbc from 11.0.21 to 11.0.22 in /modules/jdbc
- #11792 Bump com.oracle.database.jdbc:ojdbc11 from 23.26.1.0.0 to 23.26.2.0.0 in /modules/oracle-xe
- #11793 Bump org.apache.kafka:kafka-clients from 3.8.0 to 4.3.0 in /modules/kafka
- #11794 Bump software.amazon.awssdk:bom from 2.42.33 to 2.46.2 in /modules/localstack
- #11796 Bump redis.clients:jedis from 7.4.1 to 7.5.2 in /modules/junit-jupiter
- #11797 Bump org.neo4j.driver:neo4j-java-driver from 4.4.22 to 4.4.24 in /modules/neo4j
- #11798 Bump org.elasticsearch.client:elasticsearch-rest-client from 9.3.3 to 9.4.2 in /modules/elasticsearch
- #11799 Bump redis.clients:jedis from 7.4.1 to 7.5.2 in /modules/toxiproxy
- #11800 Bump com.couchbase.client:java-client from 3.11.2 to 3.12.0 in /modules/couchbase
- #11801 Bump io.fabric8:kubernetes-client from 7.6.1 to 7.7.0 in /modules/k3s
- #11802 Bump com.orientechnologies:orientdb-gremlin from 3.2.51 to 3.2.53 in /modules/orientdb
- #11803 Bump com.orientechnologies:orientdb-client from 3.2.51 to 3.2.53 in /modules/orientdb
- #11805 Bump com.google.cloud:libraries-bom from 26.79.0 to 26.83.0 in /modules/gcloud
- #11806 Bump io.trino:trino-jdbc from 480 to 481 in /modules/trino
- #11810 Bump ch.qos.logback:logback-classic from 1.5.32 to 1.5.34 in /modules/hivemq
- #11811 Bump org.apache.kafka:kafka-clients from 4.2.0 to 4.3.0 in /modules/redpanda
- #11812 Bump com.hivemq:hivemq-extension-sdk from 4.50.0 to 4.52.0 in /modules/hivemq
- #11814 Bump com.solacesystems:sol-jcsmp from 10.29.1 to 10.30.1 in /modules/solace
- #11815 Bump io.minio:minio from 9.0.0 to 9.0.1 in /modules/minio
- #11818 Bump org.apache.activemq:activemq-client from 6.2.4 to 6.2.6 in /modules/activemq
- #11819 Bump io.weaviate:client6 from 6.1.0 to 6.2.1 in /modules/weaviate
- #11820 Bump io.milvus:milvus-sdk-java from 2.6.17 to 3.0.1 in /modules/milvus
- #11821 Bump io.qdrant:client from 1.17.0 to 1.18.1 in /modules/qdrant
- #11822 Bump dev.openfga:openfga-sdk from 0.9.7 to 0.9.9 in /modules/openfga
- #11825 Bump software.amazon.awssdk:dynamodb from 2.42.34 to 2.46.2 in /modules/scylladb

### Not included (left for a future run / individual attention)

Three breaking dependency bumps were **excluded** — they don't compile, and their individual CI only showed green because of a matrix-generation bug that masks gradle failures (fixed separately in #11840):

- **#11596** cassandra-driver-core 3.10.0 → 4.0.0 (`com.datastax.driver.core` removed in 4.x; needs code migration)
- **#11791** mockserver-client-java 5.15.0 → 6.1.0 (pulls JVM 11+ transitive deps `com.lmax:disruptor`, `org.mozilla:rhino`; module targets JVM 8)
- **#11813** questdb 9.2.2 → 9.4.1 (`io.questdb.client` package no longer resolves)

Also excluded: the 9 PRs whose individual builds were already failing (#11807, #11804, #11795, #11751, #11656, #11655, #11458, #11319, #11308).
