### PR TITLE
Fix check-then-act race in container reuse (`withReuse(true)`)

### DIFF
--- a/core/src/main/java/org/testcontainers/containers/GenericContainer.java
+++ b/core/src/main/java/org/testcontainers/containers/GenericContainer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.exception.ConflictException;
 import com.github.dockerjava.api.exception.NotFoundException;
 import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.ContainerNetwork;
@@ -69,6 +70,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -85,6 +87,7 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -111,6 +114,22 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
     static final String HASH_LABEL = "org.testcontainers.hash";
 
     static final String COPIED_FILES_HASH_LABEL = "org.testcontainers.copied_files.hash";
+
+    /**
+     * Deterministic name given to a container created for reuse, derived from its reuse hash.
+     * Docker enforces container-name uniqueness across every process/host sharing a daemon, so
+     * attempting to create a container under this name is used as a cross-process arbiter: only
+     * one JVM/process can ever win the "create" call for a given hash, see {@link #tryStart()}.
+     */
+    static final String REUSE_CONTAINER_NAME_PREFIX = "testcontainers-reuse-";
+
+    /**
+     * JVM-local lock, keyed by reuse hash, guarding the "check reuse, else create" sequence in
+     * {@link #tryStart()} against same-JVM races (see "// TODO locking" history on
+     * {@link #findContainerForReuse(String)}). This does NOT protect against cross-process races.
+     * Those are handled by the Docker container-name uniqueness arbiter, see {@link #REUSE_CONTAINER_NAME_PREFIX}.
+     */
+    private static final ConcurrentHashMap<String, Object> REUSE_LOCKS = new ConcurrentHashMap<>();
 
     /*
      * Default settings
@@ -391,15 +410,31 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
                     String hash = hash(createCommand);
 
-                    containerId = findContainerForReuse(hash).orElse(null);
+                    // Layer 1: JVM-local lock, so two threads in this process can't both miss the
+                    // reuse lookup below and both fall through to creating a container.
+                    Object reuseLock = REUSE_LOCKS.computeIfAbsent(hash, h -> new Object());
+                    synchronized (reuseLock) {
+                        containerId = findContainerForReuse(hash).orElse(null);
 
-                    if (containerId != null) {
-                        logger().info("Reusing container with ID: {} and hash: {}", containerId, hash);
-                        reused = true;
-                    } else {
-                        logger().debug("Can't find a reusable running container with hash: {}", hash);
+                        if (containerId != null) {
+                            logger().info("Reusing container with ID: {} and hash: {}", containerId, hash);
+                            reused = true;
+                        } else {
+                            logger().debug("Can't find a reusable running container with hash: {}", hash);
 
-                        createCommand.getLabels().put(HASH_LABEL, hash);
+                            createCommand.getLabels().put(HASH_LABEL, hash);
+
+                            // Layer 2: the JVM-local lock above only protects this process. Two
+                            // separate processes racing on an identical config hash would both
+                            // still see "not found" here. Use Docker's own container-name
+                            // uniqueness as a cross-process arbiter for the actual create call.
+                            AbstractMap.SimpleEntry<String, Boolean> createdOrJoined = createOrJoinReusableContainer(
+                                createCommand,
+                                hash
+                            );
+                            containerId = createdOrJoined.getKey();
+                            reused = createdOrJoined.getValue();
+                        }
                     }
                     reusable = true;
                 } else {
@@ -421,9 +456,11 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
                 createCommand = ResourceReaper.instance().register(this, createCommand);
             }
 
-            if (!reused) {
+            if (!reused && !reusable) {
                 containerId = createCommand.exec().getId();
+            }
 
+            if (!reused) {
                 // TODO use single "copy" invocation (and calculate an hash of the resulting tar archive)
                 copyToFileContainerPathMap.forEach(this::copyFileToContainer);
 
@@ -587,7 +624,9 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
 
     @VisibleForTesting
     Optional<String> findContainerForReuse(String hash) {
-        // TODO locking
+        // Callers must hold the per-hash lock in REUSE_LOCKS around this call (see tryStart()) to
+        // avoid a same-JVM check-then-act race; cross-process races are handled separately by
+        // createOrJoinReusableContainer's name-based arbiter.
         return dockerClient
             .listContainersCmd()
             .withLabelFilter(ImmutableMap.of(HASH_LABEL, hash))
@@ -597,6 +636,123 @@ public class GenericContainer<SELF extends GenericContainer<SELF>>
             .stream()
             .findAny()
             .map(it -> it.getId());
+    }
+
+    /**
+     * Creates the container for reuse, using a deterministic name derived from the reuse hash as
+     * a cross-process arbiter: Docker enforces container-name uniqueness daemon-wide, so at most
+     * one process can ever win the "create" call for a given name/hash, even across separate JVMs
+     * that all missed the {@link #findContainerForReuse(String)} lookup at the same time.
+     *
+     * @return the container id, and whether it was reused (joined a container created by a
+     *         concurrent winner) rather than freshly created by this call.
+     */
+    private AbstractMap.SimpleEntry<String, Boolean> createOrJoinReusableContainer(
+        CreateContainerCmd createCommand,
+        String hash
+    ) {
+        String name = REUSE_CONTAINER_NAME_PREFIX + hash;
+        createCommand.withName(name);
+
+        while (true) {
+            try {
+                String newId = createCommand.exec().getId();
+                return new AbstractMap.SimpleEntry<>(newId, false);
+            } catch (ConflictException nameConflict) {
+                Optional<String> joinedId = resolveConflictingReusableContainer(name, hash);
+                if (joinedId.isPresent()) {
+                    return new AbstractMap.SimpleEntry<>(joinedId.get(), true);
+                }
+                // Name is confirmed free again (the conflicting container vanished, or we just
+                // cleaned up a dead one). Retry the create call above.
+            }
+        }
+    }
+
+    /**
+     * Waits out a name conflict on an in-progress concurrent creation, or resolves it directly,
+     * without re-attempting {@code createCommand.exec()} on every poll. That call is guaranteed
+     * to fail again as long as the name is still taken, so polling here re-inspects the existing
+     * container by name instead.
+     *
+     * @return the running container's id if one was found and is joinable; empty once the name
+     *         is confirmed free again, meaning the caller should retry the create call.
+     */
+    private Optional<String> resolveConflictingReusableContainer(String name, String hash) {
+        // Matches AbstractWaitStrategy's default startup timeout. A concurrent winner that
+        // hasn't finished starting within that budget is treated the same way a normal container
+        // start that overruns its timeout would be: an error, not an indefinite wait.
+        Instant deadline = Instant.now().plus(Duration.ofSeconds(60));
+        long backoffMillis = 100;
+
+        while (true) {
+            InspectContainerResponse existing;
+            try {
+                existing = dockerClient.inspectContainerCmd(name).exec();
+            } catch (NotFoundException goneAlready) {
+                // The conflicting container vanished since our create attempt (e.g. its own
+                // creator's process crashed, or Ryuk reaped it). Nothing to join.
+                return Optional.empty();
+            }
+
+            Map<String, String> existingLabels = existing.getConfig().getLabels();
+            String existingHash = existingLabels != null ? existingLabels.get(HASH_LABEL) : null;
+            if (!hash.equals(existingHash)) {
+                // A real name clash with something that isn't one of our reuse containers.
+                // Do NOT blindly reuse it, that could hand back an unrelated container.
+                throw new IllegalStateException(
+                    "Container name \"" +
+                    name +
+                    "\" is already in use by a container that is not a Testcontainers reuse " +
+                    "container for this configuration (expected label " +
+                    HASH_LABEL +
+                    "=" +
+                    hash +
+                    ", found \"" +
+                    existingHash +
+                    "\")"
+                );
+            }
+
+            String status = existing.getState().getStatus();
+            if ("running".equalsIgnoreCase(status)) {
+                return Optional.of(existing.getId());
+            }
+
+            if ("exited".equalsIgnoreCase(status) || "dead".equalsIgnoreCase(status)) {
+                // The concurrent winner crashed before starting. Clean up so the name is free for
+                // the caller to retry the create; this process is now the new winner-in-waiting.
+                try {
+                    dockerClient.removeContainerCmd(existing.getId()).withForce(true).exec();
+                } catch (NotFoundException alreadyRemoved) {
+                    // A concurrent loser (or Ryuk) already removed it. Fine, name is free either way.
+                }
+                return Optional.empty();
+            }
+
+            // Still "created" (or some other transient state): a concurrent winner is still
+            // mid create-and-start. Back off and re-inspect directly, rather than retrying the
+            // create call in the meantime.
+            if (Instant.now().isAfter(deadline)) {
+                throw new IllegalStateException(
+                    "Timed out waiting for concurrently-created reusable container \"" +
+                    name +
+                    "\" (hash: " +
+                    hash +
+                    ") to finish starting"
+                );
+            }
+            try {
+                Thread.sleep(backoffMillis);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IllegalStateException(
+                    "Interrupted while waiting for reusable container to start",
+                    interrupted
+                );
+            }
+            backoffMillis = Math.min(backoffMillis * 2, 2000);
+        }
     }
 
     /**

--- a/core/src/test/java/org/testcontainers/containers/ReusabilityNameConflictTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ReusabilityNameConflictTest.java
@@ -1,0 +1,256 @@
+package org.testcontainers.containers;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.exception.ConflictException;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.core.command.CreateContainerCmdImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+import org.testcontainers.TestImages;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the cross-process arbiter in {@code GenericContainer#createOrJoinReusableContainer}:
+ * when the JVM-local lock can't help (a different process/JVM raced us), the deterministic
+ * container name derived from the reuse hash makes Docker's own name-uniqueness constraint the
+ * tiebreaker. These tests simulate the name conflict that a concurrent process's "docker create"
+ * would produce, without needing an actual second process.
+ *
+ * <p>Since the real reuse hash depends on the fully-configured {@code CreateContainerCmd} (labels,
+ * host config, etc. are only set by {@code applyConfiguration} right before hashing), these tests
+ * capture the hash {@code GenericContainer} actually computes, via {@link GenericContainer#HASH_LABEL}
+ * on the command passed to the mocked "create" call, rather than recomputing it independently,
+ * which would silently drift from the real value and invalidate the label-matching assertions.
+ */
+class ReusabilityNameConflictTest extends ReusabilityUnitTests.AbstractReusabilityTest {
+
+    @Test
+    void reusesConflictingContainerWhenLabelMatchesAndRunning() {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).environmentSupportsReuse();
+
+        String winnerContainerId = "winner-container-id";
+        AtomicReference<String> capturedHash = new AtomicReference<>();
+        AtomicInteger createAttempts = new AtomicInteger();
+
+        when(client.createContainerCmd(any())).then(conflictOnceThenCapture(createAttempts, capturedHash));
+        when(client.listContainersCmd()).then(listContainersAnswer());
+        when(client.inspectContainerCmd(startsWith(GenericContainer.REUSE_CONTAINER_NAME_PREFIX)))
+            .then(inspectAnswer(() -> inspectResponse(winnerContainerId, "running", labelsFor(capturedHash.get()))));
+        // Once reused, tryStart() inspects by container id (not by the reuse name) to wait for
+        // mapped ports, so this needs its own stub distinct from the name-based one above.
+        when(client.inspectContainerCmd(winnerContainerId)).then(inv -> inspectContainerAnswer().answer(inv));
+
+        GenericContainer<?> container = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+        container.start();
+
+        assertThat(container.getContainerId()).isEqualTo(winnerContainerId);
+        assertThat(createAttempts.get())
+            .as("create attempts before finding the running winner")
+            .isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void refusesToReuseConflictingContainerWithMismatchedLabel() {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).environmentSupportsReuse();
+
+        when(client.createContainerCmd(any()))
+            .then(invocation -> {
+                CreateContainerCmd.Exec exec = command -> {
+                    throw new ConflictException("container name already in use");
+                };
+                return new CreateContainerCmdImpl(exec, null, "image:latest");
+            });
+        when(client.listContainersCmd()).then(listContainersAnswer());
+        when(client.inspectContainerCmd(startsWith(GenericContainer.REUSE_CONTAINER_NAME_PREFIX)))
+            .then(
+                inspectAnswer(() -> {
+                    return inspectResponse("unrelated-container-id", "running", labelsFor("some-other-hash-entirely"));
+                })
+            );
+
+        GenericContainer<?> container = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+
+        // doStart() retries tryStart() via Unreliables.retryUntilSuccess, so the IllegalStateException
+        // thrown by createOrJoinReusableContainer ends up as the *root* cause, wrapped first in a
+        // ContainerLaunchException by tryStart()'s catch block and then again after the retry gives up.
+        assertThatThrownBy(container::start)
+            .hasRootCauseInstanceOf(IllegalStateException.class)
+            .hasStackTraceContaining("is already in use by a container that is not a Testcontainers reuse container");
+    }
+
+    @Test
+    void retriesWhileConflictingContainerIsStillBeingCreated() {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).environmentSupportsReuse();
+
+        String winnerContainerId = "winner-container-id";
+        AtomicReference<String> capturedHash = new AtomicReference<>();
+        AtomicInteger createAttempts = new AtomicInteger();
+        AtomicInteger inspectCalls = new AtomicInteger();
+
+        when(client.createContainerCmd(any())).then(conflictOnceThenCapture(createAttempts, capturedHash));
+        when(client.listContainersCmd()).then(listContainersAnswer());
+
+        // First two inspects see the winner still in "created" state (not started yet), the third
+        // sees it "running". The retry/backoff loop must ride this out rather than giving up or
+        // misreporting a name clash.
+        when(client.inspectContainerCmd(startsWith(GenericContainer.REUSE_CONTAINER_NAME_PREFIX)))
+            .then(
+                inspectAnswer(() -> {
+                    int call = inspectCalls.incrementAndGet();
+                    String status = call < 3 ? "created" : "running";
+                    return inspectResponse(winnerContainerId, status, labelsFor(capturedHash.get()));
+                })
+            );
+        when(client.inspectContainerCmd(winnerContainerId)).then(inv -> inspectContainerAnswer().answer(inv));
+
+        GenericContainer<?> container = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+        container.start();
+
+        assertThat(container.getContainerId()).isEqualTo(winnerContainerId);
+        assertThat(inspectCalls.get()).as("number of re-inspects while waiting").isGreaterThanOrEqualTo(3);
+    }
+
+    @Test
+    void cleansUpDeadConflictingContainerThenRetriesCreate() {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).environmentSupportsReuse();
+
+        String deadContainerId = "dead-container-id";
+        String freshContainerId = "fresh-container-id";
+        AtomicReference<String> capturedHash = new AtomicReference<>();
+        AtomicInteger createAttempts = new AtomicInteger();
+        AtomicInteger removeAttempts = new AtomicInteger();
+
+        when(client.createContainerCmd(any()))
+            .then(invocation -> {
+                CreateContainerCmd.Exec exec = command -> {
+                    if (capturedHash.get() == null) {
+                        capturedHash.set(command.getLabels().get(GenericContainer.HASH_LABEL));
+                    }
+                    if (createAttempts.incrementAndGet() == 1) {
+                        throw new ConflictException("container name already in use");
+                    }
+                    CreateContainerResponse response = new CreateContainerResponse();
+                    response.setId(freshContainerId);
+                    return response;
+                };
+                return new CreateContainerCmdImpl(exec, null, "image:latest");
+            });
+        when(client.listContainersCmd()).then(listContainersAnswer());
+        when(client.startContainerCmd(freshContainerId)).then(inv -> startContainerAnswer().answer(inv));
+        when(client.inspectContainerCmd(freshContainerId)).then(inv -> inspectContainerAnswer().answer(inv));
+        when(client.inspectContainerCmd(startsWith(GenericContainer.REUSE_CONTAINER_NAME_PREFIX)))
+            .then(inspectAnswer(() -> inspectResponse(deadContainerId, "exited", labelsFor(capturedHash.get()))));
+
+        RemoveContainerCmd removeCmd = Mockito.mock(RemoveContainerCmd.class, Answers.RETURNS_SELF);
+        when(removeCmd.exec())
+            .then(invocation -> {
+                removeAttempts.incrementAndGet();
+                return null;
+            });
+        when(client.removeContainerCmd(deadContainerId)).thenReturn(removeCmd);
+
+        GenericContainer<?> container = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+        container.start();
+
+        assertThat(container.getContainerId()).isEqualTo(freshContainerId);
+        assertThat(removeAttempts.get()).as("dead conflicting container removed").isEqualTo(1);
+        assertThat(createAttempts.get()).as("create retried after cleanup").isEqualTo(2);
+    }
+
+    @Test
+    void toleratesConflictingContainerAlreadyRemovedByAConcurrentCleanup() {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).environmentSupportsReuse();
+
+        String freshContainerId = "fresh-container-id";
+        AtomicInteger createAttempts = new AtomicInteger();
+
+        when(client.createContainerCmd(any()))
+            .then(invocation -> {
+                CreateContainerCmd.Exec exec = command -> {
+                    if (createAttempts.incrementAndGet() == 1) {
+                        throw new ConflictException("container name already in use");
+                    }
+                    CreateContainerResponse response = new CreateContainerResponse();
+                    response.setId(freshContainerId);
+                    return response;
+                };
+                return new CreateContainerCmdImpl(exec, null, "image:latest");
+            });
+        when(client.listContainersCmd()).then(listContainersAnswer());
+        when(client.startContainerCmd(freshContainerId)).then(inv -> startContainerAnswer().answer(inv));
+        when(client.inspectContainerCmd(freshContainerId)).then(inv -> inspectContainerAnswer().answer(inv));
+
+        // Simulate a concurrent loser (or Ryuk) already removing the conflicting container by the
+        // time we inspect it: NotFoundException, not a running/created/exited container. The
+        // arbiter must treat this as "nothing to join, just retry create", not as an error.
+        when(client.inspectContainerCmd(startsWith(GenericContainer.REUSE_CONTAINER_NAME_PREFIX)))
+            .then(invocation -> {
+                InspectContainerCmd cmd = Mockito.mock(InspectContainerCmd.class);
+                when(cmd.exec()).thenThrow(new NotFoundException("no such container"));
+                return cmd;
+            });
+
+        GenericContainer<?> container = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+        container.start();
+
+        assertThat(container.getContainerId()).isEqualTo(freshContainerId);
+        assertThat(createAttempts.get()).as("create retried after conflicting container vanished").isEqualTo(2);
+    }
+
+    private static org.mockito.stubbing.Answer<CreateContainerCmd> conflictOnceThenCapture(
+        AtomicInteger createAttempts,
+        AtomicReference<String> capturedHash
+    ) {
+        return invocation -> {
+            CreateContainerCmd.Exec exec = command -> {
+                capturedHash.compareAndSet(null, command.getLabels().get(GenericContainer.HASH_LABEL));
+                createAttempts.incrementAndGet();
+                throw new ConflictException("container name already in use");
+            };
+            return new CreateContainerCmdImpl(exec, null, "image:latest");
+        };
+    }
+
+    private static Map<String, String> labelsFor(String hash) {
+        return Collections.singletonMap(GenericContainer.HASH_LABEL, hash);
+    }
+
+    private static InspectContainerResponse inspectResponse(String id, String status, Map<String, String> labels) {
+        InspectContainerResponse response = Mockito.mock(InspectContainerResponse.class, Answers.RETURNS_DEEP_STUBS);
+        when(response.getId()).thenReturn(id);
+        when(response.getConfig().getLabels()).thenReturn(labels);
+        when(response.getState().getStatus()).thenReturn(status);
+        return response;
+    }
+
+    private static org.mockito.stubbing.Answer<InspectContainerCmd> inspectAnswer(
+        Supplier<InspectContainerResponse> resultSupplier
+    ) {
+        return invocation -> {
+            // Resolve the result before opening the when(...) stub: resultSupplier.get() creates
+            // and stubs its own mock (see inspectResponse()), and nesting that inside an
+            // in-progress when(cmd.exec()) call confuses Mockito's stubbing state.
+            InspectContainerResponse result = resultSupplier.get();
+            InspectContainerCmd cmd = Mockito.mock(InspectContainerCmd.class);
+            when(cmd.exec()).thenReturn(result);
+            return cmd;
+        };
+    }
+}

