### PR TITLE
Do not pull the tiny image for gateway detection when checks are disabled

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientConfigUtils.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientConfigUtils.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.DockerClientFactory;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.File;
 import java.net.URI;
@@ -17,32 +18,45 @@ public class DockerClientConfigUtils {
     public static final boolean IN_A_CONTAINER = new File("/.dockerenv").exists();
 
     @Getter(lazy = true)
-    private static final Optional<String> defaultGateway = Optional
-        .ofNullable(
-            DockerClientFactory
-                .instance()
-                .runInsideDocker(
-                    cmd -> cmd.withCmd("sh", "-c", "ip route|awk '/default/ { print $3 }'"),
-                    (client, id) -> {
-                        try {
-                            LogToStringContainerCallback loggingCallback = new LogToStringContainerCallback();
-                            client
-                                .logContainerCmd(id)
-                                .withStdOut(true)
-                                .withFollowStream(true)
-                                .exec(loggingCallback)
-                                .awaitStarted();
-                            loggingCallback.awaitCompletion(3, TimeUnit.SECONDS);
-                            return loggingCallback.toString();
-                        } catch (Exception e) {
-                            log.warn("Can't parse the default gateway IP", e);
-                            return null;
-                        }
-                    }
+    private static final Optional<String> defaultGateway = resolveDefaultGateway();
+
+    static Optional<String> resolveDefaultGateway() {
+        if (TestcontainersConfiguration.getInstance().isDisableChecks()) {
+            log.debug("Checks are disabled, skipping default gateway detection");
+            return Optional.empty();
+        }
+        try {
+            return Optional
+                .ofNullable(
+                    DockerClientFactory
+                        .instance()
+                        .runInsideDocker(
+                            cmd -> cmd.withCmd("sh", "-c", "ip route|awk '/default/ { print $3 }'"),
+                            (client, id) -> {
+                                try {
+                                    LogToStringContainerCallback loggingCallback = new LogToStringContainerCallback();
+                                    client
+                                        .logContainerCmd(id)
+                                        .withStdOut(true)
+                                        .withFollowStream(true)
+                                        .exec(loggingCallback)
+                                        .awaitStarted();
+                                    loggingCallback.awaitCompletion(3, TimeUnit.SECONDS);
+                                    return loggingCallback.toString();
+                                } catch (Exception e) {
+                                    log.warn("Can't parse the default gateway IP", e);
+                                    return null;
+                                }
+                            }
+                        )
                 )
-        )
-        .map(StringUtils::trimToEmpty)
-        .filter(StringUtils::isNotBlank);
+                .map(StringUtils::trimToEmpty)
+                .filter(StringUtils::isNotBlank);
+        } catch (Exception e) {
+            log.warn("Can't detect the default gateway", e);
+            return Optional.empty();
+        }
+    }
 
     /**
      * @deprecated use {@link DockerClientProviderStrategy#getDockerHostIpAddress()}

--- a/core/src/test/java/org/testcontainers/dockerclient/DockerClientConfigUtilsTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/DockerClientConfigUtilsTest.java
@@ -4,12 +4,17 @@ import com.github.dockerjava.api.DockerClient;
 import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 import org.testcontainers.DockerClientFactory;
+import org.testcontainers.utility.MockTestcontainersConfigurationExtension;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ExtendWith(MockTestcontainersConfigurationExtension.class)
 class DockerClientConfigUtilsTest {
 
     DockerClient client = DockerClientFactory.lazyClient();
@@ -60,5 +65,13 @@ class DockerClientConfigUtilsTest {
     @Timeout(5)
     void getDefaultGateway() {
         assertThat(DockerClientConfigUtils.getDefaultGateway()).isNotNull();
+    }
+
+    @Test
+    @Timeout(5)
+    void resolveDefaultGatewayShouldNotRunContainerWhenChecksAreDisabled() {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).isDisableChecks();
+
+        assertThat(DockerClientConfigUtils.resolveDefaultGateway()).isEmpty();
     }
 }


### PR DESCRIPTION
Fixes #11241

## What broke

With `TESTCONTAINERS_CHECKS_DISABLE=true`, the tiny image (`alpine:3.17`) is still pulled in some environments, even though [the docs](https://java.testcontainers.org/features/configuration/#customizing-images) state the tiny image is "always required (unless startup checks are disabled)".

The unguarded path is default gateway detection. When the tests themselves run inside a container (`IN_A_CONTAINER`, e.g. a containerized Jenkins agent) and inspecting the `bridge` network yields no gateway, `DockerClientProviderStrategy.resolveDockerHostIpAddress` falls back to `DockerClientConfigUtils.getDefaultGateway()`, which runs `ip route` inside a tiny-image container — pulling `alpine:3.17` regardless of `checks.disable`.

This matches the log in #11241 exactly: `runInsideDocker` first touches `ResourceReaper.instance()` (printing the "Ryuk has been disabled" warning) and then pulls the image, which is the reported warning → pull sequence. In the reporter's CI the registry cannot serve `alpine:3.17`, so the pull fails — and because that failure propagates out of the lazy initializer, host IP resolution (and the whole test run) crashes.

## The fix

In `DockerClientConfigUtils`:

1. Skip container-based gateway detection when `checks.disable=true`, falling back to `localhost` (users who need a specific address in such setups can still set `TESTCONTAINERS_HOST_OVERRIDE`). This honors the documented contract that the tiny image is not required when checks are disabled.
2. Catch failures of the detection container itself (e.g. the image pull failing against a restricted registry) and fall back gracefully instead of crashing host IP resolution.

Added a unit test asserting that gateway detection does not touch Docker when checks are disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
