### PR TITLE
Test Kibana managed network validation without Docker

### DIFF
--- a/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/KibanaContainer.java
+++ b/modules/elasticsearch/src/main/java/org/testcontainers/elasticsearch/KibanaContainer.java
@@ -330,7 +330,7 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
     }
 
     private void configureManagedElasticsearch() {
-        ensureCorrectNetworkSetupForManagedMode();
+        ensureCorrectNetworkSetupForManagedMode(elasticsearch.getNetwork(), getNetwork());
 
         if (getNetwork() == null) {
             createAdHocNetwork();
@@ -379,10 +379,7 @@ public class KibanaContainer extends GenericContainer<KibanaContainer> {
         }
     }
 
-    private void ensureCorrectNetworkSetupForManagedMode() {
-        Network esNetwork = elasticsearch.getNetwork();
-        Network kbNetwork = this.getNetwork();
-
+    static void ensureCorrectNetworkSetupForManagedMode(Network esNetwork, Network kbNetwork) {
         if ((esNetwork == null) != (kbNetwork == null)) {
             throw new IllegalStateException(
                 "Managed mode requires either both containers share the same explicit network, " +

--- a/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
+++ b/modules/elasticsearch/src/test/java/org/testcontainers/elasticsearch/KibanaContainerTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
@@ -133,39 +134,46 @@ class KibanaContainerTest {
     }
 
     @Test
+    void managedModeAcceptsNoExplicitNetwork() {
+        assertThatCode(() -> KibanaContainer.ensureCorrectNetworkSetupForManagedMode(null, null))
+            .doesNotThrowAnyException();
+    }
+
+    @Test
+    void managedModeAcceptsSharedExplicitNetwork() {
+        try (Network network = Network.newNetwork()) {
+            assertThatCode(() -> KibanaContainer.ensureCorrectNetworkSetupForManagedMode(network, network))
+                .doesNotThrowAnyException();
+        }
+    }
+
+    @Test
     void managedModeRejectsWhenOnlyElasticsearchHasExplicitNetwork() {
-        Network network = Network.newNetwork();
-        try (
-            ElasticsearchContainer es = new ElasticsearchContainer(ELASTICSEARCH_IMAGE_LATEST).withNetwork(network);
-            KibanaContainer kibana = new KibanaContainer(es)
-        ) {
-            assertThatThrownBy(kibana::start)
+        try (Network network = Network.newNetwork()) {
+            assertThatThrownBy(() -> KibanaContainer.ensureCorrectNetworkSetupForManagedMode(network, null))
                 .as("managed mode requires Kibana to join the same explicit network as Elasticsearch")
-                .isInstanceOf(ContainerLaunchException.class)
-                .satisfies(ex -> {
-                    assertThat(ex.getCause())
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("explicit network");
-                });
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("explicit network");
+        }
+    }
+
+    @Test
+    void managedModeRejectsWhenOnlyKibanaHasExplicitNetwork() {
+        try (Network network = Network.newNetwork()) {
+            assertThatThrownBy(() -> KibanaContainer.ensureCorrectNetworkSetupForManagedMode(null, network))
+                .as("managed mode requires Elasticsearch to join the same explicit network as Kibana")
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("explicit network");
         }
     }
 
     @Test
     void managedModeRejectsWhenNetworksDiffer() {
-        try (
-            Network esNetwork = Network.newNetwork();
-            Network kibanaNetwork = Network.newNetwork();
-            ElasticsearchContainer es = new ElasticsearchContainer(ELASTICSEARCH_IMAGE_LATEST).withNetwork(esNetwork);
-            KibanaContainer kibana = new KibanaContainer(es).withNetwork(kibanaNetwork)
-        ) {
-            assertThatThrownBy(kibana::start)
+        try (Network esNetwork = Network.newNetwork(); Network kibanaNetwork = Network.newNetwork()) {
+            assertThatThrownBy(() -> KibanaContainer.ensureCorrectNetworkSetupForManagedMode(esNetwork, kibanaNetwork))
                 .as("managed mode rejects Kibana and Elasticsearch on different networks")
-                .isInstanceOf(ContainerLaunchException.class)
-                .satisfies(ex -> {
-                    assertThat(ex.getCause())
-                        .isInstanceOf(IllegalStateException.class)
-                        .hasMessageContaining("different networks");
-                });
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("different networks");
         }
     }
 


### PR DESCRIPTION
## Summary

Part of #12070: make Kibana's managed-mode network validation tests independent of Docker.

The two negative tests currently call `kibana.start()`, which starts the Elasticsearch dependency before reaching the network validation. Extract the existing validation into a package-private static helper accepting the two network instances, and exercise it directly. `configureManagedElasticsearch()` still invokes the same checks in the same order.

Simply avoiding `start()` is insufficient: constructing `KibanaContainer(es)` resolves the Elasticsearch image name and can initialize Docker. These tests now need only uninitialized `Network` objects, with no container construction, image resolution, or startup.

Coverage includes both valid configurations (neither network explicit, or the same explicit network) and all three invalid configurations (only Elasticsearch explicit, only Kibana explicit, or different networks). Existing happy-path integration tests are unchanged. This does not attempt the other CI/matrix optimizations proposed in #12070.

## Validation

- Five network validation tests pass in **0.621 s** total test time, with no Docker/Ryuk initialization in test output.
- For context, the original two tests took 174.259 s locally, and one failed during Elasticsearch startup before reaching network validation. This is not a clean passing-baseline benchmark or a claim about total CI savings.
- Module `checkstyleMain`, `checkstyleTest`, `spotlessApply`, and `spotlessCheck` pass.
- The repository's current Spotless version needs an older npm CLI; formatting was run with temporary npm 10, without changing build files.
- The full Elasticsearch integration suite was not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of network configuration for managed Kibana and Elasticsearch setups.
  * Ensured invalid configurations are rejected consistently, including cases where only Kibana is assigned to an explicit network.

* **Tests**
  * Expanded coverage for valid and invalid managed-mode network configurations.
  * Simplified validation tests for faster, more direct verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->