### PR TITLE
Don't replace the global uncaught exception handler during container startup

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HostPortWaitStrategy.java
@@ -82,6 +82,7 @@ public class HostPortWaitStrategy extends AbstractWaitStrategy {
                         Instant now = Instant.now();
                         Awaitility
                             .await()
+                            .dontCatchUncaughtExceptions() // don't replace the global uncaught exception handler, see #11483
                             .pollInSameThread()
                             .pollInterval(Duration.ofMillis(100))
                             .pollDelay(Duration.ZERO)

--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -208,6 +208,7 @@ public abstract class DockerClientProviderStrategy {
         try (Socket socket = socketProvider.call()) {
             Awaitility
                 .await()
+                .dontCatchUncaughtExceptions() // don't replace the global uncaught exception handler, see #11483
                 .atMost(TestcontainersConfiguration.getInstance().getClientPingTimeout(), TimeUnit.SECONDS) // timeout after configured duration
                 .pollInterval(Duration.ofMillis(200)) // check state every 200ms
                 .pollDelay(Duration.ofSeconds(0)) // start checking immediately

--- a/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
+++ b/core/src/main/java/org/testcontainers/images/RemoteDockerImage.java
@@ -102,6 +102,7 @@ public class RemoteDockerImage extends LazyFuture<String> {
 
             Awaitility
                 .await()
+                .dontCatchUncaughtExceptions() // don't replace the global uncaught exception handler, see #11483
                 .pollInSameThread()
                 .pollDelay(Duration.ZERO) // start checking immediately
                 .atMost(PULL_RETRY_TIME_LIMIT)

--- a/core/src/test/java/org/testcontainers/dockerclient/DockerClientProviderStrategyUncaughtExceptionHandlerTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/DockerClientProviderStrategyUncaughtExceptionHandlerTest.java
@@ -1,0 +1,72 @@
+package org.testcontainers.dockerclient;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.testcontainers.utility.MockTestcontainersConfigurationExtension;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.net.ServerSocket;
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockTestcontainersConfigurationExtension.class)
+class DockerClientProviderStrategyUncaughtExceptionHandlerTest {
+
+    @Test
+    void doesNotReplaceGlobalUncaughtExceptionHandler() throws Exception {
+        // Keep the strategy test window short, but long enough to observe.
+        Mockito.doReturn(1).when(TestcontainersConfiguration.getInstance()).getClientPingTimeout();
+
+        // A port where nothing is listening, so the strategy keeps polling until it times out.
+        int closedPort;
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            closedPort = serverSocket.getLocalPort();
+        }
+
+        DockerClientProviderStrategy strategy = new DockerClientProviderStrategy() {
+            @Override
+            public TransportConfig getTransportConfig() {
+                return TransportConfig.builder().dockerHost(URI.create("tcp://localhost:" + closedPort)).build();
+            }
+
+            @Override
+            public String getDescription() {
+                return "strategy pointing at a closed port";
+            }
+        };
+
+        Thread.UncaughtExceptionHandler original = Thread.getDefaultUncaughtExceptionHandler();
+        Thread.UncaughtExceptionHandler sentinel = (thread, throwable) -> {};
+        Thread.setDefaultUncaughtExceptionHandler(sentinel);
+
+        // Awaitility installs its own default uncaught exception handler for the duration of the await and
+        // restores the previous one afterwards, so the replacement is only observable while the await runs.
+        AtomicBoolean handlerReplaced = new AtomicBoolean(false);
+        AtomicBoolean stopWatching = new AtomicBoolean(false);
+        Thread watcher = new Thread(() -> {
+            while (!stopWatching.get()) {
+                if (Thread.getDefaultUncaughtExceptionHandler() != sentinel) {
+                    handlerReplaced.set(true);
+                    return;
+                }
+            }
+        });
+        watcher.setDaemon(true);
+
+        try {
+            watcher.start();
+            strategy.test();
+        } finally {
+            stopWatching.set(true);
+            watcher.join();
+            Thread.setDefaultUncaughtExceptionHandler(original);
+        }
+
+        assertThat(handlerReplaced)
+            .as("Testcontainers must not replace the global uncaught exception handler")
+            .isFalse();
+    }
+}


### PR DESCRIPTION
Fixes #11483

## Problem

Testcontainers uses (shaded) Awaitility in a few core paths that run on every container startup:

- `DockerClientProviderStrategy#test` – Docker client discovery
- `RemoteDockerImage` – image pull
- `HostPortWaitStrategy` – host-port wait

By default Awaitility installs a global default uncaught exception handler via `Thread.setDefaultUncaughtExceptionHandler(...)` for the duration of each `await()` and restores the previous one afterwards. So just starting a container *temporarily* replaces the caller's default handler, and during that window uncaught exceptions thrown by unrelated application threads are intercepted by Awaitility instead of reaching the application's handler.

The stack trace in the issue is exactly this path:

```
Thread.setDefaultUncaughtExceptionHandler
  ConditionAwaiter.<init>
  ...
  DockerClientProviderStrategy.test
  DockerClientProviderStrategy.getFirstValidStrategy
  DockerClientFactory.client
  GenericContainer.start
```

## Fix

Add `.dontCatchUncaughtExceptions()` to the three core `Awaitility.await()` chains, so Testcontainers no longer mutates this JVM-global state. The awaited conditions run in the awaiting / same thread (`pollInSameThread`), so there is no separate thread whose uncaught exceptions Awaitility would need to catch here.

## Verification

- Added a regression test (`DockerClientProviderStrategyUncaughtExceptionHandlerTest`) that installs a sentinel default handler, drives `DockerClientProviderStrategy#test` against a closed port, and asserts the global handler is never replaced. Because Awaitility restores the handler once the await finishes, the check has to observe *during* the await, so it uses a small watcher thread. The test fails on `main` and passes with this change.
- Also verified end-to-end against a real container (started with a delayed port listener so the wait strategy polls for a few seconds): the global handler is replaced during startup on `main`, and left untouched with this change.

---

This change was drafted with AI assistance (Claude); I reviewed and verified it end-to-end and can speak to every line.
