### PR TITLE
Combine Dependabot PRs

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,6 +9,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@v7
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/moby-latest.yml
+++ b/.github/workflows/moby-latest.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Notify to Slack on failures
         if: failure()
         id: slack
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           payload: |
             {

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -18,6 +18,6 @@ jobs:
     if: github.repository == 'testcontainers/testcontainers-java'
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@b1476f6e6eb133afa41ed8589daba6dc69b4d3f5 # v5.19.0
+      - uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v5.19.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -96,7 +96,7 @@ dependencies {
 
     shaded 'org.glassfish.main.external:trilead-ssh2-repackaged:4.1.2'
 
-    shaded 'org.zeroturnaround:zt-exec:1.12'
+    shaded 'org.zeroturnaround:zt-exec:1.13.0'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.3'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,7 +70,7 @@ dependencies {
         exclude(group: 'org.jetbrains', module: 'annotations')
     }
 
-    provided('com.google.cloud.tools:jib-core:0.28.1') {
+    provided('com.google.cloud.tools:jib-core:0.28.2') {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
@@ -101,7 +101,7 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.14.3'
 
     testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
-    testImplementation('com.google.cloud.tools:jib-core:0.28.1')  {
+    testImplementation('com.google.cloud.tools:jib-core:0.28.2')  {
         exclude group: 'com.google.guava', module: 'guava'
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     }
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation 'redis.clients:jedis:7.4.1'
-    testImplementation 'com.rabbitmq:amqp-client:5.26.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.35.0'
     testImplementation 'org.mongodb:mongo-java-driver:3.12.14'
 
     testImplementation ('org.mockito:mockito-core:4.11.0') {

--- a/modules/activemq/build.gradle
+++ b/modules/activemq/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation "org.apache.activemq:activemq-client:6.2.4"
-    testImplementation "org.apache.activemq:artemis-jakarta-client:2.53.0"
+    testImplementation "org.apache.activemq:artemis-jakarta-client:2.55.0"
 }

--- a/modules/azure/build.gradle
+++ b/modules/azure/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':testcontainers-mssqlserver')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:5.3.2'
+    shaded 'com.squareup.okhttp3:okhttp:5.4.0'
 
     testImplementation platform("com.azure:azure-sdk-bom:1.2.32")
     testImplementation 'com.azure:azure-cosmos'

--- a/modules/couchbase/build.gradle
+++ b/modules/couchbase/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Couchbase"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:5.3.2'
+    shaded 'com.squareup.okhttp3:okhttp:5.5.0'
 
     testImplementation 'com.couchbase.client:java-client:3.11.2'
     testImplementation 'org.awaitility:awaitility:4.3.0'

--- a/modules/cratedb/build.gradle
+++ b/modules/cratedb/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: JDBC :: CrateDB"
 dependencies {
     api project(':testcontainers-jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.12'
 
     testImplementation project(':testcontainers-jdbc-test')
 

--- a/modules/db2/build.gradle
+++ b/modules/db2/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'com.ibm.db2:jcc:12.1.4.0'
+    testRuntimeOnly 'com.ibm.db2:jcc:12.1.5.0'
 }

--- a/modules/elasticsearch/build.gradle
+++ b/modules/elasticsearch/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: elasticsearch"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.3.3"
+    testImplementation "org.elasticsearch.client:elasticsearch-rest-client:9.4.3"
     testImplementation "org.elasticsearch.client:transport:7.17.29"
 }

--- a/modules/gcloud/build.gradle
+++ b/modules/gcloud/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: GCloud"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("com.google.cloud:libraries-bom:26.79.0")
+    testImplementation platform("com.google.cloud:libraries-bom:26.84.0")
     testImplementation 'com.google.cloud:google-cloud-bigquery'
     testImplementation 'com.google.cloud:google-cloud-datastore'
     testImplementation 'com.google.cloud:google-cloud-firestore'

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
 
     testImplementation 'io.rest-assured:rest-assured:5.5.7'
-    testImplementation 'io.micrometer:micrometer-registry-otlp:1.16.5'
+    testImplementation 'io.micrometer:micrometer-registry-otlp:1.17.0'
     testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.8'
 
     testImplementation platform('io.opentelemetry:opentelemetry-bom:1.61.0')

--- a/modules/grafana/build.gradle
+++ b/modules/grafana/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testImplementation 'io.micrometer:micrometer-registry-otlp:1.16.5'
     testImplementation 'uk.org.webcompere:system-stubs-jupiter:2.1.8'
 
-    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.61.0')
+    testImplementation platform('io.opentelemetry:opentelemetry-bom:1.65.0')
     testImplementation 'io.opentelemetry:opentelemetry-api'
     testImplementation 'io.opentelemetry:opentelemetry-sdk'
     testImplementation 'io.opentelemetry:opentelemetry-exporter-otlp'

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 
     shaded("org.apache.commons:commons-lang3:3.20.0")
     shaded("commons-io:commons-io:2.21.0")
-    shaded("org.javassist:javassist:3.30.2-GA")
+    shaded("org.javassist:javassist:3.32.0-GA")
     shaded("org.jboss.shrinkwrap:shrinkwrap-api:1.2.6")
     shaded("org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6")
     shaded("net.lingala.zip4j:zip4j:2.11.6")

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation("com.hivemq:hivemq-extension-sdk:4.50.0")
     testImplementation("com.hivemq:hivemq-mqtt-client:1.3.13")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
-    testImplementation("ch.qos.logback:logback-classic:1.5.32")
+    testImplementation("ch.qos.logback:logback-classic:1.5.37")
 }
 
 test {

--- a/modules/hivemq/build.gradle
+++ b/modules/hivemq/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     testImplementation(project(":testcontainers-junit-jupiter"))
     testImplementation("com.hivemq:hivemq-extension-sdk:4.50.0")
-    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.13")
+    testImplementation("com.hivemq:hivemq-mqtt-client:1.3.15")
     testImplementation("org.apache.httpcomponents:httpclient:4.5.14")
     testImplementation("ch.qos.logback:logback-classic:1.5.32")
 }

--- a/modules/jdbc-test/build.gradle
+++ b/modules/jdbc-test/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 
     api 'org.assertj:assertj-core:3.27.7'
 
-    api 'org.apache.tomcat:tomcat-jdbc:11.0.21'
+    api 'org.apache.tomcat:tomcat-jdbc:11.0.23'
     api 'org.vibur:vibur-dbcp:26.0'
     api 'com.mysql:mysql-connector-j:9.6.0'
     api 'org.junit.jupiter:junit-jupiter:5.14.3'

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -14,6 +14,6 @@ dependencies {
         exclude(module: 'hamcrest-core')
     }
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.12'
     testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
 }

--- a/modules/junit-jupiter/build.gradle
+++ b/modules/junit-jupiter/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testImplementation project(':testcontainers-mysql')
     testImplementation project(':testcontainers-postgresql')
     testImplementation 'com.zaxxer:HikariCP:7.0.2'
-    testImplementation 'redis.clients:jedis:7.4.1'
+    testImplementation 'redis.clients:jedis:7.5.3'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
     testImplementation ('org.mockito:mockito-core:4.11.0') {
         exclude(module: 'hamcrest-core')

--- a/modules/k3s/build.gradle
+++ b/modules/k3s/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     // Synchronize with the jackson version, must match major and minor version
     shaded 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.4'
 
-    testImplementation 'io.fabric8:kubernetes-client:7.6.1'
+    testImplementation 'io.fabric8:kubernetes-client:7.8.0'
     testImplementation 'io.kubernetes:client-java:25.0.0-legacy'
 }

--- a/modules/kafka/build.gradle
+++ b/modules/kafka/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Kafka"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'org.apache.kafka:kafka-clients:3.8.0'
+    testImplementation 'org.apache.kafka:kafka-clients:4.3.1'
     testImplementation 'com.google.guava:guava:23.0'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/ldap/build.gradle
+++ b/modules/ldap/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: LDAP"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'com.unboundid:unboundid-ldapsdk:7.0.4'
+    testImplementation 'com.unboundid:unboundid-ldapsdk:7.0.5'
 }

