### PR TITLE
Generate an Elasticsearch API key after container start

### DIFF
--- a/docs/modules/elasticsearch.md
+++ b/docs/modules/elasticsearch.md
@@ -30,6 +30,15 @@ HTTPS can be turned off if you do not need it:
 [HttpClient with TLS disabled](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientTlsDisabled
 <!--/codeinclude-->
 
+### API key
+
+From Elasticsearch 8 onwards, with security enabled, the container generates an API key at startup.
+`getApiKey()` returns the Base64-encoded `id:api_key` credential for the `Authorization: ApiKey` header:
+
+<!--codeinclude-->
+[HttpClient with API key](../../modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java) inside_block:httpClientApiKey
+<!--/codeinclude-->
+
 ### Elasticsearch 7 (deprecated)
 
 Elasticsearch 7 listens on HTTP and does not enable security unless you opt in with `withPassword()`.

--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/ElasticsearchContainer.java
@@ -1,5 +1,8 @@
 package org.testcontainers.elasticsearch;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.exception.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
@@ -9,6 +12,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.utility.Base58;
 import org.testcontainers.utility.ComparableVersion;
 import org.testcontainers.utility.DockerImageName;
 
@@ -72,6 +76,8 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     // default location of the automatically generated self-signed HTTP cert for versions >= 8
     private static final String DEFAULT_CERT_PATH = "/usr/share/elasticsearch/config/certs/http_ca.crt";
 
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
     @Deprecated
     private boolean isOss = false;
 
@@ -80,6 +86,11 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
     private String certPath = "";
 
     private Duration healthCheckTimeout = Duration.ofSeconds(60);
+
+    /**
+     * Base64-encoded {@code id:api_key} generated after start for Elasticsearch 8+ with security enabled.
+     */
+    private String apiKey;
 
     /**
      * Create an Elasticsearch Container by passing the full docker image name
@@ -224,10 +235,90 @@ public class ElasticsearchContainer extends GenericContainer<ElasticsearchContai
         return certPath;
     }
 
+    /**
+     * Returns the encoded API key generated when the container started.
+     * Available for Elasticsearch 8+ with security enabled.
+     *
+     * @return the Base64-encoded {@code id:api_key} credential
+     * @throws IllegalStateException if no API key was generated
+     */
+    public String getApiKey() {
+        if (apiKey == null) {
+            throw new IllegalStateException(
+                "API key is only available after start for Elasticsearch 8+ with security enabled"
+            );
+        }
+        return apiKey;
+    }
+
     @Override
     protected void configure() {
         super.configure();
         configureWaitStrategy();
+    }
+
+    @Override
+    protected void containerIsStarted(InspectContainerResponse containerInfo) {
+        super.containerIsStarted(containerInfo);
+        if (shouldGenerateApiKey()) {
+            try {
+                this.apiKey = createApiKey(getHttpScheme());
+            } catch (Exception e) {
+                // Same lenient behavior as missing CA certs: a non-semantic tag such as :latest
+                // may look like 8+ while the image does not actually expose the security API.
+                log.warn("Failed to generate API key. getApiKey() will not be available.", e);
+            }
+        }
+    }
+
+    private boolean shouldGenerateApiKey() {
+        return isAtLeastMajorVersion8 && !"false".equalsIgnoreCase(getEnvMap().get("xpack.security.enabled"));
+    }
+
+    private String createApiKey(String protocol) {
+        String elasticPassword = getEnvMap().get("ELASTIC_PASSWORD");
+        if (StringUtils.isBlank(elasticPassword)) {
+            throw new IllegalStateException("Cannot create API key: ELASTIC_PASSWORD is not set");
+        }
+
+        String name = "tc-" + Base58.randomString(12);
+        String endpoint = protocol + "://localhost:" + ELASTICSEARCH_DEFAULT_PORT + "/_security/api_key";
+        String curlTlsArgs = "";
+        if ("https".equals(protocol)) {
+            curlTlsArgs = StringUtils.isNotBlank(certPath) ? " --cacert '" + certPath + "'" : " -k";
+        }
+
+        String curlCommand = String.format(
+            "curl -sS%s -u \"elastic:$1\" -H 'Content-Type: application/json' -X POST '%s' -d '{\"name\":\"%s\"}'",
+            curlTlsArgs,
+            endpoint,
+            name
+        );
+
+        try {
+            ExecResult result = execInContainer("/bin/sh", "-c", curlCommand, "sh", elasticPassword);
+            String stdout = result.getStdout() == null ? "" : result.getStdout();
+            String stderr = result.getStderr() == null ? "" : result.getStderr();
+            if (result.getExitCode() != 0) {
+                throw new IllegalStateException(
+                    "Failed to create API key. Exit code: " +
+                    result.getExitCode() +
+                    ", stdout: " +
+                    stdout +
+                    ", stderr: " +
+                    stderr
+                );
+            }
+            JsonNode encoded = OBJECT_MAPPER.readTree(stdout).path("encoded");
+            if (encoded.isTextual() && !encoded.asText().trim().isEmpty()) {
+                return encoded.asText().trim();
+            }
+            throw new IllegalStateException("API key response did not contain encoded: " + stdout);
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to create API key", e);
+        }
     }
 
     private void configureWaitStrategy() {

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/ElasticsearchContainerTest.java
@@ -1,11 +1,13 @@
 package org.testcontainers.elasticsearch;
 
 import com.github.dockerjava.api.DockerClient;
+import org.apache.http.Header;
 import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.Request;
@@ -152,6 +154,7 @@ class ElasticsearchContainerTest {
             assertThat(catchThrowable(() -> getAnonymousClient(container).performRequest(new Request("GET", "/"))))
                 .as("anonymous requests are rejected")
                 .isInstanceOf(ResponseException.class);
+            assertThat(container.getApiKey()).as("API key is generated for Elasticsearch 8+").isNotBlank();
             // httpClientLatest {{
         }
         // }
@@ -190,9 +193,65 @@ class ElasticsearchContainerTest {
             assertThat(response.getStatusLine().getStatusCode()).as("cluster health is available").isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
             assertThat(container.getHttpScheme()).as("HTTP API uses HTTP when TLS is disabled").isEqualTo("http");
+            assertThat(container.getApiKey())
+                .as("API key is generated when security stays enabled without TLS")
+                .isNotBlank();
             // httpClientTlsDisabled {{
         }
         // }
+    }
+
+    @Test
+    void latestCanAuthenticateWithGeneratedApiKey() throws IOException {
+        // httpClientApiKey {
+        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE_LATEST)) {
+            container.start();
+
+            client =
+                RestClient
+                    .builder(HttpHost.create("https://" + container.getHttpHostAddress()))
+                    .setDefaultHeaders(
+                        new Header[] { new BasicHeader("Authorization", "ApiKey " + container.getApiKey()) }
+                    )
+                    .setHttpClientConfigCallback(httpClientBuilder -> {
+                        httpClientBuilder.setSSLContext(container.createSslContextFromCa());
+                        return httpClientBuilder;
+                    })
+                    .build();
+
+            Response response = client.performRequest(new Request("GET", "/_cluster/health"));
+            // }}
+            assertThat(container.getApiKey()).as("encoded API key is generated on start").isNotBlank();
+            assertThat(response.getStatusLine().getStatusCode()).as("cluster health is available").isEqualTo(200);
+            assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
+            // httpClientApiKey {{
+        }
+        // }
+    }
+
+    @Test
+    void getApiKeyBeforeStartThrows() {
+        try (ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE_LATEST)) {
+            assertThat(catchThrowable(container::getApiKey))
+                .as("API key is not available before the container has started")
+                .isInstanceOf(IllegalStateException.class);
+        }
+    }
+
+    @Test
+    void getApiKeyThrowsWhenSecurityIsDisabled() {
+        try (
+            ElasticsearchContainer container = new ElasticsearchContainer(ELASTICSEARCH_IMAGE_LATEST)
+                .withEnv("xpack.security.enabled", "false")
+                .withEnv("xpack.security.http.ssl.enabled", "false")
+                .withEnv("xpack.security.transport.ssl.enabled", "false")
+        ) {
+            container.start();
+
+            assertThat(catchThrowable(container::getApiKey))
+                .as("API key is not generated when security is disabled")
+                .isInstanceOf(IllegalStateException.class);
+        }
     }
 
     @Test
