### PR TITLE
fix(images): prevent divide by zero in LoggedPullImageResultCallback (#11416)

### DIFF
--- a/core/src/main/java/org/testcontainers/images/LoggedPullImageResultCallback.java
+++ b/core/src/main/java/org/testcontainers/images/LoggedPullImageResultCallback.java
@@ -110,7 +110,7 @@ class LoggedPullImageResultCallback extends PullImageResultCallback {
         super.onComplete();
 
         final long downloadedLayerSize = downloadedLayerSize();
-        final long duration = Duration.between(start, Instant.now()).getSeconds();
+        final long duration = start != null ? Duration.between(start, Instant.now()).getSeconds() : 0;
 
         if (completed) {
             logger.info(
@@ -118,7 +118,7 @@ class LoggedPullImageResultCallback extends PullImageResultCallback {
                 allLayers.size(),
                 duration,
                 FileUtils.byteCountToDisplaySize(downloadedLayerSize),
-                FileUtils.byteCountToDisplaySize(downloadedLayerSize / duration)
+                FileUtils.byteCountToDisplaySize(downloadedLayerSize / Math.max(1, duration))
             );
         }
     }

--- a/core/src/test/java/org/testcontainers/images/LoggedPullImageResultCallbackTest.java
+++ b/core/src/test/java/org/testcontainers/images/LoggedPullImageResultCallbackTest.java
@@ -1,0 +1,29 @@
+package org.testcontainers.images;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.model.PullResponseItem;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class LoggedPullImageResultCallbackTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LoggedPullImageResultCallbackTest.class);
+
+    @Test
+    void testZeroDurationPullDoesNotThrowArithmeticException() throws Exception {
+        LoggedPullImageResultCallback callback = new LoggedPullImageResultCallback(LOGGER);
+        callback.onStart(null);
+
+        ObjectMapper mapper = new ObjectMapper();
+        PullResponseItem item = mapper.readValue(
+            "{\"status\":\"Download complete\",\"id\":\"layer1\"}",
+            PullResponseItem.class
+        );
+        callback.onNext(item);
+
+        assertThatCode(callback::onComplete).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
Fixes #11416

### Description
When pulling an image completes in less than 1 second (sub-second duration), `Duration.between(start, Instant.now()).getSeconds()` returns `0`.
Calculating transfer speed as `downloadedLayerSize / duration` throws `java.lang.ArithmeticException: / by zero`.

This PR uses `Math.max(1, duration)` when calculating transfer speed in `LoggedPullImageResultCallback#onComplete()`, preventing `ArithmeticException`.

### Changes
- Updated `LoggedPullImageResultCallback.java` to use `Math.max(1, duration)` when calculating transfer rate.
- Added unit test `LoggedPullImageResultCallbackTest.java` covering zero-duration pull completion.