### PR TITLE
Improve diagnostics when /bin/sh is unavailable

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheck.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/internal/InternalCommandPortListeningCheck.java
@@ -53,10 +53,21 @@ public class InternalCommandPortListeningCheck implements java.util.concurrent.C
                 result.getExitCode(),
                 result.getStdout()
             );
+
             int exitCode = result.getExitCode();
-            if (exitCode != 0 && exitCode != 1) {
+
+            if (exitCode == 127 && result.getStderr() != null && result.getStderr().contains("/bin/sh")) {
+                log.warn(
+                    "Container image does not contain /bin/sh. " +
+                    "The internal port check cannot be executed. " +
+                    "Consider using a more specific WaitStrategy. " +
+                    "Original error: {}",
+                    result.getStderr()
+                );
+            } else if (exitCode != 0 && exitCode != 1) {
                 log.warn("An exception while executing the internal check: {}", result);
             }
+
             return exitCode == 0;
         } catch (Exception e) {
             throw new IllegalStateException(e);


### PR DESCRIPTION
Some container images do not include /bin/sh (for example, scratch or distroless images).

In this case, InternalCommandPortListeningCheck fails with exit code 127, but the warning message does not clearly explain the reason.

This change adds a more specific warning message when /bin/sh is not available and includes the original error message to help users understand the problem more quickly.

Fixes #3317