### PR TITLE
Allow extra Azurite command line options

### DIFF
--- a/docs/modules/azure.md
+++ b/docs/modules/azure.md
@@ -27,6 +27,12 @@ Start Azurite Emulator during a test:
 !!! note
     SSL configuration is possible using the `withSsl(MountableFile, String)` and  `withSsl(MountableFile, MountableFile)` methods.
 
+Newer Azure Storage SDK versions can send API versions that Azurite does not support. Use `withCommandOptions(...)` to append extra Azurite flags such as `--skipApiVersionCheck`. `AzuriteContainer` rebuilds its process command in `configure()`, so `.withCommand(...)` cannot be used for extra flags.
+
+<!--codeinclude-->
+[Pass extra Azurite command options](../../modules/azure/src/test/java/org/testcontainers/azure/AzuriteContainerCommandTest.java) inside_block:commandOptions
+<!--/codeinclude-->
+
 If the tested application needs to use more than one set of credentials, the container can be configured to use custom credentials.
 Please see some examples below.
 

--- a/modules/azure/src/main/java/org/testcontainers/azure/AzuriteContainer.java
+++ b/modules/azure/src/main/java/org/testcontainers/azure/AzuriteContainer.java
@@ -4,6 +4,10 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Testcontainers implementation for Azurite Emulator.
  * <p>
@@ -52,6 +56,8 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
 
     private String pwd = null;
 
+    private final List<String> commandOptions = new ArrayList<>();
+
     /**
      * @param dockerImageName specified docker image name to run
      */
@@ -93,6 +99,20 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
         this.cert = pemCert;
         this.key = pemKey;
         this.certExtension = ".pem";
+        return this;
+    }
+
+    /**
+     * Append extra Azurite command line flags after the default host and SSL arguments.
+     * <p>
+     * {@link #withCommand(String...)} cannot be used for this: {@link #configure()} always
+     * rebuilds the process command and overwrites any previously set command.
+     *
+     * @param options additional Azurite flags, for example {@code --skipApiVersionCheck}
+     * @return this
+     */
+    public AzuriteContainer withCommandOptions(String... options) {
+        this.commandOptions.addAll(Arrays.asList(options));
         return this;
     }
 
@@ -159,6 +179,9 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
             } else {
                 args.append(" --key ").append("/key.pem");
             }
+        }
+        for (String option : this.commandOptions) {
+            args.append(" ").append(option);
         }
         final String cmd = args.toString();
         logger().debug("Using command line: '{}'", cmd);

--- a/modules/azure/src/test/java/org/testcontainers/azure/AzuriteContainerCommandTest.java
+++ b/modules/azure/src/test/java/org/testcontainers/azure/AzuriteContainerCommandTest.java
@@ -19,12 +19,13 @@ class AzuriteContainerCommandTest {
     @Test
     void commandLineIncludesExtraOptions() {
         // commandOptions {
-        AzuriteContainer emulator = new AzuriteContainer(IMAGE).withCommandOptions("--skipApiVersionCheck");
+        AzuriteContainer emulator = new AzuriteContainer("mcr.microsoft.com/azure-storage/azurite:3.33.0")
+            .withCommandOptions("--skipApiVersionCheck");
         // }
 
         assertThat(emulator.getCommandLine())
             .startsWith("azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0")
-            .contains("--skipApiVersionCheck");
+            .endsWith("--skipApiVersionCheck");
     }
 
     @Test
@@ -32,7 +33,7 @@ class AzuriteContainerCommandTest {
         AzuriteContainer emulator = new AzuriteContainer(IMAGE)
             .withCommandOptions("--skipApiVersionCheck", "--disableProductStyleUrl");
 
-        assertThat(emulator.getCommandLine()).contains("--skipApiVersionCheck").contains("--disableProductStyleUrl");
+        assertThat(emulator.getCommandLine()).endsWith("--skipApiVersionCheck --disableProductStyleUrl");
     }
 
     @Test
@@ -43,19 +44,19 @@ class AzuriteContainerCommandTest {
 
         assertThat(emulator.getCommandLine())
             .contains("--cert /cert.pfx")
-            .contains("--pwd changeit")
-            .contains("--skipApiVersionCheck");
+            .endsWith("--pwd changeit --skipApiVersionCheck");
     }
 
     @Test
     void configureAppliesCommandOptionsEvenIfWithCommandWasUsed() {
         AzuriteContainer emulator = new AzuriteContainer(IMAGE)
-            .withCommand("azurite --skipApiVersionCheck")
+            .withCommand("azurite --ignored")
             .withCommandOptions("--skipApiVersionCheck");
 
         emulator.configure();
 
-        assertThat(String.join(" ", emulator.getCommandParts())).contains("--skipApiVersionCheck");
+        assertThat(String.join(" ", emulator.getCommandParts()))
+            .isEqualTo("azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0 --skipApiVersionCheck");
         assertThat(emulator.getCommandLine()).contains("--blobHost 0.0.0.0").contains("--skipApiVersionCheck");
     }
 }

