### PR TITLE
Preserve container logs after startup failure

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -56,6 +56,7 @@ import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.DockerLoggerFactory;
 import org.testcontainers.utility.DockerMachineClient;
 import org.testcontainers.utility.DynamicPollInterval;
+import org.testcontainers.utility.LogUtils;
 import org.testcontainers.utility.MountableFile;
 import org.testcontainers.utility.PathUtils;
 import org.testcontainers.utility.ResourceReaper;
@@ -134,6 +135,15 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     private StartupCheckStrategy startupCheckStrategy = new IsRunningStartupCheckStrategy();
 
     private int startupAttempts = 1;
+
+    /**
+     * Log output captured from the container when it failed to start. Kept so that callers can still
+     * inspect it after the failed container has been removed.
+     */
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.NONE)
+    @Nullable
+    private String logsFromFailedStartup = null;
 
     @Nullable
     private String workingDirectory = null;
@@ -300,6 +310,20 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     public String getContainerId() {
         return containerId;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * If the container failed to start it will already have been removed, so the log output that was
+     * captured during the failure is returned instead.
+     */
+    @Override
+    public String getLogs() {
+        if (getContainerId() == null) {
+            return this.logsFromFailedStartup != null ? this.logsFromFailedStartup : "";
+        }
+        return LogUtils.getOutput(getDockerClient(), getContainerId());
     }
 
     /**
@@ -539,6 +563,8 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             if (containerId != null) {
                 // Log output if startup failed, either due to a container failure or exception (including timeout)
                 final String containerLogs = getLogs();
+                // Keep the logs around: stop() below removes the container, making them unreachable afterwards
+                this.logsFromFailedStartup = containerLogs;
 
                 if (containerLogs.length() > 0) {
                     logger().error("Log output from the failed container:\n{}", containerLogs);

--- a/core/src/test/java/org/testcontainers/containers/LogsAfterStartupFailureTest.java
+++ b/core/src/test/java/org/testcontainers/containers/LogsAfterStartupFailureTest.java
@@ -1,0 +1,30 @@
+package org.testcontainers.containers;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.TestImages;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LogsAfterStartupFailureTest {
+
+    @Test
+    void shouldKeepLogsAfterStartupFailure() {
+        try (
+            GenericContainer<?> container = new GenericContainer<>(TestImages.TINY_IMAGE)
+                .withCommand("sh", "-c", "echo 'something went wrong'; exit 1")
+                .waitingFor(
+                    Wait.forLogMessage(".*this will never appear.*", 1).withStartupTimeout(Duration.ofSeconds(10))
+                )
+        ) {
+            assertThatThrownBy(container::start).isInstanceOf(ContainerLaunchException.class);
+
+            assertThat(container.getLogs())
+                .as("log output of the failed container is still available after startup failed")
+                .contains("something went wrong");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #9956

### Problem

Since 1.20.2, `getLogs()` returns an empty string for a container that failed
to start. `tryStart()` reads the logs, prints them to the logger, and then calls
`stop()`, which removes the container and sets `containerId` to `null`. The log
content itself is discarded, so it is no longer reachable from user code:

```java
assertThatThrownBy(container::start).isInstanceOf(ContainerLaunchException.class);
container.getLogs(); // ""
```

This makes debugging startup failures harder, since the logs are exactly what
you need at that point.

### Solution

Keep the log output that is already captured in `tryStart()` and return it from
`getLogs()` once the container is gone. `stop()` still runs as before, so no
container is leaked.

### Notes

- With `withStartupAttempts(n)`, the logs of the last failed attempt are kept.
  Happy to reset this per attempt if you prefer.
- Added `LogsAfterStartupFailureTest`, which fails on `main` and passes with this change.