### PR TITLE
Update tiny image from alpine:3.17 to alpine:3.24

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -79,7 +79,7 @@ public class DockerClientFactory {
         return Collections.unmodifiableMap(labels);
     }
 
-    private static final DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.17");
+    private static final DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.24");
 
     private static DockerClientFactory instance;
 

--- a/core/src/test/java/org/testcontainers/TestImages.java
+++ b/core/src/test/java/org/testcontainers/TestImages.java
@@ -9,9 +9,9 @@ public interface TestImages {
 
     DockerImageName MONGODB_IMAGE = DockerImageName.parse("mongo:4.4");
 
-    DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.17");
+    DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.24");
 
     DockerImageName DOCKER_REGISTRY_IMAGE = DockerImageName.parse("registry:2.7.0");
 
-    DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.17");
+    DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.24");
 }

--- a/core/src/test/java/org/testcontainers/containers/DockerComposeFilesTest.java
+++ b/core/src/test/java/org/testcontainers/containers/DockerComposeFilesTest.java
@@ -27,6 +27,6 @@ class DockerComposeFilesTest {
             )
         );
         assertThat(dockerComposeFiles.getDependencyImages())
-            .containsExactlyInAnyOrder("alpine:3.17", "redis:b", "mysql:b", "aservice:latest");
+            .containsExactlyInAnyOrder("alpine:3.24", "redis:b", "mysql:b", "aservice:latest");
     }
 }

--- a/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/GenericContainerTest.java
@@ -237,7 +237,7 @@ class GenericContainerTest {
         GenericContainer container = new GenericContainer(TestImages.REDIS_IMAGE);
         assertThat(container.getImage().get()).isEqualTo("redis:6-alpine");
         container.setImage(new RemoteDockerImage(TestImages.ALPINE_IMAGE));
-        assertThat(container.getImage().get()).isEqualTo("alpine:3.17");
+        assertThat(container.getImage().get()).isEqualTo("alpine:3.24");
     }
 
     @Test
