### PR TITLE
feat(core): make client connection and response timeouts configurable (#10725)

### DIFF
--- a/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
+++ b/core/src/main/java/org/testcontainers/dockerclient/DockerClientProviderStrategy.java
@@ -391,11 +391,21 @@ public abstract class DockerClientProviderStrategy {
         String transportType = TestcontainersConfiguration.getInstance().getTransportType();
         switch (transportType) {
             case "httpclient5":
-                dockerHttpClient =
-                    new ZerodepDockerHttpClient.Builder()
-                        .dockerHost(transportConfig.getDockerHost())
-                        .sslConfig(transportConfig.getSslConfig())
-                        .build();
+                ZerodepDockerHttpClient.Builder builder = new ZerodepDockerHttpClient.Builder()
+                    .dockerHost(transportConfig.getDockerHost())
+                    .sslConfig(transportConfig.getSslConfig());
+
+                Duration connectionTimeout = TestcontainersConfiguration.getInstance().getClientConnectionTimeout();
+                if (connectionTimeout != null) {
+                    builder.connectionTimeout(connectionTimeout);
+                }
+
+                Duration responseTimeout = TestcontainersConfiguration.getInstance().getClientResponseTimeout();
+                if (responseTimeout != null) {
+                    builder.responseTimeout(responseTimeout);
+                }
+
+                dockerHttpClient = builder.build();
                 break;
             default:
                 throw new IllegalArgumentException("Unknown transport type '" + transportType + "'");

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -22,11 +22,11 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
-import java.time.Duration;
 import java.util.stream.Stream;
 
 /**

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
+import java.time.Duration;
 import java.util.stream.Stream;
 
 /**
@@ -222,6 +223,18 @@ public class TestcontainersConfiguration {
 
     public Integer getClientPingTimeout() {
         return Integer.parseInt(getEnvVarOrProperty("client.ping.timeout", "10"));
+    }
+
+    @Nullable
+    public Duration getClientConnectionTimeout() {
+        String timeout = getEnvVarOrProperty("client.connection.timeout", null);
+        return timeout != null ? Duration.ofSeconds(Integer.parseInt(timeout)) : null;
+    }
+
+    @Nullable
+    public Duration getClientResponseTimeout() {
+        String timeout = getEnvVarOrProperty("client.response.timeout", null);
+        return timeout != null ? Duration.ofSeconds(Integer.parseInt(timeout)) : null;
     }
 
     @Nullable

--- a/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
+++ b/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
@@ -225,6 +225,22 @@ class TestcontainersConfigurationTest {
             .isEqualTo("testcontainers/ryuk:0.3.2");
     }
 
+    @Test
+    void shouldReadClientConnectionTimeout() {
+        assertThat(newConfig().getClientConnectionTimeout()).isNull();
+
+        userProperties.setProperty("client.connection.timeout", "45");
+        assertThat(newConfig().getClientConnectionTimeout()).isEqualTo(java.time.Duration.ofSeconds(45));
+    }
+
+    @Test
+    void shouldReadClientResponseTimeout() {
+        assertThat(newConfig().getClientResponseTimeout()).isNull();
+
+        userProperties.setProperty("client.response.timeout", "120");
+        assertThat(newConfig().getClientResponseTimeout()).isEqualTo(java.time.Duration.ofSeconds(120));
+    }
+
     private TestcontainersConfiguration newConfig() {
         return new TestcontainersConfiguration(userProperties, classpathProperties, environment);
     }

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -101,6 +101,14 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 > **client.ping.timeout = 10**
 > Specifies for how long Testcontainers will try to connect to the Docker client to obtain valid info about the client before giving up and trying next strategy, if applicable (in seconds).
 
+## Customizing client connection and response timeouts
+
+> **client.connection.timeout = (not set)**
+> Specifies the maximum time allowed to establish a connection to the Docker daemon (in seconds). If not configured, the default connection timeout of the underlying transport client (3 minutes) is used.
+
+> **client.response.timeout = (not set)**
+> Specifies the maximum time allowed to wait for a response from the Docker daemon after a connection is established (in seconds). If not configured, the default response timeout of the underlying transport client is used.
+
 ## Customizing Docker host detection
 
 Testcontainers will attempt to detect the Docker environment and configure everything to work automatically.


### PR DESCRIPTION
﻿### What is the goal of this PR?
This PR addresses issue #10725 by introducing configuration options for `connectionTimeout` and `responseTimeout` in the underlying `ZerodepDockerHttpClient` (using the Apache HttpClient 5 backend). 

Without these timeouts, requests to the Docker daemon can hang indefinitely under rare circumstances (e.g., daemon/API issues, dead proxy channels), leading to hanging test suites.

### How is this implemented?
1. Added two properties to `TestcontainersConfiguration`:
   - `client.connection.timeout`: Specifies the maximum time allowed to establish a connection to the Docker daemon (in seconds).
   - `client.response.timeout`: Specifies the maximum time allowed to wait for a response from the Docker daemon after a connection is established (in seconds).
2. Updated `DockerClientProviderStrategy` to pass these configuration values into the `ZerodepDockerHttpClient.Builder` if they are set.
3. Preserved existing behavior by defaulting both values to `null` (falling back to standard library-defined timeouts) when the properties are not configured.

### How was this tested?
- Added unit tests in `TestcontainersConfigurationTest.java` verifying that both connection and response timeouts are resolved properly from configuration properties.
- Ran spotless verification and tests using Java 17 successfully.

### Config Properties Summary
| Property Name | Default Value | Description |
|---|---|---|
| `client.connection.timeout` | *(not set)* | Maximum connection establish time in seconds |
| `client.response.timeout` | *(not set)* | Maximum read response wait time in seconds |

Closes #10725
