### PR TITLE
Fix KibanaContainer reusability for external mode

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/KibanaContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/KibanaContainer.java
@@ -20,6 +20,9 @@ import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.ComparableVersion;
 import org.testcontainers.utility.DockerImageName;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +55,8 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
     private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("docker.elastic.co/kibana/kibana");
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private String encryptionKey;
 
     private ElasticsearchContainer elasticsearch;
 
@@ -105,10 +110,56 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
         super(dockerImageName);
         ensureCompatibleVersion(dockerImageName.getVersionPart());
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        this.encryptionKey = deriveDefaultEncryptionKey(dockerImageName);
 
         withExposedPorts(KIBANA_DEFAULT_PORT);
         //we have to explicitly set wait the strategy later on in configure, once we know the security configuration
         setWaitStrategy(null);
+    }
+
+    /**
+     * Sets the encryption key used for Kibana's encrypted saved objects.
+     * The key must be at least 32 characters. When not set, a deterministic default derived from
+     * the image name is used, which is required for {@link #withReuse(boolean)} to work correctly.
+     *
+     * @param encryptionKey the encryption key
+     * @return this container instance
+     */
+    public KibanaContainer withEncryptionKey(String encryptionKey) {
+        if (encryptionKey == null || encryptionKey.length() < 32) {
+            throw new IllegalArgumentException("Kibana encryption key must be at least 32 characters long");
+        }
+        this.encryptionKey = encryptionKey;
+        return this;
+    }
+
+    /**
+     * Enables or disables container reuse across JVM runs.
+     *
+     * <p><b>Supported in external mode only.</b> When Kibana is configured via
+     * {@link #withElasticsearchUrl(String)}, the container configuration is fully deterministic
+     * and TC can reliably locate the running container on subsequent runs.
+     *
+     * <p>Reuse is <b>not supported in managed mode</b> (i.e. when this container was created with
+     * an {@link ElasticsearchContainer}). Managed mode introduces several non-deterministic inputs
+     * into the container hash on every run (ad-hoc network ID, random network alias, fresh service
+     * account token), so TC always sees a different hash and starts a fresh container instead of
+     * reusing the existing one. This is a framework-level characteristic that affects any container
+     * connected via {@code withNetwork()} — not specific to {@code KibanaContainer}.
+     *
+     * @param reusable whether to enable container reuse
+     * @return this container instance
+     * @throws IllegalStateException if {@code reusable} is {@code true} and managed mode is active
+     */
+    @Override
+    public KibanaContainer withReuse(boolean reusable) {
+        if (reusable && elasticsearch != null) {
+            throw new IllegalStateException(
+                "withReuse(true) is not supported for KibanaContainer in managed mode. " +
+                "Use external mode (withElasticsearchUrl) to enable reuse."
+            );
+        }
+        return super.withReuse(reusable);
     }
 
     /**
@@ -212,7 +263,7 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
     protected void configure() {
         super.configure();
 
-        addEnv("XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY", generateRandomKey(32));
+        addEnv("XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY", encryptionKey);
         addEnv("SERVER_NAME", "kibana");
 
         if (elasticsearchCaCertificate != null) {
@@ -541,8 +592,18 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
         );
     }
 
-    private String generateRandomKey(int length) {
-        return Base58.randomString(length);
+    private static String deriveDefaultEncryptionKey(DockerImageName imageName) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(imageName.asCanonicalNameString().getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : hash) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.substring(0, 32);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
     }
 
     /**

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/KibanaContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/KibanaContainer.java
@@ -21,10 +21,9 @@ import org.testcontainers.utility.ComparableVersion;
 import org.testcontainers.utility.DockerImageName;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -110,7 +109,7 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
         super(dockerImageName);
         ensureCompatibleVersion(dockerImageName.getVersionPart());
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
-        this.encryptionKey = deriveDefaultEncryptionKey(dockerImageName);
+        this.encryptionKey = stableConfigKey(dockerImageName);
 
         withExposedPorts(KIBANA_DEFAULT_PORT);
         //we have to explicitly set wait the strategy later on in configure, once we know the security configuration
@@ -592,18 +591,14 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
         );
     }
 
-    private static String deriveDefaultEncryptionKey(DockerImageName imageName) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(imageName.asCanonicalNameString().getBytes(StandardCharsets.UTF_8));
-            StringBuilder sb = new StringBuilder(64);
-            for (byte b : hash) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.substring(0, 32);
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("SHA-256 not available", e);
-        }
+    private static String stableConfigKey(DockerImageName imageName) {
+        // UUID v3 (name-based) gives a deterministic 32-character string from the image name,
+        // keeping xpack.encryptedSavedObjects.encryptionKey identical across JVM runs —
+        // a prerequisite for container reuse. Call withEncryptionKey() for real secret management.
+        return UUID
+            .nameUUIDFromBytes(imageName.asCanonicalNameString().getBytes(StandardCharsets.UTF_8))
+            .toString()
+            .replace("-", "");
     }
 
     /**

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
@@ -16,11 +16,15 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.ContainerLaunchException;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -442,14 +446,21 @@ class KibanaContainerTest {
 
     @Test
     void withReuseShouldReuseTheSameContainer() {
+        Assumptions
+            .assumeThat(TestcontainersConfiguration.getInstance().environmentSupportsReuse())
+            .as("testcontainers.reuse.enable must be true")
+            .isTrue();
+
         final String kibanaImage = "docker.elastic.co/kibana/kibana:9.2.4";
 
-        // Kibana reaches ES via host.docker.internal (available on Docker Desktop without any
-        // TC configuration, so no extra-host entry enters the CreateContainerCmd hash).
+        // Testcontainers.exposeHostPorts + host.testcontainers.internal lets Kibana reach ES
+        // from inside the container on any platform (Linux Docker Engine included).
         // No withNetwork() on Kibana keeps the hash fully deterministic:
         //   - no dynamic network ID
         //   - the random tc-* alias added by GenericContainer's constructor is only serialised
         //     into the CreateContainerCmd when withNetwork() has been called, so it is absent here
+        // The host.testcontainers.internal extra-host IP is the same for kibana1 and kibana2
+        // because they start in the same JVM (same PortForwardingContainer instance).
         // The first Kibana container must stay running while the second one starts, because
         // withReuse(true) only skips JVM-shutdown cleanup — an explicit stop() still removes the
         // container, so there would be nothing to find.
@@ -459,7 +470,9 @@ class KibanaContainerTest {
                 .withEnv("xpack.security.http.ssl.enabled", "false")
         ) {
             es.start();
-            String esUrl = "http://host.docker.internal:" + es.getMappedPort(9200);
+            int esMappedPort = es.getMappedPort(9200);
+            Testcontainers.exposeHostPorts(esMappedPort);
+            String esUrl = "http://" + GenericContainer.INTERNAL_HOST_HOSTNAME + ":" + esMappedPort;
 
             KibanaContainer kibana1 = new KibanaContainer(kibanaImage)
                 .withElasticsearchUrl(esUrl)

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
@@ -474,12 +474,8 @@ class KibanaContainerTest {
             Testcontainers.exposeHostPorts(esMappedPort);
             String esUrl = "http://" + GenericContainer.INTERNAL_HOST_HOSTNAME + ":" + esMappedPort;
 
-            KibanaContainer kibana1 = new KibanaContainer(kibanaImage)
-                .withElasticsearchUrl(esUrl)
-                .withReuse(true);
-            KibanaContainer kibana2 = new KibanaContainer(kibanaImage)
-                .withElasticsearchUrl(esUrl)
-                .withReuse(true);
+            KibanaContainer kibana1 = new KibanaContainer(kibanaImage).withElasticsearchUrl(esUrl).withReuse(true);
+            KibanaContainer kibana2 = new KibanaContainer(kibanaImage).withElasticsearchUrl(esUrl).withReuse(true);
 
             try {
                 kibana1.start();

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
@@ -440,6 +440,51 @@ class KibanaContainerTest {
         }
     }
 
+    @Test
+    void withReuseShouldReuseTheSameContainer() {
+        final String kibanaImage = "docker.elastic.co/kibana/kibana:9.2.4";
+
+        // Kibana reaches ES via host.docker.internal (available on Docker Desktop without any
+        // TC configuration, so no extra-host entry enters the CreateContainerCmd hash).
+        // No withNetwork() on Kibana keeps the hash fully deterministic:
+        //   - no dynamic network ID
+        //   - the random tc-* alias added by GenericContainer's constructor is only serialised
+        //     into the CreateContainerCmd when withNetwork() has been called, so it is absent here
+        // The first Kibana container must stay running while the second one starts, because
+        // withReuse(true) only skips JVM-shutdown cleanup — an explicit stop() still removes the
+        // container, so there would be nothing to find.
+        try (
+            ElasticsearchContainer es = new ElasticsearchContainer(ES_IMAGE)
+                .withEnv("xpack.security.enabled", "false")
+                .withEnv("xpack.security.http.ssl.enabled", "false")
+        ) {
+            es.start();
+            String esUrl = "http://host.docker.internal:" + es.getMappedPort(9200);
+
+            KibanaContainer kibana1 = new KibanaContainer(kibanaImage)
+                .withElasticsearchUrl(esUrl)
+                .withReuse(true);
+            KibanaContainer kibana2 = new KibanaContainer(kibanaImage)
+                .withElasticsearchUrl(esUrl)
+                .withReuse(true);
+
+            try {
+                kibana1.start();
+                // kibana2 is started while kibana1 is still running; the reuse mechanism should
+                // find kibana1's container by hash and return the same container ID.
+                kibana2.start();
+
+                Assertions
+                    .assertThat(kibana2.getContainerId())
+                    .as("KibanaContainer with withReuse(true) should reuse the same container on subsequent starts")
+                    .isEqualTo(kibana1.getContainerId());
+            } finally {
+                kibana1.stop();
+                kibana2.stop();
+            }
+        }
+    }
+
     private static void applyTls(ElasticsearchContainer c, byte[] caCrt, byte[] nodeCrt, byte[] nodeKey) {
         final String certDir = "/usr/share/elasticsearch/config/certs";
 


### PR DESCRIPTION
## What changed and why

`KibanaContainer` was generating a random encryption key for `XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY` on every `configure()` call. This made the container hash non-deterministic, so `withReuse(true)` never matched an existing container — a new one was always started.

### Fix

- Replace the random key with a **deterministic key derived from the image name** (SHA-256, hex-encoded, truncated to 32 chars). Same image → same key → same container hash → reuse works.
- Add `withEncryptionKey(String)` for users who need a custom key (must be ≥ 32 chars).
- Override `withReuse(boolean)` to throw `IllegalStateException` when reuse is requested in **managed mode** (i.e. when an `ElasticsearchContainer` was passed in). Managed mode is inherently non-deterministic (dynamic network ID, random network alias, fresh service-account token), so reuse can never work there — failing fast is better than silently starting a new container every time.

## Test

Added `withReuseShouldReuseTheSameContainer` in `KibanaContainerTest`: starts two `KibanaContainer` instances with `withReuse(true)` pointing at the same ES URL while the first is still running, and asserts both get the same container ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom Kibana encryption key of at least 32 characters.
  * Kibana encryption keys are generated deterministically when not explicitly provided.
  * Added support for reusing Kibana containers when compatible configuration is provided.

* **Bug Fixes**
  * Prevented unsupported container reuse configurations for managed Elasticsearch setups.
  * Improved Kibana and Elasticsearch connectivity across supported Docker environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->