### PR TITLE
Remove obsolete Docker version startup check

### DIFF
--- a/core/src/main/java/org/testcontainers/DockerClientFactory.java
+++ b/core/src/main/java/org/testcontainers/DockerClientFactory.java
@@ -24,11 +24,9 @@ import org.testcontainers.dockerclient.DockerMachineClientProviderStrategy;
 import org.testcontainers.dockerclient.TransportConfig;
 import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.images.TimeLimitedLoggedPullImageResultCallback;
-import org.testcontainers.utility.ComparableVersion;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.ResourceReaper;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -248,37 +246,7 @@ public class DockerClientFactory {
             throw e;
         }
 
-        boolean checksEnabled = !TestcontainersConfiguration.getInstance().isDisableChecks();
-        if (checksEnabled) {
-            log.debug("Checks are enabled");
-
-            try {
-                log.info("Checking the system...");
-                checkDockerVersion(version.getVersion());
-            } catch (RuntimeException e) {
-                cachedClientFailure = e;
-                throw e;
-            }
-        } else {
-            log.debug("Checks are disabled");
-        }
-
         return client;
-    }
-
-    private void checkDockerVersion(String dockerVersion) {
-        boolean versionIsSufficient = new ComparableVersion(dockerVersion).compareTo(new ComparableVersion("1.6.0")) >=
-        0;
-        check("Docker server version should be at least 1.6.0", versionIsSufficient);
-    }
-
-    private void check(String message, boolean isSuccessful) {
-        if (isSuccessful) {
-            log.info("\u2714\ufe0e {}", message);
-        } else {
-            log.error("\u274c {}", message);
-            throw new IllegalStateException("Check failed: " + message);
-        }
     }
 
     private boolean checkMountableFile() {

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -29,7 +29,6 @@ If any keys conflict, the value will be taken on the basis of the first value fo
 Before running any containers Testcontainers will perform a set of startup checks to ensure that your environment is configured correctly. Usually they look like this:
 ```
         ℹ︎ Checking the system...
-        ✔ Docker version should be at least 1.6.0
         ✔ File should be mountable
         ✔ A port exposed by a docker container should be accessible
 ```


### PR DESCRIPTION
Removes the startup check that asserts the Docker server version is at least 1.6.0.
Docker 1.6.0 was released in 2015, and every daemon the modern client libraries can
connect to is far past it, so the check can never fail in practice — it only adds a
version parse and log output to every first container start.

## Changes

- Remove `checkDockerVersion` and the now-unused private `check` helper from
  `DockerClientFactory`, along with the surrounding checks block in `client()`.
  Both methods were private, so there is no public API impact.
- Remove the corresponding line from the startup-checks example in
  `docs/features/configuration.md`.

## Notes

- The `checks.disable` configuration property is intentionally left in place: it is
  still consumed elsewhere (`ContainerDef`), and whether to deprecate it is left as
  a follow-up decision.
- The remaining lines in the docs startup-checks example ("File should be mountable",
  "A port exposed by a docker container should be accessible") describe checks that
  were removed some time ago; happy to rewrite that docs section here or in a
  follow-up, whichever is preferred.