### PR TITLE
Append URL parameters in TrinoContainer.getJdbcUrl()

### DIFF
--- a/modules/trino/src/main/java/org/testcontainers/containers/TrinoContainer.java
+++ b/modules/trino/src/main/java/org/testcontainers/containers/TrinoContainer.java
@@ -64,11 +64,13 @@ public class TrinoContainer extends JdbcDatabaseContainer<TrinoContainer> {
 
     @Override
     public String getJdbcUrl() {
+        String additionalUrlParams = constructUrlParameters("?", "&");
         return String.format(
-            "jdbc:trino://%s:%s/%s",
+            "jdbc:trino://%s:%s/%s%s",
             getHost(),
             getMappedPort(TRINO_PORT),
-            Strings.nullToEmpty(catalog)
+            Strings.nullToEmpty(catalog),
+            additionalUrlParams
         );
     }
 

--- a/modules/trino/src/main/java/org/testcontainers/trino/TrinoContainer.java
+++ b/modules/trino/src/main/java/org/testcontainers/trino/TrinoContainer.java
@@ -62,11 +62,13 @@ public class TrinoContainer extends JdbcDatabaseContainer<TrinoContainer> {
 
     @Override
     public String getJdbcUrl() {
+        String additionalUrlParams = constructUrlParameters("?", "&");
         return String.format(
-            "jdbc:trino://%s:%s/%s",
+            "jdbc:trino://%s:%s/%s%s",
             getHost(),
             getMappedPort(TRINO_PORT),
-            Strings.nullToEmpty(catalog)
+            Strings.nullToEmpty(catalog),
+            additionalUrlParams
         );
     }
 

--- a/modules/trino/src/test/java/org/testcontainers/trino/TrinoContainerTest.java
+++ b/modules/trino/src/test/java/org/testcontainers/trino/TrinoContainerTest.java
@@ -64,6 +64,26 @@ class TrinoContainerTest {
         }
     }
 
+    @Test
+    void testWithAdditionalUrlParamInJdbcUrl() throws Exception {
+        try (
+            TrinoContainer trino = new TrinoContainer(TrinoTestImages.TRINO_TEST_IMAGE)
+                .withUrlParam("applicationNamePrefix", "tc-")
+        ) {
+            trino.start();
+            String jdbcUrl = trino.getJdbcUrl();
+            assertThat(jdbcUrl).contains("?");
+            assertThat(jdbcUrl).contains("applicationNamePrefix=tc-");
+            try (
+                Connection connection = trino.createConnection();
+                Statement statement = connection.createStatement();
+                ResultSet resultSet = statement.executeQuery("SELECT 1")
+            ) {
+                assertThat(resultSet.next()).as("results").isTrue();
+            }
+        }
+    }
+
     private void assertContainerHasCorrectExposedAndLivenessCheckPorts(TrinoContainer trino) {
         assertThat(trino.getExposedPorts()).containsExactly(8080);
         assertThat(trino.getLivenessCheckPortNumbers()).containsExactly(trino.getMappedPort(8080));


### PR DESCRIPTION
`JdbcDatabaseContainer.withUrlParam(...)` is a silent no-op on `TrinoContainer`: parameters are stored in `urlParameters`, but they only reach the JDBC URL if the subclass's `getJdbcUrl()` appends `constructUrlParameters(...)` — and Trino's never did. Every other non-Oracle `JdbcDatabaseContainer` subclass (MySQL, PostgreSQL, MariaDB, TiDB, CockroachDB, Db2, MSSQLServer, ClickHouse, CrateDB, OceanBase, Timeplus, Databend, YugabyteDB) applies the idiom; Oracle is a deliberate exception (thin-URL syntax). The gap traces to the `withUrlParam` rollout in #1874 (2019), which predated Presto's fix — Trino was created by copying Presto, and the new `org.testcontainers.trino` package copied it again.

The Trino JDBC driver supports URL query parameters (`jdbc:trino://host:port/catalog?prop=value` — SSL, `applicationNamePrefix`, session properties), so the dropped setting is meaningful, and because the failure mode leaves defaults in place there is no error pointing at Testcontainers.

This change appends `constructUrlParameters("?", "&")` in both the `org.testcontainers.trino.TrinoContainer` and the deprecated `org.testcontainers.containers.TrinoContainer` (the frozen Presto module is left untouched), and adds `testWithAdditionalUrlParamInJdbcUrl` mirroring the existing MySQL test of the same name. Verified against a live `trinodb/trino:476` container: the test fails before the change (URL contains no `?`) and passes after, including a `SELECT 1` through `createConnection()` over the parameterized URL. `spotlessApply` produced no further changes.

Prepared with the assistance of Claude (Anthropic); the failing/passing runs against the live container were verified by execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trino JDBC URLs now include configured connection parameters, such as catalog settings.
  * Queries using these parameters now work correctly through the generated connection URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->