### PR TITLE
Fail CI when Gradle matrix generation fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,7 @@ jobs:
           # we should not push empty results to the cache
           READ_ONLY_REMOTE_GRADLE_CACHE: true
         run: |
+          set -o pipefail
           TASKS=$(./gradlew --no-daemon --parallel -q testMatrix | jq 'del(.[] | select(. == ":testcontainers:check" or startswith(":docs:")))' --compact-output)
           echo $TASKS
           echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT
@@ -164,6 +165,7 @@ jobs:
           # we should not push empty results to the cache
           READ_ONLY_REMOTE_GRADLE_CACHE: true
         run: |
+          set -o pipefail
           TASKS=$(./gradlew --no-daemon --parallel -q testMatrix | jq 'map(select(startswith(":docs:")))' --compact-output)
           echo $TASKS
           echo "matrix={\"gradle_args\":$TASKS}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The dynamic Gradle matrix steps pipe Gradle output through jq. GitHub Actions runs these scripts with bash -e but without pipefail, so jq can return success after Gradle fails and leave the downstream matrix jobs skipped.

Enable pipefail for both filtered matrix-generation pipelines so Gradle failures fail the producer job. Successful empty matrices remain valid and continue to produce no matrix entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build verification so failures in Gradle task discovery are correctly reported in continuous integration checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->