### PR TITLE
Document why singleton containers are needed under Spring's test context cache

### DIFF
--- a/docs/test_framework_integration/manual_lifecycle_control.md
+++ b/docs/test_framework_integration/manual_lifecycle_control.md
@@ -47,3 +47,12 @@ The singleton container is started only once when the base class is loaded.
 The container can then be used by all inheriting test classes.
 At the end of the test suite the [Ryuk container](https://github.com/testcontainers/moby-ryuk)
 that is started by Testcontainers core will take care of stopping the singleton container.
+
+!!! warning "Spring Boot and the test context cache"
+    Under `@SpringBootTest`, this pattern is usually required rather than merely an optimisation.
+
+    Spring caches the application context and reuses it across test classes, while the JUnit 5 `@Testcontainers` extension ties container lifecycle to the test *class*. When both apply: the first test class starts a container and Spring builds a context holding its mapped port; the extension stops that container when the class finishes; the next test class then reuses the **cached** context, which still points at the container that was just stopped. Every test in it fails with connection errors.
+
+    The symptom is misleading, because the first class passes and later ones fail with errors that mention connections rather than containers — so it tends to read like test pollution or a test ordering problem.
+
+    Starting the container in a static initialiser and never stopping it keeps it alive for as long as the cached context can be reused. Ryuk still removes it when the JVM exits, so nothing is leaked.


### PR DESCRIPTION
Closes #11967

The Singleton containers section shows the static-initialiser pattern but not the reason it is needed. Under `@SpringBootTest` it is usually required rather than an optimisation: Spring caches the application context across test classes while `@Testcontainers` ties container lifecycle to the class, so a later test class reuses a cached context pointing at a container that has already been stopped.

The failure is misleading enough to be worth documenting — the first class passes, later ones fail, and the error mentions connections rather than containers.

Docs-only change, no code affected.
