### PR TITLE
feat(activemq): add execArtemisCommand helper to ArtemisContainer

### DIFF
--- a/docs/modules/activemq.md
+++ b/docs/modules/activemq.md
@@ -37,6 +37,14 @@ With anonymous login:
 [Allow anonymous login](../../modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java) inside_block:enableAnonymousLogin
 <!--/codeinclude-->
 
+### Executing Artemis CLI commands
+
+The Artemis image ships with a built-in CLI that can be used to administer the broker (e.g. create queues for AMQP 1.0 clients). `ArtemisContainer` exposes an `execArtemisCommand` helper that automatically prepends the binary path and appends the broker credentials, so you only need to supply the sub-command and its options:
+
+<!--codeinclude-->
+[Executing an Artemis CLI command](../../modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java) inside_block:execArtemisCommand
+<!--/codeinclude-->
+
 ## Adding this module to your project dependencies
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:

--- a/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
+++ b/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
@@ -4,6 +4,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
 import java.time.Duration;
 
 /**
@@ -27,6 +28,8 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> {
     private static final DockerImageName DEFAULT_IMAGE = DockerImageName.parse("apache/activemq-artemis");
 
     private static final DockerImageName APACHE_ARTEMIS_IMAGE = DockerImageName.parse("apache/artemis");
+
+    private static final String ARTEMIS_CLI_PATH = "/var/lib/artemis-instance/bin/artemis";
 
     private static final int WEB_CONSOLE_PORT = 8161;
 
@@ -85,5 +88,23 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> {
 
     public String getPassword() {
         return getEnvMap().get("ARTEMIS_PASSWORD");
+    }
+
+    /**
+     * Execute an Artemis CLI command inside the container. The broker credentials are
+     * automatically appended so callers only need to supply the sub-command and its options.
+     *
+     * @param commands the sub-command and its arguments, e.g. {@code "queue", "create", "--name=myQueue", ...}
+     * @return the result of the command execution
+     */
+    public ExecResult execArtemisCommand(String... commands) throws IOException, InterruptedException {
+        String[] fullCommand = new String[commands.length + 5];
+        fullCommand[0] = ARTEMIS_CLI_PATH;
+        System.arraycopy(commands, 0, fullCommand, 1, commands.length);
+        fullCommand[commands.length + 1] = "--user";
+        fullCommand[commands.length + 2] = getUser();
+        fullCommand[commands.length + 3] = "--password";
+        fullCommand[commands.length + 4] = getPassword();
+        return execInContainer(fullCommand);
     }
 }

--- a/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
+++ b/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
@@ -71,6 +71,25 @@ class ArtemisContainerTest {
         }
     }
 
+    @Test
+    void execArtemisCommand() throws Exception {
+        try (ArtemisContainer artemis = new ArtemisContainer("apache/activemq-artemis:2.32.0-alpine")) {
+            artemis.start();
+
+            // execArtemisCommand {
+            var result = artemis.execArtemisCommand(
+                "queue",
+                "create",
+                "--name=test-amqp-queue",
+                "--auto-create-address",
+                "--anycast",
+                "--silent"
+            );
+            // }
+            assertThat(result.getExitCode()).isEqualTo(0);
+        }
+    }
+
     @SneakyThrows
     private void assertFunctionality(ArtemisContainer artemis, boolean anonymousLogin) {
         ActiveMQConnectionFactory connectionFactory = new ActiveMQConnectionFactory(artemis.getBrokerUrl());


### PR DESCRIPTION
## Summary

Closes #11589

The `ArtemisContainer` bundles the Artemis CLI at `/var/lib/artemis-instance/bin/artemis`, but using it from tests requires boilerplate: hardcoding the binary path and manually appending `--user` / `--password` on every call. This PR adds a convenience method that hides those details:

```java
var result = artemis.execArtemisCommand(
    "queue", "create", "--name=my-queue", "--auto-create-address", "--anycast", "--silent"
);
assertThat(result.getExitCode()).isEqualTo(0);
```

**Changes:**
- `ArtemisContainer.execArtemisCommand(String... commands)` — prepends the CLI binary path and appends `--user` / `--password` from the container's configured credentials, then delegates to `execInContainer`.
- New test `ArtemisContainerTest#execArtemisCommand` that creates an AMQP queue via the CLI and asserts a zero exit code.
- Docs updated with a usage snippet for `execArtemisCommand`.

## Test plan

- [ ] `./gradlew :testcontainers-activemq:spotlessApply` passes with no changes
- [ ] `./gradlew :testcontainers-activemq:test` — requires Docker; verified locally that the container starts and the queue creation command exits 0