### PR TITLE
Add withInitScript support to MongoDBContainer (#3066)

### DIFF
--- a/modules/mongodb/src/main/java/org/testcontainers/mongodb/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/mongodb/MongoDBContainer.java
@@ -10,6 +10,8 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Testcontainers implementation for MongoDB.
@@ -45,6 +47,8 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
 
     private boolean rsEnabled;
 
+    private final List<MountableFile> initScripts = new ArrayList<>();
+
     public MongoDBContainer(@NonNull String dockerImageName) {
         this(DockerImageName.parse(dockerImageName));
     }
@@ -60,6 +64,12 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
     protected void containerIsStarting(InspectContainerResponse containerInfo) {
         if (this.shardingEnabled) {
             copyFileToContainer(MountableFile.forClasspathResource("/sharding.sh", 0777), STARTER_SCRIPT);
+        }
+        for (int i = 0; i < initScripts.size(); i++) {
+            copyFileToContainer(initScripts.get(i), "/docker-entrypoint-initdb.d/init-" + i + ".js");
+        }
+        if (this.rsEnabled && !initScripts.isEmpty()) {
+            waitingFor(Wait.forLogMessage("(?i).*waiting for connections.*", 2));
         }
     }
 
@@ -158,6 +168,18 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
         this.rsEnabled = true;
         withCommand("--replSet", "docker-rs");
         waitingFor(Wait.forLogMessage("(?i).*waiting for connections.*", 1));
+        return this;
+    }
+
+    /**
+     * Adds a JavaScript init script to be executed by MongoDB on first startup.
+     * Scripts are copied to {@code /docker-entrypoint-initdb.d/} and run in the order they were added.
+     *
+     * @param initScript the script to copy into the container
+     * @return this
+     */
+    public MongoDBContainer withInitScript(MountableFile initScript) {
+        this.initScripts.add(initScript);
         return this;
     }
 

--- a/modules/mongodb/src/test/java/org/testcontainers/mongodb/MongoDBContainerTest.java
+++ b/modules/mongodb/src/test/java/org/testcontainers/mongodb/MongoDBContainerTest.java
@@ -1,6 +1,10 @@
 package org.testcontainers.mongodb;
 
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.Document;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.MountableFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +40,39 @@ class MongoDBContainerTest extends AbstractMongo {
             mongoDBContainer.start();
             final String databaseName = "my-db";
             assertThat(mongoDBContainer.getReplicaSetUrl(databaseName)).endsWith(databaseName);
+        }
+    }
+
+    @Test
+    void shouldRunInitScriptWithReplicaSet() {
+        try (
+            MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.0.10")
+                .withReplicaSet()
+                .withInitScript(MountableFile.forClasspathResource("init-db.js"))
+        ) {
+            mongoDBContainer.start();
+
+            try (MongoClient client = MongoClients.create(mongoDBContainer.getReplicaSetUrl("testdb"))) {
+                Document doc = client.getDatabase("testdb").getCollection("items").find().first();
+                assertThat(doc).isNotNull();
+                assertThat(doc.getString("name")).isEqualTo("testcontainers");
+            }
+        }
+    }
+
+    @Test
+    void shouldRunInitScriptWithoutReplicaSet() {
+        try (
+            MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.0.10")
+                .withInitScript(MountableFile.forClasspathResource("init-db.js"))
+        ) {
+            mongoDBContainer.start();
+
+            try (MongoClient client = MongoClients.create(mongoDBContainer.getConnectionString())) {
+                Document doc = client.getDatabase("testdb").getCollection("items").find().first();
+                assertThat(doc).isNotNull();
+                assertThat(doc.getString("name")).isEqualTo("testcontainers");
+            }
         }
     }
 }

--- a/modules/mongodb/src/test/resources/init-db.js
+++ b/modules/mongodb/src/test/resources/init-db.js
@@ -1,0 +1,2 @@
+db = db.getSiblingDB('testdb');
+db.items.insertOne({ name: 'testcontainers' });


### PR DESCRIPTION
Closes #3066

When a script is placed in `/docker-entrypoint-initdb.d/`, MongoDB shuts down and restarts after executing it. The existing wait strategy only expected `"waiting for connections"` once, so startup appeared to complete before the restart finished, causing containers with init scripts to fail.

`withInitScript(MountableFile)` copies the script into the container at startup. When combined with `withReplicaSet()`, the wait strategy is automatically adjusted to expect the log message twice, accounting for the extra restart. Without `withReplicaSet()`, no wait strategy change is needed since MongoDB does not restart in standalone mode.

Multiple scripts can be chained and are executed in the order they were added.

\`\`\`java
new MongoDBContainer("mongo:6.0")
    .withReplicaSet()
    .withInitScript(MountableFile.forClasspathResource("init-db.js"))
    .start();
\`\`\`