### PR TITLE
Fix MongoDBContainer default wait strategy to support init scripts (#3066)

### DIFF
--- a/modules/mongodb/src/main/java/org/testcontainers/mongodb/MongoDBContainer.java
+++ b/modules/mongodb/src/main/java/org/testcontainers/mongodb/MongoDBContainer.java
@@ -54,6 +54,8 @@ public class MongoDBContainer extends GenericContainer<MongoDBContainer> {
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, COMMUNITY_SERVER_IMAGE, ENTERPRISE_SERVER_IMAGE);
 
         withExposedPorts(MONGODB_INTERNAL_PORT);
+
+        waitingFor(Wait.forLogMessage("(?i).*waiting for connections.*", 1));
     }
 
     @Override

--- a/modules/mongodb/src/test/java/org/testcontainers/mongodb/MongoDBContainerTest.java
+++ b/modules/mongodb/src/test/java/org/testcontainers/mongodb/MongoDBContainerTest.java
@@ -1,6 +1,7 @@
 package org.testcontainers.mongodb;
 
 import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.MountableFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,6 +37,20 @@ class MongoDBContainerTest extends AbstractMongo {
             mongoDBContainer.start();
             final String databaseName = "my-db";
             assertThat(mongoDBContainer.getReplicaSetUrl(databaseName)).endsWith(databaseName);
+        }
+    }
+
+    @Test
+    void shouldStartWithInitScript() {
+        try (
+            MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:6.0")
+                .withCopyFileToContainer(
+                    MountableFile.forClasspathResource("mongo-init.js"),
+                    "/docker-entrypoint-initdb.d/mongo-init.js"
+                )
+        ) {
+            mongoDBContainer.start();
+            System.out.println("Container started successfully: " + mongoDBContainer.getConnectionString());
         }
     }
 }

--- a/modules/mongodb/src/test/resources/mongo-init.js
+++ b/modules/mongodb/src/test/resources/mongo-init.js
@@ -1,0 +1,3 @@
+db = db.getSiblingDB('testdb');
+db.createCollection('testcollection');
+db.testcollection.insertOne({ message: 'init script ran' });


### PR DESCRIPTION
## What does this PR do?

Fixes #3066

`MongoDBContainer`'s constructor did not set an explicit wait strategy, so it fell back
to the default port-based wait strategy from `GenericContainer`. This caused a race
condition when using init scripts (e.g. via `withCopyFileToContainer` targeting
`/docker-entrypoint-initdb.d/`), because MongoDB restarts internally after running the
init script, and the port-based wait strategy could report the container as "ready"
before the restart completed.

## Changes

- Added `waitingFor(Wait.forLogMessage("(?i).*waiting for connections.*", 1))` to the
  `MongoDBContainer` constructor, so the container waits for MongoDB's actual readiness
  log message instead of relying solely on port availability.
- Added a test (`shouldStartWithInitScript`) that starts a `MongoDBContainer` with an
  init script copied to `/docker-entrypoint-initdb.d/`, verifying the container starts
  successfully.

## Testing

Ran the new test locally multiple times with `--rerun` to confirm it passes consistently.