--- a/modules/localstack/build.gradle
+++ b/modules/localstack/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Localstack"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation platform("software.amazon.awssdk:bom:2.42.33")
+    testImplementation platform("software.amazon.awssdk:bom:2.46.20")
     testImplementation 'software.amazon.awssdk:s3'
     testImplementation 'software.amazon.awssdk:sqs'
     testImplementation 'software.amazon.awssdk:cloudwatchlogs'

--- a/modules/mariadb/build.gradle
+++ b/modules/mariadb/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'org.mariadb:r2dbc-mariadb:1.0.3'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.8'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.9'
 
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
     testRuntimeOnly 'org.mariadb:r2dbc-mariadb:1.0.3'

--- a/modules/milvus/build.gradle
+++ b/modules/milvus/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: Milvus"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.milvus:milvus-sdk-java:2.6.17'
+    testImplementation 'io.milvus:milvus-sdk-java:3.0.3'
 }

--- a/modules/minio/build.gradle
+++ b/modules/minio/build.gradle
@@ -3,5 +3,5 @@ description = "Testcontainers :: MinIO"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation("io.minio:minio:9.0.0")
+    testImplementation("io.minio:minio:9.0.3")
 }

--- a/modules/mssqlserver/build.gradle
+++ b/modules/mssqlserver/build.gradle
@@ -4,13 +4,13 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     compileOnly project(':testcontainers-r2dbc')
-    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.4.RELEASE'
+    compileOnly 'io.r2dbc:r2dbc-mssql:1.0.5.RELEASE'
 
     testImplementation project(':testcontainers-jdbc-test')
     testImplementation 'com.microsoft.sqlserver:mssql-jdbc:13.4.0.jre11'
 
     testImplementation project(':testcontainers-r2dbc')
