### PR TITLE
Add execInArtemis helper to ArtemisContainer (#11589)

### DIFF
--- a/docs/modules/activemq.md
+++ b/docs/modules/activemq.md
@@ -37,6 +37,12 @@ With anonymous login:
 [Allow anonymous login](../../modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java) inside_block:enableAnonymousLogin
 <!--/codeinclude-->
 
+Running an Artemis CLI command:
+
+<!--codeinclude-->
+[Executing a CLI command](../../modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java) inside_block:execInArtemis
+<!--/codeinclude-->
+
 ## Adding this module to your project dependencies
 
 Add the following dependency to your `pom.xml`/`build.gradle` file:

--- a/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
+++ b/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
@@ -1,11 +1,11 @@
 package org.testcontainers.activemq;
 
-import lombok.SneakyThrows;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -100,8 +100,7 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> {
      * @param command the CLI arguments (e.g. {@code "queue", "create", "--name=myqueue"}).
      * @return the result of the command execution.
      */
-    @SneakyThrows
-    public ExecResult execInArtemis(String... command) {
+    public ExecResult execInArtemis(String... command) throws IOException, InterruptedException {
         List<String> fullCommand = new ArrayList<>();
         fullCommand.add(ARTEMIS_CLI);
         fullCommand.addAll(Arrays.asList(command));

--- a/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
+++ b/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
@@ -7,7 +7,9 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
-import java.util.stream.Stream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Testcontainers implementation for Apache ActiveMQ Artemis.
@@ -93,17 +95,22 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> {
     }
 
     /**
-     * Executes an Artemis CLI command inside the container, automatically prepending the binary
-     * path and injecting the configured user and password credentials.
+     * Executes an Artemis CLI command, prepending the binary path and injecting credentials unless already supplied.
      *
-     * @param command the CLI arguments (e.g. {@code "queue", "create", "--name=myqueue"})
-     * @return the result of the command execution
+     * @param command the CLI arguments (e.g. {@code "queue", "create", "--name=myqueue"}).
+     * @return the result of the command execution.
      */
     @SneakyThrows
     public ExecResult execInArtemis(String... command) {
-        String[] fullCommand = Stream
-            .concat(Stream.of(ARTEMIS_CLI), Stream.concat(Stream.of(command), Stream.of("--user=" + getUser(), "--password=" + getPassword())))
-            .toArray(String[]::new);
-        return execInContainer(fullCommand);
+        List<String> fullCommand = new ArrayList<>();
+        fullCommand.add(ARTEMIS_CLI);
+        fullCommand.addAll(Arrays.asList(command));
+        if (Arrays.stream(command).noneMatch(arg -> arg.startsWith("--user"))) {
+            fullCommand.add("--user=" + getUser());
+        }
+        if (Arrays.stream(command).noneMatch(arg -> arg.startsWith("--password"))) {
+            fullCommand.add("--password=" + getPassword());
+        }
+        return execInContainer(fullCommand.toArray(new String[0]));
     }
 }

--- a/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
+++ b/modules/activemq/src/main/java/org/testcontainers/activemq/ArtemisContainer.java
@@ -1,10 +1,13 @@
 package org.testcontainers.activemq;
 
+import lombok.SneakyThrows;
+import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
+import java.util.stream.Stream;
 
 /**
  * Testcontainers implementation for Apache ActiveMQ Artemis.
@@ -42,6 +45,8 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> {
     private static final int MQTT_PORT = 1883;
 
     private static final int WS_PORT = 61614;
+
+    private static final String ARTEMIS_CLI = "/var/lib/artemis-instance/bin/artemis";
 
     private String username = "artemis";
 
@@ -85,5 +90,20 @@ public class ArtemisContainer extends GenericContainer<ArtemisContainer> {
 
     public String getPassword() {
         return getEnvMap().get("ARTEMIS_PASSWORD");
+    }
+
+    /**
+     * Executes an Artemis CLI command inside the container, automatically prepending the binary
+     * path and injecting the configured user and password credentials.
+     *
+     * @param command the CLI arguments (e.g. {@code "queue", "create", "--name=myqueue"})
+     * @return the result of the command execution
+     */
+    @SneakyThrows
+    public ExecResult execInArtemis(String... command) {
+        String[] fullCommand = Stream
+            .concat(Stream.of(ARTEMIS_CLI), Stream.concat(Stream.of(command), Stream.of("--user=" + getUser(), "--password=" + getPassword())))
+            .toArray(String[]::new);
+        return execInContainer(fullCommand);
     }
 }

--- a/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
+++ b/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
@@ -11,6 +11,7 @@ import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.testcontainers.containers.Container.ExecResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +60,19 @@ class ArtemisContainerTest {
             artemis.start();
 
             assertFunctionality(artemis, true);
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    void execInArtemis() {
+        try (ArtemisContainer artemis = new ArtemisContainer("apache/activemq-artemis:2.32.0-alpine")) {
+            artemis.start();
+
+            ExecResult result = artemis.execInArtemis(
+                "queue", "create", "--name=exec-test-queue", "--auto-create-address", "--anycast", "--silent"
+            );
+            assertThat(result.getExitCode()).isEqualTo(0);
         }
     }
 

--- a/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
+++ b/modules/activemq/src/test/java/org/testcontainers/activemq/ArtemisContainerTest.java
@@ -69,10 +69,18 @@ class ArtemisContainerTest {
         try (ArtemisContainer artemis = new ArtemisContainer("apache/activemq-artemis:2.32.0-alpine")) {
             artemis.start();
 
-            ExecResult result = artemis.execInArtemis(
-                "queue", "create", "--name=exec-test-queue", "--auto-create-address", "--anycast", "--silent"
+            // execInArtemis {
+            artemis.execInArtemis(
+                "queue",
+                "create",
+                "--name=exec-test-queue",
+                "--auto-create-address",
+                "--anycast",
+                "--silent"
             );
-            assertThat(result.getExitCode()).isEqualTo(0);
+            ExecResult stat = artemis.execInArtemis("queue", "stat", "--queueName=exec-test-queue");
+            assertThat(stat.getStdout()).contains("exec-test-queue");
+            // }
         }
     }
 


### PR DESCRIPTION
Closes #11589

Invoking the Artemis CLI from a container required callers to hard-code the internal binary path and manually append `--user`/`--password` on every call. `execInArtemis` wraps `execInContainer`, prepending the binary path and injecting the configured credentials automatically.

```java
ExecResult result = artemis.execInArtemis(
    "queue", "create", "--name=myqueue", "--auto-create-address", "--anycast", "--silent"
);
```

The binary path and credentials are always resolved from the container's current configuration, so multiple CLI commands can be chained without any extra setup.