### PR TITLE
feat: add execInBroker to ArtemisContainer to easily invoke Artemis CLI

### DIFF
--- a/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
+++ b/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
@@ -1,9 +1,11 @@
 package org.testcontainers.activemq;
 
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
 import java.time.Duration;
 
 /**
@@ -85,5 +87,23 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> {
 
     public String getPassword() {
         return getEnvMap().get("ARTEMIS_PASSWORD");
+    }
+
+    /**
+     * Executes a command using the Artemis CLI inside the container.
+     * The command is executed as the configured user.
+     *
+     * @param command the command parts to execute (e.g. "queue", "create", "--name=my-queue")
+     * @return the result of the execution
+     * @throws IOException if an I/O error occurs
+     * @throws InterruptedException if the execution is interrupted
+     */
+    public Container.ExecResult execInBroker(String... command) throws IOException, InterruptedException {
+        String[] execCommand = new String[command.length + 3];
+        execCommand[0] = "/var/lib/artemis-instance/bin/artemis";
+        System.arraycopy(command, 0, execCommand, 1, command.length);
+        execCommand[command.length + 1] = "--user=" + getUser();
+        execCommand[command.length + 2] = "--password=" + getPassword();
+        return execInContainer(execCommand);
     }
 }

--- a/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
+++ b/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
@@ -11,6 +11,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.containers.Container;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +60,22 @@ class ArtemisContainerTest {
             artemis.start();
 
             assertFunctionality(artemis, true);
+        }
+    }
+
+    @Test
+    void execInBroker() throws Exception {
+        try (ArtemisContainer artemis = new ArtemisContainer("apache/activemq-artemis:2.32.0-alpine")) {
+            artemis.start();
+            Container.ExecResult execResult = artemis.execInBroker(
+                "queue",
+                "create",
+                "--name=my-queue",
+                "--auto-create-address",
+                "--anycast",
+                "--silent"
+            );
+            assertThat(execResult.getExitCode()).isEqualTo(0);
         }
     }
 


### PR DESCRIPTION
This PR adds the `execInBroker` method to `ArtemisContainer` to make it easy to invoke the Artemis CLI without manually providing the artemis binary path and the configured user/password parameters.

Fixes #11589