### PR TITLE
Fix CockroachDB SCRAM iteration limit

### DIFF
--- a/modules/cockroachdb/src/main/java/org/testcontainers/cockroachdb/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/cockroachdb/CockroachContainer.java
@@ -31,6 +31,9 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
 
     private static final String TEST_QUERY_STRING = "SELECT 1";
 
+    // CockroachDB v22.2 uses 119,680 SCRAM iterations, above pgJDBC's default safety limit.
+    private static final String DEFAULT_SCRAM_MAX_ITERATIONS = "119680";
+
     private static final int REST_API_PORT = 8080;
 
     private static final int DB_PORT = 26257;
@@ -52,6 +55,7 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
     public CockroachContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        withUrlParam("scramMaxIterations", DEFAULT_SCRAM_MAX_ITERATIONS);
         this.isVersionGreaterThanOrEqualTo221 = isVersionGreaterThanOrEqualTo221(dockerImageName);
 
         WaitAllStrategy waitStrategy = new WaitAllStrategy();

--- a/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
+++ b/modules/cockroachdb/src/main/java/org/testcontainers/containers/CockroachContainer.java
@@ -41,6 +41,9 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
 
     private static final String TEST_QUERY_STRING = "SELECT 1";
 
+    // CockroachDB v22.2 uses 119,680 SCRAM iterations, above pgJDBC's default safety limit.
+    private static final String DEFAULT_SCRAM_MAX_ITERATIONS = "119680";
+
     private static final int REST_API_PORT = 8080;
 
     private static final int DB_PORT = 26257;
@@ -70,6 +73,7 @@ public class CockroachContainer extends JdbcDatabaseContainer<CockroachContainer
     public CockroachContainer(final DockerImageName dockerImageName) {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
+        withUrlParam("scramMaxIterations", DEFAULT_SCRAM_MAX_ITERATIONS);
         this.isVersionGreaterThanOrEqualTo221 = isVersionGreaterThanOrEqualTo221(dockerImageName);
 
         WaitAllStrategy waitStrategy = new WaitAllStrategy();

--- a/modules/cockroachdb/src/test/java/org/testcontainers/cockroachdb/CockroachContainerTest.java
+++ b/modules/cockroachdb/src/test/java/org/testcontainers/cockroachdb/CockroachContainerTest.java
@@ -60,6 +60,7 @@ class CockroachContainerTest extends AbstractContainerDatabaseTest {
             assertThat(jdbcUrl)
                 .contains("?")
                 .contains("&")
+                .contains("scramMaxIterations=119680")
                 .contains("sslmode=disable")
                 .contains("application_name=cockroach");
         } finally {


### PR DESCRIPTION
Companion fix for #11879.

pgJDBC 42.7.12 adds a secure default cap of 100,000 SCRAM PBKDF2 iterations. CockroachDB v22.2 requests exactly 119,680, so the module’s runtime tests now fail with the driver’s explicit instruction to raise `scramMaxIterations`.

This sets a bounded default of 119,680 in both the current and deprecated Cockroach container APIs. It preserves pgJDBC’s protection rather than disabling it, and callers can still override the value through the existing URL-parameter map. The integration test now asserts that the generated JDBC URL contains the compatibility setting.

Verification:

- `:testcontainers-cockroachdb:compileJava` passed
- `:testcontainers-cockroachdb:compileTestJava` passed
- `:testcontainers-cockroachdb:checkstyleMain` passed
- `:testcontainers-cockroachdb:checkstyleTest` passed
- 13 Gradle tasks completed successfully
- `git diff --check`

The source PR’s CI reproduces the runtime failure three times against CockroachDB with the exact 119,680-versus-100,000 diagnostic. A post-fix runtime rerun was not available locally because Docker is not running, so no runtime pass is claimed. `spotlessCheck` was also attempted but blocked before source checking by a stale global Equo P2 cache lock; that user cache was left untouched.