### PR TITLE
Index images by RepoDigests in LocalImagesCache, not just RepoTags

### DIFF
--- a/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
+++ b/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
@@ -70,17 +70,23 @@ enum LocalImagesCache {
         return true;
     }
 
-    private void populateFromList(List<Image> images) {
+    @VisibleForTesting
+    void populateFromList(List<Image> images) {
         for (Image image : images) {
             String[] repoTags = image.getRepoTags();
-            if (repoTags == null) {
-                log.debug("repoTags is null, skipping image: {}", image);
+            String[] repoDigests = image.getRepoDigests();
+
+            if (repoTags == null && repoDigests == null) {
+                log.debug("repoTags and repoDigests are both null, skipping image: {}", image);
                 continue;
             }
 
+            Stream<String> tagNames = repoTags != null ? Stream.of(repoTags) : Stream.empty();
+            Stream<String> digestNames = repoDigests != null ? Stream.of(repoDigests) : Stream.empty();
+
             cache.putAll(
                 Stream
-                    .of(repoTags)
+                    .concat(tagNames, digestNames)
                     // Protection against some edge case where local image repository tags end up with duplicates
                     // making toMap crash at merge time.
                     .distinct()

--- a/core/src/test/java/org/testcontainers/images/LocalImagesCacheTest.java
+++ b/core/src/test/java/org/testcontainers/images/LocalImagesCacheTest.java
@@ -1,0 +1,67 @@
+package org.testcontainers.images;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.model.Image;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalImagesCacheTest {
+
+    @AfterEach
+    void tearDown() {
+        LocalImagesCacheAccessor.clearCache();
+    }
+
+    @Test
+    void shouldIndexImageByRepoDigestEvenWhenRepoTagsIsNull() {
+        Image image = imageWith(null, new String[] { "example.com/my/image@sha256:" + "a".repeat(64) });
+
+        LocalImagesCache.INSTANCE.populateFromList(Collections.singletonList(image));
+
+        DockerImageName byDigest = DockerImageName.parse("example.com/my/image@sha256:" + "a".repeat(64));
+        assertThat(LocalImagesCache.INSTANCE.cache).containsKey(byDigest);
+    }
+
+    @Test
+    void shouldIndexImageByBothRepoTagsAndRepoDigests() {
+        Image image = imageWith(
+            new String[] { "example.com/my/image:latest" },
+            new String[] { "example.com/my/image@sha256:" + "b".repeat(64) }
+        );
+
+        LocalImagesCache.INSTANCE.populateFromList(Collections.singletonList(image));
+
+        assertThat(LocalImagesCache.INSTANCE.cache)
+            .containsKey(DockerImageName.parse("example.com/my/image:latest"))
+            .containsKey(DockerImageName.parse("example.com/my/image@sha256:" + "b".repeat(64)));
+    }
+
+    @Test
+    void shouldSkipImageWithNeitherRepoTagsNorRepoDigests() {
+        Image image = imageWith(null, null);
+
+        LocalImagesCache.INSTANCE.populateFromList(Collections.singletonList(image));
+
+        assertThat(LocalImagesCache.INSTANCE.cache).isEmpty();
+    }
+
+    private static Image imageWith(String[] repoTags, String[] repoDigests) {
+        Map<String, Object> fields = new HashMap<>();
+        fields.put("Id", "sha256:" + "c".repeat(64));
+        if (repoTags != null) {
+            fields.put("RepoTags", Arrays.asList(repoTags));
+        }
+        if (repoDigests != null) {
+            fields.put("RepoDigests", Arrays.asList(repoDigests));
+        }
+        return new ObjectMapper().convertValue(fields, Image.class);
+    }
+}


### PR DESCRIPTION
Fixes #1406.

`LocalImagesCache.populateFromList()` only indexed local images by their `RepoTags`. An image reachable only by digest (e.g. `docker pull image@sha256:...`) - or a tagged image where Docker reports `RepoTags` as `null`/`["<none>:<none>"]` after certain rebuild/retag sequences, while `RepoDigests` remains populated (see moby/moby#29157 for a concrete real-world case of this) - was never added to the cache. Testcontainers would then treat the image as absent locally and re-pull it every time, even though it was already present, defeating both the configured `ImagePullPolicy` and any lookup of an image by digest.

**Change:** `populateFromList()` now also reads `Image::getRepoDigests()` and indexes those digest-qualified names into the same cache, alongside `RepoTags`. An image with neither field populated is still skipped, as before (just with an updated log message reflecting the new condition).

**Tests:** added `LocalImagesCacheTest` covering a digest-only image, an image with both a tag and a digest, and the neither-present case. Uses the same `ObjectMapper#convertValue(Map, Class)` pattern already used in `ReusabilityUnitTests` for constructing docker-java model objects in tests, and the existing (previously unused) `LocalImagesCacheAccessor` test helper for cache isolation between tests.

Scope note: I did not additionally add Image ID-based lookup (mentioned in the issue's 2020 edit) since `DockerImageName` parsing doesn't cleanly represent a bare image ID (e.g. `sha256:abcdef...` without a repository) today - that would need its own design discussion, so I've kept this PR focused on the RepoDigests fix. Happy to look at Image ID support separately if maintainers want it.