### PR TITLE
Auto-label containers with test class and field in @Testcontainers extension

### DIFF
--- a/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
+++ b/modules/junit-jupiter/src/main/java/org/testcontainers/junit/jupiter/TestcontainersExtension.java
@@ -41,6 +41,10 @@ public class TestcontainersExtension
 
     private static final String LOCAL_LIFECYCLE_AWARE_CONTAINERS = "localLifecycleAwareContainers";
 
+    private static final String TEST_CLASS_LABEL = "testcontainers/test-class";
+
+    private static final String TEST_FIELD_LABEL = "testcontainers/test-field";
+
     private final DockerAvailableDetector dockerDetector = new DockerAvailableDetector();
 
     @Override
@@ -267,12 +271,24 @@ public class TestcontainersExtension
 
         private Startable container;
 
+        private Class<?> declaringClass;
+
+        private String fieldName;
+
         private StoreAdapter(Class<?> declaringClass, String fieldName, Startable container) {
+            this.declaringClass = declaringClass;
+            this.fieldName = fieldName;
             this.key = declaringClass.getName() + "." + fieldName;
             this.container = container;
         }
 
         private StoreAdapter start() {
+            if (container instanceof org.testcontainers.containers.Container) {
+                ((org.testcontainers.containers.Container<?>) container)
+                    .withLabel(TEST_CLASS_LABEL, declaringClass.getName());
+                ((org.testcontainers.containers.Container<?>) container)
+                    .withLabel(TEST_FIELD_LABEL, fieldName);
+            }
             container.start();
             return this;
         }

--- a/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ContainerLabelingTest.java
+++ b/modules/junit-jupiter/src/test/java/org/testcontainers/junit/jupiter/ContainerLabelingTest.java
@@ -1,0 +1,34 @@
+package org.testcontainers.junit.jupiter;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ContainerLabelingTest {
+
+    private static final DockerImageName IMAGE = DockerImageName.parse("nginx:1.27-alpine");
+
+    @Testcontainers
+    static class LabeledContainerTest {
+
+        @Container
+        @SuppressWarnings("unused")
+        static GenericContainer<?> container = new GenericContainer<>(IMAGE)
+            .withExposedPorts(80)
+            .waitingFor(new HostPortWaitStrategy());
+
+        @Test
+        void shouldHaveTestClassLabel() {
+            Map<String, String> labels = container.getContainerInfo().getConfig().getLabels();
+            assertThat(labels)
+                .containsEntry("testcontainers/test-class",
+                    ContainerLabelingTest.class.getName() + "$LabeledContainerTest")
+                .containsEntry("testcontainers/test-field", "container");
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/testcontainers/testcontainers-java/discussions/11919

Before starting a container via `@Testcontainers`, the JUnit extension now sets two identifying labels on the container:
```
testcontainers/test-class  -> "com.example.MyPostgresTest"
testcontainers/test-field  -> "postgresContainer"
```

This lets users identify which container belongs to which test at a glance:

```
docker ps --filter label=testcontainers/test-class=com.example.MyPostgresTest
```
And trace CI failures back to the owning test from container metadata.

<!--
Thanks for contributing to Testcontainers. Before submitting a pull request, please
review our contributing guidelines at https://java.testcontainers.org/contributing/

Please also review the following notes before submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
