### PR TITLE
fix(localstack): copy the starter script before the container starts

### DIFF
--- a/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/containers/localstack/LocalStackContainer.java
@@ -1,6 +1,5 @@
 package org.testcontainers.containers.localstack;
 
-import com.github.dockerjava.api.command.InspectContainerResponse;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
@@ -20,6 +19,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -203,13 +203,19 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         exposePorts();
     }
 
+    /**
+     * Copied before the container starts: the entrypoint waits only for the script to exist, so copying it
+     * into an already running container can have it executed while still incomplete, exiting with code 126.
+     */
     @Override
-    protected void containerIsStarting(InspectContainerResponse containerInfo) {
+    protected void containerIsCreated(String containerId) {
+        Map<String, String> labels = getDockerClient().inspectContainerCmd(containerId).exec().getConfig().getLabels();
         String command = "#!/bin/bash\n";
-        command += "export LAMBDA_DOCKER_FLAGS=" + configureServiceContainerLabels("LAMBDA_DOCKER_FLAGS") + "\n";
-        command += "export ECS_DOCKER_FLAGS=" + configureServiceContainerLabels("ECS_DOCKER_FLAGS") + "\n";
-        command += "export EC2_DOCKER_FLAGS=" + configureServiceContainerLabels("EC2_DOCKER_FLAGS") + "\n";
-        command += "export BATCH_DOCKER_FLAGS=" + configureServiceContainerLabels("BATCH_DOCKER_FLAGS") + "\n";
+        command +=
+            "export LAMBDA_DOCKER_FLAGS=" + configureServiceContainerLabels("LAMBDA_DOCKER_FLAGS", labels) + "\n";
+        command += "export ECS_DOCKER_FLAGS=" + configureServiceContainerLabels("ECS_DOCKER_FLAGS", labels) + "\n";
+        command += "export EC2_DOCKER_FLAGS=" + configureServiceContainerLabels("EC2_DOCKER_FLAGS", labels) + "\n";
+        command += "export BATCH_DOCKER_FLAGS=" + configureServiceContainerLabels("BATCH_DOCKER_FLAGS", labels) + "\n";
         command += "/usr/local/bin/docker-entrypoint.sh\n";
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
     }
@@ -220,8 +226,8 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * chance.
      * @return the lambda container labels as a string
      */
-    private String configureServiceContainerLabels(String existingEnvFlagKey) {
-        String internalMarkerFlags = internalMarkerLabels();
+    private String configureServiceContainerLabels(String existingEnvFlagKey, Map<String, String> labels) {
+        String internalMarkerFlags = internalMarkerLabels(labels);
         String existingFlags = getEnvMap().get(existingEnvFlagKey);
         if (existingFlags != null) {
             internalMarkerFlags = existingFlags + " " + internalMarkerFlags;
@@ -233,10 +239,8 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * Provides a docker argument string including all default labels set on testcontainers containers (excluding reuse labels)
      * @return Argument string in the format `-l key1=value1 -l key2=value2`
      */
-    private String internalMarkerLabels() {
-        return getContainerInfo()
-            .getConfig()
-            .getLabels()
+    private String internalMarkerLabels(Map<String, String> labels) {
+        return labels
             .entrySet()
             .stream()
             .filter(entry -> entry.getKey().startsWith(DockerClientFactory.TESTCONTAINERS_LABEL))

--- a/modules/localstack/src/main/java/org/testcontainers/localstack/LocalStackContainer.java
+++ b/modules/localstack/src/main/java/org/testcontainers/localstack/LocalStackContainer.java
@@ -1,6 +1,5 @@
 package org.testcontainers.localstack;
 
-import com.github.dockerjava.api.command.InspectContainerResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
@@ -15,6 +14,7 @@ import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -76,13 +76,19 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
         }
     }
 
+    /**
+     * Copied before the container starts: the entrypoint waits only for the script to exist, so copying it
+     * into an already running container can have it executed while still incomplete, exiting with code 126.
+     */
     @Override
-    protected void containerIsStarting(InspectContainerResponse containerInfo) {
+    protected void containerIsCreated(String containerId) {
+        Map<String, String> labels = getDockerClient().inspectContainerCmd(containerId).exec().getConfig().getLabels();
         String command = "#!/bin/bash\n";
-        command += "export LAMBDA_DOCKER_FLAGS=" + configureServiceContainerLabels("LAMBDA_DOCKER_FLAGS") + "\n";
-        command += "export ECS_DOCKER_FLAGS=" + configureServiceContainerLabels("ECS_DOCKER_FLAGS") + "\n";
-        command += "export EC2_DOCKER_FLAGS=" + configureServiceContainerLabels("EC2_DOCKER_FLAGS") + "\n";
-        command += "export BATCH_DOCKER_FLAGS=" + configureServiceContainerLabels("BATCH_DOCKER_FLAGS") + "\n";
+        command +=
+            "export LAMBDA_DOCKER_FLAGS=" + configureServiceContainerLabels("LAMBDA_DOCKER_FLAGS", labels) + "\n";
+        command += "export ECS_DOCKER_FLAGS=" + configureServiceContainerLabels("ECS_DOCKER_FLAGS", labels) + "\n";
+        command += "export EC2_DOCKER_FLAGS=" + configureServiceContainerLabels("EC2_DOCKER_FLAGS", labels) + "\n";
+        command += "export BATCH_DOCKER_FLAGS=" + configureServiceContainerLabels("BATCH_DOCKER_FLAGS", labels) + "\n";
         command += "/usr/local/bin/docker-entrypoint.sh\n";
         copyFileToContainer(Transferable.of(command, 0777), STARTER_SCRIPT);
     }
@@ -93,8 +99,8 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * chance.
      * @return the lambda container labels as a string
      */
-    private String configureServiceContainerLabels(String existingEnvFlagKey) {
-        String internalMarkerFlags = internalMarkerLabels();
+    private String configureServiceContainerLabels(String existingEnvFlagKey, Map<String, String> labels) {
+        String internalMarkerFlags = internalMarkerLabels(labels);
         String existingFlags = getEnvMap().get(existingEnvFlagKey);
         if (existingFlags != null) {
             internalMarkerFlags = existingFlags + " " + internalMarkerFlags;
@@ -106,10 +112,8 @@ public class LocalStackContainer extends GenericContainer<LocalStackContainer> {
      * Provides a docker argument string including all default labels set on testcontainers containers (excluding reuse labels)
      * @return Argument string in the format `-l key1=value1 -l key2=value2`
      */
-    private String internalMarkerLabels() {
-        return getContainerInfo()
-            .getConfig()
-            .getLabels()
+    private String internalMarkerLabels(Map<String, String> labels) {
+        return labels
             .entrySet()
             .stream()
             .filter(entry -> entry.getKey().startsWith(DockerClientFactory.TESTCONTAINERS_LABEL))

--- a/modules/localstack/src/test/java/org/testcontainers/localstack/StarterScriptTest.java
+++ b/modules/localstack/src/test/java/org/testcontainers/localstack/StarterScriptTest.java
@@ -1,0 +1,39 @@
+package org.testcontainers.localstack;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalstackTestImages;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class StarterScriptTest {
+
+    @Test
+    void starterScriptIsCompleteBeforeTheContainerStarts() {
+        AtomicReference<String> script = new AtomicReference<>();
+
+        try (
+            LocalStackContainer localstack = new LocalStackContainer(LocalstackTestImages.LOCALSTACK_IMAGE) {
+                @Override
+                protected void containerIsCreated(String containerId) {
+                    super.containerIsCreated(containerId);
+                    script.set(
+                        copyFileFromContainer(
+                            "/testcontainers_start.sh",
+                            stream -> IOUtils.toString(stream, StandardCharsets.UTF_8)
+                        )
+                    );
+                }
+            }
+        ) {
+            localstack.start();
+        }
+
+        // read back while the container was created but not yet started, so the entrypoint could not
+        // have executed a partially copied script
+        assertThat(script.get()).endsWith("/usr/local/bin/docker-entrypoint.sh\n");
+    }
+}


### PR DESCRIPTION
### Problem

`LocalStackContainer` starts the container with an entrypoint that waits for
`/testcontainers_start.sh` to *exist* and then executes it:

```java
cmd.withEntrypoint("sh", "-c",
    "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
```

but the script is copied from `containerIsStarting`, i.e. once the container is already running. The
copy publishes the filename before the contents, so a poll landing mid-copy executes an unfinished
file. The container exits with code 126, never logs `Ready.`, and the failure surfaces 60s later as a
wait-strategy timeout that points away from the cause:

```
Caused by: java.lang.IllegalStateException: Wait strategy failed. Container exited with code 126
Caused by: ContainerLaunchException: Timed out waiting for log output matching '.*Ready\.'
```

The container's own stderr says what really happened, but nothing surfaces it:

```
sh: 1: /testcontainers_start.sh: Text file busy
```

Existence is not readiness: during extraction the path exists while the file is still incomplete and
open for writing, so `execve` fails with `ETXTBSY`, or with `EACCES` on runtimes that apply the mode
only after the write. Both make a POSIX shell exit 126.

We hit this on CI at roughly 1% of builds (about 0.33% per container start) on Docker 20.10.21.

### Fix

Move the copy to `containerIsCreated`, which `GenericContainer.doStart` calls between
`createCommand.exec()` and `startContainerCmd`, the same window `withCopyToContainer` entries already
use. Nothing is running in the container there, so an incomplete script cannot be executed. This
removes the race rather than narrowing it, and does not depend on whether the runtime applies the file
mode before or after the write.

`internalMarkerLabels()` read `getContainerInfo()`, which is not populated that early, so the labels
now come from an explicit `inspectContainerCmd(containerId)`.

Applied to both `org.testcontainers.localstack.LocalStackContainer` and the deprecated
`org.testcontainers.containers.localstack.LocalStackContainer`.

Note that `containerIsStarting` also ran on the reuse path, so a reused container had the script
re-copied over itself while running. `containerIsCreated` does not, which is both correct (the script
is already there, same container, same labels) and safer.

### Testing

- `StarterScriptTest` reads the script back out of the created but not yet started container and
  asserts it is complete. Without this change it fails with `NotFoundException: no such file or
  directory`, so it guards the ordering rather than passing alongside it.
- Full `:testcontainers-localstack:test` green (35 tests), including
  `LambdaContainerLabels.shouldLabelLambdaContainers`, which covers the refactored label path.
- A/B through the library with the same padded starter script in both arms: copied from
  `containerIsStarting` it fails with `Container exited with code 126`, copied from
  `containerIsCreated` it starts cleanly.
