### PR TITLE
Expose MySQL and PostgreSQL protocol ports in ClickHouseContainer

### DIFF
--- a/modules/clickhouse/build.gradle
+++ b/modules/clickhouse/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-jdbc', version: '0.9.8', classifier: 'all')
 
     testImplementation 'com.clickhouse:client-v2:0.9.8'
+    testImplementation 'org.mariadb.jdbc:mariadb-java-client:3.5.9'
+    testImplementation 'org.postgresql:postgresql:42.7.12'
     testImplementation testFixtures(project(':testcontainers-r2dbc'))
     testRuntimeOnly(group: 'com.clickhouse', name: 'clickhouse-r2dbc', version: '0.9.8', classifier: 'http')
 }

--- a/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/clickhouse/ClickHouseContainer.java
@@ -17,6 +17,8 @@ import java.util.Set;
  * <ul>
  *     <li>Database: 8123</li>
  *     <li>Console: 9000</li>
+ *     <li>MySQL: 9004</li>
+ *     <li>PostgreSQL: 9005</li>
  * </ul>
  */
 public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContainer> {
@@ -28,6 +30,10 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
     static final Integer HTTP_PORT = 8123;
 
     static final Integer NATIVE_PORT = 9000;
+
+    static final Integer MYSQL_PORT = 9004;
+
+    static final Integer POSTGRESQL_PORT = 9005;
 
     private static final String LEGACY_V1_DRIVER_CLASS_NAME = "com.clickhouse.jdbc.ClickHouseDriver";
 
@@ -55,7 +61,7 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(CLICKHOUSE_IMAGE_NAME);
 
-        addExposedPorts(HTTP_PORT, NATIVE_PORT);
+        addExposedPorts(HTTP_PORT, NATIVE_PORT, MYSQL_PORT, POSTGRESQL_PORT);
         waitingFor(
             Wait
                 .forHttp("/")
@@ -103,6 +109,46 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
 
     public String getHttpUrl() {
         return "http://" + getHost() + ":" + getMappedPort(HTTP_PORT);
+    }
+
+    public String getMysqlJdbcUrl() {
+        return (
+            "jdbc:mysql://" +
+            getHost() +
+            ":" +
+            getMappedPort(MYSQL_PORT) +
+            "/" +
+            this.databaseName +
+            constructUrlParameters("?", "&")
+        );
+    }
+
+    public Integer getHttpPort() {
+        return getMappedPort(HTTP_PORT);
+    }
+
+    public Integer getNativePort() {
+        return getMappedPort(NATIVE_PORT);
+    }
+
+    public Integer getMysqlPort() {
+        return getMappedPort(MYSQL_PORT);
+    }
+
+    public Integer getPostgresqlPort() {
+        return getMappedPort(POSTGRESQL_PORT);
+    }
+
+    public String getPostgresqlJdbcUrl() {
+        return (
+            "jdbc:postgresql://" +
+            getHost() +
+            ":" +
+            getMappedPort(POSTGRESQL_PORT) +
+            "/" +
+            this.databaseName +
+            constructUrlParameters("?", "&")
+        );
     }
 
     @Override

--- a/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
+++ b/modules/clickhouse/src/main/java/org/testcontainers/containers/ClickHouseContainer.java
@@ -31,6 +31,10 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
 
     public static final Integer NATIVE_PORT = 9000;
 
+    public static final Integer MYSQL_PORT = 9004;
+
+    public static final Integer POSTGRESQL_PORT = 9005;
+
     private static final String LEGACY_DRIVER_CLASS_NAME = "ru.yandex.clickhouse.ClickHouseDriver";
 
     private static final String DRIVER_CLASS_NAME = "com.clickhouse.jdbc.ClickHouseDriver";
@@ -64,7 +68,7 @@ public class ClickHouseContainer extends JdbcDatabaseContainer<ClickHouseContain
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME, CLICKHOUSE_IMAGE_NAME);
         supportsNewDriver = isNewDriverSupported(dockerImageName);
 
-        addExposedPorts(HTTP_PORT, NATIVE_PORT);
+        addExposedPorts(HTTP_PORT, NATIVE_PORT, MYSQL_PORT, POSTGRESQL_PORT);
         this.waitStrategy =
             new HttpWaitStrategy()
                 .forStatusCode(200)

--- a/modules/clickhouse/src/test/java/org/testcontainers/clickhouse/ClickHouseContainerTest.java
+++ b/modules/clickhouse/src/test/java/org/testcontainers/clickhouse/ClickHouseContainerTest.java
@@ -7,8 +7,11 @@ import org.junit.jupiter.api.Test;
 import org.testcontainers.ClickhouseTestImages;
 import org.testcontainers.db.AbstractContainerDatabaseTest;
 
+import java.sql.Connection;
+import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -87,6 +90,68 @@ class ClickHouseContainerTest extends AbstractContainerDatabaseTest {
         } finally {
             clickhouse.close();
             client.close();
+        }
+    }
+
+    @Test
+    void testMysqlProtocol() throws SQLException {
+        try (ClickHouseContainer clickhouse = new ClickHouseContainer(ClickhouseTestImages.CLICKHOUSE_24_12_IMAGE)) {
+            clickhouse.start();
+
+            assertThat(clickhouse.getMysqlPort()).isNotNull();
+            assertThat(clickhouse.getHttpPort()).isNotNull();
+            assertThat(clickhouse.getNativePort()).isNotNull();
+
+            String mysqlUrl = clickhouse.getMysqlJdbcUrl();
+            assertThat(mysqlUrl).startsWith("jdbc:mysql://");
+
+            String mariadbUrl =
+                "jdbc:mariadb://" +
+                clickhouse.getHost() +
+                ":" +
+                clickhouse.getMysqlPort() +
+                "/" +
+                clickhouse.getDatabaseName();
+
+            try (
+                Connection connection = DriverManager.getConnection(
+                    mariadbUrl,
+                    clickhouse.getUsername(),
+                    clickhouse.getPassword()
+                );
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT 1")
+            ) {
+                resultSet.next();
+                int resultSetInt = resultSet.getInt(1);
+                assertThat(resultSetInt).isEqualTo(1);
+            }
+        }
+    }
+
+    @Test
+    void testPostgresqlProtocol() throws SQLException {
+        try (ClickHouseContainer clickhouse = new ClickHouseContainer(ClickhouseTestImages.CLICKHOUSE_24_12_IMAGE)) {
+            clickhouse.start();
+
+            assertThat(clickhouse.getPostgresqlPort()).isNotNull();
+
+            String pgUrl = clickhouse.getPostgresqlJdbcUrl() + "?sslmode=disable&preferQueryMode=simple";
+            assertThat(pgUrl).startsWith("jdbc:postgresql://");
+
+            try (
+                Connection connection = DriverManager.getConnection(
+                    pgUrl,
+                    clickhouse.getUsername(),
+                    clickhouse.getPassword()
+                );
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT 1")
+            ) {
+                resultSet.next();
+                int resultSetInt = resultSet.getInt(1);
+                assertThat(resultSetInt).isEqualTo(1);
+            }
         }
     }
 }


### PR DESCRIPTION
### Description
ClickHouse server provides native compatibility with MySQL (port 9004) and PostgreSQL (port 9005) wire protocols by default. Previously, `ClickHouseContainer` only exposed the HTTP (8123) and Native (9000) ports, preventing users from connecting via MySQL and PostgreSQL drivers/clients without manual port configuration.

### Changes
- Added `MYSQL_PORT = 9004` and `POSTGRESQL_PORT = 9005` to `ClickHouseContainer` and exposed them by default.
- Added helper methods: `getMysqlPort()`, `getPostgresqlPort()`, `getHttpPort()`, `getNativePort()`, `getMysqlJdbcUrl()`, and `getPostgresqlJdbcUrl()`.
- Updated Javadoc documentation to list the MySQL and PostgreSQL ports.
- Added tests in `ClickHouseContainerTest` verifying end-to-end query execution across both MySQL and PostgreSQL protocols.

Fixes #3827

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to ClickHouse through MySQL and PostgreSQL protocols.
  - Added access to mapped HTTP, native, MySQL, and PostgreSQL ports.
  - Added JDBC URL helpers for MySQL and PostgreSQL connections.

- **Tests**
  - Added coverage confirming both new protocols support JDBC connections and queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->