### PR TITLE
fix(kafka): use sentinel file to eliminate starter-script race condition (#11682)

### DIFF
--- a/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/containers/KafkaContainer.java
@@ -6,6 +6,7 @@ import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.ComparableVersion;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -44,6 +45,8 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
     private static final String DEFAULT_INTERNAL_TOPIC_RF = "1";
 
     private static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
+
+    private static final String STARTER_SCRIPT_SENTINEL = STARTER_SCRIPT + ".ready";
 
     // https://docs.confluent.io/platform/7.0.0/release-notes/index.html#ak-raft-kraft
     private static final String MIN_KRAFT_TAG = "7.0.0";
@@ -200,6 +203,11 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
         // Run the original command
         command += "/etc/confluent/docker/run \n";
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+        try {
+            execInContainer("touch", STARTER_SCRIPT_SENTINEL);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     protected String commandKraft() {
@@ -272,7 +280,7 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
             addExposedTcpPort(KAFKA_PORT);
 
             setEntrypoint("sh");
-            setCommand("-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+            setCommand("-c", "while [ ! -f " + STARTER_SCRIPT_SENTINEL + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
 
             setWaitStrategy(Wait.forLogMessage(".*\\[KafkaServer id=\\d+\\] started.*", 1));
         }

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/ConfluentKafkaContainer.java
@@ -5,6 +5,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -66,6 +67,11 @@ public class ConfluentKafkaContainer extends GenericContainer<ConfluentKafkaCont
 
         command += "/etc/confluent/docker/run \n";
         copyFileToContainer(Transferable.of(command, 0777), KafkaHelper.STARTER_SCRIPT);
+        try {
+            execInContainer("touch", KafkaHelper.STARTER_SCRIPT_SENTINEL);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaContainer.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaContainer.java
@@ -5,6 +5,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -72,6 +73,11 @@ public class KafkaContainer extends GenericContainer<KafkaContainer> {
 
         command += "/etc/kafka/docker/run \n";
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
+        try {
+            execInContainer("touch", KafkaHelper.STARTER_SCRIPT_SENTINEL);
+        } catch (IOException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
+++ b/modules/kafka/src/main/java/org/testcontainers/kafka/KafkaHelper.java
@@ -25,10 +25,12 @@ class KafkaHelper {
 
     static final String STARTER_SCRIPT = "/tmp/testcontainers_start.sh";
 
+    static final String STARTER_SCRIPT_SENTINEL = STARTER_SCRIPT + ".ready";
+
     static final String[] COMMAND = {
         "sh",
         "-c",
-        "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
+        "while [ ! -f " + STARTER_SCRIPT_SENTINEL + " ]; do sleep 0.1; done; " + STARTER_SCRIPT,
     };
 
     static final WaitStrategy WAIT_STRATEGY = Wait.forLogMessage(".*Transitioning from RECOVERY to RUNNING.*", 1);


### PR DESCRIPTION
The Kafka containers start the broker by writing a startup script into the container via `copyFileToContainer`, then executing it with a shell loop that polls for the file. Because the loop checks only for file existence, it can detect the script the instant its inode is created and attempt to execute it before the write completes. On busy hosts this produces `Text file busy` (ETXTBSY) and a container exit code of 126.

This was confirmed in #11682 by the reporter and a second commenter. The suggestion of checking file size with `[ -s file ]` was also tested and failed for the same reason: size becomes non-zero before the write finishes.

The fix introduces a sentinel file (`/tmp/testcontainers_start.sh.ready`) that is created via `execInContainer("touch", ...)` only after `copyFileToContainer` returns. The wait loop now polls for the sentinel instead of the script itself. Because `copyFileToContainer` completes fully before the sentinel is touched, the loop cannot proceed until the script is both fully written and closed.

The change is applied consistently to all affected containers: `org.testcontainers.kafka.KafkaHelper` (shared COMMAND constant), `org.testcontainers.kafka.KafkaContainer`, `org.testcontainers.kafka.ConfluentKafkaContainer`, and the deprecated `org.testcontainers.containers.KafkaContainer`.

Fixes #11682