@@ -312,6 +371,7 @@ class ElasticsearchContainerTest {
                 .as("reported version matches the 8.x image")
                 .contains(ELASTICSEARCH_VERSION_8);
             assertThat(container.getHttpScheme()).as("HTTP API uses HTTPS by default").isEqualTo("https");
+            assertThat(container.getApiKey()).as("API key is generated for Elasticsearch 8").isNotBlank();
         }
     }
 
@@ -332,6 +392,9 @@ class ElasticsearchContainerTest {
             assertThat(response.getStatusLine().getStatusCode()).as("cluster health is available").isEqualTo(200);
             assertThat(EntityUtils.toString(response.getEntity())).contains("cluster_name");
             assertThat(container.getHttpScheme()).as("HTTP API uses HTTP by default on 7.x").isEqualTo("http");
+            assertThat(catchThrowable(container::getApiKey))
+                .as("API key is not generated for Elasticsearch 7")
+                .isInstanceOf(IllegalStateException.class);
             // httpClientV7 {{
         }
         // }


### PR DESCRIPTION
Elasticsearch 8+ with security now exposes getApiKey() so tests can authenticate without the elastic password.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Elasticsearch containers running version 8 or later with security enabled now generate an API key at startup.
  * Added access to the generated key for authenticating API requests.

* **Documentation**
  * Added guidance on retrieving and using the API key with the `Authorization: ApiKey` header.

* **Bug Fixes**
  * Added coverage to ensure API keys are handled correctly across supported versions and security configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->