### PR TITLE
Add MinIO container implementation under org.testcontainers.minio

### DIFF
--- a/docs/modules/minio.md
+++ b/docs/modules/minio.md
@@ -6,17 +6,17 @@ Testcontainers can be used to automatically instantiate and manage [MinIO](https
 
 Create a `MinIOContainer` to use it in your tests:
 <!--codeinclude-->
-[Starting a MinIO container](../../modules/minio/src/test/java/org/testcontainers/containers/MinIOContainerTest.java) inside_block:minioContainer
+[Starting a MinIO container](../../modules/minio/src/test/java/org/testcontainers/minio/MinIOContainerTest.java) inside_block:minioContainer
 <!--/codeinclude-->
 
 The [MinIO Java client](https://min.io/docs/minio/linux/developers/java/API.html) can be configured with the container as such:
 <!--codeinclude-->
-[Configuring a MinIO client](../../modules/minio/src/test/java/org/testcontainers/containers/MinIOContainerTest.java) inside_block:configuringClient
+[Configuring a MinIO client](../../modules/minio/src/test/java/org/testcontainers/minio/MinIOContainerTest.java) inside_block:configuringClient
 <!--/codeinclude-->
 
 If needed the username and password can be overridden as such:
 <!--codeinclude-->
-[Overriding a MinIO container](../../modules/minio/src/test/java/org/testcontainers/containers/MinIOContainerTest.java) inside_block:minioOverrides
+[Overriding a MinIO container](../../modules/minio/src/test/java/org/testcontainers/minio/MinIOContainerTest.java) inside_block:minioOverrides
 <!--/codeinclude-->
 
 ## Adding this module to your project dependencies

--- a/modules/minio/src/main/java/org/testcontainers/minio/MinIOContainer.java
+++ b/modules/minio/src/main/java/org/testcontainers/minio/MinIOContainer.java
@@ -1,5 +1,6 @@
-package org.testcontainers.containers;
+package org.testcontainers.minio;
 
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
@@ -16,8 +17,6 @@ import java.time.temporal.ChronoUnit;
  *     <li>S3: 9000</li>
  *     <li>Console: 9001</li>
  * </ul>
- *
- * @deprecated use {@link org.testcontainers.minio.MinIOContainer} instead.
  */
 public class MinIOContainer extends GenericContainer<MinIOContainer> {
 

--- a/modules/minio/src/test/java/org/testcontainers/minio/MinIOContainerTest.java
+++ b/modules/minio/src/test/java/org/testcontainers/minio/MinIOContainerTest.java
@@ -1,4 +1,4 @@
-package org.testcontainers.containers;
+package org.testcontainers.minio;
 
 import io.minio.BucketExistsArgs;
 import io.minio.MakeBucketArgs;


### PR DESCRIPTION
Continues the ongoing package migration by adding a MinIO container implementation
under `org.testcontainers.minio`, following the same approach as the Solr (#11104)
and Cassandra (#8616) migrations.

## Changes

- Add `org.testcontainers.minio.MinIOContainer` with an API identical to the
  existing class (constructors, `withUserName`, `withPassword`, `getS3URL`,
  credential getters).
- Deprecate `org.testcontainers.containers.MinIOContainer` via a `@deprecated`
  javadoc tag pointing to the new class. The deprecated class is otherwise
  untouched, so existing users are unaffected apart from a compile-time
  deprecation warning.
- Move `MinIOContainerTest` to `org.testcontainers.minio` so the documentation
  snippets (codeinclude blocks) demonstrate the new package.
- Update the codeinclude paths in `docs/modules/minio.md` accordingly.

## Notes

- No behavior changes: the new class is a copy of the existing implementation,
  differing only in package declaration and an explicit `GenericContainer` import.
- Migrating user code is an import change:
  `org.testcontainers.containers.MinIOContainer` → `org.testcontainers.minio.MinIOContainer`.
- `./gradlew :testcontainers-minio:checkstyleMain :testcontainers-minio:checkstyleTest
  :testcontainers-minio:spotlessApply` passes, and the module tests were run
  locally against Docker.