### PR TITLE
Fix NullPointerException on concurrent GenericContainer.stop() calls

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -635,6 +635,11 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
      */
     @Override
     public void stop() {
+        // Read the mutable state once: a concurrent or reentrant stop() call nulls the
+        // fields in its finally block, and a second read would pass a null containerId
+        // to the ResourceReaper (see GH-11492).
+        String containerId = this.containerId;
+        InspectContainerResponse containerInfo = this.containerInfo;
         if (containerId == null) {
             return;
         }
@@ -652,8 +657,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             ResourceReaper.instance().stopAndRemoveContainer(containerId, imageName);
             containerIsStopped(containerInfo);
         } finally {
-            containerId = null;
-            containerInfo = null;
+            this.containerId = null;
+            this.containerInfo = null;
         }
     }
 

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -37,7 +37,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -295,6 +300,50 @@ class GenericContainerTest {
         assertThat(reportLeakedContainers()).isEmpty();
     }
 
+    /**
+     * Test case for: https://github.com/testcontainers/testcontainers-java/issues/11492
+     */
+    @Test
+    void concurrentStopShouldNotPassNullContainerIdToResourceReaper() throws Exception {
+        try (LatchedStopContainer container = new LatchedStopContainer(TestImages.TINY_IMAGE)) {
+            container.withCommand("tail", "-f", "/dev/null");
+            container.start();
+
+            ExecutorService executor = Executors.newSingleThreadExecutor();
+            try {
+                Future<?> blockedStop = executor.submit(container::stop);
+                assertThat(container.stopping.await(10, TimeUnit.SECONDS)).isTrue();
+
+                // completes fully and nulls the container state while the first call is
+                // still inside containerIsStopping
+                container.stop();
+                container.proceed.countDown();
+
+                // throws NullPointerException without the containerId snapshot in stop()
+                blockedStop.get(30, TimeUnit.SECONDS);
+            } finally {
+                executor.shutdownNow();
+            }
+            assertThat(container.isRunning()).isFalse();
+        }
+    }
+
+    /**
+     * Test case for: https://github.com/testcontainers/testcontainers-java/issues/11492
+     */
+    @Test
+    void reentrantStopFromContainerIsStoppingHookShouldNotThrow() {
+        try (ReentrantStopContainer container = new ReentrantStopContainer(TestImages.TINY_IMAGE)) {
+            container.withCommand("tail", "-f", "/dev/null");
+            container.start();
+
+            // throws NullPointerException without the containerId snapshot in stop()
+            container.stop();
+
+            assertThat(container.isRunning()).isFalse();
+        }
+    }
+
     private static Optional<String> reportLeakedContainers() {
         @SuppressWarnings("resource") // Throws when close is attempted, as this is a global instance.
         DockerClient dockerClient = DockerClientFactory.lazyClient();
@@ -334,6 +383,45 @@ class GenericContainerTest {
                     .collect(Collectors.joining(", ", "[", "]"))
             )
         );
+    }
+
+    static class LatchedStopContainer extends GenericContainer<LatchedStopContainer> {
+
+        final CountDownLatch stopping = new CountDownLatch(1);
+
+        final CountDownLatch proceed = new CountDownLatch(1);
+
+        private final AtomicBoolean firstStop = new AtomicBoolean(true);
+
+        LatchedStopContainer(DockerImageName image) {
+            super(image);
+        }
+
+        @Override
+        @SneakyThrows
+        protected void containerIsStopping(InspectContainerResponse containerInfo) {
+            if (this.firstStop.getAndSet(false)) {
+                this.stopping.countDown();
+                this.proceed.await(10, TimeUnit.SECONDS);
+            }
+        }
+    }
+
+    static class ReentrantStopContainer extends GenericContainer<ReentrantStopContainer> {
+
+        private final AtomicBoolean reentered = new AtomicBoolean(false);
+
+        ReentrantStopContainer(DockerImageName image) {
+            super(image);
+        }
+
+        @Override
+        protected void containerIsStopping(InspectContainerResponse containerInfo) {
+            if (this.reentered.compareAndSet(false, true)) {
+                // simulates a hook implementation that triggers another stop of the same container
+                stop();
+            }
+        }
     }
 
     static class NoopStartupCheckStrategy extends StartupCheckStrategy {


### PR DESCRIPTION
Fixes #11492

stop() reads the mutable containerId field twice: in the null guard and again when calling ResourceReaper.stopAndRemoveContainer(). The only null write is stop()'s own finally block, so a concurrent stop() that completes between the two reads (the Trino CI case: cleanup racing after a failed startup), or a containerIsStopping() hook that reenters stop(), makes the second read pass null to the reaper and crash with the reported NullPointerException in ConcurrentHashMap.remove(). The fix reads the container state into locals once, so null can never reach the reaper from stop().

This is deliberately fixed at the caller rather than with a null guard inside ResourceReaper.stopAndRemoveContainer() (suggested earlier in the issue): the reaper methods are deprecated public API with a non-null contract, and a guard there would hide caller bugs instead of fixing this one. The duplicate removal attempt by the losing thread is already tolerated - removeContainer() swallows NotFoundException. stop() intentionally stays non-atomic: exactly-once semantics would require holding a lock across Docker calls and user hooks, and the duplicate path is benign.

Both race variants have deterministic tests: a latch-based concurrent test and a reentrant-hook test. Both fail on main with the exact NPE from the issue and pass with the fix; full GenericContainerTest is green; spotless applied.