### PR TITLE
Fix silent failure in BrowserWebDriverContainer#getSeleniumAddress

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -280,8 +280,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         try {
             return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
         } catch (MalformedURLException e) {
-            e.printStackTrace(); // TODO
-            return null;
+            throw new ContainerLaunchException("Could not construct Selenium address", e);
         }
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
@@ -179,8 +179,7 @@ public class BrowserWebDriverContainer
         try {
             return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
         } catch (MalformedURLException e) {
-            e.printStackTrace(); // TODO
-            return null;
+            throw new ContainerLaunchException("Could not construct Selenium address", e);
         }
     }
 


### PR DESCRIPTION
### Fix silent failure in BrowserWebDriverContainer#getSeleniumAddress

What does this PR do?

Fixed the `// TODO` left in `BrowserWebDriverContainer#getSeleniumAddress()`.

The existing code caught `MalformedURLException` and only called `e.printStackTrace()`, returning `null`:

```java
public URL getSeleniumAddress() {
    try {
        return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
    } catch (MalformedURLException e) {
        e.printStackTrace(); // TODO
        return null;
    }
}
```

This PR wraps the exception in `ContainerLaunchException` and throws it immediately, matching the existing error-handling pattern already used elsewhere in this class (e.g. for temp directory creation failures):

```java
public URL getSeleniumAddress() {
    try {
        return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
    } catch (MalformedURLException e) {
        throw new ContainerLaunchException("Could not construct Selenium address", e);
    }
}
```

The identical duplicated code in `org.testcontainers.selenium.BrowserWebDriverContainer` is fixed the same way.