### PR TITLE
Add MongoDB init script regression test

### DIFF
--- a/modules/mongodb/src/test/java/org/testcontainers/mongodb/MongoDBContainerTest.java
+++ b/modules/mongodb/src/test/java/org/testcontainers/mongodb/MongoDBContainerTest.java
@@ -1,6 +1,10 @@
 package org.testcontainers.mongodb;
 
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.MountableFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,6 +31,29 @@ class MongoDBContainerTest extends AbstractMongo {
     void supportsMongoDB_7_0() {
         try (MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:7.0")) {
             mongoDBContainer.start();
+        }
+    }
+
+    @Test
+    void shouldRunInitScript() {
+        try (
+            MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.0.10")
+                .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("mongo-init.js"),
+                    "/docker-entrypoint-initdb.d/mongo-init.js"
+                )
+        ) {
+            mongoDBContainer.start();
+
+            try (MongoClient mongoClient = MongoClients.create(mongoDBContainer.getConnectionString())) {
+                final Document document = mongoClient
+                    .getDatabase("init-script-db")
+                    .getCollection("messages")
+                    .find()
+                    .first();
+
+                assertThat(document).containsEntry("message", "init script ran");
+            }
         }
     }
 

--- a/modules/mongodb/src/test/resources/mongo-init.js
+++ b/modules/mongodb/src/test/resources/mongo-init.js
@@ -1,0 +1,2 @@
+db = db.getSiblingDB("init-script-db");
+db.messages.insertOne({ message: "init script ran" });


### PR DESCRIPTION
## Summary

Related to #3066.

This PR adds a regression test for MongoDB init script support in `MongoDBContainer`.

The new test verifies that a JavaScript init file copied into `/docker-entrypoint-initdb.d/mongo-init.js` is executed during MongoDB startup, and that the data inserted by the script is available after the container starts.

## Context

MongoDB Docker images support initialization scripts placed under `/docker-entrypoint-initdb.d/`. This is useful in tests where users want to create initial databases, collections, users, or seed data automatically when the container starts.

This PR adds test coverage for that behavior in `MongoDBContainer`, so future changes do not accidentally break init-script support.

## Changes

- Added `shouldRunInitScript()` to `MongoDBContainerTest`
- Added a small `mongo-init.js` test resource
- The test:
  - copies `mongo-init.js` into `/docker-entrypoint-initdb.d/mongo-init.js`
  - starts `MongoDBContainer`
  - connects to MongoDB after startup
  - verifies that the init script inserted the expected document
- No production code changes
- No dependency changes
- No new module added

## Verification

Ran:

```bash
./gradlew checkstyleMain checkstyleTest spotlessApply

./gradlew spotlessCheck

./gradlew :testcontainers-mongodb:test --tests "org.testcontainers.mongodb.MongoDBContainerTest.shouldRunInitScript"

