### PR TITLE
Don't hijack the global uncaught exception handler during Docker probing

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -208,6 +208,7 @@ public abstract class DockerClientProviderStrategy {
         try (Socket socket = socketProvider.call()) {
             Awaitility
                 .await()
+                .dontCatchUncaughtExceptions() // avoid mutating the global uncaught exception handler, see #11483
                 .atMost(TestcontainersConfiguration.getInstance().getClientPingTimeout(), TimeUnit.SECONDS) // timeout after configured duration
                 .pollInterval(Duration.ofMillis(200)) // check state every 200ms
                 .pollDelay(Duration.ofSeconds(0)) // start checking immediately

--- a/core/src/test/java/org/testcontainers/dockerclient/AwaitilityUncaughtExceptionHandlerTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/AwaitilityUncaughtExceptionHandlerTest.java
@@ -1,0 +1,58 @@
+package org.testcontainers.dockerclient;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Regression test for <a href="https://github.com/testcontainers/testcontainers-java/issues/11483">#11483</a>.
+ *
+ * <p>{@code DockerClientProviderStrategy.test()} pings the Docker socket through an executor-backed
+ * {@code Awaitility.await()...untilAsserted(...)}. With Awaitility's default (uncaught-exception catching enabled),
+ * Awaitility installs its own {@link UncaughtExceptionHandler} as the JVM-global default handler for the duration of
+ * that await, hijacking the application's handler (see the stack trace in the issue). The probed condition runs on a
+ * single dedicated thread and never relies on exceptions surfacing from other threads, so the catching provides no
+ * value here and the strategy opts out via {@code dontCatchUncaughtExceptions()}.
+ */
+class AwaitilityUncaughtExceptionHandlerTest {
+
+    private static final UncaughtExceptionHandler SENTINEL = (thread, throwable) -> {};
+
+    @Test
+    void defaultExecutorPollingHijacksTheGlobalHandler() {
+        // Documents the broken behaviour: while the await runs, the global handler is no longer the application's one.
+        assertThat(handlerSeenWhilePolling(Awaitility.await())).isNotSameAs(SENTINEL);
+    }
+
+    @Test
+    void dontCatchUncaughtExceptionsKeepsTheGlobalHandler() {
+        // The fix applied in DockerClientProviderStrategy#test(): the application's handler stays in place throughout.
+        assertThat(handlerSeenWhilePolling(Awaitility.await().dontCatchUncaughtExceptions())).isSameAs(SENTINEL);
+    }
+
+    /**
+     * Installs {@link #SENTINEL} as the global default handler, then drives an executor-backed await exactly as
+     * {@code DockerClientProviderStrategy#test()} does, and returns the handler that was active <em>while</em> polling.
+     */
+    private static UncaughtExceptionHandler handlerSeenWhilePolling(org.awaitility.core.ConditionFactory factory) {
+        UncaughtExceptionHandler original = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler(SENTINEL);
+        AtomicReference<UncaughtExceptionHandler> observed = new AtomicReference<>();
+        try {
+            factory
+                .atMost(5, TimeUnit.SECONDS)
+                .pollInterval(Duration.ofMillis(10))
+                .pollDelay(Duration.ZERO)
+                .untilAsserted(() -> observed.set(Thread.getDefaultUncaughtExceptionHandler()));
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(original);
+        }
+        return observed.get();
+    }
+}


### PR DESCRIPTION
Fixes #11483

## Problem

`DockerClientProviderStrategy.test()` probes the Docker socket through an executor-backed `Awaitility.await()...untilAsserted(...)`. Awaitility's default has uncaught-exception catching **enabled**, and in that mode `ConditionAwaiter` installs its own `Thread.UncaughtExceptionHandler` as the **JVM-global** default handler for the duration of the await:

```java
// org.awaitility.core.ConditionAwaiter (4.3.0)
OriginalDefaultUncaughtExceptionHandler.set(Thread.getDefaultUncaughtExceptionHandler());
if (conditionSettings.shouldCatchUncaughtExceptions()) {
    Thread.setDefaultUncaughtExceptionHandler(this);
}
```

So while Testcontainers initializes, the application's global uncaught exception handler is replaced and exceptions can be intercepted by Awaitility instead of the application's handler — exactly the stack trace in #11483:

```
at java.lang.Thread.setDefaultUncaughtExceptionHandler(Thread.java:2496)
at org.testcontainers.shaded.org.awaitility.core.ConditionAwaiter.<init>(ConditionAwaiter.java:59)
...
at org.testcontainers.dockerclient.DockerClientProviderStrategy.test(DockerClientProviderStrategy.java:214)
```

## Fix

The probed condition (`socket.connect(...)`) runs on a single dedicated poll thread and never relies on exceptions surfacing from *other* threads, so Awaitility's uncaught-exception catching provides no value here. Opt out per-call with `dontCatchUncaughtExceptions()` so the application's global handler is left untouched.

This is scoped to the one affected call site. I verified that the other `Awaitility.await()` usages in core (`GenericContainer`, `HostPortWaitStrategy`, `RemoteDockerImage`) all use `pollInSameThread()`, and same-thread polling does **not** install the global handler — so they are unaffected (confirmed by the test below). A per-call opt-out is preferred over the global `Awaitility.doNotCatchUncaughtExceptionsByDefault()` switch, which would change Awaitility's behaviour for user code too.

## Test evidence

Added `AwaitilityUncaughtExceptionHandlerTest`, which drives the same executor-backed await `test()` uses and observes the active default handler *while polling*:

- `defaultExecutorPollingHijacksTheGlobalHandler` — documents the broken behaviour (handler is replaced).
- `dontCatchUncaughtExceptionsKeepsTheGlobalHandler` — with the fix the application handler stays in place.

Both pass; the first fails if `dontCatchUncaughtExceptions()` is removed.

## Verification done

1. No in-flight PR (searched open PRs for `UncaughtExceptionHandler`).
2. No assignee / no self-claim on the issue.
3. Code-only change + regression test.
4. Confirmed against current `main`: decompiled the shaded Awaitility 4.3.0 `ConditionAwaiter` to verify the handler install is gated on `shouldCatchUncaughtExceptions()`, and demonstrated via the test that executor polling installs it while same-thread polling does not.
5. `./gradlew :testcontainers:test --tests "...AwaitilityUncaughtExceptionHandlerTest"` and `:testcontainers:spotlessApply` pass.
