### PR TITLE
Make container port mapping timeout configurable

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -447,7 +447,10 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             // Wait until inspect container returns the mapped ports
             containerInfo =
                 await()
-                    .atMost(5, TimeUnit.SECONDS)
+                    .atMost(
+                        TestcontainersConfiguration.getInstance().getContainerPortMappingTimeout(),
+                        TimeUnit.SECONDS
+                    )
                     .pollInterval(DynamicPollInterval.ofMillis(50))
                     .pollInSameThread()
                     .until(

--- a/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
+++ b/core/src/main/java/org/testcontainers/utility/TestcontainersConfiguration.java
@@ -224,6 +224,10 @@ public class TestcontainersConfiguration {
         return Integer.parseInt(getEnvVarOrProperty("client.ping.timeout", "10"));
     }
 
+    public Integer getContainerPortMappingTimeout() {
+        return Integer.parseInt(getEnvVarOrProperty("container.port.mapping.timeout", "5"));
+    }
+
     @Nullable
     @Contract("_, !null, _ -> !null")
     private String getConfigurable(

--- a/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
+++ b/core/src/test/java/org/testcontainers/utility/TestcontainersConfigurationTest.java
@@ -218,6 +218,28 @@ class TestcontainersConfigurationTest {
     }
 
     @Test
+    void shouldReadContainerPortMappingTimeout() {
+        assertThat(newConfig().getContainerPortMappingTimeout())
+            .as("port mapping timeout is 5 seconds by default")
+            .isEqualTo(5);
+
+        classpathProperties.setProperty("container.port.mapping.timeout", "31");
+        assertThat(newConfig().getContainerPortMappingTimeout())
+            .as("port mapping timeout is changed by classpath properties")
+            .isEqualTo(31);
+
+        userProperties.setProperty("container.port.mapping.timeout", "32");
+        assertThat(newConfig().getContainerPortMappingTimeout())
+            .as("port mapping timeout is changed by user properties")
+            .isEqualTo(32);
+
+        environment.put("TESTCONTAINERS_CONTAINER_PORT_MAPPING_TIMEOUT", "33");
+        assertThat(newConfig().getContainerPortMappingTimeout())
+            .as("port mapping timeout is changed by env var")
+            .isEqualTo(33);
+    }
+
+    @Test
     void shouldTrimImageNames() {
         userProperties.setProperty("ryuk.container.image", " testcontainers/ryuk:0.3.2 ");
         assertThat(newConfig().getRyukImage())

--- a/docs/features/configuration.md
+++ b/docs/features/configuration.md
@@ -101,6 +101,11 @@ but does not allow starting privileged containers, you can turn off the Ryuk con
 > **client.ping.timeout = 10**
 > Specifies for how long Testcontainers will try to connect to the Docker client to obtain valid info about the client before giving up and trying next strategy, if applicable (in seconds).
 
+## Customizing container startup behaviour
+
+> **container.port.mapping.timeout = 5**
+> Specifies for how long Testcontainers will wait for the Docker daemon to report the mapped ports of a starting container before giving up (in seconds).
+
 ## Customizing Docker host detection
 
 Testcontainers will attempt to detect the Docker environment and configure everything to work automatically.


### PR DESCRIPTION
During container startup, `GenericContainer` polls `inspectContainer` until the Docker
daemon reports all exposed ports as mapped, with a hard-coded 5-second limit. On heavily
loaded hosts (shared CI runners in particular) the daemon can take longer, and the
resulting failure is an opaque Awaitility timeout rather than the detailed diagnostics
produced for later startup failures.

## Changes

- Add a `container.port.mapping.timeout` configuration property (default: 5 seconds, so
  out-of-the-box behavior is unchanged), read via the standard mechanism — env var
  `TESTCONTAINERS_CONTAINER_PORT_MAPPING_TIMEOUT`, `~/.testcontainers.properties`, or a
  classpath `testcontainers.properties`.
- Use it in `GenericContainer.tryStart()` in place of the hard-coded value.
- Document the property in `docs/features/configuration.md` and cover the
  default/property/env-var precedence in `TestcontainersConfigurationTest`.

A configuration property (rather than a per-container API) was chosen deliberately: the
latency this timeout absorbs is a characteristic of the Docker daemon and host load, not
of any particular container, mirroring existing environment-level knobs such as
`client.ping.timeout`.