### PR TITLE
Add Javadocs to AuthConfigUtil

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/AuthConfigUtil.java
+++ b/core/src/main/java/org/testcontainers/utility/AuthConfigUtil.java
@@ -7,11 +7,30 @@ import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * TODO: Javadocs
+ * Utility methods for safely representing {@link AuthConfig} objects as strings.
+ * <p>
+ * This class masks sensitive authentication information such as passwords,
+ * authentication tokens, and registry tokens before including them in the
+ * returned string. It is intended for logging and debugging purposes where
+ * exposing secrets would be a security risk.
  */
 @UtilityClass
 public class AuthConfigUtil {
 
+    /**
+     * Returns a safe string representation of the given {@link AuthConfig}.
+     * <p>
+     * Sensitive fields including the password, authentication value, and
+     * registry token are replaced with an obfuscated placeholder, while
+     * non-sensitive fields such as the username, email, and registry address
+     * are included in the output. If the supplied configuration is
+     * {@code null}, the string {@code "null"} is returned.
+     *
+     * @param authConfig the authentication configuration to represent safely;
+     *                   may be {@code null}
+     * @return a string representation with sensitive values hidden, or
+     *         {@code "null"} if {@code authConfig} is {@code null}
+     */
     public static String toSafeString(AuthConfig authConfig) {
         if (authConfig == null) {
             return "null";
@@ -28,6 +47,17 @@ public class AuthConfigUtil {
             .toString();
     }
 
+    /**
+     * Returns an obfuscated representation of a potentially sensitive value.
+     * <p>
+     * If the value is {@code null} or empty, the string {@code "blank"} is
+     * returned. Otherwise, the actual value is concealed by returning
+     * {@code "hidden non-blank value"}.
+     *
+     * @param value the value to obfuscate
+     * @return {@code "blank"} if the value is null or empty; otherwise
+     *         {@code "hidden non-blank value"}
+     */
     @NotNull
     private static String obfuscated(String value) {
         return Strings.isNullOrEmpty(value) ? "blank" : "hidden non-blank value";


### PR DESCRIPTION
## What does this PR do?

Adds missing Javadoc to 'AuthConfigUtil' and its methods.

## Why?

'AuthConfigUtil' previously contained a 'TODO: Javadocs' placeholder. This change documents the purpose of the class, explains how sensitive authentication data is handled in 'toSafeString()', and describes the behavior of the 'obfuscated()' helper method.

## Changes

- Added class-level Javadoc describing the purpose of 'AuthConfigUtil'
- Added Javadoc for 'toSafeString()', including its handling of 'null' input
- Added Javadoc for the 'obfuscated()' helper method

This is a documentation-only change and does not modify runtime behavior.