### PR TITLE
Fail fast with a clear exception instead of returning null in getSele…

### DIFF
--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -280,8 +280,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         try {
             return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
         } catch (MalformedURLException e) {
-            e.printStackTrace(); // TODO
-            return null;
+            throw new IllegalStateException("Failed to construct Selenium address", e);
         }
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/containers/BrowserWebDriverContainer.java
@@ -280,7 +280,7 @@ public class BrowserWebDriverContainer<SELF extends BrowserWebDriverContainer<SE
         try {
             return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
         } catch (MalformedURLException e) {
-            throw new IllegalStateException("Failed to construct Selenium address", e);
+            throw new ContainerLaunchException("Could not construct Selenium address", e);
         }
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
@@ -179,8 +179,7 @@ public class BrowserWebDriverContainer
         try {
             return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
         } catch (MalformedURLException e) {
-            e.printStackTrace(); // TODO
-            return null;
+            throw new IllegalStateException("Failed to construct Selenium address", e);
         }
     }
 

--- a/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
+++ b/modules/selenium/src/main/java/org/testcontainers/selenium/BrowserWebDriverContainer.java
@@ -179,7 +179,7 @@ public class BrowserWebDriverContainer
         try {
             return new URL("http", getHost(), getMappedPort(SELENIUM_PORT), "/wd/hub");
         } catch (MalformedURLException e) {
-            throw new IllegalStateException("Failed to construct Selenium address", e);
+            throw new ContainerLaunchException("Could not construct Selenium address", e);
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

`BrowserWebDriverContainer#getSeleniumAddress()` currently catches `MalformedURLException`,
calls `e.printStackTrace()` (marked with an open `// TODO`), and returns `null`.

Every caller of this method in the codebase (`RemoteWebDriver` constructors in tests and
examples) passes the result straight into `new RemoteWebDriver(seleniumAddress, ...)` with
no null check. So a malformed URL doesn't actually fail safely today — it just turns into a
confusing `NullPointerException` inside Selenium's `RemoteWebDriver` constructor, several
frames away from the real cause, with the original exception only visible via a stderr dump
instead of the test's actual logs.

This PR replaces the `printStackTrace` + `return null` with throwing an `IllegalStateException`
that wraps the original `MalformedURLException`, so the failure surfaces immediately, at the
actual point of failure, with a clear message and full cause chain.

Applied the same fix to both copies of the class (`org.testcontainers.containers.BrowserWebDriverContainer`
and `org.testcontainers.selenium.BrowserWebDriverContainer`), since both had the identical TODO.

## Why is it important?

This method effectively never returns null safely in practice (no call site checks for it),
so the current behavior only delays and obscures a real failure. Failing fast with a clear
message is strictly more debuggable and doesn't change behavior for any passing case —
`MalformedURLException` here would only realistically occur if the container itself were
already in a broken state.
