### PR TITLE
Avoid duplicate /dev/shm bind when reusing BrowserWebDriverContainer

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -220,7 +220,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         if (getShmSize() == null) {
             if (SystemUtils.IS_OS_WINDOWS) {
                 withSharedMemorySize(512 * FileUtils.ONE_MB);
-            } else {
+            } else if (getBinds().stream().noneMatch(bind -> "/dev/shm".equals(bind.getVolume().getPath()))) {
                 this.getBinds().add(new Bind("/dev/shm", new Volume("/dev/shm"), AccessMode.rw));
             }
         }

--- a/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
@@ -164,7 +164,7 @@ public class BrowserWebDriverContainer
         if (getShmSize() == null) {
             if (SystemUtils.IS_OS_WINDOWS) {
                 withSharedMemorySize(512 * FileUtils.ONE_MB);
-            } else {
+            } else if (getBinds().stream().noneMatch(bind -> "/dev/shm".equals(bind.getVolume().getPath()))) {
                 this.getBinds().add(new Bind("/dev/shm", new Volume("/dev/shm"), AccessMode.rw));
             }
         }

--- a/modules/selenium/src/test/java/org/testcontainers/containers/BrowserWebDriverContainerReuseTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/BrowserWebDriverContainerReuseTest.java
@@ -31,4 +31,18 @@ class BrowserWebDriverContainerReuseTest {
 
         assertThat(shmBinds).isEqualTo(1);
     }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void configureKeepsACallerSuppliedShmBind() {
+        BrowserWebDriverContainer<?> container = new BrowserWebDriverContainer<>(CHROME_IMAGE);
+        container.withFileSystemBind("/tmp/shm", "/dev/shm", BindMode.READ_ONLY);
+
+        container.configure();
+
+        assertThat(container.getBinds())
+            .filteredOn(bind -> "/dev/shm".equals(bind.getVolume().getPath()))
+            .singleElement()
+            .satisfies(bind -> assertThat(bind.getPath()).isEqualTo("/tmp/shm"));
+    }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/containers/BrowserWebDriverContainerReuseTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/containers/BrowserWebDriverContainerReuseTest.java
@@ -1,4 +1,4 @@
-package org.testcontainers.selenium;
+package org.testcontainers.containers;
 
 import com.github.dockerjava.api.model.Bind;
 import org.junit.jupiter.api.Test;