@@ -301,7 +301,7 @@ class GenericContainerTest {
 
         List<Container> containers = dockerClient
             .listContainersCmd()
-            .withAncestorFilter(Collections.singletonList("alpine:3.17"))
+            .withAncestorFilter(Collections.singletonList("alpine:3.24"))
             .withLabelFilter(
                 Arrays.asList(
                     DockerClientFactory.TESTCONTAINERS_SESSION_ID_LABEL + "=" + DockerClientFactory.SESSION_ID,

--- a/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ParsedDockerComposeFileValidationTest.java
@@ -133,8 +133,8 @@ class ParsedDockerComposeFileValidationTest {
             .contains(
                 entry("mysql", Sets.newHashSet("mysql")),
                 entry("redis", Sets.newHashSet("redis")),
-                entry("custom", Sets.newHashSet("alpine:3.17"))
-            ); // r/ redis, mysql from compose file, alpine:3.17 from Dockerfile build
+                entry("custom", Sets.newHashSet("alpine:3.24"))
+            ); // r/ redis, mysql from compose file, alpine:3.24 from Dockerfile build
     }
 
     @Test
@@ -146,8 +146,8 @@ class ParsedDockerComposeFileValidationTest {
             .contains(
                 entry("mysql", Sets.newHashSet("mysql")),
                 entry("redis", Sets.newHashSet("redis")),
-                entry("custom", Sets.newHashSet("alpine:3.17"))
-            ); // redis, mysql from compose file, alpine:3.17 from Dockerfile build
+                entry("custom", Sets.newHashSet("alpine:3.24"))
+            ); // redis, mysql from compose file, alpine:3.24 from Dockerfile build
     }
 
     @Test

--- a/core/src/test/java/org/testcontainers/containers/output/ToStringConsumerTest.java
+++ b/core/src/test/java/org/testcontainers/containers/output/ToStringConsumerTest.java
@@ -24,7 +24,7 @@ class ToStringConsumerTest {
 
     @Test
     void newlines_are_not_added_to_exec_output() throws Exception {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.17")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.24")) {
             container.withCommand("sleep", "2m");
             container.start();
 
@@ -36,7 +36,7 @@ class ToStringConsumerTest {
     @Test
     @Timeout(60)
     void newlines_are_not_added_to_exec_output_with_tty() throws Exception {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.17")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.24")) {
             container.withCreateContainerCmdModifier(cmd -> {
                 cmd.withAttachStdin(true).withStdinOpen(true).withTty(true);
             });
@@ -50,7 +50,7 @@ class ToStringConsumerTest {
 
     @Test
     void newlines_are_not_added_to_container_output() {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.17")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.24")) {
             container.withCommand("echo", "-n", LARGE_PAYLOAD);
             container.setStartupCheckStrategy(new OneShotStartupCheckStrategy());
             container.start();
@@ -63,7 +63,7 @@ class ToStringConsumerTest {
 
     @Test
     void newlines_are_not_added_to_container_output_with_tty() {
-        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.17")) {
+        try (GenericContainer<?> container = new GenericContainer<>("alpine:3.24")) {
             container.withCreateContainerCmdModifier(cmd -> {
                 cmd.withTty(true);
             });

--- a/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
+++ b/core/src/test/java/org/testcontainers/dockerclient/ImagePullTest.java
@@ -11,7 +11,7 @@ class ImagePullTest {
     public static String[] parameters() {
         return new String[] {
             "alpine:latest",
-            "alpine:3.17",
+            "alpine:3.24",
             "alpine", // omitting the tag should work and default to latest
             "alpine@sha256:1775bebec23e1f3ce486989bfc9ff3c4e951690df84aa9f926497d82f2ffca9d",
             "docker.io/testcontainers/ryuk:latest",

--- a/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
+++ b/core/src/test/java/org/testcontainers/junit/DockerfileTest.java
@@ -38,7 +38,7 @@ class DockerfileTest {
                 super.configure(buildImageCmd);
 
                 List<String> dockerfile = Arrays.asList(
-                    "FROM alpine:3.17",
+                    "FROM alpine:3.24",
                     "RUN echo 'hello from Docker build process'",
                     "CMD yes"
                 );
@@ -58,7 +58,7 @@ class DockerfileTest {
             .withFileFromString("folder/someFile.txt", "hello")
             .withDockerfileFromBuilder(builder -> {
                 builder
-                    .from("alpine:3.17")
+                    .from("alpine:3.24")
                     .workDir("/app")
                     .add("test.txt", "test file.txt")
                     .run("ls", "-la", "/app/test file.txt")
@@ -101,7 +101,7 @@ class DockerfileTest {
             )
             .withDockerfileFromBuilder(builder -> {
                 builder
-                    .from("alpine:3.17") //
+                    .from("alpine:3.24") //
                     .copy("someFile.txt", "/someFile.txt")
                     .cmd("stat -c \"%a\" /someFile.txt");
             });

--- a/core/src/test/java/org/testcontainers/junit/FixedHostPortContainerTest.java
+++ b/core/src/test/java/org/testcontainers/junit/FixedHostPortContainerTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class FixedHostPortContainerTest {
 
-    private static final String TEST_IMAGE = "alpine:3.17";
+    private static final String TEST_IMAGE = "alpine:3.24";
 
     /**
      * Default http server port (just something different from default)

--- a/core/src/test/java/org/testcontainers/utility/DirectoryTarResourceTest.java
+++ b/core/src/test/java/org/testcontainers/utility/DirectoryTarResourceTest.java
@@ -22,7 +22,7 @@ class DirectoryTarResourceTest {
             new ImageFromDockerfile()
                 .withDockerfileFromBuilder(builder -> {
                     builder
-                        .from("alpine:3.17")
+                        .from("alpine:3.24")
                         .copy("/tmp/foo", "/foo")
                         .cmd("cat /foo/test/resources/test-recursive-file.txt")
                         .build();
@@ -47,7 +47,7 @@ class DirectoryTarResourceTest {
                 new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> {
                         builder
-                            .from("alpine:3.17") //
+                            .from("alpine:3.24") //
                             .copy("/tmp/foo", "/foo")
                             .cmd("ls", "-al", "/")
                             .build();
@@ -75,7 +75,7 @@ class DirectoryTarResourceTest {
                 new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> {
                         builder
-                            .from("alpine:3.17") //
+                            .from("alpine:3.24") //
                             .copy("/tmp/foo", "/foo")
                             .cmd("ls -lRt /foo")
                             .build();

--- a/core/src/test/resources/compose-dockerfile/Dockerfile
+++ b/core/src/test/resources/compose-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.24
 
 ADD passthrough.sh /passthrough.sh
 

--- a/core/src/test/resources/compose-scaling-multiple-containers.yml
+++ b/core/src/test/resources/compose-scaling-multiple-containers.yml
@@ -3,5 +3,5 @@ services:
   redis:
     image: redis
   other:
-    image: alpine:3.17
+    image: alpine:3.24
     command: sleep 10000

--- a/docs/examples/junit4/generic/src/test/java/generic/ContainerCreationTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ContainerCreationTest.java
@@ -20,7 +20,7 @@ public class ContainerCreationTest {
     // }
     // spotless:on
 
-    public static final DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.17");
+    public static final DockerImageName ALPINE_IMAGE = DockerImageName.parse("alpine:3.24");
 
     // spotless:off
     // withOptions {

--- a/docs/examples/junit4/generic/src/test/java/generic/ContainerLabelTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ContainerLabelTest.java
@@ -9,7 +9,7 @@ import java.util.Map;
 public class ContainerLabelTest {
 
     // single_label {
-    public GenericContainer containerWithLabel = new GenericContainer(DockerImageName.parse("alpine:3.17"))
+    public GenericContainer containerWithLabel = new GenericContainer(DockerImageName.parse("alpine:3.24"))
         .withLabel("key", "value");
     // }
 
@@ -17,7 +17,7 @@ public class ContainerLabelTest {
     private Map<String, String> mapOfLabels = new HashMap<>();
     // populate map, e.g. mapOfLabels.put("key1", "value1");
 
-    public GenericContainer containerWithMultipleLabels = new GenericContainer(DockerImageName.parse("alpine:3.17"))
+    public GenericContainer containerWithMultipleLabels = new GenericContainer(DockerImageName.parse("alpine:3.24"))
         .withLabels(mapOfLabels);
     // }
 }

--- a/docs/examples/junit4/generic/src/test/java/generic/ExecTest.java
+++ b/docs/examples/junit4/generic/src/test/java/generic/ExecTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ExecTest {
 
     @Rule
-    public GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine:3.17"))
+    public GenericContainer<?> container = new GenericContainer<>(DockerImageName.parse("alpine:3.24"))
         .withCommand("top");
 
     @Test

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -49,7 +49,7 @@ Some companies disallow the usage of Docker Hub, but you can override `*.image` 
 > **ryuk.container.image = testcontainers/ryuk:0.3.3**
 > Performs fail-safe cleanup of containers, and always required (unless [Ryuk is disabled](#disabling-ryuk))
 
-> **tinyimage.container.image = alpine:3.17**  
+> **tinyimage.container.image = alpine:3.24**  
 > Used to check whether images can be pulled at startup, and always required (unless [startup checks are disabled](#disabling-the-startup-checks))
 
 > **sshd.container.image = testcontainers/sshd:1.4.0**  

--- a/docs/features/creating_images.md
+++ b/docs/features/creating_images.md
@@ -51,7 +51,7 @@ new GenericContainer(
         new ImageFromDockerfile()
                 .withDockerfileFromBuilder(builder ->
                         builder
-                                .from("alpine:3.17")
+                                .from("alpine:3.24")
                                 .run("apk add --update nginx")
                                 .cmd("nginx", "-g", "daemon off;")
                                 .build()))

--- a/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
+++ b/modules/spock/src/test/groovy/org/testcontainers/spock/SpockTestImages.groovy
@@ -6,5 +6,5 @@ interface SpockTestImages {
 	DockerImageName MYSQL_IMAGE = DockerImageName.parse("mysql:8.0.36")
 	DockerImageName POSTGRES_TEST_IMAGE = DockerImageName.parse("postgres:9.6.12")
 	DockerImageName HTTPD_IMAGE = DockerImageName.parse("httpd:2.4-alpine")
-	DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.17")
+	DockerImageName TINY_IMAGE = DockerImageName.parse("alpine:3.24")
 }


### PR DESCRIPTION
Updates the default tiny image used for startup capability probes (`runInsideDocker`,
the mountable-file check) from `alpine:3.17` to `alpine:3.24`. Alpine 3.17 reached
end of support in November 2024 and no longer receives security updates; 3.24 is the
current stable release.

Note on the dependency-upgrade policy: this pin is a constant in
`DockerClientFactory`, not a build dependency, so it is not covered by the automated
weekly upgrade process — hence the manual bump.

## Changes

- Bump `TINY_IMAGE` in `DockerClientFactory` and update the documented default for
  the `tinyimage.container.image` property in `docs/features/configuration.md`.
  The property itself is unchanged — users overriding the tiny image via
  `tinyimage.container.image` are unaffected.
- Update all co-located references to the old tag for consistency: core test images
  (`TestImages`), test fixtures (Dockerfile and compose files), docs examples, and
  the Spock module's test images.

No behavior changes beyond the image tag.
