### PR TITLE
Support SHA256 digests and Image IDs in image cache lookup

### DIFF
--- a/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
+++ b/core/src/main/java/org/testcontainers/images/LocalImagesCache.java
@@ -14,8 +14,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Slf4j
 enum LocalImagesCache {
@@ -35,8 +33,6 @@ enum LocalImagesCache {
     public Optional<ImageData> refreshCache(DockerImageName imageName) {
         DockerClient dockerClient = DockerClientFactory.instance().client();
         if (!maybeInitCache(dockerClient)) {
-            // Cache may be stale, trying inspectImageCmd...
-
             InspectImageResponse response = null;
             try {
                 response = dockerClient.inspectImageCmd(imageName.asCanonicalNameString()).exec();
@@ -46,6 +42,24 @@ enum LocalImagesCache {
             if (response != null) {
                 ImageData imageData = ImageData.from(response);
                 cache.put(imageName, imageData);
+                if (response.getRepoDigests() != null) {
+                    for (String repoDigest : response.getRepoDigests()) {
+                        if (repoDigest != null && !"<none>@<none>".equals(repoDigest)) {
+                            try {
+                                cache.put(DockerImageName.parse(repoDigest), imageData);
+                            } catch (IllegalArgumentException ignored) {}
+                        }
+                    }
+                }
+                String imageId = response.getId();
+                if (imageId != null) {
+                    try {
+                        cache.put(DockerImageName.parse(imageId), imageData);
+                        if (imageId.startsWith("sha256:")) {
+                            cache.put(DockerImageName.parse(imageId.substring(7)), imageData);
+                        }
+                    } catch (IllegalArgumentException ignored) {}
+                }
                 return Optional.of(imageData);
             } else {
                 cache.remove(imageName);
@@ -56,7 +70,8 @@ enum LocalImagesCache {
         return Optional.ofNullable(cache.get(imageName));
     }
 
-    private synchronized boolean maybeInitCache(DockerClient dockerClient) {
+    @VisibleForTesting
+    synchronized boolean maybeInitCache(DockerClient dockerClient) {
         if (!initialized.compareAndSet(false, true)) {
             return false;
         }
@@ -72,20 +87,43 @@ enum LocalImagesCache {
 
     private void populateFromList(List<Image> images) {
         for (Image image : images) {
-            String[] repoTags = image.getRepoTags();
-            if (repoTags == null) {
-                log.debug("repoTags is null, skipping image: {}", image);
-                continue;
+            ImageData imageData = ImageData.from(image);
+
+            if (image.getRepoTags() != null) {
+                for (String repoTag : image.getRepoTags()) {
+                    if (repoTag != null && !"<none>:<none>".equals(repoTag)) {
+                        try {
+                            cache.put(DockerImageName.parse(repoTag), imageData);
+                        } catch (IllegalArgumentException e) {
+                            log.debug("Failed to parse repoTag: {}", repoTag, e);
+                        }
+                    }
+                }
             }
 
-            cache.putAll(
-                Stream
-                    .of(repoTags)
-                    // Protection against some edge case where local image repository tags end up with duplicates
-                    // making toMap crash at merge time.
-                    .distinct()
-                    .collect(Collectors.toMap(DockerImageName::new, it -> ImageData.from(image)))
-            );
+            if (image.getRepoDigests() != null) {
+                for (String repoDigest : image.getRepoDigests()) {
+                    if (repoDigest != null && !"<none>@<none>".equals(repoDigest)) {
+                        try {
+                            cache.put(DockerImageName.parse(repoDigest), imageData);
+                        } catch (IllegalArgumentException e) {
+                            log.debug("Failed to parse repoDigest: {}", repoDigest, e);
+                        }
+                    }
+                }
+            }
+
+            String imageId = image.getId();
+            if (imageId != null) {
+                try {
+                    cache.put(DockerImageName.parse(imageId), imageData);
+                    if (imageId.startsWith("sha256:")) {
+                        cache.put(DockerImageName.parse(imageId.substring(7)), imageData);
+                    }
+                } catch (IllegalArgumentException e) {
+                    log.debug("Failed to parse image id: {}", imageId, e);
+                }
+            }
         }
     }
 }

--- a/core/src/test/java/org/testcontainers/images/LocalImagesCacheTest.java
+++ b/core/src/test/java/org/testcontainers/images/LocalImagesCacheTest.java
@@ -1,0 +1,69 @@
+package org.testcontainers.images;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.ListImagesCmd;
+import com.github.dockerjava.api.model.Image;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class LocalImagesCacheTest {
+
+    @BeforeEach
+    @AfterEach
+    void resetCache() {
+        LocalImagesCacheAccessor.clearCache();
+    }
+
+    @Test
+    void shouldCacheRepoDigestsAndImageIds() {
+        DockerClient dockerClient = Mockito.mock(DockerClient.class);
+        ListImagesCmd listImagesCmd = Mockito.mock(ListImagesCmd.class);
+
+        when(dockerClient.listImagesCmd()).thenReturn(listImagesCmd);
+
+        Image image = Mockito.mock(Image.class);
+        when(image.getRepoTags()).thenReturn(new String[] { "test-repo:1.0", "<none>:<none>" });
+        when(image.getRepoDigests())
+            .thenReturn(
+                new String[] {
+                    "test-repo@sha256:e1594798e61a75abde649ed1432fa955853a7816f516fe49360d623213a01d96",
+                    "<none>@<none>",
+                }
+            );
+        when(image.getId()).thenReturn("sha256:e1594798e61a75abde649ed1432fa955853a7816f516fe49360d623213a01d96");
+        when(image.getCreated()).thenReturn(1595874211L);
+
+        when(listImagesCmd.exec()).thenReturn(Collections.singletonList(image));
+
+        LocalImagesCache.INSTANCE.maybeInitCache(dockerClient);
+
+        ImageData byTag = LocalImagesCache.INSTANCE.cache.get(DockerImageName.parse("test-repo:1.0"));
+        assertThat(byTag).isNotNull();
+
+        ImageData byDigest = LocalImagesCache.INSTANCE.cache.get(
+            DockerImageName.parse("test-repo@sha256:e1594798e61a75abde649ed1432fa955853a7816f516fe49360d623213a01d96")
+        );
+        assertThat(byDigest).isNotNull();
+
+        ImageData byIdWithPrefix = LocalImagesCache.INSTANCE.cache.get(
+            DockerImageName.parse("sha256:e1594798e61a75abde649ed1432fa955853a7816f516fe49360d623213a01d96")
+        );
+        assertThat(byIdWithPrefix).isNotNull();
+
+        ImageData byIdWithoutPrefix = LocalImagesCache.INSTANCE.cache.get(
+            DockerImageName.parse("e1594798e61a75abde649ed1432fa955853a7816f516fe49360d623213a01d96")
+        );
+        assertThat(byIdWithoutPrefix).isNotNull();
+
+        ImageData noneTag = LocalImagesCache.INSTANCE.cache.get(DockerImageName.parse("<none>:<none>"));
+        assertThat(noneTag).isNull();
+    }
+}


### PR DESCRIPTION
### Description
Previously, `LocalImagesCache` only indexed `RepoTags` from Docker image metadata when checking if images were already available locally.
This caused cache misses when:
1. Referencing images via immutable SHA256 digests (e.g. `image@sha256:...`), which only exist in `RepoDigests`.
2. Referencing images via raw Image IDs (`sha256:...` or short hex IDs), or using images without standard tags (`<none>:<none>`).

These cache misses led to redundant pull attempts, which caused failures in offline/air-gapped environments and unnecessary network overhead.

### Changes
- Updated `LocalImagesCache.java` to index `RepoDigests` and `Image ID`s (with and without `sha256:` prefix) in addition to `RepoTags`.
- Filtered out placeholder values like `<none>:<none>` and `<none>@<none>`.
- Added unit tests in `LocalImagesCacheTest.java` verifying that tags, digests, and IDs are properly indexed in the cache.

Fixes #1406

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local image lookup across repository tags, repository digests, and image IDs.
  * Added support for image IDs with or without the `sha256:` prefix.
  * Excluded invalid or placeholder image references from the cache.
  * Improved resilience when image metadata cannot be parsed during cache refreshes.

* **Tests**
  * Added coverage verifying cache population and exclusion of placeholder entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->