### PR TITLE
feat(questdb): Append URL parameters in QuestDBContainer.getJdbcUrl()

### DIFF
--- a/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
+++ b/modules/questdb/src/main/java/org/testcontainers/containers/QuestDBContainer.java
@@ -59,8 +59,20 @@ public class QuestDBContainer extends JdbcDatabaseContainer<QuestDBContainer> {
     }
 
     @Override
+    public String getDatabaseName() {
+        return getDefaultDatabaseName();
+    }
+
+    @Override
     public String getJdbcUrl() {
-        return String.format("jdbc:postgresql://%s:%d/%s", getHost(), getMappedPort(8812), getDefaultDatabaseName());
+        String additionalUrlParams = constructUrlParameters("?", "&");
+        return String.format(
+            "jdbc:postgresql://%s:%d/%s%s",
+            getHost(),
+            getMappedPort(POSTGRES_PORT),
+            getDatabaseName(),
+            additionalUrlParams
+        );
     }
 
     @Override

--- a/modules/questdb/src/test/java/org/testcontainers/junit/questdb/SimpleQuestDBTest.java
+++ b/modules/questdb/src/test/java/org/testcontainers/junit/questdb/SimpleQuestDBTest.java
@@ -40,6 +40,30 @@ class SimpleQuestDBTest extends AbstractContainerDatabaseTest {
     }
 
     @Test
+    void testWithAdditionalUrlParamInJdbcUrl() {
+        try (
+            QuestDBContainer questdb = new QuestDBContainer(QuestDBTestImages.QUESTDB_IMAGE)
+                .withUrlParam("sslmode", "disable")
+                .withUrlParam("binaryTransfer", "true")
+        ) {
+            questdb.start();
+            String jdbcUrl = questdb.getJdbcUrl();
+            assertThat(jdbcUrl)
+                .contains("?")
+                .contains("&")
+                .contains("sslmode=disable")
+                .contains("binaryTransfer=true");
+        }
+    }
+
+    @Test
+    void testDatabaseName() {
+        try (QuestDBContainer questdb = new QuestDBContainer(QuestDBTestImages.QUESTDB_IMAGE)) {
+            assertThat(questdb.getDatabaseName()).isEqualTo("qdb");
+        }
+    }
+
+    @Test
     void testRest() throws IOException {
         try (QuestDBContainer questdb = new QuestDBContainer(QuestDBTestImages.QUESTDB_IMAGE)) {
             questdb.start();


### PR DESCRIPTION
### What does this PR do?

Currently, `QuestDBContainer.getJdbcUrl()` does not include query parameters configured via `withUrlParam(key, value)`. This PR updates `QuestDBContainer.getJdbcUrl()` to append URL parameters via `constructUrlParameters("?", "&")`, use `POSTGRES_PORT`, and overrides `getDatabaseName()` to return `getDefaultDatabaseName()`.

This aligns `QuestDBContainer` with the other JDBC database containers in Testcontainers (such as PostgreSQL, CockroachDB, TiDB, MariaDB, etc.).

### Why are these changes needed?

Users who configure connection parameters on `QuestDBContainer` (e.g., SSL options, binary transfer, or session parameters) expect `getJdbcUrl()` to contain them when connecting via JDBC.

### How was this tested?

Added tests in `SimpleQuestDBTest`:
- `testWithAdditionalUrlParamInJdbcUrl`: Verifies URL parameters configured with `.withUrlParam(...)` are correctly appended to `getJdbcUrl()`.
- `testDatabaseName`: Verifies `getDatabaseName()` returns `"qdb"`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JDBC URLs now use the configured database name and port consistently.
  * Additional JDBC URL parameters are now included when configured.
  * The default QuestDB database name is exposed as `qdb`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->