### PR TITLE
Fix host UID/GID leakage in copyFileToContainer TAR entries

### DIFF
--- a/core/src/main/java/org/testcontainers/utility/MountableFile.java
+++ b/core/src/main/java/org/testcontainers/utility/MountableFile.java
@@ -353,6 +353,10 @@ public class MountableFile implements Transferable {
             }
 
             final TarArchiveEntry tarEntry = new TarArchiveEntry(sourceFile, tarEntryFilename.replaceAll("^/", ""));
+            tarEntry.setUserId(0);
+            tarEntry.setGroupId(0);
+            tarEntry.setUserName("root");
+            tarEntry.setGroupName("root");
 
             // TarArchiveEntry automatically sets the mode for file/directory, but we can update to ensure that the mode is set exactly (inc executable bits)
             tarEntry.setMode(getUnixFileMode(itemPath));

--- a/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
+++ b/core/src/test/java/org/testcontainers/utility/MountableFileTest.java
@@ -2,6 +2,7 @@ package org.testcontainers.utility;
 
 import lombok.Cleanup;
 import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.jetbrains.annotations.NotNull;
@@ -30,6 +31,27 @@ class MountableFileTest {
         final MountableFile mountableFile = MountableFile.forClasspathResource("mappable-resource/test-resource.txt");
 
         performChecks(mountableFile);
+    }
+
+    @Test
+    void tarEntriesShouldUseRootOwnership() throws Exception {
+        final Path file = createTempFile("ownership-test.txt");
+        final MountableFile mountableFile = MountableFile.forHostPath(file);
+
+        @Cleanup
+        final TarArchiveInputStream tais = intoTarArchive(taos -> {
+            mountableFile.transferTo(taos, "/ownership-test.txt");
+        });
+
+        final TarArchiveEntry tarEntry = tais.getNextEntry();
+
+        assertThat(tarEntry).isNotNull();
+
+        System.out.println("UID = " + tarEntry.getLongUserId());
+        System.out.println("GID = " + tarEntry.getLongGroupId());
+
+        assertThat(tarEntry.getLongUserId()).isZero();
+        assertThat(tarEntry.getLongGroupId()).isZero();
     }
 
     @Test


### PR DESCRIPTION
Fixes #11487

When copyFileToContainer copies a MountableFile,
TAR entries may carry host UID/GID values into
the container.

On rootless Docker setups these IDs may be
unmapped, causing permission and ownership issues.

This change normalizes TAR entry ownership to
uid=0 and gid=0 and adds a regression test.