### PR TITLE
Add getR2dbcUrl helper method to JdbcDatabaseContainer

### DIFF
--- a/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
+++ b/modules/jdbc/src/main/java/org/testcontainers/containers/JdbcDatabaseContainer.java
@@ -77,6 +77,15 @@ public abstract class JdbcDatabaseContainer<SELF extends JdbcDatabaseContainer<S
     public abstract String getJdbcUrl();
 
     /**
+     * @return an R2DBC URL that may be used to connect to the dockerized DB
+     */
+    public String getR2dbcUrl() {
+        String jdbcUrl = getJdbcUrl();
+        // Convert JDBC URL to R2DBC URL by replacing jdbc: with r2dbc:
+        return jdbcUrl.replaceFirst("^jdbc:", "r2dbc:");
+    }
+
+    /**
      * @return the database name
      */
     public String getDatabaseName() {

--- a/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerTest.java
+++ b/modules/jdbc/src/test/java/org/testcontainers/containers/JdbcDatabaseContainerTest.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import java.sql.Connection;
 import java.sql.SQLException;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
@@ -18,6 +19,20 @@ class JdbcDatabaseContainerTest {
             .withStartupTimeoutSeconds(1);
 
         assertThatExceptionOfType(IllegalStateException.class).isThrownBy(jdbcContainer::waitUntilContainerStarted);
+    }
+
+    @Test
+    void getR2dbcUrlConvertsJdbcUrlToR2dbcUrl() {
+        JdbcDatabaseContainerStub jdbcContainer = new JdbcDatabaseContainerStub("mysql:latest") {
+            @Override
+            public String getJdbcUrl() {
+                return "jdbc:mysql://localhost:3306/test";
+            }
+        };
+
+        String r2dbcUrl = jdbcContainer.getR2dbcUrl();
+
+        assertThat(r2dbcUrl).isEqualTo("r2dbc:mysql://localhost:3306/test");
     }
 
     static class JdbcDatabaseContainerStub extends JdbcDatabaseContainer {


### PR DESCRIPTION
Adds a convenience method to generate R2DBC connection strings from JDBC URLs, similar to the existing getJdbcUrl() method. This makes integration with R2DBC drivers more seamless.

Fixes #8797

<!--
Thanks for contributing to Testcontainers. Before submitting a pull request, please
review our contributing guidelines at https://java.testcontainers.org/contributing/

Please also review the following notes before submitting a pull request.

New Modules:

If you are contributing a new module, please add your module name to the following files:

* `./.github/ISSUE_TEMPLATE/bug_report.yaml`
* `./.github/ISSUE_TEMPLATE/enhancement.yaml`
* `./.github/ISSUE_TEMPLATE/feature.yaml`
* `./.github/dependabot.yml`
* `./.github/labeler.yml`

Also make sure that your new module has the appropriate documentation under `./docs/modules/`

Before committing any change, please run `./gradlew checkstyleMain checkstyleTest spotlessApply` and fix any issues that occur.

Dependency Upgrades:
Please do not open a pull request to update only a version dependency. Existing process will perform
the upgrade every week. However, if the upgrade involves more changes (changes for deprecated API) then
your pull request is very welcome.

Describing Your Changes:

If, after having reviewed the notes above, you're ready to submit your pull request, please
provide a brief description of the proposed changes and their context. If they fix a bug, please
describe the broken behaviour and how the changes fix it. If they make an enhancement,
please describe the new functionality and why you believe it's useful. If your pull
request relates to any existing issues, please reference them by using the issue number
prefixed with #.
-->
