### PR TITLE
Add tests for MinimumDurationRunningStartupCheckStrategy

### DIFF
--- a/core/src/test/java/org/testcontainers/containers/startupcheck/MinimumDurationRunningStartupCheckStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/containers/startupcheck/MinimumDurationRunningStartupCheckStrategyTest.java
@@ -1,0 +1,39 @@
+package org.testcontainers.containers.startupcheck;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.TestImages;
+import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.GenericContainer;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class MinimumDurationRunningStartupCheckStrategyTest {
+
+    @Test
+    void shouldPassStartupCheckIfContainerExceedsMinimumRunningDuration() {
+        try (
+            GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand("sleep", "1")
+                .withMinimumRunningDuration(Duration.ofMillis(100))
+        ) {
+            assertThatNoException().isThrownBy(container::start);
+        }
+    }
+
+    @Test
+    void shouldFailStartupCheckIfContainerExitsPrematurely() {
+        try (
+            GenericContainer container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand("/bin/false")
+                .withMinimumRunningDuration(Duration.ofMillis(500))
+        ) {
+            assertThatThrownBy(container::start)
+                .isInstanceOf(ContainerLaunchException.class)
+                .hasStackTraceContaining("Container startup failed")
+                .hasStackTraceContaining("Container did not start correctly");
+        }
+    }
+}


### PR DESCRIPTION
Added tests for MinimumDurationRunningStartupCheckStrategy. Currently, it has 0% test coverage in the core module. 

Coverage comparison screenshots are below.

Before this PR:
<img width="2560" height="472" alt="before" src="https://github.com/user-attachments/assets/b2339eb0-cfa0-4e3f-bc57-60cd41401eea" />

After this PR:
<img width="2560" height="472" alt="after" src="https://github.com/user-attachments/assets/5f1f254e-8a77-4f42-8a57-2e18447a72aa" />

