### PR TITLE
Update testcontainers/sshd image from 1.3.0 to 1.4.0

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/PortForwardingContainer.java
@@ -24,7 +24,7 @@ public enum PortForwardingContainer {
 
     private static ContainerDef DEFINITION = new ContainerDef() {
         {
-            setImage(DockerImageName.parse("testcontainers/sshd:1.3.0"));
+            setImage(DockerImageName.parse("testcontainers/sshd:1.4.0"));
             addExposedTcpPort(22);
             addEnvVar("PASSWORD", PASSWORD);
         }

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -52,7 +52,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **tinyimage.container.image = alpine:3.17**  
 > Used to check whether images can be pulled at startup, and always required (unless [startup checks are disabled](#disabling-the-startup-checks))
 
-> **sshd.container.image = testcontainers/sshd:1.1.0**  
+> **sshd.container.image = testcontainers/sshd:1.4.0**  
 > Required if [exposing host ports to containers](./networking.md#exposing-host-ports-to-the-container)
 
 > **vncrecorder.container.image = testcontainers/vnc-recorder:1.3.0**


### PR DESCRIPTION
Bumps the `testcontainers/sshd` image used for host port forwarding from `1.3.0` to `1.4.0`.

**What changed:**
- `PortForwardingContainer.java`: image reference updated to `testcontainers/sshd:1.4.0`
- `docs/features/configuration.md`: example config updated to reflect `1.4.0`

**Why:**
The 1.4.0 release includes:
- Alpine 3.23 base image
- `AddressFamily=any` sshd option (fixes IPv4/IPv6 dual-stack binding)

**Tests:**
`ExposedHostTest` (the primary test class for sshd/port-forwarding/host port exposure) was found and run locally. The `testcontainers/sshd:1.4.0` image pulls and starts successfully. Test failures observed are pre-existing environment issues (SSH port forwarding via sandbox networking) unrelated to this version bump — confirmed by reproducing identical failures against `1.3.0`.