### PR TITLE
Fix false positive in DockerImageName.isCompatibleWith for library/-prefixed images

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -233,15 +233,13 @@ public final class DockerImageName {
      * @return whether this image has declared compatibility.
      */
     public boolean isCompatibleWith(DockerImageName other) {
-        // Make sure we always compare against a version of the image name containing the LIBRARY_PREFIX
-        String finalImageName;
-        if (this.repository.startsWith(LIBRARY_PREFIX)) {
-            finalImageName = this.repository;
-        } else {
-            finalImageName = LIBRARY_PREFIX + this.repository;
+        if (other.equals(this)) {
+            return true;
         }
-        DockerImageName imageWithLibraryPrefix = DockerImageName.parse(finalImageName);
-        if (other.equals(this) || imageWithLibraryPrefix.equals(this)) {
+
+        // 'library/foo' and 'foo' refer to the same official Docker Hub image, so compare both
+        // names normalized to include the LIBRARY_PREFIX.
+        if (withLibraryPrefix(other).equals(withLibraryPrefix(this))) {
             return true;
         }
 
@@ -250,6 +248,13 @@ public final class DockerImageName {
         }
 
         return this.compatibleSubstituteFor.isCompatibleWith(other);
+    }
+
+    private static DockerImageName withLibraryPrefix(DockerImageName image) {
+        if (!image.registry.isEmpty() || image.repository.startsWith(LIBRARY_PREFIX)) {
+            return image;
+        }
+        return image.withRepository(LIBRARY_PREFIX + image.repository);
     }
 
     /**

--- a/core/src/main/java/org/testcontainers/utility/DockerImageName.java
+++ b/core/src/main/java/org/testcontainers/utility/DockerImageName.java
@@ -254,6 +254,10 @@ public final class DockerImageName {
         if (!image.registry.isEmpty() || image.repository.startsWith(LIBRARY_PREFIX)) {
             return image;
         }
+        if (image.repository.indexOf('/') >= 0) {
+            // Not a Docker Hub official image; the library/ namespace only applies to single-segment names.
+            return image;
+        }
         return image.withRepository(LIBRARY_PREFIX + image.repository);
     }
 

--- a/core/src/test/java/org/testcontainers/utility/DockerImageNameCompatibilityTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DockerImageNameCompatibilityTest.java
@@ -98,6 +98,54 @@ class DockerImageNameCompatibilityTest {
     }
 
     @Test
+    void testLibraryPrefixedImageIsNotCompatibleWithDifferentImage() {
+        DockerImageName subject = DockerImageName.parse("library/foo:1.2.3");
+
+        assertThat(subject.isCompatibleWith(DockerImageName.parse("bar"))).as("library/foo:1.2.3 != bar").isFalse();
+        assertThat(subject.isCompatibleWith(DockerImageName.parse("repo/bar")))
+            .as("library/foo:1.2.3 != repo/bar")
+            .isFalse();
+        assertThat(subject.isCompatibleWith(DockerImageName.parse("library/bar")))
+            .as("library/foo:1.2.3 != library/bar")
+            .isFalse();
+    }
+
+    @Test
+    void testLibraryPrefixIsInterchangeable() {
+        assertThat(DockerImageName.parse("library/foo").isCompatibleWith(DockerImageName.parse("foo")))
+            .as("library/foo ~= foo")
+            .isTrue();
+        assertThat(DockerImageName.parse("foo").isCompatibleWith(DockerImageName.parse("library/foo")))
+            .as("foo ~= library/foo")
+            .isTrue();
+        assertThat(DockerImageName.parse("library/foo:1.2.3").isCompatibleWith(DockerImageName.parse("foo")))
+            .as("library/foo:1.2.3 ~= foo")
+            .isTrue();
+        assertThat(DockerImageName.parse("foo:1.2.3").isCompatibleWith(DockerImageName.parse("library/foo")))
+            .as("foo:1.2.3 ~= library/foo")
+            .isTrue();
+        assertThat(DockerImageName.parse("library/foo:1.2.3").isCompatibleWith(DockerImageName.parse("foo:1.2.3")))
+            .as("library/foo:1.2.3 ~= foo:1.2.3")
+            .isTrue();
+        assertThat(DockerImageName.parse("library/foo:1.2.3").isCompatibleWith(DockerImageName.parse("foo:4.5.6")))
+            .as("library/foo:1.2.3 != foo:4.5.6")
+            .isFalse();
+        assertThat(DockerImageName.parse("some.registry/foo").isCompatibleWith(DockerImageName.parse("library/foo")))
+            .as("some.registry/foo != library/foo")
+            .isFalse();
+    }
+
+    @Test
+    void testLibraryPrefixedImageWithClaimedCompatibility() {
+        DockerImageName subject = DockerImageName.parse("library/foo:1.2.3").asCompatibleSubstituteFor("bar");
+
+        assertThat(subject.isCompatibleWith(DockerImageName.parse("bar"))).as("library/foo:1.2.3(bar) ~= bar").isTrue();
+        assertThat(subject.isCompatibleWith(DockerImageName.parse("fizz")))
+            .as("library/foo:1.2.3(bar) != fizz")
+            .isFalse();
+    }
+
+    @Test
     void testAssertMethodRejectsIncompatible() {
         DockerImageName subject = DockerImageName.parse("foo");
         assertThatThrownBy(() -> subject.assertCompatibleWith(DockerImageName.parse("bar")))

--- a/core/src/test/java/org/testcontainers/utility/DockerImageNameCompatibilityTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DockerImageNameCompatibilityTest.java
@@ -136,6 +136,23 @@ class DockerImageNameCompatibilityTest {
     }
 
     @Test
+    void testLibraryPrefixOnlyAppliesToSingleSegmentNames() {
+        // 'library/' is the single-segment official-image namespace, so a multi-segment user namespace
+        // (e.g. 'foo/bar') must not be treated as interchangeable with a 'library/'-prefixed form.
+        assertThat(DockerImageName.parse("foo/bar").isCompatibleWith(DockerImageName.parse("library/foo/bar")))
+            .as("foo/bar != library/foo/bar")
+            .isFalse();
+        assertThat(
+            DockerImageName.parse("myuser/myimage:1").isCompatibleWith(DockerImageName.parse("library/myuser/myimage"))
+        )
+            .as("myuser/myimage:1 != library/myuser/myimage")
+            .isFalse();
+        assertThat(DockerImageName.parse("library/foo/bar").isCompatibleWith(DockerImageName.parse("foo/bar")))
+            .as("library/foo/bar != foo/bar")
+            .isFalse();
+    }
+
+    @Test
     void testLibraryPrefixedImageWithClaimedCompatibility() {
         DockerImageName subject = DockerImageName.parse("library/foo:1.2.3").asCompatibleSubstituteFor("bar");
 


### PR DESCRIPTION
## Broken behaviour

`DockerImageName.isCompatibleWith()` returns `true` for *any* image whose repository starts with `library/`, regardless of what it is compared against:

```java
DockerImageName.parse("library/mysql:8")
    .isCompatibleWith(DockerImageName.parse("postgres")); // true (!)
```

The library-prefix handling introduced in #6174 derives `imageWithLibraryPrefix` from `this` only and then compares it back against `this`:

```java
DockerImageName imageWithLibraryPrefix = DockerImageName.parse(finalImageName);
if (other.equals(this) || imageWithLibraryPrefix.equals(this)) {
```

`other` never takes part in that comparison, so for any registry-less `library/…` name the check degenerates to `parse(this.repository).equals(this)`, which is always true (`parse` drops the tag and `AnyVersion` equals everything). Since `assertCompatibleWith(...)` guards the constructors of essentially every module (~96 call sites), it silently accepts wrong images instead of failing fast with the `asCompatibleSubstituteFor` guidance. The existing test `testAssertMethodAcceptsCompatibleLibraryPrefix` kept passing for this same wrong reason.

## Fix

Normalize **both** sides to the `library/`-prefixed form before comparing, and only for names without a registry (Docker Hub official images):

- `library/foo:1.2.3 ~ bar` → `false` (was `true`)
- `library/foo ~ foo` → `true` (as before, now for the right reason)
- `foo ~ library/foo` → `true` (previously `false`; same image, now symmetric)
- Version semantics are unchanged: `other` stays on the left-hand side of `equals`, so a tag present in `other` must still match exactly and an untagged `other` still acts as a wildcard (`library/foo:1.2.3 ~ foo:4.5.6` → `false`).
- Names with an explicit registry are left untouched (`some.registry/foo` ≠ `library/foo`).

Images named `library/…` that previously passed the check only because of the false positive now fail with the standard compatibility error — that is the intended behaviour of the guard.

Related to #9958: the `library/postgres` case reported there is what #6174 targeted; the `docker.io/…` registry-qualified cases from that issue are out of scope for this PR.

## Testing

Added regression tests to `DockerImageNameCompatibilityTest` covering the false positive, prefix symmetry in both directions (with and without tags), registry exclusion, and `asCompatibleSubstituteFor` interaction. The new tests fail on `main` and pass with this change; all pre-existing tests pass, `checkstyle` and `spotless` are clean.
