### PR TITLE
Declare the jar and shadowJar dependencies of the test classpath

### DIFF
--- a/gradle/shading.gradle
+++ b/gradle/shading.gradle
@@ -58,9 +58,11 @@ project.afterEvaluate {
 
     // Add shaded JARs first. Wrapping the producing tasks in files() keeps their task dependencies
     // on the classpath; a plain sum of outputs drops them. shadowJar clears its classifier and
-    // writes the same file as jar, so test has to depend on both.
-    def producers = findShadedProjects(project)
-        .plus(project)
+    // writes the same file as jar, so test has to depend on both. Test-scoped project dependencies
+    // (e.g. testcontainers-jdbc-test) are shaded the same way and need the same wiring.
+    def testProjectDependencies = configurations.testRuntimeClasspath.allDependencies
+        .withType(ProjectDependency)*.dependencyProject
+    def producers = (findShadedProjects(project) + project + testProjectDependencies)
         .collectMany { [it.tasks.findByName("shadowJar"), it.tasks.findByName("jar")] }
         .findAll { it != null }
     tasks.test.classpath = files(producers).plus(sourceSets.test.runtimeClasspath)

--- a/gradle/shading.gradle
+++ b/gradle/shading.gradle
@@ -56,11 +56,14 @@ project.afterEvaluate {
         tasks.shadowJar.relocate(pkg, "org.testcontainers.shaded.${pkg}")
     }
 
-    // Add shaded JARs first
-    tasks.test.classpath = findShadedProjects(project)
+    // Add shaded JARs first. Wrapping the producing tasks in files() keeps their task dependencies
+    // on the classpath; a plain sum of outputs drops them. shadowJar clears its classifier and
+    // writes the same file as jar, so test has to depend on both.
+    def producers = findShadedProjects(project)
         .plus(project)
-        .sum { it.tasks.findByName("shadowJar").outputs.files }
-        .plus(sourceSets.test.runtimeClasspath)
+        .collectMany { [it.tasks.findByName("shadowJar"), it.tasks.findByName("jar")] }
+        .findAll { it != null }
+    tasks.test.classpath = files(producers).plus(sourceSets.test.runtimeClasspath)
 }
 
 static Set<Project> findShadedProjects(Project project) {


### PR DESCRIPTION
## What

Running `jar` (or `build`) and `test` together in a shaded module fails on current Gradle:

```
Task ':docs:examples:junit5:redis:test' uses this output of task ':docs:examples:junit5:redis:jar'
without declaring an explicit or implicit dependency.
```

`gradle/shading.gradle` sets `tasks.test.classpath` to a plain sum of `shadowJar` output files. A plain file collection does not carry task dependencies, so `test` reads the archive without depending on the task that writes it. This applies to every subproject through `build.gradle`.

The same wiring is missing for test-scoped project dependencies. Every JDBC module has `testImplementation project(':testcontainers-jdbc-test')`, and `:testcontainers-jdbc-test:shadowJar` writes the file that `test` resolves, so `./gradlew :testcontainers-jdbc-test:shadowJar :testcontainers-mariadb:test` fails the same way.

Fixes #10353

## Why

Gradle reports missing producer/consumer wiring as an error, so any invocation that runs both tasks in one build stops. The original report used `:docs:examples:junit4:generic`, which is no longer in `settings.gradle`; the two examples still registered (`junit5:redis`, `spock:redis`) fail the same way.

## How

- Collect the `shadowJar` and `jar` tasks of the project, its shaded (`api`) dependencies and its test-scoped project dependencies, and wrap them in `files(...)`, so the resulting classpath carries their task dependencies.
- Depend on `jar` as well as `shadowJar`: `shadowJar` clears its archive classifier and writes the same file `jar` writes, so Gradle attributes that path to both tasks and a dependency on `shadowJar` alone still leaves the warning for `jar`.
- Classpath order is unchanged: shaded JARs first, then `sourceSets.test.runtimeClasspath`.

## Test plan

Executed locally on Java 21 with `--no-build-cache`:

- `./gradlew :docs:examples:junit5:redis:clean :docs:examples:junit5:redis:jar :docs:examples:junit5:redis:test` — fails before, passes after with no dependency warning
- same for `:docs:examples:spock:redis` and for `:test-support` (`jar`, `shadowJar`, `test` in one build)
- `./gradlew :testcontainers-jdbc-test:clean :testcontainers-jdbc-test:shadowJar :testcontainers-mariadb:test` and the same with `:testcontainers-clickhouse:test` — fail before, pass after. ClickHouse is evaluated before `jdbc-test`, so this also checks that the wiring does not depend on project evaluation order
- `./gradlew :testcontainers:test` — the shaded classpath still comes first (stack traces show `org.testcontainers.shaded.com.github.dockerjava...`); the failures seen locally were Docker environment timeouts that also fail without this change
- `./gradlew checkstyleMain checkstyleTest spotlessApply`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test runtime classpath setup to include shaded dependencies and their packaged artifacts.
  * Prevented unavailable build tasks from being added to the test classpath.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->