### PR TITLE
Do not treat multi-stage build stage references as images to pull in ParsedDockerfile

### DIFF
--- a/core/src/main/java/org/testcontainers/images/ParsedDockerfile.java
+++ b/core/src/main/java/org/testcontainers/images/ParsedDockerfile.java
@@ -9,11 +9,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Representation of a Dockerfile, with partial parsing for extraction of a minimal set of data.
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
 public class ParsedDockerfile {
 
     private static final Pattern FROM_LINE_PATTERN = Pattern.compile(
-        "FROM (?<arg>--[^\\s]+\\s)*(?<image>[^\\s]+).*",
+        "FROM (?<arg>--[^\\s]+\\s)*(?<image>[^\\s]+)(\\s+AS\\s+(?<stage>[^\\s]+))?.*",
         Pattern.CASE_INSENSITIVE
     );
 
@@ -57,12 +58,25 @@ public class ParsedDockerfile {
     }
 
     private Set<String> parse(List<String> lines) {
-        Set<String> imageNames = lines
-            .stream()
-            .map(FROM_LINE_PATTERN::matcher)
-            .filter(Matcher::matches)
-            .map(matcher -> matcher.group("image"))
-            .collect(Collectors.toSet());
+        Set<String> imageNames = new HashSet<>();
+        Set<String> buildStageNames = new HashSet<>();
+
+        for (String line : lines) {
+            Matcher matcher = FROM_LINE_PATTERN.matcher(line);
+            if (!matcher.matches()) {
+                continue;
+            }
+            // A FROM referring to a previously declared build stage (e.g. `FROM builder`) is an internal
+            // stage reference, not an external image to be pulled. Build stage names are case-insensitive.
+            String image = matcher.group("image");
+            if (!buildStageNames.contains(image.toLowerCase(Locale.ROOT))) {
+                imageNames.add(image);
+            }
+            String stage = matcher.group("stage");
+            if (stage != null) {
+                buildStageNames.add(stage.toLowerCase(Locale.ROOT));
+            }
+        }
 
         if (!imageNames.isEmpty()) {
             log.debug("Found dependency images in Dockerfile {}: {}", dockerFilePath, imageNames);

--- a/core/src/test/java/org/testcontainers/images/ParsedDockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/images/ParsedDockerfileTest.java
@@ -91,6 +91,53 @@ class ParsedDockerfileTest {
     }
 
     @Test
+    void doesNotTreatBuildStageReferencesAsDependencyImages() {
+        final ParsedDockerfile parsedDockerfile = new ParsedDockerfile(
+            Arrays.asList("FROM alpine:3.17 AS build", "RUN something", "FROM build", "RUN somethingelse")
+        );
+        assertThat(parsedDockerfile.getDependencyImageNames())
+            .as("does not treat references to a previously declared build stage as images to pull")
+            .isEqualTo(Sets.newHashSet("alpine:3.17"));
+    }
+
+    @Test
+    void extractsOnlyExternalImagesFromMultiStageDockerfile() {
+        final ParsedDockerfile parsedDockerfile = new ParsedDockerfile(
+            Arrays.asList(
+                "FROM maven:3.9-eclipse-temurin-17 AS build",
+                "COPY . /workspace",
+                "RUN mvn -f /workspace package",
+                "FROM eclipse-temurin:17-jre",
+                "COPY --from=build /workspace/target/app.jar /app.jar",
+                "CMD [\"java\", \"-jar\", \"/app.jar\"]"
+            )
+        );
+        assertThat(parsedDockerfile.getDependencyImageNames())
+            .as("extracts only external images from a multi-stage Dockerfile")
+            .isEqualTo(Sets.newHashSet("maven:3.9-eclipse-temurin-17", "eclipse-temurin:17-jre"));
+    }
+
+    @Test
+    void matchesBuildStageNamesCaseInsensitively() {
+        final ParsedDockerfile parsedDockerfile = new ParsedDockerfile(
+            Arrays.asList("FROM someimage As Build", "RUN something", "FROM BUILD", "RUN somethingelse")
+        );
+        assertThat(parsedDockerfile.getDependencyImageNames())
+            .as("matches build stage names case-insensitively, as Docker does")
+            .isEqualTo(Sets.newHashSet("someimage"));
+    }
+
+    @Test
+    void retainsImagesOfUnreferencedBuildStages() {
+        final ParsedDockerfile parsedDockerfile = new ParsedDockerfile(
+            Arrays.asList("FROM someimage AS unusedstage", "RUN something", "FROM nextimage", "RUN somethingelse")
+        );
+        assertThat(parsedDockerfile.getDependencyImageNames())
+            .as("still extracts images of stages whose alias is never referenced")
+            .isEqualTo(Sets.newHashSet("someimage", "nextimage"));
+    }
+
+    @Test
     void handlesGracefullyIfNoFromLine() {
         final ParsedDockerfile parsedDockerfile = new ParsedDockerfile(
             Arrays.asList("RUN something", "# is this even a valid Dockerfile?")


### PR DESCRIPTION
## What

`ParsedDockerfile` treats every `FROM` line's first non-flag token as an external image to pre-pull. In a multi-stage Dockerfile, a `FROM` referencing a previously declared build stage is an internal reference, not an external image:

```dockerfile
FROM alpine:3.17 AS build
RUN ...
FROM build
```

Before this change, `getDependencyImageNames()` returned `{alpine:3.17, build}`, and Testcontainers attempted to pull an image named `build` from the registry.

## Impact of the broken behaviour

- A pointless registry roundtrip per stage reference, which also counts against Docker Hub pull rate limits, and a confusing `WARN`/retry in the logs when the phantom image does not exist.
- If the stage alias happens to collide with a real image name on Docker Hub (e.g. `build`, `test`, `base`), an unrelated image is actually pulled.

The build itself succeeded despite this, so this is about spurious network traffic and log noise rather than failures.

## How it is fixed

- The `FROM` line pattern now also captures an optional `AS <stage>` alias (case-insensitively, matching Docker's semantics).
- `parse()` collects declared stage names and skips `FROM` images that reference a previously declared stage. Ordering follows Docker semantics: an alias only shadows an image name after the stage is declared.

Existing behaviour is preserved: `--platform`/other flags (#2772), tags, digests, trailing content after the image, and stages whose alias is never referenced are all still handled as before; `COPY --from=<stage>` lines were never matched and still are not.

## Tests

Added unit tests covering: a stage referenced by a later `FROM` (fails without the fix with `expected: ["alpine:3.17"] but was: ["build", "alpine:3.17"]`), a typical maven/eclipse-temurin multi-stage file, case-insensitive stage name matching, and unreferenced stage aliases.
