### PR TITLE
Fallback to amd64 on InternalServerErrorException during image pull

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -1180,6 +1180,13 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
         this.image = this.image.withImagePullPolicy(imagePullPolicy);
         return self();
     }
+    /**
+    * Sets the platform to use when pulling the image, for example linux/amd64.
+    */
+    public SELF withImagePlatform(String imagePlatform) {
+        this.image = this.image.withImagePlatform(imagePlatform);
+        return self();
+    }
 
     /**
      * {@inheritDoc}

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -159,7 +159,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
         throws InterruptedException {
         try {
             return pullImageCmd.exec(new TimeLimitedLoggedPullImageResultCallback(logger)).awaitCompletion();
-        } catch (DockerClientException | NotFoundException e) {
+        } catch (DockerClientException | NotFoundException | InternalServerErrorException e) {
             // Try to fallback to x86
             return pullImageCmd
                 .withPlatform("linux/amd64")

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -1,9 +1,9 @@
 package org.testcontainers.images;
 
+import org.jetbrains.annotations.Nullable;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.exception.DockerClientException;
-import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.google.common.util.concurrent.Futures;
 import lombok.AccessLevel;
@@ -47,8 +47,13 @@ public class RemoteDockerImage extends LazyFuture<String> {
     ImagePullPolicy imagePullPolicy = PullPolicy.defaultPolicy();
 
     @With
+    @Nullable
+    private String imagePlatform;
+
+    @With
     private ImageNameSubstitutor imageNameSubstitutor = ImageNameSubstitutor.instance();
 
+    @With
     @ToString.Exclude
     private DockerClient dockerClient = DockerClientFactory.lazyClient();
 
@@ -92,6 +97,9 @@ public class RemoteDockerImage extends LazyFuture<String> {
             final PullImageCmd pullImageCmd = dockerClient
                 .pullImageCmd(imageName.getUnversionedPart())
                 .withTag(imageName.getVersionPart());
+            if (imagePlatform != null) {
+                pullImageCmd.withPlatform(imagePlatform);
+            }
             final AtomicReference<String> dockerImageName = new AtomicReference<>();
 
             // The following poll interval in ms: 50, 100, 200, 400, 800....
@@ -142,7 +150,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
                 pullImage(pullImageCmd, logger);
                 dockerImageName.set(imageName.asCanonicalNameString());
                 return true;
-            } catch (InterruptedException | InternalServerErrorException e) {
+            } catch (InterruptedException e) {
                 // these classes of exception often relate to timeout/connection errors so should be retried
                 lastFailure.set(e);
                 logger.warn(
@@ -159,7 +167,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
         throws InterruptedException {
         try {
             return pullImageCmd.exec(new TimeLimitedLoggedPullImageResultCallback(logger)).awaitCompletion();
-        } catch (DockerClientException | NotFoundException | InternalServerErrorException e) {
+        } catch (DockerClientException | NotFoundException e) {
             // Try to fallback to x86
             return pullImageCmd
                 .withPlatform("linux/amd64")

--- a/core/src/test/java/org/testcontainers/images/RemoteDockerImageTest.java
+++ b/core/src/test/java/org/testcontainers/images/RemoteDockerImageTest.java
@@ -1,9 +1,8 @@
 package org.testcontainers.images;
+
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PullImageCmd;
-import com.github.dockerjava.api.exception.InternalServerErrorException;
-import org.testcontainers.utility.ImageNameSubstitutor;
-
+import org.testcontainers.images.TimeLimitedLoggedPullImageResultCallback;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -85,29 +84,23 @@ class RemoteDockerImageTest {
         assertThat(remoteDockerImage.toString()).contains("imageName=" + imageName);
     }
     @Test
-    void fallsBackToAmd64WhenPullFailsWithInternalServerError() throws Exception {
-        DockerImageName imageName = DockerImageName.parse("test/image:latest");
+    void passesExplicitPlatformToPullImageCommand() throws Exception {
         DockerClient dockerClient = mock(DockerClient.class);
         PullImageCmd pullImageCmd = mock(PullImageCmd.class);
 
         when(dockerClient.pullImageCmd("test/image")).thenReturn(pullImageCmd);
         when(pullImageCmd.withTag("latest")).thenReturn(pullImageCmd);
         when(pullImageCmd.withPlatform("linux/amd64")).thenReturn(pullImageCmd);
+        TimeLimitedLoggedPullImageResultCallback callback = mock(TimeLimitedLoggedPullImageResultCallback.class);
+        when(pullImageCmd.exec(any(TimeLimitedLoggedPullImageResultCallback.class))).thenReturn(callback);
+        when(callback.awaitCompletion()).thenReturn(callback);
 
-        when(pullImageCmd.exec(any(TimeLimitedLoggedPullImageResultCallback.class)))
-            .thenThrow(new InternalServerErrorException("no image found in manifest list for architecture \"arm64\""))
-            .thenReturn(mock(TimeLimitedLoggedPullImageResultCallback.class));
+        RemoteDockerImage remoteDockerImage = new RemoteDockerImage(DockerImageName.parse("test/image:latest"))
+            .withImagePlatform("linux/amd64");
 
-        RemoteDockerImage remoteDockerImage = new RemoteDockerImage(
-            CompletableFuture.completedFuture(imageName),
-            __ -> true,
-            ImageNameSubstitutor.noop(),
-            dockerClient
-        );
-
-        remoteDockerImage.resolve();
+        remoteDockerImage.withDockerClient(dockerClient).get();
 
         verify(pullImageCmd).withPlatform("linux/amd64");
     }
-
+    
 }

--- a/core/src/test/java/org/testcontainers/images/RemoteDockerImageTest.java
+++ b/core/src/test/java/org/testcontainers/images/RemoteDockerImageTest.java
@@ -1,5 +1,13 @@
 package org.testcontainers.images;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.PullImageCmd;
+import com.github.dockerjava.api.exception.InternalServerErrorException;
+import org.testcontainers.utility.ImageNameSubstitutor;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.testcontainers.utility.Base58;
@@ -76,4 +84,30 @@ class RemoteDockerImageTest {
         imageNameFuture.get();
         assertThat(remoteDockerImage.toString()).contains("imageName=" + imageName);
     }
+    @Test
+    void fallsBackToAmd64WhenPullFailsWithInternalServerError() throws Exception {
+        DockerImageName imageName = DockerImageName.parse("test/image:latest");
+        DockerClient dockerClient = mock(DockerClient.class);
+        PullImageCmd pullImageCmd = mock(PullImageCmd.class);
+
+        when(dockerClient.pullImageCmd("test/image")).thenReturn(pullImageCmd);
+        when(pullImageCmd.withTag("latest")).thenReturn(pullImageCmd);
+        when(pullImageCmd.withPlatform("linux/amd64")).thenReturn(pullImageCmd);
+
+        when(pullImageCmd.exec(any(TimeLimitedLoggedPullImageResultCallback.class)))
+            .thenThrow(new InternalServerErrorException("no image found in manifest list for architecture \"arm64\""))
+            .thenReturn(mock(TimeLimitedLoggedPullImageResultCallback.class));
+
+        RemoteDockerImage remoteDockerImage = new RemoteDockerImage(
+            CompletableFuture.completedFuture(imageName),
+            __ -> true,
+            ImageNameSubstitutor.noop(),
+            dockerClient
+        );
+
+        remoteDockerImage.resolve();
+
+        verify(pullImageCmd).withPlatform("linux/amd64");
+    }
+
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Testcontainers. Before submitting a pull request, please
review our contributing guidelines at https://java.testcontainers.org/contributing/

Please also review the following notes before submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