--- a/core/src/test/java/org/testcontainers/containers/ReusabilityRaceConditionTest.java
+++ b/core/src/test/java/org/testcontainers/containers/ReusabilityRaceConditionTest.java
@@ -1,0 +1,186 @@
+package org.testcontainers.containers;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.core.command.CreateContainerCmdImpl;
+import com.github.dockerjava.core.command.ListContainersCmdImpl;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.testcontainers.TestImages;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the check-then-act race in {@link GenericContainer#findContainerForReuse(String)} that
+ * used to be marked with a "// TODO locking" comment: two containers with the identical reuse
+ * hash, started concurrently, could both miss the reuse lookup and both end up creating a new
+ * container, silently defeating the purpose of {@code withReuse(true)}.
+ *
+ * <p>{@link GenericContainer#tryStart()} now guards the "check reuse, else create" sequence with
+ * a per-hash JVM-local lock, which is what this test now verifies: exactly one real container is
+ * created for two same-JVM concurrent starts with an identical hash, and the second one reuses
+ * the first. The lock only protects same-JVM races; cross-process races are covered separately by
+ * {@code GenericContainer#createOrJoinReusableContainer}'s name-conflict handling, exercised in
+ * {@link ReusabilityNameConflictTest}.
+ */
+class ReusabilityRaceConditionTest extends ReusabilityUnitTests.AbstractReusabilityTest {
+
+    // Simulates the Docker daemon's container list, updated only once a "create" call completes -
+    // exactly like the real docker daemon, there is no lock held between the "list" read and the "create" write.
+    private final List<String> runningContainerIds = new CopyOnWriteArrayList<>();
+
+    @Test
+    void concurrentStartsWithIdenticalHashCreateExactlyOneContainer() throws InterruptedException {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).environmentSupportsReuse();
+
+        when(client.listContainersCmd())
+            .then(invocation -> {
+                ListContainersCmd.Exec exec = command -> {
+                    return new ObjectMapper()
+                        .convertValue(
+                            runningContainerIds.stream().map(id -> singletonIdMap(id)).collect(Collectors.toList()),
+                            new TypeReference<List<Container>>() {}
+                        );
+                };
+                return new ListContainersCmdImpl(exec);
+            });
+
+        when(client.createContainerCmd(any()))
+            .then(invocation -> {
+                CreateContainerCmd.Exec exec = command -> {
+                    // Simulate real-world latency of an actual "docker create" round trip,
+                    // widening the window between the reuse lookup and the container becoming visible.
+                    sleepQuietly(300);
+                    String newId = "created-" + java.util.UUID.randomUUID();
+                    runningContainerIds.add(newId);
+                    CreateContainerResponse response = new CreateContainerResponse();
+                    response.setId(newId);
+                    return response;
+                };
+                return new CreateContainerCmdImpl(exec, null, "image:latest");
+            });
+
+        when(client.startContainerCmd(any())).then(inv -> startContainerAnswer().answer(inv));
+        when(client.inspectContainerCmd(any())).then(inv -> inspectContainerAnswer().answer(inv));
+
+        GenericContainer<?> containerA = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+        GenericContainer<?> containerB = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+
+        CountDownLatch bothReady = new CountDownLatch(2);
+        Runnable startAndCountDown = () -> {
+            bothReady.countDown();
+            try {
+                bothReady.await(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        Thread t1 = new Thread(() -> {
+            startAndCountDown.run();
+            containerA.start();
+        });
+        Thread t2 = new Thread(() -> {
+            startAndCountDown.run();
+            containerB.start();
+        });
+
+        t1.start();
+        t2.start();
+        t1.join(10_000);
+        t2.join(10_000);
+
+        // Both containers were configured identically (same image, same reuse hash), and reuse
+        // was requested for both. With the per-hash JVM-local lock in tryStart(), the two threads
+        // are serialized around "check reuse, else create": whichever thread wins the lock first
+        // creates the real container, and the other thread's lookup (also inside the lock) then
+        // finds it and reuses it, so exactly one real container is ever created.
+        assertThat(runningContainerIds).as("number of containers actually created").hasSize(1);
+        assertThat(containerA.getContainerId()).isEqualTo(containerB.getContainerId());
+    }
+
+    @Test
+    void twoOrMoreThreadsRacingStillCreateExactlyOneContainer() throws InterruptedException {
+        Mockito.doReturn(true).when(TestcontainersConfiguration.getInstance()).environmentSupportsReuse();
+
+        when(client.listContainersCmd())
+            .then(invocation -> {
+                ListContainersCmd.Exec exec = command -> {
+                    return new ObjectMapper()
+                        .convertValue(
+                            runningContainerIds.stream().map(id -> singletonIdMap(id)).collect(Collectors.toList()),
+                            new TypeReference<List<Container>>() {}
+                        );
+                };
+                return new ListContainersCmdImpl(exec);
+            });
+
+        when(client.createContainerCmd(any()))
+            .then(invocation -> {
+                CreateContainerCmd.Exec exec = command -> {
+                    sleepQuietly(100);
+                    String newId = "created-" + java.util.UUID.randomUUID();
+                    runningContainerIds.add(newId);
+                    CreateContainerResponse response = new CreateContainerResponse();
+                    response.setId(newId);
+                    return response;
+                };
+                return new CreateContainerCmdImpl(exec, null, "image:latest");
+            });
+
+        when(client.startContainerCmd(any())).then(inv -> startContainerAnswer().answer(inv));
+        when(client.inspectContainerCmd(any())).then(inv -> inspectContainerAnswer().answer(inv));
+
+        int threadCount = 5;
+        CountDownLatch allReady = new CountDownLatch(threadCount);
+        List<GenericContainer<?>> containers = new CopyOnWriteArrayList<>();
+        List<Thread> threads = new java.util.ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            GenericContainer<?> container = makeReusable(new GenericContainer<>(TestImages.TINY_IMAGE));
+            containers.add(container);
+            Thread t = new Thread(() -> {
+                allReady.countDown();
+                try {
+                    allReady.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                container.start();
+            });
+            threads.add(t);
+        }
+
+        threads.forEach(Thread::start);
+        for (Thread t : threads) {
+            t.join(10_000);
+        }
+
+        assertThat(runningContainerIds).as("number of containers actually created").hasSize(1);
+        assertThat(containers.stream().map(GenericContainer::getContainerId).collect(Collectors.toSet())).hasSize(1);
+    }
+
+    private static void sleepQuietly(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static java.util.Map<String, String> singletonIdMap(String id) {
+        return java.util.Collections.singletonMap("Id", id);
+    }
+}


### PR DESCRIPTION
Fixes #11979

Opening as draft, want feedback on the approach before finalizing (see Open questions below).

## Problem

`GenericContainer.tryStart()`'s reuse logic (`findContainerForReuse(hash)` then, if not found, `createCommand.exec()`) has no synchronization between the check and the act. Two concurrent `start()` calls with an identical config hash can both observe "not found" and both create a container. This was reproduced with a mock test and, with no artificial delay, against a real Docker daemon: 5/5 cross-process trials and both same-JVM multi-thread trials (2 and 5 threads) produced duplicate containers, while a sequential control trial did not. Full detail in the linked issue.

## Changes

Two layers, matching the two different races:

**1. Same-JVM lock** (`GenericContainer.java`): a `ConcurrentHashMap<String, Object>` keyed by the reuse hash, obtained via `computeIfAbsent`, guarding the existing check-then-create block with `synchronized`. Mirrors the `synchronized` + create-once idiom already used in `Network.getId()`. Only fixes same-JVM races; processes don't share memory.

**2. Cross-process arbiter using Docker's own name uniqueness** (new `createOrJoinReusableContainer(...)` / `resolveConflictingReusableContainer(...)`): the create call sets a deterministic name (`testcontainers-reuse-<hash>`). If creation succeeds, this call is the winner. If it fails on a name conflict:

- Inspect the conflicting container and check its `HASH_LABEL` actually matches. If not, this is an unrelated name clash, not a reuse race, and we fail loudly instead of guessing.
- `running` → reuse it.
- `created` (winner still mid-setup) → poll by re-inspecting (not by retrying the create call, which would just fail again) with exponential backoff (100ms, doubling, capped at 2s), bounded by a 60s deadline matching `AbstractWaitStrategy`'s default startup timeout.
- `exited`/`dead` (winner crashed before starting) → remove it (tolerating a concurrent removal already having happened, e.g. by another loser or by Ryuk) and let the caller retry the create.

The existing label-based `findContainerForReuse(hash)` lookup is unchanged, so containers created by an older testcontainers version (without the deterministic name) are still found and reused.

Ran `./gradlew spotlessApply` and `checkstyleMain`/`checkstyleTest` locally per the contributing guidelines; both pass.

## Test plan

Mock suite (`./gradlew :testcontainers:test --tests "org.testcontainers.containers.Reusability*"`): 40 tests, 0 failures. Breakdown by class:

| Test class | Tests | Failures |
|---|---|---|
| `ReusabilityUnitTests$CanBeReusedTest` | 5 | 0 |
| `ReusabilityUnitTests$CopyFilesHashTest` | 20 | 0 |
| `ReusabilityUnitTests$HashTest` | 5 | 0 |
| `ReusabilityUnitTests$HooksTest` | 3 | 0 |
| `ReusabilityRaceConditionTest` (updated) | 2 | 0 |
| `ReusabilityNameConflictTest` (new) | 5 | 0 |

`ReusabilityRaceConditionTest` previously asserted 2 containers were created under a same-JVM race (documenting the bug); now asserts exactly 1, plus a 5-thread variant. `ReusabilityNameConflictTest` covers: reuse when found-and-running, refusal on label mismatch, retry-by-reinspecting when `created`, cleanup-and-retry when `exited`/dead, tolerating a `NotFoundException` when the conflicting container is removed by someone else concurrently.

`./gradlew spotlessApply`, `checkstyleMain`, `checkstyleTest` all pass.

Real Docker verification (no mocks, actual `dockerd` 29.2.0, `alpine:3.17`):

**Sequential control** (same config, one call after another): second call reused the first's container.

```
seqA containerId=0de3ee921faf... tookMs=7128   (fresh create)
seqB containerId=0de3ee921faf... tookMs=2039   (reused, log: "Reusing container with ID: 0de3ee921faf... and hash: 876e80fe2d0a...")
```

**5 cross-process trials** (two separate OS processes, concurrent, distinct config per trial so each trial uses a fresh hash):

| Trial | Process A container ID | Process B container ID | Result |
|---|---|---|---|
| 1 | `1c631f2015c1...` | `1c631f2015c1...` | identical (reused) |
| 2 | `7b7f2692e5e8...` | `7b7f2692e5e8...` | identical (reused) |
| 3 | `ae8760d6a6db...` | `ae8760d6a6db...` | identical (reused) |
| 4 | `022f53deecd6...` | `022f53deecd6...` | identical (reused) |
| 5 | `21d6b1752eac...` | `21d6b1752eac...` | identical (reused) |

`docker ps -a` after all 5 trials confirmed exactly 5 containers total (one per trial, not 10).

**Same-JVM multi-thread races:**

```
2 threads: thread0=177d20743a4a...  thread1=177d20743a4a...   (identical, 1 container in docker ps)
5 threads: thread0..thread4 all = 14bd1c48d791...              (identical, 1 container in docker ps)
```

All containers removed after verification, confirmed zero leftover (`docker ps -a --filter "label=org.testcontainers.hash"` returns empty).

## Open questions for maintainers

- Name prefix (`testcontainers-reuse-<hash>`). Happy to match an existing convention if there's a preferred one.
- Retry/backoff tuning (100ms/2s cap/60s deadline, chosen to match `AbstractWaitStrategy`'s default). Should this be configurable instead of fixed?
- Whether the new method(s) should carry the same `@UnstableAPI` marker as `findContainerForReuse`/`hash`.
- Whether the dead-container removal should force-remove or use a plain remove.
- The per-hash lock map (`REUSE_LOCKS`) is never evicted, so it grows with the number of distinct reuse configurations over a JVM's lifetime. In practice that's bounded by how many distinct container configs a test run actually uses, not by test count, but flagging it in case a bound is wanted.