### PR TITLE
Use fixed locale when deriving environment variable names from properties

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -231,7 +232,7 @@ public class TestcontainersConfiguration {
         @Nullable final String defaultValue,
         Properties... propertiesSources
     ) {
-        String envVarName = propertyName.replaceAll("\\.", "_").toUpperCase();
+        String envVarName = propertyName.replaceAll("\\.", "_").toUpperCase(Locale.ROOT);
         if (!envVarName.startsWith("TESTCONTAINERS_") && !envVarName.startsWith("DOCKER_")) {
             envVarName = "TESTCONTAINERS_" + envVarName;
         }

--- a/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
+++ b/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
@@ -223,6 +224,24 @@ class TestcontainersConfigurationTest {
         assertThat(newConfig().getRyukImage())
             .as("trailing whitespace was not removed from image name property")
             .isEqualTo("testcontainers/ryuk:0.3.2");
+    }
+
+    @Test
+    void shouldReadEnvVarRegardlessOfDefaultLocale() {
+        // Property names such as "image.substitutor" contain the letter 'i', which
+        // upper-cases to a dotted capital 'İ' (U+0130) under the Turkish locale. The
+        // derived environment variable name must not depend on the JVM default locale,
+        // otherwise the lookup silently fails and the environment variable is ignored.
+        Locale previousDefault = Locale.getDefault();
+        try {
+            Locale.setDefault(new Locale("tr", "TR"));
+            environment.put("TESTCONTAINERS_IMAGE_SUBSTITUTOR", "com.example.MySubstitutor");
+            assertThat(newConfig().getImageSubstitutorClassName())
+                .as("environment variables are resolved independently of the default locale")
+                .isEqualTo("com.example.MySubstitutor");
+        } finally {
+            Locale.setDefault(previousDefault);
+        }
     }
 
     private TestcontainersConfiguration newConfig() {


### PR DESCRIPTION
### Describe the broken behaviour

`TestcontainersConfiguration#getConfigurable` maps a configuration property
name to the corresponding environment variable name by upper-casing it:

```java
String envVarName = propertyName.replaceAll("\\.", "_").toUpperCase();
```

`String#toUpperCase()` uses the JVM default locale. Several property names
contain the letter `i` (`docker.client.strategy`, `image.substitutor`,
`client.ping.timeout`, `testcontainers.reuse.enable`, ...). Under a locale
with different case-mapping rules — most notably the Turkish locale, where
`i` upper-cases to the dotted capital `İ` (U+0130) — the derived name becomes
e.g. `TESTCONTAINERS_İMAGE_SUBSTİTUTOR` instead of
`TESTCONTAINERS_IMAGE_SUBSTITUTOR`. It no longer matches the ASCII environment
variable that is actually set in the process, so the variable is **silently
ignored** and Testcontainers falls back to the property/default value.

This reproduces on any JVM whose default locale has non-ASCII case mapping for
`i` (e.g. started with `-Duser.language=tr`, or on a machine with a Turkish or
Azerbaijani system locale). The failure is silent — no error is logged, the
environment variable simply has no effect — which makes it easy to miss.

### How the change fixes it

Derive the environment variable name with `Locale.ROOT`, so the case
conversion is independent of the JVM default locale.

The change is intentionally scoped to this single configuration entry point.
Other locale-less `toUpperCase()`/`toLowerCase()` call sites exist elsewhere in
the codebase, but they are left out to keep this fix atomic and easy to review.

### Test

Added `TestcontainersConfigurationTest#shouldReadEnvVarRegardlessOfDefaultLocale`,
which sets the default locale to Turkish and verifies that an environment
variable is still resolved. It fails before the change and passes after it;
the default locale is restored in a `finally` block.