--- a/modules/azure/src/test/java/org/testcontainers/azure/AzuriteContainerCommandTest.java
+++ b/modules/azure/src/test/java/org/testcontainers/azure/AzuriteContainerCommandTest.java
@@ -1,0 +1,61 @@
+package org.testcontainers.azure;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.utility.MountableFile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AzuriteContainerCommandTest {
+
+    private static final String IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.33.0";
+
+    @Test
+    void commandLineOmitsExtraOptionsByDefault() {
+        AzuriteContainer emulator = new AzuriteContainer(IMAGE);
+
+        assertThat(emulator.getCommandLine()).doesNotContain("--skipApiVersionCheck");
+    }
+
+    @Test
+    void commandLineIncludesExtraOptions() {
+        // commandOptions {
+        AzuriteContainer emulator = new AzuriteContainer(IMAGE).withCommandOptions("--skipApiVersionCheck");
+        // }
+
+        assertThat(emulator.getCommandLine())
+            .startsWith("azurite --blobHost 0.0.0.0 --queueHost 0.0.0.0 --tableHost 0.0.0.0")
+            .contains("--skipApiVersionCheck");
+    }
+
+    @Test
+    void commandLineAppendsMultipleOptions() {
+        AzuriteContainer emulator = new AzuriteContainer(IMAGE)
+            .withCommandOptions("--skipApiVersionCheck", "--disableProductStyleUrl");
+
+        assertThat(emulator.getCommandLine()).contains("--skipApiVersionCheck").contains("--disableProductStyleUrl");
+    }
+
+    @Test
+    void commandLineKeepsExtraOptionsTogetherWithSsl() {
+        AzuriteContainer emulator = new AzuriteContainer(IMAGE)
+            .withSsl(MountableFile.forClasspathResource("/keystore.pfx"), "changeit")
+            .withCommandOptions("--skipApiVersionCheck");
+
+        assertThat(emulator.getCommandLine())
+            .contains("--cert /cert.pfx")
+            .contains("--pwd changeit")
+            .contains("--skipApiVersionCheck");
+    }
+
+    @Test
+    void configureAppliesCommandOptionsEvenIfWithCommandWasUsed() {
+        AzuriteContainer emulator = new AzuriteContainer(IMAGE)
+            .withCommand("azurite --skipApiVersionCheck")
+            .withCommandOptions("--skipApiVersionCheck");
+
+        emulator.configure();
+
+        assertThat(String.join(" ", emulator.getCommandParts())).contains("--skipApiVersionCheck");
+        assertThat(emulator.getCommandLine()).contains("--blobHost 0.0.0.0").contains("--skipApiVersionCheck");
+    }
+}


### PR DESCRIPTION
## What
`AzuriteContainer.configure()` always rebuilds the process command via `getCommandLine()`, so extra flags passed with `withCommand(...)` never reach Azurite.

This adds `withCommandOptions(...)` so users can append extra Azurite flags, including `--skipApiVersionCheck` for newer Azure Storage SDKs.

Fixes #11966

## Why
Microsoft currently recommends `--skipApiVersionCheck` when Azurite lags behind the Azure Storage Blob SDK API version. Users cannot pass that flag through `AzuriteContainer` today and have to drop back to a raw `GenericContainer`. A generic options API covers that case and other Azurite flags, same idea as `K6Container.withCmdOptions(...)`.

## How
- Store extra flags on `AzuriteContainer` and append them in `getCommandLine()`
- Keep the existing host/SSL command construction unchanged
- Document the method and why `withCommand(...)` cannot be used for extra Azurite flags

## Test plan
Executed locally on Java 17:

- `./gradlew :testcontainers-azure:test --tests org.testcontainers.azure.AzuriteContainerCommandTest` — 5/5
  - default command omits extra flags
  - extra options are appended after the host flags
  - multiple options are kept
  - flags are kept together with SSL cert/password args
  - `configure()` still applies extra options after a prior `withCommand(...)`
- `./gradlew :testcontainers-azure:spotlessApply :testcontainers-azure:checkstyleMain :testcontainers-azure:checkstyleTest`

These command-line tests do not start a container.