### PR TITLE
feat(jdbc): Add getR2dbcUrl helper method to JdbcDatabaseContainer

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -77,6 +77,23 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     public abstract String getJdbcUrl();
 
     /**
+     * @return a R2DBC URL that may be used to connect to the dockerized DB
+     */
+    public String getR2dbcUrl() {
+        String jdbcUrl = getJdbcUrl();
+        if (jdbcUrl == null) {
+            return null;
+        }
+        if (jdbcUrl.startsWith("jdbc:sqlserver:")) {
+            return jdbcUrl.replace("jdbc:sqlserver:", "r2dbc:mssql:");
+        }
+        if (jdbcUrl.startsWith("jdbc:oracle:thin:@")) {
+            return jdbcUrl.replace("jdbc:oracle:thin:@", "r2dbc:oracle://");
+        }
+        return jdbcUrl.replace("jdbc:", "r2dbc:");
+    }
+
+    /**
      * @return the database name
      */
     public String getDatabaseName() {

--- a/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerTest.java
@@ -7,10 +7,53 @@ import org.slf4j.Logger;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 class JdbcDatabaseContainerTest {
+
+    @Test
+    void testGetR2dbcUrlWithDifferentJdbcUrls() {
+        // Null URL
+        JdbcDatabaseContainer<?> nullUrlContainer = new JdbcDatabaseContainerStub("mysql:latest") {
+            @Override
+            public String getJdbcUrl() {
+                return null;
+            }
+        };
+        assertThat(nullUrlContainer.getR2dbcUrl()).isNull();
+
+        // Standard postgres URL
+        JdbcDatabaseContainer<?> postgresContainer = new JdbcDatabaseContainerStub("postgres:latest") {
+            @Override
+            public String getJdbcUrl() {
+                return "jdbc:postgresql://localhost:5432/testdb";
+            }
+        };
+        assertThat(postgresContainer.getR2dbcUrl())
+            .isEqualTo("r2dbc:postgresql://localhost:5432/testdb");
+
+        // MSSQL server URL
+        JdbcDatabaseContainer<?> mssqlContainer = new JdbcDatabaseContainerStub("mssql:latest") {
+            @Override
+            public String getJdbcUrl() {
+                return "jdbc:sqlserver://localhost:1433;databaseName=testdb";
+            }
+        };
+        assertThat(mssqlContainer.getR2dbcUrl())
+            .isEqualTo("r2dbc:mssql://localhost:1433;databaseName=testdb");
+
+        // Oracle server URL
+        JdbcDatabaseContainer<?> oracleContainer = new JdbcDatabaseContainerStub("oracle:latest") {
+            @Override
+            public String getJdbcUrl() {
+                return "jdbc:oracle:thin:@localhost:1521/xepdb1";
+            }
+        };
+        assertThat(oracleContainer.getR2dbcUrl())
+            .isEqualTo("r2dbc:oracle://localhost:1521/xepdb1");
+    }
 
     @Test
     void anExceptionIsThrownIfJdbcIsNotAvailable() {


### PR DESCRIPTION
Resolves #8797. Adds getR2dbcUrl helper method to JdbcDatabaseContainer and corresponding unit tests to verify standard, MSSQL, and Oracle R2DBC URL mappings.