### PR TITLE
docs: fix broken Docker Hub link for the alpine image

### DIFF
--- a/docs/supported_docker_environment/image_registry_rate_limiting.md
+++ b/docs/supported_docker_environment/image_registry_rate_limiting.md
@@ -12,7 +12,7 @@ As of the current version of Testcontainers ({{latest_version}}):
 * every image directly used by your tests
 * images pulled by Testcontainers itself to support functionality:
     * [`testcontainers/ryuk`](https://hub.docker.com/r/testcontainers/ryuk) - performs fail-safe cleanup of containers, and always required (unless [Ryuk is disabled](../features/configuration.md#disabling-ryuk))
-    * [`alpine`](https://hub.docker.com/r/_/alpine) - used to check whether images can be pulled at startup, and always required (unless [startup checks are disabled](../features/configuration.md#disabling-the-startup-checks))
+    * [`alpine`](https://hub.docker.com/_/alpine) - used to check whether images can be pulled at startup, and always required (unless [startup checks are disabled](../features/configuration.md#disabling-the-startup-checks))
     * [`testcontainers/sshd`](https://hub.docker.com/r/testcontainers/sshd) - required if [exposing host ports to containers](../features/networking.md#exposing-host-ports-to-the-container)
     * [`testcontainers/vnc-recorder`](https://hub.docker.com/r/testcontainers/vnc-recorder) - required if using [Webdriver containers](../modules/webdriver_containers.md) and using the screen recording feature
     * [`docker/compose`](https://hub.docker.com/r/docker/compose) - required if using [Docker Compose](../modules/docker_compose.md)


### PR DESCRIPTION
The `alpine` link on the image registry rate limiting page points to `https://hub.docker.com/r/_/alpine`, which returns a 404. Official images on Docker Hub are served under `/_/<name>`, so the working URL is `https://hub.docker.com/_/alpine`.

This updates the single occurrence in `docs/supported_docker_environment/image_registry_rate_limiting.md`.