-    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.4.RELEASE'
+    testRuntimeOnly 'io.r2dbc:r2dbc-mssql:1.0.5.RELEASE'
 
     // MSSQL's wait strategy requires the JDBC driver
     testImplementation testFixtures(project(':testcontainers-r2dbc'))

--- a/modules/openfga/build.gradle
+++ b/modules/openfga/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: OpenFGA"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'dev.openfga:openfga-sdk:0.9.7'
+    testImplementation 'dev.openfga:openfga-sdk:0.9.9'
 }
 
 test {

--- a/modules/oracle-free/build.gradle
+++ b/modules/oracle-free/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'com.oracle.database.r2dbc:oracle-r2dbc:1.3.0'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.1.0.0'
+    testImplementation 'com.oracle.database.jdbc:ojdbc11:23.26.2.0.0'
 
     compileOnly 'org.jetbrains:annotations:26.1.0'
 

--- a/modules/postgresql/build.gradle
+++ b/modules/postgresql/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     compileOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.12'
 
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
     testRuntimeOnly 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'

--- a/modules/qdrant/build.gradle
+++ b/modules/qdrant/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Qdrant"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.qdrant:client:1.17.0'
+    testImplementation 'io.qdrant:client:1.18.3'
     testImplementation platform('io.grpc:grpc-bom:1.80.0')
     testImplementation 'io.grpc:grpc-stub'
     testImplementation 'io.grpc:grpc-protobuf'

--- a/modules/questdb/build.gradle
+++ b/modules/questdb/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     api project(':testcontainers-jdbc')
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.12'
 
     testImplementation project(':testcontainers-jdbc-test')
     testImplementation 'org.questdb:questdb:9.2.2'

--- a/modules/r2dbc/build.gradle
+++ b/modules/r2dbc/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     testImplementation 'io.r2dbc:r2dbc-postgresql:0.8.13.RELEASE'
     testImplementation project(':testcontainers-postgresql')
 
-    testFixturesImplementation 'io.projectreactor:reactor-core:3.8.4'
+    testFixturesImplementation 'io.projectreactor:reactor-core:3.8.6'
     testFixturesImplementation 'org.assertj:assertj-core:3.27.7'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
 }

--- a/modules/rabbitmq/build.gradle
+++ b/modules/rabbitmq/build.gradle
@@ -3,6 +3,6 @@ description = "Testcontainers :: RabbitMQ"
 dependencies {
     api project(":testcontainers")
 
-    testImplementation 'com.rabbitmq:amqp-client:5.29.0'
+    testImplementation 'com.rabbitmq:amqp-client:5.33.0'
     compileOnly 'org.jetbrains:annotations:26.1.0'
 }

--- a/modules/redpanda/build.gradle
+++ b/modules/redpanda/build.gradle
@@ -4,7 +4,7 @@ dependencies {
     api project(':testcontainers')
     shaded 'org.freemarker:freemarker:2.3.34'
 
-    testImplementation 'org.apache.kafka:kafka-clients:4.2.0'
+    testImplementation 'org.apache.kafka:kafka-clients:4.3.1'
     testImplementation 'io.rest-assured:rest-assured:5.5.7'
     testImplementation 'org.awaitility:awaitility:4.3.0'
 }

--- a/modules/scylladb/build.gradle
+++ b/modules/scylladb/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(":testcontainers")
 
     testImplementation 'com.scylladb:java-driver-core:4.19.0.8'
-    testImplementation 'software.amazon.awssdk:dynamodb:2.42.34'
+    testImplementation 'software.amazon.awssdk:dynamodb:2.46.20'
 }

