### PR TITLE
Ignore JVM array descriptors when packaging HiveMQ extensions

### DIFF
--- a/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQExtension.java
+++ b/modules/hivemq/src/main/java/org/testcontainers/hivemq/HiveMQExtension.java
@@ -152,7 +152,7 @@ public class HiveMQExtension {
             for (final String subClassName : subClassNames) {
                 final String className = subClassName.replaceAll("/", ".");
 
-                if (!className.startsWith("[L")) {
+                if (!className.startsWith("[")) {
                     LOGGER.debug("Trying to package subclass '{}' into extension '{}'.", className, extensionId);
                     javaArchive.addClass(className);
                 } else {

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionSubclassIT.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/ContainerWithExtensionSubclassIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.event.Level;
 import org.testcontainers.hivemq.util.MyExtensionWithSubclasses;
+import org.testcontainers.hivemq.util.PrimitiveArrayClass;
 import org.testcontainers.hivemq.util.TestPublishModifiedUtil;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
@@ -21,6 +22,7 @@ class ContainerWithExtensionSubclassIT {
             .name("my-extension")
             .version("1.0")
             .mainClass(MyExtensionWithSubclasses.class)
+            .addAdditionalClass(PrimitiveArrayClass.class)
             .build();
 
         try (

--- a/modules/hivemq/src/test/java/org/testcontainers/hivemq/util/PrimitiveArrayClass.java
+++ b/modules/hivemq/src/test/java/org/testcontainers/hivemq/util/PrimitiveArrayClass.java
@@ -1,0 +1,12 @@
+package org.testcontainers.hivemq.util;
+
+/**
+ * Helper class that generates a primitive array descriptor ("[B")
+ * in the constant pool through a byte array cast.
+ */
+public class PrimitiveArrayClass {
+
+    public void castToByteArray(Object value) {
+        byte[] ignored = (byte[]) value;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #10074.

'HiveMQExtension' currently ignores only object array descriptors ('[L') when collecting classes from Javassist's constant pool.

However, 'ConstPool#getClassNames()' may also return primitive array descriptors such as '[B'. These are JVM descriptors rather than fully qualified class names, so passing them to 'JavaArchive.addClass(String)' results in a 'PatternSyntaxException'.

This change ignores all JVM array descriptors by checking for '[' instead of only '[L'.

## Changes

- Ignore all JVM array descriptors returned from the constant pool when packaging additional classes
- Add a regression test covering a primitive array descriptor ('[B')
- Add a helper test class that generates a primitive array descriptor in the constant pool

## Testing

- Reproduced the reported 'PatternSyntaxException' before the fix
- Verified that the regression test fails with the original implementation
- Verified that the regression test passes after the fix