@@ -15,7 +15,7 @@ class BrowserWebDriverContainerReuseTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void configureDoesNotAddDuplicateShmBindOnReuse() {
-        BrowserWebDriverContainer container = new BrowserWebDriverContainer(CHROME_IMAGE);
+        BrowserWebDriverContainer<?> container = new BrowserWebDriverContainer<>(CHROME_IMAGE);
 
         // configure() runs on every start(), so a reused container that is started
         // more than once must not accumulate duplicate /dev/shm binds (see #11941).

--- a/modules/selenium/src/test/java/org/testcontainers/selenium/BrowserWebDriverContainerReuseTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/selenium/BrowserWebDriverContainerReuseTest.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.model.Bind;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,5 +31,19 @@ class BrowserWebDriverContainerReuseTest {
             .count();
 
         assertThat(shmBinds).isEqualTo(1);
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void configureKeepsACallerSuppliedShmBind() {
+        BrowserWebDriverContainer container = new BrowserWebDriverContainer(CHROME_IMAGE);
+        container.withFileSystemBind("/tmp/shm", "/dev/shm", BindMode.READ_ONLY);
+
+        container.configure();
+
+        assertThat(container.getBinds())
+            .filteredOn(bind -> "/dev/shm".equals(bind.getVolume().getPath()))
+            .singleElement()
+            .satisfies(bind -> assertThat(bind.getPath()).isEqualTo("/tmp/shm"));
     }
 }

--- a/modules/selenium/src/test/java/org/testcontainers/selenium/BrowserWebDriverContainerReuseTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/selenium/BrowserWebDriverContainerReuseTest.java
@@ -1,0 +1,31 @@
+package org.testcontainers.selenium;
+
+import com.github.dockerjava.api.model.Bind;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BrowserWebDriverContainerReuseTest {
+
+    private static final DockerImageName CHROME_IMAGE = DockerImageName.parse("selenium/standalone-chrome:4.10.0");
+
+    @Test
+    void configureDoesNotAddDuplicateShmBindOnReuse() {
+        BrowserWebDriverContainer container = new BrowserWebDriverContainer(CHROME_IMAGE);
+
+        // configure() runs on every start(), so a reused container that is started
+        // more than once must not accumulate duplicate /dev/shm binds (see #11941).
+        container.configure();
+        container.configure();
+
+        long shmBinds = container
+            .getBinds()
+            .stream()
+            .map(Bind::getVolume)
+            .filter(volume -> "/dev/shm".equals(volume.getPath()))
+            .count();
+
+        assertThat(shmBinds).isEqualTo(1);
+    }
+}

--- a/modules/selenium/src/test/java/org/testcontainers/selenium/BrowserWebDriverContainerReuseTest.java
+++ b/modules/selenium/src/test/java/org/testcontainers/selenium/BrowserWebDriverContainerReuseTest.java
@@ -2,6 +2,8 @@ package org.testcontainers.selenium;
 
 import com.github.dockerjava.api.model.Bind;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.testcontainers.utility.DockerImageName;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -11,6 +13,7 @@ class BrowserWebDriverContainerReuseTest {
     private static final DockerImageName CHROME_IMAGE = DockerImageName.parse("selenium/standalone-chrome:4.10.0");
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void configureDoesNotAddDuplicateShmBindOnReuse() {
         BrowserWebDriverContainer container = new BrowserWebDriverContainer(CHROME_IMAGE);
 


### PR DESCRIPTION
## What

Reusing a `BrowserWebDriverContainer` (stop, then start again) fails on Linux with:

```
com.github.dockerjava.api.exception.BadRequestException: Status 400: {"message":"Duplicate mount point: /dev/shm"}
```

## Why

`configure()` runs on every `start()` (`GenericContainer#doStart`). On non-Windows hosts it appended a `/dev/shm` bind to the container binds unconditionally. When the same container instance is started more than once (reuse), the bind was added again, producing a duplicate mount point that Docker rejects at create time.

## Change

Only add the `/dev/shm` bind when one is not already present. Applied to both the `org.testcontainers.selenium.BrowserWebDriverContainer` and its deprecated `org.testcontainers.containers.BrowserWebDriverContainer` counterpart, which shared the same logic. `getBinds().add(...)` has exactly two production call sites in the repository, and both are these.

## Scope of the guard

The guard skips the built-in bind whenever some bind already targets the `/dev/shm` container path, so it is worth showing exactly which inputs change. Probed on `main` and on this branch with the same five cases (JDK 17.0.15, `modules/selenium`), printing the resulting bind list:

| case | main | this branch |
| --- | --- | --- |
| plain, one `configure()` | `/dev/shm:/dev/shm:rw` | unchanged |
| reused, two `configure()` calls | `/dev/shm:/dev/shm:rw` twice | one bind |
| caller-supplied `/dev/shm` bind, `withFileSystemBind("/tmp/shm", "/dev/shm", READ_ONLY)` | `/tmp/shm:/dev/shm:ro` plus `/dev/shm:/dev/shm:rw` | `/tmp/shm:/dev/shm:ro` only |
| unrelated caller bind on `/tmp/other` | caller bind plus `/dev/shm:/dev/shm:rw` | unchanged |
| `withSharedMemorySize(64MB)` | no bind | unchanged |

Only the two rows that produce a duplicate `/dev/shm` mount point change; the other three are identical. The caller-supplied case is the same `Duplicate mount point: /dev/shm` failure without any reuse involved, so it gets its own test method instead of being left implicit.

## Verification

`BrowserWebDriverContainerReuseTest` (one copy per package, mirroring the two container classes) calls `configure()` the way a reused container would and asserts a single `/dev/shm` bind, plus asserts that a caller-supplied bind survives untouched. No Docker daemon is required; the tests only exercise container configuration.

Reverting just the one-line guard in both classes and leaving the tests in place makes all four tests fail (`expected: 1L but was: 2L`, and the caller-supplied assertion on `singleElement()`); restoring it makes them pass.

```
./gradlew :testcontainers-selenium:spotlessCheck :testcontainers-selenium:test --tests "*BrowserWebDriverContainerReuseTest"
```

is green (4 tests, 0 failures).

Fixes #11941


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate shared-memory mounts when reusing browser containers.
  * Preserved existing, caller-provided shared-memory mounts during configuration.

* **Tests**
  * Added coverage for repeated container configuration and custom shared-memory mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->