### PR TITLE
Add Java automatic module names to published artifacts

### DIFF
--- a/gradle/publishing.gradle
+++ b/gradle/publishing.gradle
@@ -13,6 +13,19 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 
 jar.archiveClassifier.set("original")
 
+// Derive a JPMS automatic module name from the group id plus a trailing element
+// based on the artifact name (e.g. testcontainers-junit-jupiter -> org.testcontainers.junitjupiter).
+// The plain `jar` carries the attribute and `shadowJar` inherits it for the published artifact.
+def automaticModuleName = "org.testcontainers." + (
+    project.name == "testcontainers" ? "core" : project.name.replaceFirst(/^testcontainers-/, "")
+).replace("-", "")
+
+jar {
+    manifest {
+        attributes('Automatic-Module-Name': automaticModuleName)
+    }
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) { publication ->


### PR DESCRIPTION
## What

Adds a JPMS `Automatic-Module-Name` manifest attribute to every published artifact.

The name is derived from the group id (`org.testcontainers`) plus a single trailing element based on the artifact name, with hyphens collapsed:

| Artifact | `Automatic-Module-Name` |
|---|---|
| `testcontainers` (core) | `org.testcontainers.core` |
| `testcontainers-mysql` | `org.testcontainers.mysql` |
| `testcontainers-junit-jupiter` | `org.testcontainers.junitjupiter` |
| `testcontainers-oracle-free` | `org.testcontainers.oraclefree` |
| `testcontainers-database-commons` | `org.testcontainers.databasecommons` |

## Why

Giving consumers stable module names lets them `requires` Testcontainers from a `module-info.java` without depending on the unstable filename-derived automatic name.

## How

A single addition to `gradle/publishing.gradle`, which is already applied to exactly the set of published projects. The attribute is set on the `jar` manifest and inherited by the published `shadowJar`. This keeps the change minimal and leaves non-published artifacts (e.g. `test-support`, `jdbc-test`) untouched. Existing manifest attributes (such as core's `Implementation-Version`) are preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Published JAR files now include a stable automatic module name, improving compatibility with Java’s module system.
  - Shadowed JAR artifacts inherit the same module metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->