### PR TITLE
fix(ci): prevent matrix-generation steps from masking gradle failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,9 @@ jobs:
           # we should not push empty results to the cache
           READ_ONLY_REMOTE_GRADLE_CACHE: true
         run: |
-          TASKS=$(./gradlew --no-daemon --parallel -q testMatrix | jq 'del(.[] | select(. == ":testcontainers:check" or startswith(":docs:")))' --compact-output)
+          set -o pipefail
+          ./gradlew --no-daemon --parallel -q testMatrix > matrix.json
+          TASKS=$(jq 'del(.[] | select(. == ":testcontainers:check" or startswith(":docs:")))' --compact-output matrix.json)
           echo $TASKS
           echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
   check:
@@ -130,7 +132,9 @@ jobs:
           # we should not push empty results to the cache
           READ_ONLY_REMOTE_GRADLE_CACHE: true
         run: |
-          TASKS=$(./gradlew --no-daemon --parallel -q testMatrix)
+          set -o pipefail
+          ./gradlew --no-daemon --parallel -q testMatrix > matrix.json
+          TASKS=$(cat matrix.json)
           echo $TASKS
           echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
   check_examples:
@@ -164,7 +168,9 @@ jobs:
           # we should not push empty results to the cache
           READ_ONLY_REMOTE_GRADLE_CACHE: true
         run: |
-          TASKS=$(./gradlew --no-daemon --parallel -q testMatrix | jq 'map(select(startswith(":docs:")))' --compact-output)
+          set -o pipefail
+          ./gradlew --no-daemon --parallel -q testMatrix > matrix.json
+          TASKS=$(jq 'map(select(startswith(":docs:")))' --compact-output matrix.json)
           echo $TASKS
           echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
   check_docs_examples:


### PR DESCRIPTION
## Problem

The dynamic-matrix steps in `.github/workflows/ci.yml` (`find_gradle_jobs`, `find_examples_jobs`, `find_docs_examples_jobs`) captured `./gradlew testMatrix` output inside a command substitution — in two of them piped into `jq`:

```bash
TASKS=$(./gradlew --no-daemon --parallel -q testMatrix | jq '...' --compact-output)
echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
```

In a shell pipeline `A | B`, the exit status is that of the **last** command. GitHub Actions `run:` blocks run bash with `set -e` by default, but **not** `pipefail`. So when `./gradlew testMatrix` fails (e.g. a module no longer compiles), the failure is swallowed: `jq` exits `0` on empty input, the step reports success, and an empty/invalid matrix is emitted. (The non-piped job had the same class of bug: a failing command inside a `$(...)` assignment does not trip `set -e` either.)

An empty matrix means GitHub spawns **zero** `check` jobs. Because the downstream jobs are chained via `needs:`:

```
check -> find_examples_jobs -> check_examples -> find_docs_examples_jobs -> check_docs_examples
```

they all get **skipped**, including the required `check_docs_examples (:docs:examples:check)` context. The net effect is a falsely-green build that ran no module checks at all.

This was discovered while combining Dependabot PRs: a `cassandra-driver-core` 4.0.0 bump broke compilation, yet individual CI still went green.

## Fix

Add `set -o pipefail` and run gradle on its own line, redirecting its output to a file before handing it to `jq`. Gradle's non-zero exit status is now caught directly by the default `set -e`, before any matrix output is written — so a non-compiling module fails the matrix-generation job loudly instead of cascading silent skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
