### PR TITLE
Wait for cluster health instead of log message in ElasticsearchContainer

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.ComparableVersion;
@@ -235,21 +236,29 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         if (getWaitStrategy() != null) {
             return;
         }
-        HttpWaitStrategy strategy = "https".equals(getHttpScheme())
-            ? Wait.forHttps("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT).allowInsecure()
-            : Wait.forHttp("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT);
-
         String password = getEnvMap().get("ELASTIC_PASSWORD");
-        if (password != null) {
-            strategy = strategy.withBasicCredentials("elastic", password);
-        }
-
         setWaitStrategy(
-            strategy
-                .forStatusCode(200)
-                .forResponsePredicate(body ->
-                    body.contains("\"status\":\"green\"") || body.contains("\"status\":\"yellow\"")
-                )
+            new AbstractWaitStrategy() {
+                @Override
+                protected void waitUntilReady() {
+                    // getHttpScheme() is called here, after the container has started,
+                    // so the curl probe is available for cases where the scheme cannot
+                    // be determined from env vars or the version tag alone.
+                    HttpWaitStrategy inner = "https".equals(getHttpScheme())
+                        ? Wait.forHttps("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT).allowInsecure()
+                        : Wait.forHttp("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT);
+                    if (password != null) {
+                        inner = inner.withBasicCredentials("elastic", password);
+                    }
+                    inner
+                        .forStatusCode(200)
+                        .forResponsePredicate(body ->
+                            body.contains("\"status\":\"green\"") || body.contains("\"status\":\"yellow\"")
+                        )
+                        .withStartupTimeout(startupTimeout)
+                        .waitUntilReady(waitStrategyTarget);
+                }
+            }
                 .withStartupTimeout(healthCheckTimeout)
         );
     }

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -121,7 +121,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         addExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT);
         String versionPart = dockerImageName.getVersionPart();
         this.isAtLeastMajorVersion8 = new ComparableVersion(versionPart).isGreaterThanOrEqualTo("8.0.0");
-        this.isVersionNumeric = versionPart.matches("\\d+\\..*");
+        this.isVersionNumeric = versionPart.matches("\\d+\\.\\d+.*");
         // Wait strategy is deferred to configure() so it can read the final env map
         // (e.g. password and SSL settings that the user may set after construction).
         setWaitStrategy(null);

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.ComparableVersion;
 import org.testcontainers.utility.DockerImageName;
@@ -15,6 +16,7 @@ import java.net.InetSocketAddress;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
+import java.time.Duration;
 import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
@@ -73,7 +75,11 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
     private final boolean isAtLeastMajorVersion8;
 
+    private final boolean isVersionNumeric;
+
     private String certPath = "";
+
+    private Duration healthCheckTimeout = Duration.ofSeconds(60);
 
     /**
      * Create an Elasticsearch Container by passing the full docker image name
@@ -113,15 +119,12 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
             BindMode.READ_ONLY
         );
         addExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT);
-        this.isAtLeastMajorVersion8 =
-            new ComparableVersion(dockerImageName.getVersionPart()).isGreaterThanOrEqualTo("8.0.0");
-        // regex that
-        //   matches 8.3 JSON logging with started message and some follow up content within the message field
-        //   matches 8.0 JSON logging with no whitespace between message field and content
-        //   matches 7.x JSON logging with whitespace between message field and content
-        //   matches 6.x text logging with node name in brackets and just a 'started' message till the end of the line
-        String regex = ".*(\"message\":\\s?\"started[\\s?|\"].*|] started\n$)";
-        setWaitStrategy(Wait.forLogMessage(regex, 1));
+        String versionPart = dockerImageName.getVersionPart();
+        this.isAtLeastMajorVersion8 = new ComparableVersion(versionPart).isGreaterThanOrEqualTo("8.0.0");
+        this.isVersionNumeric = versionPart.matches("\\d+\\..*");
+        // Wait strategy is deferred to configure() so it can read the final env map
+        // (e.g. password and SSL settings that the user may set after construction).
+        setWaitStrategy(null);
         if (isAtLeastMajorVersion8) {
             withPassword(ELASTICSEARCH_DEFAULT_PASSWORD);
             withCertPath(DEFAULT_CERT_PATH);
@@ -209,8 +212,46 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         return this;
     }
 
+    @Override
+    public ElasticsearchContainer withStartupTimeout(Duration startupTimeout) {
+        this.healthCheckTimeout = startupTimeout;
+        if (getWaitStrategy() != null) {
+            getWaitStrategy().withStartupTimeout(startupTimeout);
+        }
+        return self();
+    }
+
     String getCertPath() {
         return certPath;
+    }
+
+    @Override
+    protected void configure() {
+        super.configure();
+        configureWaitStrategy();
+    }
+
+    private void configureWaitStrategy() {
+        if (getWaitStrategy() != null) {
+            return;
+        }
+        HttpWaitStrategy strategy = "https".equals(getHttpScheme())
+            ? Wait.forHttps("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT).allowInsecure()
+            : Wait.forHttp("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT);
+
+        String password = getEnvMap().get("ELASTIC_PASSWORD");
+        if (password != null) {
+            strategy = strategy.withBasicCredentials("elastic", password);
+        }
+
+        setWaitStrategy(
+            strategy
+                .forStatusCode(200)
+                .forResponsePredicate(body ->
+                    body.contains("\"status\":\"green\"") || body.contains("\"status\":\"yellow\"")
+                )
+                .withStartupTimeout(healthCheckTimeout)
+        );
     }
 
     public String getHttpHostAddress() {
@@ -218,8 +259,8 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     }
 
     /**
-     * Checks env first if this implies HTTP/HTTPS.
-     * Otherwise, detects the scheme used by Elasticsearch using <code>curl</code>
+     * Checks env first if this implies HTTP/HTTPS, then falls back to version-based defaults.
+     * For 7.x with non-standard SSL configured outside env vars, runs a curl probe (requires a running container).
      *
      * @return "http" or "https"
      */
@@ -235,10 +276,17 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
             return "https";
         }
 
+        // Version-based default: 8.x uses HTTPS by default.
+        // Only apply when the version tag is a concrete numeric version; ambiguous tags
+        // like "latest" may point to an older image that uses HTTP.
+        if (isAtLeastMajorVersion8 && isVersionNumeric) {
+            return "https";
+        }
+
+        // 7.x without explicit SSL config: HTTP is the default.
+        // When running, we probe with curl in case SSL was configured outside env vars.
         if (!isRunning()) {
-            throw new IllegalStateException(
-                "Cannot determine HTTP scheme: environment variables are not set and container is not running for curl probe"
-            );
+            return "http";
         }
 
         ExecResult httpsResult = null;

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -76,8 +76,6 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
 
     private final boolean isAtLeastMajorVersion8;
 
-    private final boolean isVersionNumeric;
-
     private String certPath = "";
 
     private Duration healthCheckTimeout = Duration.ofSeconds(60);
@@ -122,7 +120,6 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         addExposedPorts(ELASTICSEARCH_DEFAULT_PORT, ELASTICSEARCH_DEFAULT_TCP_PORT);
         String versionPart = dockerImageName.getVersionPart();
         this.isAtLeastMajorVersion8 = new ComparableVersion(versionPart).isGreaterThanOrEqualTo("8.0.0");
-        this.isVersionNumeric = versionPart.matches("\\d+\\.\\d+.*");
         // Wait strategy is deferred to configure() so it can read the final env map
         // (e.g. password and SSL settings that the user may set after construction).
         setWaitStrategy(null);
@@ -241,9 +238,10 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
             new AbstractWaitStrategy() {
                 @Override
                 protected void waitUntilReady() {
-                    // getHttpScheme() is called here, after the container has started,
-                    // so the curl probe is available for cases where the scheme cannot
-                    // be determined from env vars or the version tag alone.
+                    // Wait for port 9200 to accept TCP connections first, so that
+                    // getHttpScheme()'s curl probe always finds a live socket and no
+                    // version-based heuristics are needed.
+                    Wait.forListeningPort().withStartupTimeout(startupTimeout).waitUntilReady(waitStrategyTarget);
                     HttpWaitStrategy inner = "https".equals(getHttpScheme())
                         ? Wait.forHttps("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT).allowInsecure()
                         : Wait.forHttp("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT);
@@ -252,9 +250,9 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
                     }
                     inner
                         .forStatusCode(200)
-                        .forResponsePredicate(body ->
-                            body.contains("\"status\":\"green\"") || body.contains("\"status\":\"yellow\"")
-                        )
+                        .forResponsePredicate(body -> {
+                            return body.contains("\"status\":\"green\"") || body.contains("\"status\":\"yellow\"");
+                        })
                         .withStartupTimeout(startupTimeout)
                         .waitUntilReady(waitStrategyTarget);
                 }
@@ -268,8 +266,8 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     }
 
     /**
-     * Checks env first if this implies HTTP/HTTPS, then falls back to version-based defaults.
-     * For 7.x with non-standard SSL configured outside env vars, runs a curl probe (requires a running container).
+     * Detects the HTTP scheme used by Elasticsearch. Respects explicit env-var config first;
+     * when ambiguous, probes the live socket with curl (requires a running container on port 9200).
      *
      * @return "http" or "https"
      */
@@ -285,17 +283,10 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
             return "https";
         }
 
-        // Version-based default: 8.x uses HTTPS by default.
-        // Only apply when the version tag is a concrete numeric version; ambiguous tags
-        // like "latest" may point to an older image that uses HTTP.
-        if (isAtLeastMajorVersion8 && isVersionNumeric) {
-            return "https";
-        }
-
-        // 7.x without explicit SSL config: HTTP is the default.
-        // When running, we probe with curl in case SSL was configured outside env vars.
         if (!isRunning()) {
-            return "http";
+            throw new IllegalStateException(
+                "Cannot determine HTTP scheme: environment variables are not set and container is not running for curl probe"
+            );
         }
 
         ExecResult httpsResult = null;

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -18,6 +18,7 @@ import java.security.KeyStore;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
@@ -241,7 +242,10 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
                     // Wait for port 9200 to accept TCP connections first, so that
                     // getHttpScheme()'s curl probe always finds a live socket and no
                     // version-based heuristics are needed.
+                    // Track the deadline so both steps share the same total timeout.
+                    Instant deadline = Instant.now().plus(startupTimeout);
                     Wait.forListeningPort().withStartupTimeout(startupTimeout).waitUntilReady(waitStrategyTarget);
+                    Duration remaining = Duration.between(Instant.now(), deadline);
                     HttpWaitStrategy inner = "https".equals(getHttpScheme())
                         ? Wait.forHttps("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT).allowInsecure()
                         : Wait.forHttp("/_cluster/health").forPort(ELASTICSEARCH_DEFAULT_PORT);
@@ -253,7 +257,7 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
                         .forResponsePredicate(body -> {
                             return body.contains("\"status\":\"green\"") || body.contains("\"status\":\"yellow\"");
                         })
-                        .withStartupTimeout(startupTimeout)
+                        .withStartupTimeout(remaining.isNegative() ? Duration.ZERO : remaining)
                         .waitUntilReady(waitStrategyTarget);
                 }
             }

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -234,11 +234,11 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         if (getWaitStrategy() != null) {
             return;
         }
