### PR TITLE
Enforce verbatim response fetching in HttpWaitStrategy (#7326)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
+++ b/core/src/main/java/org/testcontainers/containers/wait/strategy/HttpWaitStrategy.java
@@ -3,17 +3,18 @@ package org.testcontainers.containers.wait.strategy;
 import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.rnorth.ducttape.TimeoutException;
 import org.testcontainers.containers.ContainerLaunchException;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -406,18 +407,10 @@ public class HttpWaitStrategy extends AbstractWaitStrategy {
     }
 
     private String getResponseBody(HttpURLConnection connection) throws IOException {
-        BufferedReader reader;
-        if (200 <= connection.getResponseCode() && connection.getResponseCode() <= 299) {
-            reader = new BufferedReader(new InputStreamReader((connection.getInputStream())));
-        } else {
-            reader = new BufferedReader(new InputStreamReader((connection.getErrorStream())));
-        }
+        boolean isSuccess = 200 <= connection.getResponseCode() && connection.getResponseCode() <= 299;
 
-        StringBuilder builder = new StringBuilder();
-        String line;
-        while ((line = reader.readLine()) != null) {
-            builder.append(line);
+        try (InputStream stream = isSuccess ? connection.getInputStream() : connection.getErrorStream()) {
+            return IOUtils.toString(stream, StandardCharsets.UTF_8);
         }
-        return builder.toString();
     }
 }

--- a/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
+++ b/core/src/test/java/org/testcontainers/junit/wait/strategy/HttpWaitStrategyTest.java
@@ -3,6 +3,8 @@ package org.testcontainers.junit.wait.strategy;
 import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.rnorth.ducttape.RetryCountExceededException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
@@ -12,6 +14,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -237,6 +240,38 @@ class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrategy> {
         }
     }
 
+    static Stream<String> provideResponseBodies() {
+        return Stream.of(
+            // A multiline block
+            """
+            A first line,
+            A second line,
+            And a third one.
+            """,
+            // A single line without any linebreaks
+            "A single line without any linebreaks",
+            // Edge cases for leading, trailing and enclosed newlines
+            "\n\n\nA sample string with leading newlines",
+            "A sample string with trailing newlines\n\n\n",
+            "\n\n\nA sample string with both leading and trailing newlines\n\n\n",
+            // Special symbols
+            "A sample string with special symbols \uD83D\uDC19 \uD83D\uDC41️"
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideResponseBodies")
+    void shouldPreserveResponseBody(String expectedResponseBody) {
+        try (
+            GenericContainer container = startContainerWithCommand(
+                createShellCommand("200 OK", expectedResponseBody),
+                createHttpWaitStrategy(ready).forResponsePredicate(response -> response.equals(expectedResponseBody))
+            )
+        ) {
+            waitUntilReadyAndSucceed(container);
+        }
+    }
+
     /**
      * @param ready the AtomicBoolean on which to indicate success
      * @return the WaitStrategy under test
@@ -279,7 +314,7 @@ class HttpWaitStrategyTest extends AbstractWaitStrategyTest<HttpWaitStrategy> {
             length +
             NEWLINE +
             "\";" +
-            " echo \"" +
+            " echo -n \"" +
             responseBody +
             "\";} | nc -lp " +
             port +


### PR DESCRIPTION
This PR replaces manual stream reading with a standard utility method to fix #7326, because Apache's `IOUtils.toString()` preserves raw response formatting and line breaks unlike BufferedReader's `readLine()`, and also buffers the input internally, so there is no need to use manual buffering.
The same approach has already been used in `ContainerDatabaseDriver`, `ScriptUtils`, etc.
