### PR TITLE
Upgrade Spotless to fix npm compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,7 @@ updates:
     directory: "/"
     allow:
       - dependency-name: "com.gradle*"
+      - dependency-name: "com.diffplug.spotless"
     registries:
       - gradle-plugin-portal
     schedule:

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'io.franzbecker.gradle-lombok' version '5.0.0'
     id 'com.gradleup.shadow' version '8.3.9'
     id 'me.champeau.gradle.japicmp' version '0.4.3' apply false
-    id 'com.diffplug.spotless' version '6.22.0' apply false
+    id 'com.diffplug.spotless' version '8.10.1' apply false
     id 'org.jreleaser' version '1.20.0' apply false
 }
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,6 +1,6 @@
 // empty build.gradle for dependabot
 plugins {
-    id 'com.diffplug.spotless' version '6.22.0' apply false
+    id 'com.diffplug.spotless' version '8.10.1' apply false
 }
 
 apply from: "$rootDir/../gradle/ci-support.gradle"

--- a/smoke-test/build.gradle
+++ b/smoke-test/build.gradle
@@ -1,6 +1,6 @@
 // empty build.gradle for dependabot
 plugins {
-    id 'com.diffplug.spotless' version '6.22.0' apply false
+    id 'com.diffplug.spotless' version '8.10.1' apply false
 }
 
 apply from: "$rootDir/../gradle/ci-support.gradle"


### PR DESCRIPTION
## Description

This pull request fixes the Spotless/Prettier build failure reported in #11997.

Spotless `6.22.0` invokes npm with the `--scripts-prepend-node-path` option, which is no longer supported by current npm versions and causes the build to fail with:

```text
npm error Unknown cli flag: --scripts-prepend-node-path
```

This change upgrades the Spotless Gradle plugin from `6.22.0` to `8.10.1`, which contains the upstream fix for this issue.

### Verification

* `./gradlew :test-support:spotlessJava --rerun-tasks` ✅
* `./gradlew :test-support:test --rerun-tasks` ✅
* `git diff --check` ✅

Fixes #11997.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated code formatting tooling across the project, examples, and smoke-test builds.
  * Enabled automated dependency updates for the formatting tooling.
  * No user-facing functionality or public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->