### PR TITLE
Migrate to OSS Community Develocity Instance

### DIFF
--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -43,7 +43,7 @@ permissions:
   contents: read
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   main:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ permissions:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   core:

--- a/.github/workflows/moby-latest.yml
+++ b/.github/workflows/moby-latest.yml
@@ -13,7 +13,7 @@ on:
     - cron:  '59 23 * * *'
 
 env:
-  DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+  DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
 jobs:
   test_docker:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=main&repo=33816473&machine=standardLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=EastUs)
 
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.testcontainers.org/scans)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=testcontainers-java)
 
 > Testcontainers is a Java library that supports JUnit tests, providing lightweight, throwaway instances of common databases, Selenium web browsers, or anything else that can run in a Docker container.
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,8 +5,8 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.enterprise:com.gradle.enterprise.gradle.plugin:3.19.2"
-        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.5.0"
+        classpath "com.gradle:develocity-gradle-plugin:4.4.1"
+        classpath "com.gradle:common-custom-user-data-gradle-plugin:2.6.0"
         classpath "org.gradle.toolchains:foojay-resolver:0.8.0"
     }
 }
@@ -45,13 +45,16 @@ buildCache {
 }
 
 develocity {
+    server = "https://community.develocity.cloud"
+    projectId = "testcontainers"
     buildScan {
-        server = "https://ge.testcontainers.org/"
         publishing.onlyIf {
             it.authenticated
         }
         uploadInBackground = !isCI
         capture.fileFingerprints = true
+        obfuscation {
+            ipAddresses { it.collect { "0.0.0.0" } }
+        }
     }
-
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,8 +39,9 @@ buildCache {
         enabled = !isCI
     }
     remote(develocity.buildCache) {
-        push = isCI && !System.getenv("READ_ONLY_REMOTE_GRADLE_CACHE") && System.getenv("DEVELOCITY_ACCESS_KEY")
         enabled = true
+        // Check access key presence to avoid build cache errors on PR builds when access key is not present
+        push = isCI && !System.getenv("READ_ONLY_REMOTE_GRADLE_CACHE") && System.getenv("DEVELOCITY_ACCESS_KEY") != null
     }
 }
 
@@ -52,7 +53,6 @@ develocity {
             it.authenticated
         }
         uploadInBackground = !isCI
-        capture.fileFingerprints = true
         obfuscation {
             ipAddresses { it.collect { "0.0.0.0" } }
         }


### PR DESCRIPTION
# Migrate to the OSS Community Develocity Instance

This PR migrates [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project to the **OSS Community Develocity Instance** at
https://community.develocity.cloud under project ID `testcontainers`.

## What this PR changes

- Updates `settings.gradle` to point at `https://community.develocity.cloud` with project ID `testcontainers` and adds IP address obfuscation
- Upgrades `develocity-gradle-plugin` to `4.4.1` and `common-custom-user-data-gradle-plugin` to `2.6.0` in `settings.gradle`
- Renames `GRADLE_ENTERPRISE_ACCESS_KEY` → `DEVELOCITY_ACCESS_KEY` in all GitHub Actions workflow files
- Updates the "Revved up by Develocity" badge in the README to link to the filtered Build Scan list for this project on the community instance

## Step 1 — Get an access key for `community.develocity.cloud`

Build Scan publishing **and** Build Cache writes from CI need a Develocity access key.

1. Visit https://community.develocity.cloud.
2. **Sign in as the CI service account that the Develocity Solutions team has provisioned for your project** — that account's project memberships and permissions are already set up for this migration. The access key inherits those memberships and permissions.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy the generated key. Keep this tab open until you complete Step 2 — the key is only shown once.

## Step 2 — Set the GitHub Actions secret on this repository

CI uses a repository secret named `DEVELOCITY_ACCESS_KEY` to authenticate to `community.develocity.cloud`.

1. Open this repository on GitHub and click **Settings**.
2. In the left sidebar, click **Secrets and variables** → **Actions**.
3. Click **New repository secret** (or update the existing `GRADLE_ENTERPRISE_ACCESS_KEY` if present — but note the name must change to `DEVELOCITY_ACCESS_KEY`).
4. Set **Name** to: `DEVELOCITY_ACCESS_KEY`
5. Set **Secret** to the value `community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE` (the `community.develocity.cloud=` prefix is **required** — this is the most common point of failure).
6. Click **Add secret** (or **Update secret**).

## Step 3 — Provision an access key for local builds

Developers building locally should run: `./gradlew provisionDevelocityAccessKey`

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read repository secrets, so the workflow run on this PR cannot publish to `community.develocity.cloud` even after setting the secret. To get CI verification before merging, push the branch `build/migrate-to-oss-community-develocity-instance` to a temporary branch on the main repo and re-run.