--- a/modules/solace/build.gradle
+++ b/modules/solace/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 
     shaded 'org.awaitility:awaitility:4.3.0'
 
-    testImplementation 'com.solacesystems:sol-jcsmp:10.29.1'
+    testImplementation 'com.solacesystems:sol-jcsmp:10.30.1'
     testImplementation 'org.apache.qpid:qpid-jms-client:0.61.0'
     testImplementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
     testImplementation 'org.apache.httpcomponents:fluent-hc:4.5.14'

--- a/modules/solr/build.gradle
+++ b/modules/solr/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Solr"
 dependencies {
     api project(':testcontainers')
     // TODO use JDK's HTTP client and/or Apache HttpClient5
-    shaded 'com.squareup.okhttp3:okhttp:5.3.2'
+    shaded 'com.squareup.okhttp3:okhttp:5.4.0'
 
     testImplementation 'org.apache.solr:solr-solrj:8.11.4'
 }

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation 'com.zaxxer:HikariCP:7.0.2'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
-    testRuntimeOnly 'org.postgresql:postgresql:42.7.10'
+    testRuntimeOnly 'org.postgresql:postgresql:42.7.12'
     testRuntimeOnly 'com.mysql:mysql-connector-j:9.6.0'
     testRuntimeOnly platform('org.junit:junit-bom:5.14.3')
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/modules/spock/build.gradle
+++ b/modules/spock/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     testImplementation project(':testcontainers-mysql')
     testImplementation project(':testcontainers-postgresql')
 
-    testImplementation 'com.zaxxer:HikariCP:7.0.2'
+    testImplementation 'com.zaxxer:HikariCP:7.1.0'
     testImplementation 'org.apache.httpcomponents:httpclient:4.5.14'
 
     testRuntimeOnly 'org.postgresql:postgresql:42.7.10'

--- a/modules/toxiproxy/build.gradle
+++ b/modules/toxiproxy/build.gradle
@@ -4,5 +4,5 @@ dependencies {
     api project(':testcontainers')
     api 'eu.rekawek.toxiproxy:toxiproxy-java:2.1.11'
 
-    testImplementation 'redis.clients:jedis:7.4.1'
+    testImplementation 'redis.clients:jedis:7.5.3'
 }

--- a/modules/trino/build.gradle
+++ b/modules/trino/build.gradle
@@ -4,6 +4,6 @@ dependencies {
     api project(':testcontainers-jdbc')
 
     testImplementation project(':testcontainers-jdbc-test')
-    testRuntimeOnly 'io.trino:trino-jdbc:480'
+    testRuntimeOnly 'io.trino:trino-jdbc:483'
     compileOnly 'org.jetbrains:annotations:26.1.0'
 }