-        String password = getEnvMap().get("ELASTIC_PASSWORD");
         setWaitStrategy(
             new AbstractWaitStrategy() {
                 @Override
                 protected void waitUntilReady() {
+                    String password = getEnvMap().get("ELASTIC_PASSWORD");
                     // Wait for port 9200 to accept TCP connections first, so that
                     // getHttpScheme()'s curl probe always finds a live socket and no
                     // version-based heuristics are needed.

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -45,6 +45,10 @@ class ElasticsearchContainerTest {
         .parse("docker.elastic.co/elasticsearch/elasticsearch")
         .withTag(ELASTICSEARCH_VERSION);
 
+    private static final DockerImageName ELASTICSEARCH_LATEST_IMAGE = DockerImageName.parse(
+        "docker.elastic.co/elasticsearch/elasticsearch:9.2.4"
+    );
+
     /**
      * Elasticsearch default username, when secured
      */
@@ -159,6 +163,23 @@ class ElasticsearchContainerTest {
             Response response = getClient(container).performRequest(new Request("GET", "/"));
             assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("8.3.0");
+        }
+    }
+
+    @Test
+    void clusterHealthIsAtLeastYellowAfterStart() throws IOException {
+        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_LATEST_IMAGE)) {
+            container.start();
+
+            Response response = getClient(container).performRequest(new Request("GET", "/_cluster/health"));
+            assertThat(response.getStatusLine().getStatusCode()).isEqualTo(200);
+            String body = EntityUtils.toString(response.getEntity());
+            assertThat(body)
+                .as("Cluster health status should be at least yellow after container start")
+                .satisfiesAnyOf(
+                    b -> assertThat(b).contains("\"status\":\"yellow\""),
+                    b -> assertThat(b).contains("\"status\":\"green\"")
+                );
         }
     }
 


### PR DESCRIPTION
Elasticsearch may open port 9200 and emit the `started` log message before
completing security initialization (e.g. generating keys, creating internal
indices). Replace the log-message wait strategy with an HTTP health check on
`/_cluster/health` that only passes when the cluster status is yellow or green.

The wait strategy is configured in `configure()` so it can read the final env
map, including any password or SSL settings the user applies after construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Elasticsearch container startup checks by verifying cluster health over HTTP or HTTPS after the service becomes available.
  * Added authenticated health checks using the configured Elasticsearch password.
  * Startup checks now honor custom startup timeouts across all readiness steps.
  * Health validation accepts healthy cluster states reported as either yellow or green.
  * Startup detection now supports Elasticsearch configurations using either HTTP or HTTPS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->