### PR TITLE
Fix broken double-checked locking in the R2DBC connection factory

### DIFF
--- a/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/TestcontainersR2DBCConnectionFactory.java
+++ b/modules/r2dbc/src/main/java/org/testcontainers/r2dbc/TestcontainersR2DBCConnectionFactory.java
@@ -31,7 +31,7 @@ class TestcontainersR2DBCConnectionFactory implements ConnectionFactory, Closeab
 
     private final R2DBCDatabaseContainerProvider containerProvider;
 
-    private CompletableFuture<R2DBCDatabaseContainer> future;
+    private volatile CompletableFuture<R2DBCDatabaseContainer> future;
 
     TestcontainersR2DBCConnectionFactory(ConnectionFactoryOptions options) {
         this.options = options;
@@ -47,10 +47,12 @@ class TestcontainersR2DBCConnectionFactory implements ConnectionFactory, Closeab
     @Override
     public Publisher<? extends Connection> create() {
         return new ConnectionPublisher(() -> {
-            if (future == null) {
+            CompletableFuture<R2DBCDatabaseContainer> futureRef = future;
+            if (futureRef == null) {
                 synchronized (this) {
-                    if (future == null) {
-                        future =
+                    futureRef = future;
+                    if (futureRef == null) {
+                        futureRef =
                             CompletableFuture.supplyAsync(
                                 () -> {
                                     R2DBCDatabaseContainer container = containerProvider.createContainer(options);
@@ -59,12 +61,11 @@ class TestcontainersR2DBCConnectionFactory implements ConnectionFactory, Closeab
                                 },
                                 EXECUTOR
                             );
+                        future = futureRef;
                     }
                 }
             }
-            return future.thenApply(it -> {
-                return ConnectionFactories.find(it.configure(options));
-            });
+            return futureRef.thenApply(it -> ConnectionFactories.find(it.configure(options)));
         });
     }
 


### PR DESCRIPTION
This PR fixes a thread-safety issue in TestcontainersR2DBCConnectionFactory caused by the incorrectly implemented double-checked locking.

According to Java's memory model, a concurrently used variable without a `volatile` keyword lacks happens-before semantics, so this can lead to visibility and/or instruction reordering issues, such as seeing stale values or intermittent exceptions. By adding `volatile` before `CompletableFuture<R2DBCDatabaseContainer> future` we ensure that it is visible to other threads immediately after its modification.

Additionally, the `futureRef` trick reduces volatile read overhead as described in Joshua Bloch's "Effective Java" (see [this](https://www.oracle.com/technical-resources/articles/javase/bloch-effective-08-qa.html#:~:text=fast%2E-,If,model%2E) Oracle article for details), thereby increasing overall performance.