### PR TITLE
Jackson upgrade to 2.18.9

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,8 +56,8 @@ tasks.japicmp {
 
 configurations.all {
     resolutionStrategy {
-        force 'com.fasterxml.jackson.core:jackson-databind:2.18.4'
-        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.4'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.18.8'
+        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.8'
     }
 }
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,8 +56,8 @@ tasks.japicmp {
 
 configurations.all {
     resolutionStrategy {
-        force 'com.fasterxml.jackson.core:jackson-databind:2.18.8'
-        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.8'
+        force 'com.fasterxml.jackson.core:jackson-databind:2.18.9'
+        force 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18.9'
     }
 }
 

--- a/core/src/jarFileTest/java/org/testcontainers/JarFileShadingTest.java
+++ b/core/src/jarFileTest/java/org/testcontainers/JarFileShadingTest.java
@@ -26,8 +26,8 @@ class JarFileShadingTest extends AbstractJarFileTest {
                 "services",
                 "versions",
                 "native-image",
-                "thirdparty-LICENSE",
-                "FastDoubleParser-NOTICE",
+                "Schubfach-LICENSE",
+                "FastDoubleParser-ThirdParty-LICENSE",
                 "FastDoubleParser-LICENSE"
             );
     }

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(":testcontainers")
 
     // Synchronize with the jackson version, must match major and minor version
-    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.4'
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.8'
 
     testImplementation 'io.fabric8:kubernetes-client:7.6.1'
     testImplementation 'io.kubernetes:client-java:25.0.0-legacy'

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(":testcontainers")
 
     // Synchronize with the jackson version, must match major and minor version
-    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.8'
+    shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.9'
 
     testImplementation 'io.fabric8:kubernetes-client:7.6.1'
     testImplementation 'io.kubernetes:client-java:25.0.0-legacy'


### PR DESCRIPTION
jackson-databind 2.18.4 has 2 high-scored vulnerabilities: https://www.cve.org/CVERecord?id=CVE-2026-54512
https://www.cve.org/CVERecord?id=CVE-2026-54513

Due to shadowing of jackson-databind in testcontainers, some scanners (Sonatype Firewall in my case) flags testcontainers as having the same vulnerabilities and blocks its usage.

In version 2.18.8 these vulnerabilities have been fixed, so upgrading to that version will also remove these vulnerabilities from testcontainers.

This fixes #11912

I'm aware of the following paragraph:

> Dependency Upgrades:
> Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

But this dependency doesn't seem to be upgraded automatically. It hasn't been updated for ~6 months. 