--- a/modules/weaviate/build.gradle
+++ b/modules/weaviate/build.gradle
@@ -3,7 +3,7 @@ description = "Testcontainers :: Weaviate"
 dependencies {
     api project(':testcontainers')
 
-    testImplementation 'io.weaviate:client6:6.1.0'
+    testImplementation 'io.weaviate:client6:6.3.0'
 }
 
 test {


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump release-drafter/release-drafter from 6.1.0 to 7.6.0 in /.github/workflows (#11944) @app/dependabot
* Bump actions/labeler from 6 to 7 in /.github/workflows (#11943) @app/dependabot
* Bump slackapi/slack-github-action from 3.0.1 to 4.0.0 in /.github/workflows (#11934) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.26.0 to 5.35.0 in /core (#11933) @app/dependabot
* bump org.zeroturnaround:zt-exec from 1.12 to 1.13.0 in /core (#11932) @app/dependabot
* bump com.google.cloud.tools:jib-core from 0.28.1 to 0.28.2 in /core (#11931) @app/dependabot
* Bump redis.clients:jedis from 7.4.1 to 7.5.3 in /core (#11910) @app/dependabot
* Bump com.unboundid:unboundid-ldapsdk from 7.0.4 to 7.0.5 in /modules/ldap (#11907) @app/dependabot
* Bump software.amazon.awssdk:dynamodb from 2.42.34 to 2.46.20 in /modules/scylladb (#11906) @app/dependabot
* Bump io.opentelemetry:opentelemetry-bom from 1.61.0 to 1.65.0 in /modules/grafana (#11904) @app/dependabot
* Bump io.micrometer:micrometer-registry-otlp from 1.16.5 to 1.17.0 in /modules/grafana (#11903) @app/dependabot
* Bump io.milvus:milvus-sdk-java from 2.6.17 to 3.0.3 in /modules/milvus (#11902) @app/dependabot
* Bump io.qdrant:client from 1.17.0 to 1.18.3 in /modules/qdrant (#11901) @app/dependabot
* Bump io.weaviate:client6 from 6.1.0 to 6.3.0 in /modules/weaviate (#11899) @app/dependabot
* Bump org.apache.activemq:artemis-jakarta-client from 2.53.0 to 2.55.0 in /modules/activemq (#11898) @app/dependabot
* Bump io.minio:minio from 9.0.0 to 9.0.3 in /modules/minio (#11896) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.10 to 42.7.12 in /modules/cratedb (#11895) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.10 to 42.7.12 in /modules/questdb (#11894) @app/dependabot
* Bump com.hivemq:hivemq-mqtt-client from 1.3.13 to 1.3.15 in /modules/hivemq (#11892) @app/dependabot
* Bump ch.qos.logback:logback-classic from 1.5.32 to 1.5.37 in /modules/hivemq (#11890) @app/dependabot
* Bump org.javassist:javassist from 3.30.2-GA to 3.32.0-GA in /modules/hivemq (#11889) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 4.2.0 to 4.3.1 in /modules/redpanda (#11888) @app/dependabot
* Bump com.rabbitmq:amqp-client from 5.29.0 to 5.33.0 in /modules/rabbitmq (#11887) @app/dependabot
* Bump io.fabric8:kubernetes-client from 7.6.1 to 7.8.0 in /modules/k3s (#11886) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 5.3.2 to 5.4.0 in /modules/solr (#11885) @app/dependabot
* Bump com.ibm.db2:jcc from 12.1.4.0 to 12.1.5.0 in /modules/db2 (#11884) @app/dependabot
* Bump io.trino:trino-jdbc from 480 to 483 in /modules/trino (#11883) @app/dependabot
* Bump io.projectreactor:reactor-core from 3.8.4 to 3.8.6 in /modules/r2dbc (#11882) @app/dependabot
* Bump com.google.cloud:libraries-bom from 26.79.0 to 26.84.0 in /modules/gcloud (#11881) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 5.3.2 to 5.4.0 in /modules/azure (#11880) @app/dependabot
* Bump com.zaxxer:HikariCP from 7.0.2 to 7.1.0 in /modules/spock (#11878) @app/dependabot
* Bump io.r2dbc:r2dbc-mssql from 1.0.4.RELEASE to 1.0.5.RELEASE in /modules/mssqlserver (#11877) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.10 to 42.7.12 in /modules/spock (#11876) @app/dependabot
* Bump redis.clients:jedis from 7.4.1 to 7.5.3 in /modules/toxiproxy (#11875) @app/dependabot
* Bump org.elasticsearch.client:elasticsearch-rest-client from 9.3.3 to 9.4.3 in /modules/elasticsearch (#11874) @app/dependabot
* Bump org.apache.tomcat:tomcat-jdbc from 11.0.21 to 11.0.23 in /modules/jdbc-test (#11873) @app/dependabot
* Bump redis.clients:jedis from 7.4.1 to 7.5.3 in /modules/junit-jupiter (#11872) @app/dependabot
* Bump org.mariadb.jdbc:mariadb-java-client from 3.5.8 to 3.5.9 in /modules/mariadb (#11869) @app/dependabot
* Bump org.apache.kafka:kafka-clients from 3.8.0 to 4.3.1 in /modules/kafka (#11868) @app/dependabot
* Bump com.squareup.okhttp3:okhttp from 5.3.2 to 5.5.0 in /modules/couchbase (#11867) @app/dependabot
* Bump software.amazon.awssdk:bom from 2.42.33 to 2.46.20 in /modules/localstack (#11865) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.10 to 42.7.12 in /modules/junit-jupiter (#11866) @app/dependabot
* Bump org.postgresql:postgresql from 42.7.10 to 42.7.12 in /modules/postgresql (#11864) @app/dependabot
* Bump dev.openfga:openfga-sdk from 0.9.7 to 0.9.9 in /modules/openfga (#11822) @app/dependabot
* Bump com.oracle.database.jdbc:ojdbc11 from 23.26.1.0.0 to 23.26.2.0.0 in /modules/oracle-free (#11816) @app/dependabot
* Bump com.solacesystems:sol-jcsmp from 10.29.1 to 10.30.1 in /modules/solace (#11814) @app/dependabot
